### PR TITLE
Reload mobile app notify service upon device name change, add device name to all webhook logs

### DIFF
--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
   "requirements": ["PyNaCl==1.3.0", "emoji==0.5.4"],
   "dependencies": ["http", "webhook", "person", "tag"],
-  "after_dependencies": ["cloud", "camera"],
+  "after_dependencies": ["cloud", "camera", "notify"],
   "codeowners": ["@robbiet480"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -149,10 +149,11 @@ async def handle_webhook(
 
     config_entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id]
 
+    device_name = config_entry.data[ATTR_DEVICE_NAME]
     try:
         req_data = await request.json()
     except ValueError:
-        _LOGGER.warning("Received invalid JSON from mobile_app")
+        _LOGGER.warning("Received invalid JSON from mobile_app device: %s", device_name)
         return empty_okay_response(status=HTTP_BAD_REQUEST)
 
     if (
@@ -161,7 +162,7 @@ async def handle_webhook(
     ):
         _LOGGER.warning(
             "Refusing to accept unencrypted webhook from %s",
-            config_entry.data[ATTR_DEVICE_NAME],
+            device_name,
         )
         return error_response(ERR_ENCRYPTION_REQUIRED, "Encryption required")
 
@@ -169,7 +170,9 @@ async def handle_webhook(
         req_data = WEBHOOK_PAYLOAD_SCHEMA(req_data)
     except vol.Invalid as ex:
         err = vol.humanize.humanize_error(req_data, ex)
-        _LOGGER.error("Received invalid webhook payload: %s", err)
+        _LOGGER.error(
+            "Received invalid webhook from %s with payload: %s", device_name, err
+        )
         return empty_okay_response()
 
     webhook_type = req_data[ATTR_WEBHOOK_TYPE]
@@ -181,7 +184,9 @@ async def handle_webhook(
         webhook_payload = _decrypt_payload(config_entry.data[CONF_SECRET], enc_data)
 
     if webhook_type not in WEBHOOK_COMMANDS:
-        _LOGGER.error("Received invalid webhook type: %s", webhook_type)
+        _LOGGER.error(
+            "Received invalid webhook from %s of type: %s", device_name, webhook_type
+        )
         return empty_okay_response()
 
     device_name = config_entry.data[ATTR_DEVICE_NAME]
@@ -403,6 +408,7 @@ async def webhook_register_sensor(hass, config_entry, data):
     """Handle a register sensor webhook."""
     entity_type = data[ATTR_SENSOR_TYPE]
     unique_id = data[ATTR_SENSOR_UNIQUE_ID]
+    device_name = config_entry.data[ATTR_DEVICE_NAME]
 
     unique_store_key = f"{config_entry.data[CONF_WEBHOOK_ID]}_{unique_id}"
     existing_sensor = unique_store_key in hass.data[DOMAIN][entity_type]
@@ -411,7 +417,9 @@ async def webhook_register_sensor(hass, config_entry, data):
 
     # If sensor already is registered, update current state instead
     if existing_sensor:
-        _LOGGER.debug("Re-register existing sensor %s", unique_id)
+        _LOGGER.debug(
+            "Re-register for %s of existing sensor %s", device_name, unique_id
+        )
         entry = hass.data[DOMAIN][entity_type][unique_store_key]
         data = {**entry, **data}
 
@@ -464,6 +472,7 @@ async def webhook_update_sensor_states(hass, config_entry, data):
         }
     )
 
+    device_name = config_entry.data[ATTR_DEVICE_NAME]
     resp = {}
     for sensor in data:
         entity_type = sensor[ATTR_SENSOR_TYPE]
@@ -474,7 +483,9 @@ async def webhook_update_sensor_states(hass, config_entry, data):
 
         if unique_store_key not in hass.data[DOMAIN][entity_type]:
             _LOGGER.error(
-                "Refusing to update non-registered sensor: %s", unique_store_key
+                "Refusing to update %s non-registered sensor: %s",
+                device_name,
+                unique_store_key,
             )
             err_msg = f"{entity_type} {unique_id} is not registered"
             resp[unique_id] = {
@@ -490,7 +501,10 @@ async def webhook_update_sensor_states(hass, config_entry, data):
         except vol.Invalid as err:
             err_msg = vol.humanize.humanize_error(sensor, err)
             _LOGGER.error(
-                "Received invalid sensor payload for %s: %s", unique_id, err_msg
+                "Received invalid sensor payload from %s for %s: %s",
+                device_name,
+                unique_id,
+                err_msg,
             )
             resp[unique_id] = {
                 "success": False,

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -8,7 +8,7 @@ from aiohttp.web import HTTPBadRequest, Request, Response, json_response
 from nacl.secret import SecretBox
 import voluptuous as vol
 
-from homeassistant.components import tag
+from homeassistant.components import notify as hass_notify, tag
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES as BINARY_SENSOR_CLASSES,
 )
@@ -150,6 +150,7 @@ async def handle_webhook(
     config_entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id]
 
     device_name = config_entry.data[ATTR_DEVICE_NAME]
+
     try:
         req_data = await request.json()
     except ValueError:
@@ -188,8 +189,6 @@ async def handle_webhook(
             "Received invalid webhook from %s of type: %s", device_name, webhook_type
         )
         return empty_okay_response()
-
-    device_name = config_entry.data[ATTR_DEVICE_NAME]
 
     _LOGGER.debug(
         "Received webhook payload from %s for type %s: %s",
@@ -352,6 +351,8 @@ async def webhook_update_registration(hass, config_entry, data):
     )
 
     hass.config_entries.async_update_entry(config_entry, data=new_registration)
+
+    await hass_notify.async_reload(hass, DOMAIN)
 
     return webhook_response(
         safe_registration(new_registration),

--- a/tests/components/mobile_app/test_entity.py
+++ b/tests/components/mobile_app/test_entity.py
@@ -122,7 +122,7 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
     assert reg_json == {"success": True}
     await hass.async_block_till_done()
 
-    assert "Re-register existing sensor" not in caplog.text
+    assert "Re-register" not in caplog.text
 
     entity = hass.states.get("sensor.test_1_battery_state")
     assert entity is not None
@@ -143,7 +143,7 @@ async def test_sensor_id_no_dupes(hass, create_registrations, webhook_client, ca
     assert dupe_reg_json == {"success": True}
     await hass.async_block_till_done()
 
-    assert "Re-register existing sensor" in caplog.text
+    assert "Re-register" in caplog.text
 
     entity = hass.states.get("sensor.test_1_battery_state")
     assert entity is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None because the user is explicitly changing the device name for the notify service so they are aware of this change, we are just making it faster and removing the need to restart HA for the change to take place

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reload the notify service when we update the registration.
Add device name to the rest of the webhook logs after #38518 has been merged (great idea)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
