### PR TITLE
Eliminate unnecessary automation state changes

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -450,9 +450,7 @@ class _ScriptRun:
                 )
             except exceptions.TemplateError as ex:
                 self._log(
-                    "Error rendering event data template: %s",
-                    ex,
-                    level=logging.ERROR,
+                    "Error rendering event data template: %s", ex, level=logging.ERROR
                 )
 
         self._hass.bus.async_fire(
@@ -859,7 +857,10 @@ class Script:
         ).result()
 
     async def async_run(
-        self, variables: Optional[_VarsType] = None, context: Optional[Context] = None
+        self,
+        variables: Optional[_VarsType] = None,
+        context: Optional[Context] = None,
+        started_action: Optional[Callable[..., Any]] = None,
     ) -> None:
         """Run script."""
         if context is None:
@@ -894,6 +895,8 @@ class Script:
             self._hass, self, cast(dict, variables), context, self._log_exceptions
         )
         self._runs.append(run)
+        if started_action:
+            self._hass.async_run_job(started_action)
         self.last_triggered = utcnow()
         self._changed()
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -73,7 +73,7 @@ async def test_service_specify_data(hass, calls):
 
     time = dt_util.utcnow()
 
-    with patch("homeassistant.components.automation.utcnow", return_value=time):
+    with patch("homeassistant.helpers.script.utcnow", return_value=time):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
 
@@ -587,11 +587,7 @@ async def test_automation_stops(hass, calls, service):
             ],
         }
     }
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        config,
-    )
+    assert await async_setup_component(hass, automation.DOMAIN, config)
 
     running = asyncio.Event()
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1706,3 +1706,22 @@ async def test_update_logger(hass, caplog):
     await hass.async_block_till_done()
 
     assert log_name in caplog.text
+
+
+async def test_started_action(hass, caplog):
+    """Test the callback of started_action."""
+    event = "test_event"
+    log_message = "The script started!"
+    logger = logging.getLogger("TEST")
+
+    sequence = cv.SCRIPT_SCHEMA({"event": event})
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+
+    @callback
+    def started_action():
+        logger.info(log_message)
+
+    await script_obj.async_run(context=Context(), started_action=started_action)
+    await hass.async_block_till_done()
+
+    assert log_message in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously an automation's `last_triggered` attribute was updated, and an `automation_triggered` event was fired, whenever a trigger fired and the conditions (if any) were true, regardless if the actions actually ran. (For example, in `single` mode, the actions won't run if they are still running from a previous trigger event.) Now the attribute will be updated, and the event fired, only if the actions actually run.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current situation regarding an automation's `last_triggered` attribute, and the `automation_triggered` event, are less than optimal (as described above in the Breaking change section.) Not only are they misleading, the current implementation results in three `state_changed` events every time the automation runs -- two when it starts, and one when it finishes.

The change only updates the automation's state, and fires the event, if the automation actually runs, resulting in fewer `state_changed` events (i.e., none when the actions are not run, and only one at the beginning when it does), and fewer log messages, but more importantly, a more accurate `last_triggered` attribute.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
