### PR TITLE
Revert "Support selecting http vs https protocols for qvrpro"

### DIFF
--- a/homeassistant/components/qvr_pro/__init__.py
+++ b/homeassistant/components/qvr_pro/__init__.py
@@ -8,13 +8,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 import voluptuous as vol
 
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_PROTOCOL,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 
@@ -26,7 +20,6 @@ from .const import (
 )
 
 DEFAULT_PORT = 8080
-DEFAULT_PROTOCOL = "http"
 
 SERVICE_CHANNEL_GUID = "guid"
 
@@ -40,9 +33,6 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): vol.All(
-                    cv.string, vol.In(["http", "https"])
-                ),
                 vol.Optional(CONF_EXCLUDE_CHANNELS, default=[]): vol.All(
                     cv.ensure_list_csv, [cv.positive_int]
                 ),
@@ -64,11 +54,10 @@ def setup(hass, config):
     password = conf[CONF_PASSWORD]
     host = conf[CONF_HOST]
     port = conf[CONF_PORT]
-    protocol = conf[CONF_PROTOCOL]
     excluded_channels = conf[CONF_EXCLUDE_CHANNELS]
 
     try:
-        qvrpro = Client(user, password, host, protocol=protocol, port=port)
+        qvrpro = Client(user, password, host, port=port)
 
         channel_resp = qvrpro.get_channel_list()
 


### PR DESCRIPTION
This PR reverts home-assistant/core#38951, as the PR was merged, but conflicts with ADR-0010.

Changes to the YAML configuration were made, while this is no longer allowed.

<https://github.com/home-assistant/architecture/blob/master/adr/0010-integration-configuration.md#decision>

CC: @bachya @ctalkington @woneill @MartinHjelmare 