### PR TITLE
Add the ability to reload homekit from yaml

### DIFF
--- a/homeassistant/components/homekit/services.yaml
+++ b/homeassistant/components/homekit/services.yaml
@@ -3,6 +3,9 @@
 start:
   description: Starts the HomeKit driver.
 
+reload:
+  description: Reload homekit and re-process yaml configuration.
+
 reset_accessory:
   description: Reset a HomeKit accessory. This can be useful when changing a media_player’s device class to tv, linking a battery, or whenever Home Assistant adds support for new HomeKit features to existing entities.
   fields:

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from homeassistant import config as conf_util
 from homeassistant.const import SERVICE_RELOAD
@@ -57,6 +57,17 @@ async def async_reload_integration_platforms(
                 continue
 
             await platform.async_setup(p_config)  # type: ignore
+
+
+async def async_integration_yaml_config(
+    hass: HomeAssistantType, integration_name: str
+) -> Optional[Dict[Any, Any]]:
+    """Fetch the latest yaml configuration for an integration."""
+    integration = await async_get_integration(hass, integration_name)
+
+    return await conf_util.async_process_component_config(
+        hass, await conf_util.async_hass_config_yaml(hass), integration
+    )
 
 
 @callback

--- a/tests/fixtures/helpers/test_domain_configuration.yaml
+++ b/tests/fixtures/helpers/test_domain_configuration.yaml
@@ -1,0 +1,4 @@
+test_domain:
+  - name: one
+  - name: two
+

--- a/tests/fixtures/homekit/configuration.yaml
+++ b/tests/fixtures/homekit/configuration.yaml
@@ -1,0 +1,3 @@
+homekit:
+  - name: reloadable
+    port: 45678

--- a/tests/helpers/test_reload.py
+++ b/tests/helpers/test_reload.py
@@ -2,11 +2,14 @@
 import logging
 from os import path
 
+import pytest
+
 from homeassistant import config
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.reload import (
     async_get_platform,
+    async_integration_yaml_config,
     async_reload_integration_platforms,
     async_setup_reload_service,
 )
@@ -104,6 +107,36 @@ async def test_setup_reload_service(hass):
         await hass.async_block_till_done()
 
     assert len(setup_called) == 2
+
+
+async def test_async_integration_yaml_config(hass):
+    """Test loading yaml config for an integration."""
+    mock_integration(hass, MockModule(DOMAIN))
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        f"helpers/{DOMAIN}_configuration.yaml",
+    )
+    with patch.object(config, "YAML_CONFIG_FILE", yaml_path):
+        processed_config = await async_integration_yaml_config(hass, DOMAIN)
+
+    assert processed_config == {DOMAIN: [{"name": "one"}, {"name": "two"}]}
+
+
+async def test_async_integration_missing_yaml_config(hass):
+    """Test loading missing yaml config for an integration."""
+    mock_integration(hass, MockModule(DOMAIN))
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "helpers/does_not_exist_configuration.yaml",
+    )
+    with pytest.raises(FileNotFoundError), patch.object(
+        config, "YAML_CONFIG_FILE", yaml_path
+    ):
+        await async_integration_yaml_config(hass, DOMAIN)
 
 
 def _get_fixtures_base_path():


### PR DESCRIPTION
WTH: https://community.home-assistant.io/t/why-the-heck-is-a-restart-needed-for-each-an-every-change-to-configuration-yaml/219630/10?u=bdraco

- [x] Frontend PR: https://github.com/home-assistant/frontend/pull/6721
- [x] Services.yaml: done

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the ability to reload homekit from yaml

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
