### PR TITLE
Ensure we always fire time pattern changes after microsecond 0

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -34,6 +34,8 @@ from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
 from homeassistant.util.async_ import run_callback_threadsafe
 
+MAX_TIME_TRACKING_ERROR = 0.001
+
 TRACK_STATE_CHANGE_CALLBACKS = "track_state_change_callbacks"
 TRACK_STATE_CHANGE_LISTENER = "track_state_change_listener"
 
@@ -996,19 +998,40 @@ def async_track_utc_time_change(
 
         calculate_next(now + timedelta(seconds=1))
 
-        # We always get time.time() first to avoid time.time()
-        # ticking forward after fetching hass.loop.time()
-        # and callback being scheduled a few microseconds early
         cancel_callback = hass.loop.call_at(
-            -time.time() + hass.loop.time() + next_time.timestamp(),
+            -time.time()
+            + hass.loop.time()
+            + next_time.timestamp()
+            + MAX_TIME_TRACKING_ERROR,
             pattern_time_change_listener,
         )
 
     # We always get time.time() first to avoid time.time()
     # ticking forward after fetching hass.loop.time()
-    # and callback being scheduled a few microseconds early
+    # and callback being scheduled a few microseconds early.
+    #
+    # Since we loose additional time calling `hass.loop.time()`
+    # we add MAX_TIME_TRACKING_ERROR to ensure
+    # we always schedule the call within the time window between
+    # second and the next second.
+    #
+    # For example:
+    # If the clock ticks forward 30 microseconds when fectching
+    # `hass.loop.time()` and we want the event to fire at exactly
+    # 03:00:00.000000, the event would actually fire around
+    # 02:59:59.999970. To ensure we always fire sometime between
+    # 03:00:00.000000 and 03:00:00.999999 we add
+    # MAX_TIME_TRACKING_ERROR to make up for the time
+    # lost fetching the time. This ensures we do not fire the
+    # event before the next time pattern match which would result
+    # in the event being fired again since we would otherwise
+    # potentially fire early.
+    #
     cancel_callback = hass.loop.call_at(
-        -time.time() + hass.loop.time() + next_time.timestamp(),
+        -time.time()
+        + hass.loop.time()
+        + next_time.timestamp()
+        + MAX_TIME_TRACKING_ERROR,
         pattern_time_change_listener,
     )
 

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -219,6 +219,10 @@ def test_find_next_time_expression_time_basic():
         datetime(2018, 10, 7, 10, 30, 0), 5, 0, 0
     )
 
+    assert find(datetime(2018, 10, 7, 10, 30, 0, 999999), "*", "/30", 0) == datetime(
+        2018, 10, 7, 10, 30, 0
+    )
+
 
 def test_find_next_time_expression_time_dst():
     """Test daylight saving time for find_next_time_expression_time."""


### PR DESCRIPTION
2nd attempt at fixing https://github.com/home-assistant/core/issues/39012 (more desirable option)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure we always fire time pattern changes after microsecond 0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
