### PR TITLE
Make async_track_template_result track multiple templates

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -187,7 +187,8 @@ class BayesianBinarySensor(BinarySensorEntity):
         )
 
         @callback
-        def _async_template_result_changed(event, template, last_result, result):
+        def _async_template_result_changed(event, updates):
+            template, _, result = updates.pop()
             entity = event and event.data.get("entity_id")
 
             if isinstance(result, TemplateError):
@@ -215,7 +216,7 @@ class BayesianBinarySensor(BinarySensorEntity):
 
         for template in self.observations_by_template:
             info = async_track_template_result(
-                self.hass, template, _async_template_result_changed
+                self.hass, [(template, None)], _async_template_result_changed
             )
 
             self._callbacks.append(info)

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -21,6 +21,7 @@ from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import condition
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import (
+    TrackTemplate,
     async_track_state_change_event,
     async_track_template_result,
 )
@@ -188,7 +189,9 @@ class BayesianBinarySensor(BinarySensorEntity):
 
         @callback
         def _async_template_result_changed(event, updates):
-            template, _, result = updates.pop()
+            track_template_result = updates.pop()
+            template = track_template_result.template
+            result = track_template_result.result
             entity = event and event.data.get("entity_id")
 
             if isinstance(result, TemplateError):
@@ -216,7 +219,9 @@ class BayesianBinarySensor(BinarySensorEntity):
 
         for template in self.observations_by_template:
             info = async_track_template_result(
-                self.hass, [(template, None)], _async_template_result_changed
+                self.hass,
+                [TrackTemplate(template, None)],
+                _async_template_result_changed,
             )
 
             self._callbacks.append(info)

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -1,7 +1,7 @@
 """TemplateEntity utility class."""
 
 import logging
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import voluptuous as vol
 
@@ -34,7 +34,6 @@ class _TemplateAttribute:
         self.validator = validator
         self.on_update = on_update
         self.async_update = None
-        self.add_complete = False
         self.none_on_template_error = none_on_template_error
 
     @callback
@@ -54,21 +53,14 @@ class _TemplateAttribute:
         setattr(self._entity, self._attribute, attr_result)
 
     @callback
-    def _write_update_if_added(self):
-        if self.add_complete:
-            self._entity.async_write_ha_state()
-
-    @callback
-    def _handle_result(
+    def handle_result(
         self,
         event: Optional[Event],
         template: Template,
         last_result: Optional[str],
         result: Union[str, TemplateError],
     ) -> None:
-        if event:
-            self._entity.async_set_context(event.context)
-
+        """Handle a template result event callback."""
         if isinstance(result, TemplateError):
             _LOGGER.error(
                 "TemplateError('%s') "
@@ -83,13 +75,10 @@ class _TemplateAttribute:
                 self._default_update(result)
             else:
                 self.on_update(result)
-            self._write_update_if_added()
-
             return
 
         if not self.validator:
             self.on_update(result)
-            self._write_update_if_added()
             return
 
         try:
@@ -107,26 +96,10 @@ class _TemplateAttribute:
                 ex.msg,
             )
             self.on_update(None)
-            self._write_update_if_added()
             return
 
         self.on_update(validated)
-        self._write_update_if_added()
-
-    @callback
-    def async_template_startup(self) -> None:
-        """Call from containing entity when added to hass."""
-        result_info = async_track_template_result(
-            self._entity.hass, self.template, self._handle_result
-        )
-
-        self.async_update = result_info.async_refresh
-
-        @callback
-        def _remove_from_hass():
-            result_info.async_remove()
-
-        return _remove_from_hass
+        return
 
 
 class TemplateEntity(Entity):
@@ -141,7 +114,8 @@ class TemplateEntity(Entity):
         attribute_templates=None,
     ):
         """Template Entity."""
-        self._template_attrs = []
+        self._template_attrs = {}
+        self._async_update = None
         self._attribute_templates = attribute_templates
         self._attributes = {}
         self._availability_template = availability_template
@@ -233,17 +207,40 @@ class TemplateEntity(Entity):
             self, attribute, template, validator, on_update, none_on_template_error
         )
         attribute.async_setup()
-        self._template_attrs.append(attribute)
+        self._template_attrs.setdefault(template, [])
+        self._template_attrs[template].append(attribute)
+
+    @callback
+    def _handle_results(
+        self,
+        event: Optional[Event],
+        updates: List[
+            Tuple[Template, Union[str, TemplateError], Union[str, TemplateError]]
+        ],
+    ) -> None:
+        """Call back the results to the attributes."""
+        if event:
+            self.async_set_context(event.context)
+
+        for update in updates:
+            template, last_result, result = update
+            for attr in self._template_attrs[template]:
+                attr.handle_result(event, template, last_result, result)
+
+        if self._async_update:
+            self.async_write_ha_state()
 
     async def _async_template_startup(self, *_) -> None:
-        # async_update will not write state
-        # until "add_complete" is set on the attribute
-        for attribute in self._template_attrs:
-            self.async_on_remove(attribute.async_template_startup())
-        await self.async_update()
-        for attribute in self._template_attrs:
-            attribute.add_complete = True
+        # _handle_results will not write state until "_async_update" is set
+        template_var_tups = [(template, None) for template in self._template_attrs]
+
+        result_info = async_track_template_result(
+            self.hass, template_var_tups, self._handle_results
+        )
+        self.async_on_remove(result_info.async_remove)
+        result_info.async_refresh()
         self.async_write_ha_state()
+        self._async_update = result_info.async_refresh
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -272,6 +269,4 @@ class TemplateEntity(Entity):
 
     async def async_update(self) -> None:
         """Call for forced update."""
-        for attribute in self._template_attrs:
-            if attribute.async_update:
-                attribute.async_update()
+        self._async_update()

--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -7,7 +7,11 @@ from homeassistant import exceptions
 from homeassistant.const import CONF_FOR, CONF_PLATFORM, CONF_VALUE_TEMPLATE
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, template
-from homeassistant.helpers.event import async_call_later, async_track_template_result
+from homeassistant.helpers.event import (
+    TrackTemplate,
+    async_call_later,
+    async_track_template_result,
+)
 from homeassistant.helpers.template import result_as_boolean
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
@@ -37,7 +41,7 @@ async def async_attach_trigger(
     def template_listener(event, updates):
         """Listen for state changes and calls action."""
         nonlocal delay_cancel
-        _, _, result = updates.pop()
+        result = updates.pop().result
 
         if delay_cancel:
             # pylint: disable=not-callable
@@ -95,7 +99,9 @@ async def async_attach_trigger(
         delay_cancel = async_call_later(hass, period.seconds, call_action)
 
     info = async_track_template_result(
-        hass, [(value_template, automation_info["variables"])], template_listener
+        hass,
+        [TrackTemplate(value_template, automation_info["variables"])],
+        template_listener,
     )
     unsub = info.async_remove
 

--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -34,9 +34,10 @@ async def async_attach_trigger(
     delay_cancel = None
 
     @callback
-    def template_listener(event, _, last_result, result):
+    def template_listener(event, updates):
         """Listen for state changes and calls action."""
         nonlocal delay_cancel
+        _, _, result = updates.pop()
 
         if delay_cancel:
             # pylint: disable=not-callable
@@ -94,7 +95,7 @@ async def async_attach_trigger(
         delay_cancel = async_call_later(hass, period.seconds, call_action)
 
     info = async_track_template_result(
-        hass, value_template, template_listener, automation_info["variables"]
+        hass, [(value_template, automation_info["variables"])], template_listener
     )
     unsub = info.async_remove
 

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -149,8 +149,10 @@ class UniversalMediaPlayer(MediaPlayerEntity):
             self.async_schedule_update_ha_state(True)
 
         @callback
-        def _async_on_template_update(event, template, last_result, result):
+        def _async_on_template_update(event, updates):
             """Update ha state when dependencies update."""
+            _, _, result = updates.pop()
+
             if isinstance(result, TemplateError):
                 self._state_template_result = None
             else:
@@ -159,7 +161,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
 
         if self._state_template is not None:
             result = self.hass.helpers.event.async_track_template_result(
-                self._state_template, _async_on_template_update
+                [(self._state_template, None)], _async_on_template_update
             )
             self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_START, callback(lambda _: result.async_refresh())

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -71,6 +71,7 @@ from homeassistant.const import (
 from homeassistant.core import EVENT_HOMEASSISTANT_START, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import TrackTemplate, async_track_template_result
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.service import async_call_from_config
 
@@ -151,7 +152,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         @callback
         def _async_on_template_update(event, updates):
             """Update ha state when dependencies update."""
-            _, _, result = updates.pop()
+            result = updates.pop().result
 
             if isinstance(result, TemplateError):
                 self._state_template_result = None
@@ -160,8 +161,10 @@ class UniversalMediaPlayer(MediaPlayerEntity):
             self.async_schedule_update_ha_state(True)
 
         if self._state_template is not None:
-            result = self.hass.helpers.event.async_track_template_result(
-                [(self._state_template, None)], _async_on_template_update
+            result = async_track_template_result(
+                self.hass,
+                [TrackTemplate(self._state_template, None)],
+                _async_on_template_update,
             )
             self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_START, callback(lambda _: result.async_refresh())

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -255,7 +255,8 @@ def handle_render_template(hass, connection, msg):
     variables = msg.get("variables")
 
     @callback
-    def _template_listener(event, template, last_result, result):
+    def _template_listener(event, updates):
+        template, _, result = updates.pop()
         if isinstance(result, TemplateError):
             _LOGGER.error(
                 "TemplateError('%s') " "while processing template '%s'",
@@ -267,7 +268,9 @@ def handle_render_template(hass, connection, msg):
 
         connection.send_message(messages.event_message(msg["id"], {"result": result}))
 
-    info = async_track_template_result(hass, template, _template_listener, variables)
+    info = async_track_template_result(
+        hass, [(template, variables)], _template_listener
+    )
 
     connection.subscriptions[msg["id"]] = info.async_remove
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -495,8 +495,8 @@ class _TrackTemplateResultInfo:
         self.hass = hass
         self._action = action
 
-        for track_template in track_templates:
-            track_template.template.hass = hass
+        for track_template_ in track_templates:
+            track_template_.template.hass = hass
         self._track_templates = track_templates
 
         self._all_listener: Optional[Callable] = None
@@ -511,15 +511,15 @@ class _TrackTemplateResultInfo:
 
     def async_setup(self) -> None:
         """Activation of template tracking."""
-        for track_template in self._track_templates:
-            template = track_template.template
-            variables = track_template.variables
+        for track_template_ in self._track_templates:
+            template = track_template_.template
+            variables = track_template_.variables
 
             self._info[template] = template.async_render_to_info(variables)
             if self._info[template].exception:
                 _LOGGER.error(
                     "Error while processing template: %s",
-                    template.template,
+                    track_template_.template,
                     exc_info=self._info[template].exception,
                 )
 
@@ -528,8 +528,8 @@ class _TrackTemplateResultInfo:
 
     @property
     def _needs_all_listener(self) -> bool:
-        for track_template in self._track_templates:
-            template = track_template.template
+        for track_template_ in self._track_templates:
+            template = track_template_.template
 
             # Tracking all states
             if self._info[template].all_states:
@@ -545,8 +545,8 @@ class _TrackTemplateResultInfo:
 
     @property
     def _all_templates_are_static(self) -> bool:
-        for track_template in self._track_templates:
-            if not self._info[track_template.template].is_static:
+        for track_template_ in self._track_templates:
+            if not self._info[track_template_.template].is_static:
                 return False
 
         return True
@@ -665,8 +665,8 @@ class _TrackTemplateResultInfo:
         updates = []
         info_changed = False
 
-        for track_template in self._track_templates:
-            template = track_template.template
+        for track_template_ in self._track_templates:
+            template = track_template_.template
             if (
                 entity_id
                 and len(self._last_info) > 1
@@ -675,7 +675,7 @@ class _TrackTemplateResultInfo:
                 continue
 
             self._info[template] = template.async_render_to_info(
-                track_template.variables
+                track_template_.variables
             )
             info_changed = True
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1,5 +1,6 @@
 """Helpers for listening to events."""
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import functools as ft
 import logging
@@ -58,6 +59,37 @@ TRACK_ENTITY_REGISTRY_UPDATED_CALLBACKS = "track_entity_registry_updated_callbac
 TRACK_ENTITY_REGISTRY_UPDATED_LISTENER = "track_entity_registry_updated_listener"
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class TrackTemplate:
+    """Class for keeping track of a template with variables.
+
+    The template is template to calculate.
+    The variables are variables to pass to the template.
+    """
+
+    template: Template
+    variables: TemplateVarsType
+
+
+@dataclass
+class TrackTemplateResult:
+    """Class for result of template tracking.
+
+    template
+        The template that has changed.
+    last_result
+        The output from the template on the last successful run, or None
+        if no previous successful run.
+    result
+        Result from the template run. This will be a string or an
+        TemplateError if the template resulted in an error.
+    """
+
+    template: Template
+    last_result: Union[str, None, TemplateError]
+    result: Union[str, TemplateError]
 
 
 def threaded_listener_factory(async_factory: Callable[..., Any]) -> CALLBACK_TYPE:
@@ -409,13 +441,14 @@ def async_track_template(
 
     @callback
     def _template_changed_listener(
-        event: Event,
-        updates: List[
-            Tuple[Template, Union[str, TemplateError], Union[str, TemplateError]]
-        ],
+        event: Event, updates: List[TrackTemplateResult]
     ) -> None:
         """Check if condition is correct and run action."""
-        template, last_result, result = updates.pop()
+        track_result = updates.pop()
+
+        template = track_result.template
+        last_result = track_result.last_result
+        result = track_result.result
 
         if isinstance(result, TemplateError):
             _LOGGER.error(
@@ -440,7 +473,7 @@ def async_track_template(
         )
 
     info = async_track_template_result(
-        hass, [(template, variables)], _template_changed_listener
+        hass, [TrackTemplate(template, variables)], _template_changed_listener
     )
 
     return info.async_remove
@@ -455,16 +488,16 @@ class _TrackTemplateResultInfo:
     def __init__(
         self,
         hass: HomeAssistant,
-        templates: Iterable[Tuple[Template, Optional[TemplateVarsType]]],
+        track_templates: Iterable[TrackTemplate],
         action: Callable,
     ):
         """Handle removal / refresh of tracker init."""
         self.hass = hass
         self._action = action
-        self._templates = templates
 
-        for template, _ in self._templates:
-            template.hass = hass
+        for track_template in track_templates:
+            track_template.template.hass = hass
+        self._track_templates = track_templates
 
         self._all_listener: Optional[Callable] = None
         self._domains_listener: Optional[Callable] = None
@@ -478,7 +511,10 @@ class _TrackTemplateResultInfo:
 
     def async_setup(self) -> None:
         """Activation of template tracking."""
-        for template, variables in self._templates:
+        for track_template in self._track_templates:
+            template = track_template.template
+            variables = track_template.variables
+
             self._info[template] = template.async_render_to_info(variables)
             if self._info[template].exception:
                 _LOGGER.error(
@@ -492,7 +528,9 @@ class _TrackTemplateResultInfo:
 
     @property
     def _needs_all_listener(self) -> bool:
-        for template, _ in self._templates:
+        for track_template in self._track_templates:
+            template = track_template.template
+
             # Tracking all states
             if self._info[template].all_states:
                 return True
@@ -507,8 +545,8 @@ class _TrackTemplateResultInfo:
 
     @property
     def _all_templates_are_static(self) -> bool:
-        for template, _ in self._templates:
-            if not self._info[template].is_static:
+        for track_template in self._track_templates:
+            if not self._info[track_template.template].is_static:
                 return False
 
         return True
@@ -627,7 +665,8 @@ class _TrackTemplateResultInfo:
         updates = []
         info_changed = False
 
-        for template, variables in self._templates:
+        for track_template in self._track_templates:
+            template = track_template.template
             if (
                 entity_id
                 and len(self._last_info) > 1
@@ -635,7 +674,9 @@ class _TrackTemplateResultInfo:
             ):
                 continue
 
-            self._info[template] = template.async_render_to_info(variables)
+            self._info[template] = template.async_render_to_info(
+                track_template.variables
+            )
             info_changed = True
 
             try:
@@ -654,7 +695,7 @@ class _TrackTemplateResultInfo:
             ):
                 continue
 
-            updates.append((template, last_result, result))
+            updates.append(TrackTemplateResult(template, last_result, result))
 
         if info_changed:
             self._update_listeners()
@@ -663,18 +704,14 @@ class _TrackTemplateResultInfo:
         if not updates:
             return
 
-        for template, _, result in updates:
-            self._last_result[template] = result
+        for track_result in updates:
+            self._last_result[track_result.template] = track_result.result
 
         self.hass.async_run_job(self._action, event, updates)
 
 
 TrackTemplateResultListener = Callable[
-    [
-        Event,
-        List[Tuple[Template, Union[str, TemplateError], Union[str, TemplateError]]],
-    ],
-    None,
+    [Event, List[TrackTemplateResult],], None,
 ]
 """Type for the listener for template results.
 
@@ -684,15 +721,7 @@ TrackTemplateResultListener = Callable[
         Event that caused the template to change output. None if not
         triggered by an event.
     updates
-        A list of tuples with the following elements:
-            template
-                The template that has changed.
-            last_result
-                The output from the template on the last successful run, or None
-                if no previous successful run.
-            result
-                Result from the template run. This will be a string or an
-                TemplateError if the template resulted in an error.
+        A list of TrackTemplateResult
 """
 
 
@@ -700,7 +729,7 @@ TrackTemplateResultListener = Callable[
 @bind_hass
 def async_track_template_result(
     hass: HomeAssistant,
-    templates: Iterable[Tuple[Template, Optional[TemplateVarsType]]],
+    track_templates: Iterable[TrackTemplate],
     action: TrackTemplateResultListener,
 ) -> _TrackTemplateResultInfo:
     """Add a listener that fires when a the result of a template changes.
@@ -721,11 +750,9 @@ def async_track_template_result(
     ----------
     hass
         Home assistant object.
-    templates
-        An iterable of tuples.
+    track_templates
+        An iterable of TrackTemplate.
 
-        The first value of the tuple is the template to calculate.
-        The second value of the tuple are variables to pass to the template.
     action
         Callable to call with results.
 
@@ -734,7 +761,7 @@ def async_track_template_result(
     Info object used to unregister the listener, and refresh the template.
 
     """
-    tracker = _TrackTemplateResultInfo(hass, templates, action)
+    tracker = _TrackTemplateResultInfo(hass, track_templates, action)
     tracker.async_setup()
     return tracker
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -711,7 +711,11 @@ class _TrackTemplateResultInfo:
 
 
 TrackTemplateResultListener = Callable[
-    [Event, List[TrackTemplateResult],], None,
+    [
+        Event,
+        List[TrackTemplateResult],
+    ],
+    None,
 ]
 """Type for the listener for template results.
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -4,11 +4,23 @@ from datetime import datetime, timedelta
 import functools as ft
 import logging
 import time
-from typing import Any, Awaitable, Callable, Iterable, Optional, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import attr
 
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_NOW,
     EVENT_CORE_CONFIG_UPDATE,
     EVENT_STATE_CHANGED,
@@ -396,13 +408,15 @@ def async_track_template(
     """
 
     @callback
-    def state_changed_listener(
+    def _template_changed_listener(
         event: Event,
-        template: Template,
-        last_result: Optional[str],
-        result: Union[str, TemplateError],
+        updates: List[
+            Tuple[Template, Union[str, TemplateError], Union[str, TemplateError]]
+        ],
     ) -> None:
         """Check if condition is correct and run action."""
+        template, last_result, result = updates.pop()
+
         if isinstance(result, TemplateError):
             _LOGGER.error(
                 "Error while processing template: %s",
@@ -411,7 +425,11 @@ def async_track_template(
             )
             return
 
-        if result_as_boolean(last_result) or not result_as_boolean(result):
+        if (
+            not isinstance(last_result, TemplateError)
+            and result_as_boolean(last_result)
+            or not result_as_boolean(result)
+        ):
             return
 
         hass.async_run_job(
@@ -422,7 +440,7 @@ def async_track_template(
         )
 
     info = async_track_template_result(
-        hass, template, state_changed_listener, variables
+        hass, [(template, variables)], _template_changed_listener
     )
 
     return info.async_remove
@@ -431,76 +449,84 @@ def async_track_template(
 track_template = threaded_listener_factory(async_track_template)
 
 
-_UNCHANGED = object()
-
-
 class _TrackTemplateResultInfo:
     """Handle removal / refresh of tracker."""
 
     def __init__(
         self,
         hass: HomeAssistant,
-        template: Template,
+        templates: Iterable[Tuple[Template, Optional[TemplateVarsType]]],
         action: Callable,
-        variables: Optional[TemplateVarsType],
     ):
         """Handle removal / refresh of tracker init."""
         self.hass = hass
-        self._template = template
-        self._template.hass = hass
         self._action = action
-        self._variables = variables
-        self._last_result: Optional[Union[str, TemplateError]] = None
+        self._templates = templates
+
+        for template, _ in self._templates:
+            template.hass = hass
+
         self._all_listener: Optional[Callable] = None
         self._domains_listener: Optional[Callable] = None
         self._entities_listener: Optional[Callable] = None
-        self._info: Optional[RenderInfo] = None
-        self._last_info: Optional[RenderInfo] = None
+
+        self._last_result: Dict[Template, Union[str, TemplateError]] = {}
+        self._last_info: Dict[Template, RenderInfo] = {}
+        self._info: Dict[Template, RenderInfo] = {}
+        self._last_domains: Set = set()
+        self._last_entities: Set = set()
 
     def async_setup(self) -> None:
         """Activation of template tracking."""
-        self._info = self._template.async_render_to_info(self._variables)
-        if self._info.exception:
-            _LOGGER.error(
-                "Error while processing template: %s",
-                self._template.template,
-                exc_info=self._info.exception,
-            )
+        for template, variables in self._templates:
+            self._info[template] = template.async_render_to_info(variables)
+            if self._info[template].exception:
+                _LOGGER.error(
+                    "Error while processing template: %s",
+                    template.template,
+                    exc_info=self._info[template].exception,
+                )
+
+        self._last_info = self._info.copy()
         self._create_listeners()
-        self._last_info = self._info
 
     @property
     def _needs_all_listener(self) -> bool:
-        assert self._info
+        for template, _ in self._templates:
+            # Tracking all states
+            if self._info[template].all_states:
+                return True
 
-        # Tracking all states
-        if self._info.all_states:
-            return True
-
-        # Previous call had an exception
-        # so we do not know which states
-        # to track
-        if self._info.exception:
-            return True
+            # Previous call had an exception
+            # so we do not know which states
+            # to track
+            if self._info[template].exception:
+                return True
 
         return False
 
+    @property
+    def _all_templates_are_static(self) -> bool:
+        for template, _ in self._templates:
+            if not self._info[template].is_static:
+                return False
+
+        return True
+
     @callback
     def _create_listeners(self) -> None:
-        assert self._info
-
-        if self._info.is_static:
+        if self._all_templates_are_static:
             return
 
         if self._needs_all_listener:
             self._setup_all_listener()
             return
 
-        if self._info.domains:
-            self._setup_domains_listener()
-
-        if self._info.entities or self._info.domains:
-            self._setup_entities_listener()
+        self._last_entities, self._last_domains = _entities_domains_from_info(
+            self._info.values()
+        )
+        self._setup_domains_listener(self._last_domains)
+        self._setup_entities_listener(self._last_domains, self._last_entities)
 
     @callback
     def _cancel_domains_listener(self) -> None:
@@ -525,12 +551,11 @@ class _TrackTemplateResultInfo:
 
     @callback
     def _update_listeners(self) -> None:
-        assert self._info
-        assert self._last_info
-
         if self._needs_all_listener:
             if self._all_listener:
                 return
+            self._last_domains = set()
+            self._last_entities = set()
             self._cancel_domains_listener()
             self._cancel_entities_listener()
             self._setup_all_listener()
@@ -540,27 +565,26 @@ class _TrackTemplateResultInfo:
         if had_all_listener:
             self._cancel_all_listener()
 
-        domains_changed = self._info.domains != self._last_info.domains
+        entities, domains = _entities_domains_from_info(self._info.values())
+        domains_changed = domains != self._last_domains
+
         if had_all_listener or domains_changed:
             domains_changed = True
             self._cancel_domains_listener()
-            self._setup_domains_listener()
+            self._setup_domains_listener(domains)
 
-        if (
-            had_all_listener
-            or domains_changed
-            or self._info.entities != self._last_info.entities
-        ):
+        if had_all_listener or domains_changed or entities != self._last_entities:
             self._cancel_entities_listener()
-            self._setup_entities_listener()
+            self._setup_entities_listener(domains, entities)
+
+        self._last_domains = domains
+        self._last_entities = entities
 
     @callback
-    def _setup_entities_listener(self) -> None:
-        assert self._info
-
-        entities = set(self._info.entities)
-        for entity_id in self.hass.states.async_entity_ids(self._info.domains):
-            entities.add(entity_id)
+    def _setup_entities_listener(self, domains: Set, entities: Set) -> None:
+        if domains:
+            entities = entities.copy()
+            entities.update(self.hass.states.async_entity_ids(domains))
 
         # Entities has changed to none
         if not entities:
@@ -571,15 +595,12 @@ class _TrackTemplateResultInfo:
         )
 
     @callback
-    def _setup_domains_listener(self) -> None:
-        assert self._info
-
-        # Domains has changed to none
-        if not self._info.domains:
+    def _setup_domains_listener(self, domains: Set) -> None:
+        if not domains:
             return
 
         self._domains_listener = async_track_state_added_domain(
-            self.hass, self._info.domains, self._refresh
+            self.hass, domains, self._refresh
         )
 
     @callback
@@ -596,40 +617,64 @@ class _TrackTemplateResultInfo:
         self._cancel_entities_listener()
 
     @callback
-    def async_refresh(self, variables: Any = _UNCHANGED) -> None:
+    def async_refresh(self) -> None:
         """Force recalculate the template."""
-        if variables is not _UNCHANGED:
-            self._variables = variables
         self._refresh(None)
 
     @callback
     def _refresh(self, event: Optional[Event]) -> None:
-        self._info = self._template.async_render_to_info(self._variables)
-        self._update_listeners()
-        self._last_info = self._info
+        entity_id = event and event.data.get(ATTR_ENTITY_ID)
+        updates = []
+        info_changed = False
 
-        try:
-            result: Union[str, TemplateError] = self._info.result
-        except TemplateError as ex:
-            result = ex
+        for template, variables in self._templates:
+            if (
+                entity_id
+                and len(self._last_info) > 1
+                and not self._last_info[template].filter_lifecycle(entity_id)
+            ):
+                continue
 
-        # Check to see if the result has changed
-        if result == self._last_result:
+            self._info[template] = template.async_render_to_info(variables)
+            info_changed = True
+
+            try:
+                result: Union[str, TemplateError] = self._info[template].result
+            except TemplateError as ex:
+                result = ex
+
+            last_result = self._last_result.get(template)
+
+            # Check to see if the result has changed
+            if result == last_result:
+                continue
+
+            if isinstance(result, TemplateError) and isinstance(
+                last_result, TemplateError
+            ):
+                continue
+
+            updates.append((template, last_result, result))
+
+        if info_changed:
+            self._update_listeners()
+            self._last_info = self._info.copy()
+
+        if not updates:
             return
 
-        if isinstance(result, TemplateError) and isinstance(
-            self._last_result, TemplateError
-        ):
-            return
+        for template, _, result in updates:
+            self._last_result[template] = result
 
-        self.hass.async_run_job(
-            self._action, event, self._template, self._last_result, result
-        )
-        self._last_result = result
+        self.hass.async_run_job(self._action, event, updates)
 
 
 TrackTemplateResultListener = Callable[
-    [Event, Template, Optional[str], Union[str, TemplateError]], None
+    [
+        Event,
+        List[Tuple[Template, Union[str, TemplateError], Union[str, TemplateError]]],
+    ],
+    None,
 ]
 """Type for the listener for template results.
 
@@ -638,14 +683,16 @@ TrackTemplateResultListener = Callable[
     event
         Event that caused the template to change output. None if not
         triggered by an event.
-    template
-        The template that has changed.
-    last_result
-        The output from the template on the last successful run, or None
-        if no previous successful run.
-    result
-        Result from the template run. This will be a string or an
-        TemplateError if the template resulted in an error.
+    updates
+        A list of tuples with the following elements:
+            template
+                The template that has changed.
+            last_result
+                The output from the template on the last successful run, or None
+                if no previous successful run.
+            result
+                Result from the template run. This will be a string or an
+                TemplateError if the template resulted in an error.
 """
 
 
@@ -653,9 +700,8 @@ TrackTemplateResultListener = Callable[
 @bind_hass
 def async_track_template_result(
     hass: HomeAssistant,
-    template: Template,
+    templates: Iterable[Tuple[Template, Optional[TemplateVarsType]]],
     action: TrackTemplateResultListener,
-    variables: Optional[TemplateVarsType] = None,
 ) -> _TrackTemplateResultInfo:
     """Add a listener that fires when a the result of a template changes.
 
@@ -675,19 +721,20 @@ def async_track_template_result(
     ----------
     hass
         Home assistant object.
-    template
-        The template to calculate.
+    templates
+        An iterable of tuples.
+
+        The first value of the tuple is the template to calculate.
+        The second value of the tuple are variables to pass to the template.
     action
         Callable to call with results.
-    variables
-        Variables to pass to the template.
 
     Returns
     -------
     Info object used to unregister the listener, and refresh the template.
 
     """
-    tracker = _TrackTemplateResultInfo(hass, template, action, variables)
+    tracker = _TrackTemplateResultInfo(hass, templates, action)
     tracker.async_setup()
     return tracker
 
@@ -1073,3 +1120,16 @@ def process_state_match(
 
     parameter_set = set(parameter)
     return lambda state: state in parameter_set
+
+
+def _entities_domains_from_info(render_infos: Iterable[RenderInfo]) -> Tuple[Set, Set]:
+    """Combine from multiple RenderInfo."""
+    entities = set()
+    domains = set()
+
+    for render_info in render_infos:
+        if render_info.entities:
+            entities.update(render_info.entities)
+        if render_info.domains:
+            domains.update(render_info.domains)
+    return entities, domains

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -192,7 +192,7 @@ class RenderInfo:
         self.entities = frozenset(self.entities)
         self.domains = frozenset(self.domains)
 
-        if self.all_states:
+        if self.all_states or self.exception:
             return
 
         if not self.domains:

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -581,22 +581,29 @@ async def test_track_template_result(hass):
         "{{(states.sensor.test.state|int) + test }}", hass
     )
 
-    def specific_run_callback(event, template, old_result, new_result):
+    def specific_run_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         specific_runs.append(int(new_result))
 
-    async_track_template_result(hass, template_condition, specific_run_callback)
+    async_track_template_result(
+        hass, [(template_condition, None)], specific_run_callback
+    )
 
     @ha.callback
-    def wildcard_run_callback(event, template, old_result, new_result):
+    def wildcard_run_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         wildcard_runs.append((int(old_result or 0), int(new_result)))
 
-    async_track_template_result(hass, template_condition, wildcard_run_callback)
+    async_track_template_result(
+        hass, [(template_condition, None)], wildcard_run_callback
+    )
 
-    async def wildercard_run_callback(event, template, old_result, new_result):
+    async def wildercard_run_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         wildercard_runs.append((int(old_result or 0), int(new_result)))
 
     async_track_template_result(
-        hass, template_condition_var, wildercard_run_callback, {"test": 5}
+        hass, [(template_condition_var, {"test": 5})], wildercard_run_callback
     )
     await hass.async_block_till_done()
 
@@ -661,13 +668,14 @@ async def test_track_template_result_complex(hass):
 """
     template_complex = Template(template_complex_str, hass)
 
-    def specific_run_callback(event, template, old_result, new_result):
+    def specific_run_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         specific_runs.append(new_result)
 
     hass.states.async_set("light.one", "on")
     hass.states.async_set("lock.one", "locked")
 
-    async_track_template_result(hass, template_complex, specific_run_callback)
+    async_track_template_result(hass, [(template_complex, None)], specific_run_callback)
     await hass.async_block_till_done()
 
     hass.states.async_set("sensor.domain", "light")
@@ -742,14 +750,15 @@ async def test_track_template_result_with_wildcard(hass):
 """
     template_complex = Template(template_complex_str, hass)
 
-    def specific_run_callback(event, template, old_result, new_result):
+    def specific_run_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         specific_runs.append(new_result)
 
     hass.states.async_set("cover.office_drapes", "closed")
     hass.states.async_set("cover.office_window", "closed")
     hass.states.async_set("cover.office_skylight", "open")
 
-    async_track_template_result(hass, template_complex, specific_run_callback)
+    async_track_template_result(hass, [(template_complex, None)], specific_run_callback)
     await hass.async_block_till_done()
 
     hass.states.async_set("cover.office_window", "open")
@@ -786,10 +795,11 @@ async def test_track_template_result_with_group(hass):
 """
     template_complex = Template(template_complex_str, hass)
 
-    def specific_run_callback(event, template, old_result, new_result):
+    def specific_run_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         specific_runs.append(new_result)
 
-    async_track_template_result(hass, template_complex, specific_run_callback)
+    async_track_template_result(hass, [(template_complex, None)], specific_run_callback)
     await hass.async_block_till_done()
 
     hass.states.async_set("sensor.power_1", 100.1)
@@ -827,13 +837,11 @@ async def test_track_template_result_and_conditional(hass):
 
     template = Template(template_str, hass)
 
-    def specific_run_callback(event, template, old_result, new_result):
-        import pprint
-
-        pprint.pprint([event, template, old_result, new_result])
+    def specific_run_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         specific_runs.append(new_result)
 
-    async_track_template_result(hass, template, specific_run_callback)
+    async_track_template_result(hass, [(template, None)], specific_run_callback)
     await hass.async_block_till_done()
 
     hass.states.async_set("light.b", "on")
@@ -869,21 +877,27 @@ async def test_track_template_result_iterator(hass):
     iterator_runs = []
 
     @ha.callback
-    def iterator_callback(event, template, old_result, new_result):
+    def iterator_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         iterator_runs.append(new_result)
 
     async_track_template_result(
         hass,
-        Template(
-            """
+        [
+            (
+                Template(
+                    """
             {% for state in states.sensor %}
                 {% if state.state == 'on' %}
                     {{ state.entity_id }},
                 {% endif %}
             {% endfor %}
             """,
-            hass,
-        ),
+                    hass,
+                ),
+                None,
+            )
+        ],
         iterator_callback,
     )
     await hass.async_block_till_done()
@@ -896,16 +910,22 @@ async def test_track_template_result_iterator(hass):
     filter_runs = []
 
     @ha.callback
-    def filter_callback(event, template, old_result, new_result):
+    def filter_callback(event, updates):
+        template, old_result, new_result = updates.pop()
         filter_runs.append(new_result)
 
     async_track_template_result(
         hass,
-        Template(
-            """{{ states.sensor|selectattr("state","equalto","on")
+        [
+            (
+                Template(
+                    """{{ states.sensor|selectattr("state","equalto","on")
                 |join(",", attribute="entity_id") }}""",
-            hass,
-        ),
+                    hass,
+                ),
+                None,
+            )
+        ],
         filter_callback,
     )
     await hass.async_block_till_done()
@@ -931,21 +951,28 @@ async def test_track_template_result_errors(hass, caplog):
     syntax_error_runs = []
     not_exist_runs = []
 
-    def syntax_error_listener(event, template, last_result, result):
+    @ha.callback
+    def syntax_error_listener(event, updates):
+        template, last_result, result = updates.pop()
         syntax_error_runs.append((event, template, last_result, result))
 
-    async_track_template_result(hass, template_syntax_error, syntax_error_listener)
+    async_track_template_result(
+        hass, [(template_syntax_error, None)], syntax_error_listener
+    )
     await hass.async_block_till_done()
 
     assert len(syntax_error_runs) == 0
     assert "TemplateSyntaxError" in caplog.text
 
+    @ha.callback
+    def not_exist_runs_error_listener(event, updates):
+        template, last_result, result = updates.pop()
+        not_exist_runs.append((event, template, last_result, result))
+
     async_track_template_result(
         hass,
-        template_not_exist,
-        lambda event, template, last_result, result: (
-            not_exist_runs.append((event, template, last_result, result))
-        ),
+        [(template_not_exist, None)],
+        not_exist_runs_error_listener,
     )
     await hass.async_block_till_done()
 
@@ -990,10 +1017,14 @@ async def test_track_template_result_refresh_cancel(hass):
 
     refresh_runs = []
 
-    def refresh_listener(event, template, last_result, result):
+    @ha.callback
+    def refresh_listener(event, updates):
+        template, last_result, result = updates.pop()
         refresh_runs.append(result)
 
-    info = async_track_template_result(hass, template_refresh, refresh_listener)
+    info = async_track_template_result(
+        hass, [(template_refresh, None)], refresh_listener
+    )
     await hass.async_block_till_done()
 
     hass.states.async_set("switch.test", "off")
@@ -1020,7 +1051,9 @@ async def test_track_template_result_refresh_cancel(hass):
     refresh_runs = []
 
     info = async_track_template_result(
-        hass, template_refresh, refresh_listener, {"value": "duck"}
+        hass,
+        [(template_refresh, {"value": "duck"})],
+        refresh_listener,
     )
     await hass.async_block_till_done()
     info.async_refresh()
@@ -1032,9 +1065,126 @@ async def test_track_template_result_refresh_cancel(hass):
     await hass.async_block_till_done()
     assert refresh_runs == ["duck"]
 
-    info.async_refresh({"value": "dog"})
+
+async def test_async_track_template_result_multiple_templates(hass):
+    """Test tracking multiple templates."""
+
+    template_1 = Template("{{ states.switch.test.state == 'on' }}")
+    template_2 = Template("{{ states.switch.test.state == 'on' }}")
+    template_3 = Template("{{ states.switch.test.state == 'off' }}")
+    template_4 = Template(
+        "{{ states.binary_sensor | map(attribute='entity_id') | list }}"
+    )
+
+    refresh_runs = []
+
+    @ha.callback
+    def refresh_listener(event, updates):
+        refresh_runs.append(updates)
+
+    async_track_template_result(
+        hass,
+        [
+            (template_1, None),
+            (template_2, None),
+            (template_3, None),
+            (template_4, None),
+        ],
+        refresh_listener,
+    )
+
+    hass.states.async_set("switch.test", "on")
     await hass.async_block_till_done()
-    assert refresh_runs == ["duck", "dog"]
+
+    assert refresh_runs == [
+        [
+            (template_1, None, "True"),
+            (template_2, None, "True"),
+            (template_3, None, "False"),
+        ]
+    ]
+
+    refresh_runs = []
+    hass.states.async_set("switch.test", "off")
+    await hass.async_block_till_done()
+
+    assert refresh_runs == [
+        [
+            (template_1, "True", "False"),
+            (template_2, "True", "False"),
+            (template_3, "False", "True"),
+        ]
+    ]
+
+    refresh_runs = []
+    hass.states.async_set("binary_sensor.test", "off")
+    await hass.async_block_till_done()
+
+    assert refresh_runs == [[(template_4, None, "['binary_sensor.test']")]]
+
+
+async def test_async_track_template_result_multiple_templates_mixing_domain(hass):
+    """Test tracking multiple templates when tracking entities and an entire domain."""
+
+    template_1 = Template("{{ states.switch.test.state == 'on' }}")
+    template_2 = Template("{{ states.switch.test.state == 'on' }}")
+    template_3 = Template("{{ states.switch.test.state == 'off' }}")
+    template_4 = Template("{{ states.switch | map(attribute='entity_id') | list }}")
+
+    refresh_runs = []
+
+    @ha.callback
+    def refresh_listener(event, updates):
+        refresh_runs.append(updates)
+
+    async_track_template_result(
+        hass,
+        [
+            (template_1, None),
+            (template_2, None),
+            (template_3, None),
+            (template_4, None),
+        ],
+        refresh_listener,
+    )
+
+    hass.states.async_set("switch.test", "on")
+    await hass.async_block_till_done()
+
+    assert refresh_runs == [
+        [
+            (template_1, None, "True"),
+            (template_2, None, "True"),
+            (template_3, None, "False"),
+            (template_4, None, "['switch.test']"),
+        ]
+    ]
+
+    refresh_runs = []
+    hass.states.async_set("switch.test", "off")
+    await hass.async_block_till_done()
+
+    assert refresh_runs == [
+        [
+            (template_1, "True", "False"),
+            (template_2, "True", "False"),
+            (template_3, "False", "True"),
+        ]
+    ]
+
+    refresh_runs = []
+    hass.states.async_set("binary_sensor.test", "off")
+    await hass.async_block_till_done()
+
+    assert refresh_runs == []
+
+    refresh_runs = []
+    hass.states.async_set("switch.new", "off")
+    await hass.async_block_till_done()
+
+    assert refresh_runs == [
+        [(template_4, "['switch.test']", "['switch.new', 'switch.test']")]
+    ]
 
 
 async def test_track_same_state_simple_no_trigger(hass):


### PR DESCRIPTION
Not a breaking change as long as it goes in before 0.115 

Addresses https://github.com/home-assistant/core/pull/39188#issuecomment-679089883


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Combine template entity updates to only write ha
state once per template group update


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
