### PR TITLE
Ensure mobile_app notifications get re-registered after add/remove/add

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -66,7 +66,12 @@ async def async_reload(hass, integration_name):
     ):
         return
 
-    data = hass.data[NOTIFY_SERVICES][integration_name]
+    for data in hass.data[NOTIFY_SERVICES][integration_name]:
+        await _async_setup_notify_services(hass, data)
+
+
+async def _async_setup_notify_services(hass, data):
+    """Create or remove the notify services."""
     notify_service = data[SERVICE]
     friendly_name = data[FRIENDLY_NAME]
     targets = data[TARGETS]
@@ -94,6 +99,7 @@ async def async_reload(hass, integration_name):
             )
 
         for stale_target_name in stale_targets:
+            del targets[stale_target_name]
             hass.services.async_remove(
                 DOMAIN,
                 stale_target_name,
@@ -187,12 +193,11 @@ async def async_setup(hass, config):
         target_friendly_name = (
             p_config.get(CONF_NAME) or discovery_info.get(CONF_NAME) or integration_name
         )
-
         friendly_name = (
             p_config.get(CONF_NAME) or discovery_info.get(CONF_NAME) or SERVICE_NOTIFY
         )
 
-        hass.data[NOTIFY_SERVICES][integration_name] = {
+        data = {
             FRIENDLY_NAME: friendly_name,
             # The targets use a slightly different friendly name
             # selection pattern than the base service
@@ -200,8 +205,10 @@ async def async_setup(hass, config):
             SERVICE: notify_service,
             TARGETS: {},
         }
+        hass.data[NOTIFY_SERVICES].setdefault(integration_name, [])
+        hass.data[NOTIFY_SERVICES][integration_name].append(data)
 
-        await async_reload(hass, integration_name)
+        await _async_setup_notify_services(hass, data)
 
         hass.config.components.add(f"{DOMAIN}.{integration_name}")
 

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -96,6 +96,13 @@ async def setup_push_receiver(hass, aioclient_mock):
     assert hass.services.has_service("notify", "mobile_app_test")
     assert not hass.services.has_service("notify", "mobile_app_loaded_late")
 
+    loaded_late_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(loaded_late_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.services.has_service("notify", "mobile_app_test")
+    assert hass.services.has_service("notify", "mobile_app_loaded_late")
+
 
 async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
     """Test notify works."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure mobile_app notifications get re-registered after add/remove/add

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
