### PR TITLE
Update DSMR integration to import yaml to ConfigEntry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,6 +102,7 @@ homeassistant/components/digital_ocean/* @fabaff
 homeassistant/components/directv/* @ctalkington
 homeassistant/components/discogs/* @thibmaek
 homeassistant/components/doorbird/* @oblogic7 @bdraco
+homeassistant/components/dsmr/* @Robbie1221
 homeassistant/components/dsmr_reader/* @depl0y
 homeassistant/components/dunehd/* @bieniu
 homeassistant/components/dwd_weather_warnings/* @runningman84 @stephan192 @Hummel95

--- a/homeassistant/components/dsmr/__init__.py
+++ b/homeassistant/components/dsmr/__init__.py
@@ -26,9 +26,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
-    if not entry.update_listeners:
-        listener = entry.add_update_listener(async_update_options)
-        hass.data[DOMAIN][entry.entry_id][DATA_LISTENER] = listener
+    listener = entry.add_update_listener(async_update_options)
+    hass.data[DOMAIN][entry.entry_id][DATA_LISTENER] = listener
 
     return True
 

--- a/homeassistant/components/dsmr/__init__.py
+++ b/homeassistant/components/dsmr/__init__.py
@@ -48,7 +48,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             ]
         )
     )
-
-    hass.data[DOMAIN].pop(entry.entry_id)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/dsmr/__init__.py
+++ b/homeassistant/components/dsmr/__init__.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DATA_LISTENER, DATA_TASK, DOMAIN, PLATFORMS
+from .const import DATA_TASK, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,19 +26,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
-    listener = entry.add_update_listener(async_update_options)
-    hass.data[DOMAIN][entry.entry_id][DATA_LISTENER] = listener
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     task = hass.data[DOMAIN][entry.entry_id][DATA_TASK]
-    listener = hass.data[DOMAIN][entry.entry_id][DATA_LISTENER]
 
     # Cancel the reconnect task
-    listener()
     task.cancel()
     try:
         await task
@@ -57,8 +52,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry):
-    """Update options."""
-    await hass.config_entries.async_reload(config_entry.entry_id)

--- a/homeassistant/components/dsmr/__init__.py
+++ b/homeassistant/components/dsmr/__init__.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DATA_TASK, DOMAIN, PLATFORMS
+from .const import DATA_LISTENER, DATA_TASK, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,14 +26,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
+    if not entry.update_listeners:
+        listener = entry.add_update_listener(async_update_options)
+        hass.data[DOMAIN][entry.entry_id][DATA_LISTENER] = listener
+
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     task = hass.data[DOMAIN][entry.entry_id][DATA_TASK]
+    listener = hass.data[DOMAIN][entry.entry_id][DATA_LISTENER]
 
     # Cancel the reconnect task
+    listener()
     task.cancel()
     try:
         await task
@@ -52,3 +58,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Update options."""
+    await hass.config_entries.async_reload(config_entry.entry_id)

--- a/homeassistant/components/dsmr/__init__.py
+++ b/homeassistant/components/dsmr/__init__.py
@@ -1,1 +1,54 @@
 """The dsmr component."""
+import asyncio
+from asyncio import CancelledError
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DATA_TASK, DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass, config: dict):
+    """Set up the DSMR platform."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up DSMR from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {}
+
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    task = hass.data[DOMAIN][entry.entry_id][DATA_TASK]
+
+    # Cancel the reconnect task
+    task.cancel()
+    try:
+        await task
+    except CancelledError:
+        pass
+
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+
+    hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for DSMR integration."""
 import logging
+from typing import Any, Dict, Optional
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -17,17 +18,14 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _abort_if_host_port_configured(
         self,
-        host: str,
-        port: int,
+        port: str,
+        host: str = None,
         updates: Optional[Dict[Any, Any]] = None,
         reload_on_update: bool = True,
     ):
         """Test if host and port are already configured."""
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if (
-                entry.data[CONF_HOST] == host
-                and entry.data[CONF_PORT] == port
-            ):
+            if entry.data.get(CONF_HOST) == host and entry.data[CONF_PORT] == port:
                 if updates is not None:
                     changed = self.hass.config_entries.async_update_entry(
                         entry, data={**entry.data, **updates}
@@ -35,7 +33,11 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     if (
                         changed
                         and reload_on_update
-                        and entry.state in (ENTRY_STATE_LOADED, ENTRY_STATE_SETUP_RETRY)
+                        and entry.state
+                        in (
+                            config_entries.ENTRY_STATE_LOADED,
+                            config_entries.ENTRY_STATE_SETUP_RETRY,
+                        )
                     ):
                         self.hass.async_create_task(
                             self.hass.config_entries.async_reload(entry.entry_id)
@@ -44,11 +46,16 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
-        if CONF_HOST in import_config:
-            name = f"{import_config[CONF_HOST]}:{import_config[CONF_PORT]}"
-        else:
-            name = import_config[CONF_PORT]
+        host = import_config.get(CONF_HOST)
+        port = import_config[CONF_PORT]
 
-        await self.async_set_unique_id(name)
-        self._abort_if_unique_id_configured(import_config)
+        status = self._abort_if_host_port_configured(port, host, import_config)
+        if status is not None:
+            return status
+
+        if host is not None:
+            name = f"{host}:{port}"
+        else:
+            name = port
+
         return self.async_create_entry(title=name, data=import_config)

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -1,0 +1,27 @@
+"""Config flow for DSMR integration."""
+import logging
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for DSMR."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_import(self, import_config=None):
+        """Handle the initial step."""
+        if CONF_HOST in import_config:
+            name = f"{import_config[CONF_HOST]}:{import_config[CONF_PORT]}"
+        else:
+            name = import_config[CONF_PORT]
+
+        await self.async_set_unique_id(name)
+        self._abort_if_unique_id_configured(import_config)
+        return self.async_create_entry(title=name, data=import_config)

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -15,6 +15,33 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
+    def _abort_if_host_port_configured(
+        self,
+        host: str,
+        port: int,
+        updates: Optional[Dict[Any, Any]] = None,
+        reload_on_update: bool = True,
+    ):
+        """Test if host and port are already configured."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if (
+                entry.data[CONF_HOST] == host
+                and entry.data[CONF_PORT] == port
+            ):
+                if updates is not None:
+                    changed = self.hass.config_entries.async_update_entry(
+                        entry, data={**entry.data, **updates}
+                    )
+                    if (
+                        changed
+                        and reload_on_update
+                        and entry.state in (ENTRY_STATE_LOADED, ENTRY_STATE_SETUP_RETRY)
+                    ):
+                        self.hass.async_create_task(
+                            self.hass.config_entries.async_reload(entry.entry_id)
+                        )
+                return self.async_abort(reason="already_configured")
+
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
         if CONF_HOST in import_config:

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
-from .const import DOMAIN
+from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -1,0 +1,21 @@
+"""Constants for the DSMR integration."""
+
+DOMAIN = "dsmr"
+
+PLATFORMS = ["sensor"]
+
+CONF_DSMR_VERSION = "dsmr_version"
+CONF_RECONNECT_INTERVAL = "reconnect_interval"
+CONF_PRECISION = "precision"
+
+DEFAULT_DSMR_VERSION = "2.2"
+DEFAULT_PORT = "/dev/ttyUSB0"
+DEFAULT_PRECISION = 3
+DEFAULT_RECONNECT_INTERVAL = 30
+
+DATA_TASK = "task"
+
+ICON_GAS = "mdi:fire"
+ICON_POWER = "mdi:flash"
+ICON_POWER_FAILURE = "mdi:flash-off"
+ICON_SWELL_SAG = "mdi:pulse"

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -14,7 +14,6 @@ DEFAULT_PRECISION = 3
 DEFAULT_RECONNECT_INTERVAL = 30
 
 DATA_TASK = "task"
-DATA_LISTENER = "listener"
 
 ICON_GAS = "mdi:fire"
 ICON_POWER = "mdi:flash"

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -14,6 +14,7 @@ DEFAULT_PRECISION = 3
 DEFAULT_RECONNECT_INTERVAL = 30
 
 DATA_TASK = "task"
+DATA_LISTENER = "listener"
 
 ICON_GAS = "mdi:fire"
 ICON_POWER = "mdi:flash"

--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -3,5 +3,6 @@
   "name": "DSMR Slimme Meter",
   "documentation": "https://www.home-assistant.io/integrations/dsmr",
   "requirements": ["dsmr_parser==0.18"],
-  "codeowners": []
+  "codeowners": ["@Robbie1221"],
+  "config_flow": false
 }

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -1,5 +1,6 @@
 """Support for Dutch Smart Meter (also known as Smartmeter or P1 port)."""
 import asyncio
+from asyncio import CancelledError
 from functools import partial
 import logging
 
@@ -9,6 +10,7 @@ import serial
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -18,25 +20,25 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import (
+    CONF_DSMR_VERSION,
+    CONF_PRECISION,
+    CONF_RECONNECT_INTERVAL,
+    DATA_TASK,
+    DEFAULT_DSMR_VERSION,
+    DEFAULT_PORT,
+    DEFAULT_PRECISION,
+    DEFAULT_RECONNECT_INTERVAL,
+    DOMAIN,
+    ICON_GAS,
+    ICON_POWER,
+    ICON_POWER_FAILURE,
+    ICON_SWELL_SAG,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_DSMR_VERSION = "dsmr_version"
-CONF_RECONNECT_INTERVAL = "reconnect_interval"
-CONF_PRECISION = "precision"
-
-DEFAULT_DSMR_VERSION = "2.2"
-DEFAULT_PORT = "/dev/ttyUSB0"
-DEFAULT_PRECISION = 3
-
-DOMAIN = "dsmr"
-
-ICON_GAS = "mdi:fire"
-ICON_POWER = "mdi:flash"
-ICON_POWER_FAILURE = "mdi:flash-off"
-ICON_SWELL_SAG = "mdi:pulse"
-
-RECONNECT_INTERVAL = 5
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -45,16 +47,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_DSMR_VERSION, default=DEFAULT_DSMR_VERSION): vol.All(
             cv.string, vol.In(["5B", "5", "4", "2.2"])
         ),
-        vol.Optional(CONF_RECONNECT_INTERVAL, default=30): int,
+        vol.Optional(CONF_RECONNECT_INTERVAL, default=DEFAULT_RECONNECT_INTERVAL): int,
         vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): vol.Coerce(int),
     }
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+) -> None:
     """Set up the DSMR sensor."""
     # Suppress logging
     logging.getLogger("dsmr_parser").setLevel(logging.ERROR)
+
+    config = entry.data
 
     dsmr_version = config[CONF_DSMR_VERSION]
 
@@ -137,34 +143,30 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     async def connect_and_reconnect():
         """Connect to DSMR and keep reconnecting until Home Assistant stops."""
-        while hass.state != CoreState.stopping:
+        while True:
             # Start DSMR asyncio.Protocol reader
             try:
                 transport, protocol = await hass.loop.create_task(reader_factory())
-            except (
-                serial.serialutil.SerialException,
-                ConnectionRefusedError,
-                TimeoutError,
-            ):
-                # Log any error while establishing connection and drop to retry
-                # connection wait
-                _LOGGER.exception("Error connecting to DSMR")
-                transport = None
 
-            if transport:
-                # Register listener to close transport on HA shutdown
-                stop_listener = hass.bus.async_listen_once(
-                    EVENT_HOMEASSISTANT_STOP, transport.close
-                )
+                if transport:
+                    # Register listener to close transport on HA shutdown
+                    stop_listener = hass.bus.async_listen_once(
+                        EVENT_HOMEASSISTANT_STOP, transport.close
+                    )
 
-                # Wait for reader to close
-                await protocol.wait_closed()
+                    # Wait for reader to close
+                    await protocol.wait_closed()
 
-            if hass.state != CoreState.stopping:
+                if hass.state == CoreState.stopping:
+                    return
+
                 # Unexpected disconnect
                 if transport:
                     # remove listener
                     stop_listener()
+
+                transport = None
+                protocol = None
 
                 # Reflect disconnect state in devices state by setting an
                 # empty telegram resulting in `unknown` states
@@ -173,8 +175,38 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 # throttle reconnect attempts
                 await asyncio.sleep(config[CONF_RECONNECT_INTERVAL])
 
+            except (serial.serialutil.SerialException, OSError):
+                # Log any error while establishing connection and drop to retry
+                # connection wait
+                _LOGGER.exception("Error connecting to DSMR")
+                transport = None
+                protocol = None
+            except CancelledError:
+                if stop_listener:
+                    stop_listener()
+
+                if transport:
+                    transport.close()
+
+                if protocol:
+                    await protocol.wait_closed()
+
+                return
+
     # Can't be hass.async_add_job because job runs forever
-    hass.loop.create_task(connect_and_reconnect())
+    task = hass.loop.create_task(connect_and_reconnect())
+
+    # Save the task to be able to cancel it when unloading
+    hass.data[DOMAIN][entry.entry_id][DATA_TASK] = task
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Import the platform into a config entry."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
 
 
 class DSMREntity(Entity):

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -53,6 +53,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Import the platform into a config entry."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:
@@ -157,9 +166,6 @@ async def async_setup_entry(
                     # Wait for reader to close
                     await protocol.wait_closed()
 
-                if hass.state == CoreState.stopping:
-                    return
-
                 # Unexpected disconnect
                 if transport:
                     # remove listener
@@ -198,15 +204,6 @@ async def async_setup_entry(
 
     # Save the task to be able to cancel it when unloading
     hass.data[DOMAIN][entry.entry_id][DATA_TASK] = task
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Import the platform into a config entry."""
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
 
 
 class DSMREntity(Entity):

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -143,7 +143,7 @@ async def async_setup_entry(
 
     async def connect_and_reconnect():
         """Connect to DSMR and keep reconnecting until Home Assistant stops."""
-        while True:
+        while hass.state != CoreState.stopping:
             # Start DSMR asyncio.Protocol reader
             try:
                 transport, protocol = await hass.loop.create_task(reader_factory())

--- a/homeassistant/components/dsmr/strings.json
+++ b/homeassistant/components/dsmr/strings.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "step": {},
+    "error": {},
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -71,11 +71,32 @@ async def test_import_update(hass):
     )
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data=entry_data,
-    )
+    with patch(
+        "homeassistant.components.dsmr.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.dsmr.async_unload_entry", return_value=True):
+        await hass.config_entries.async_setup(entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    new_entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "precision": 3,
+        "reconnect_interval": 30,
+    }
+
+    with patch(
+        "homeassistant.components.dsmr.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.dsmr.async_unload_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=new_entry_data,
+        )
+
+    await hass.async_block_till_done()
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
+
+    assert entry.data["precision"] == 3

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -1,0 +1,81 @@
+"""Test the DSMR config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.dsmr import DOMAIN
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_import_usb(hass):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=entry_data,
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "/dev/ttyUSB0"
+    assert result["data"] == entry_data
+
+
+async def test_import_network(hass):
+    """Test we can import from network."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry_data = {
+        "host": "localhost",
+        "port": "1234",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=entry_data,
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "localhost:1234"
+    assert result["data"] == entry_data
+
+
+async def test_import_update(hass):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+        unique_id="/dev/ttyUSB0",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=entry_data,
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.setup import async_setup_component
 
 import tests.async_mock
 from tests.async_mock import DEFAULT, MagicMock, Mock
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, patch
 
 
 @pytest.fixture
@@ -61,7 +61,13 @@ async def test_setup_platform(hass, mock_connection_factory):
         "reconnect_interval": 30,
     }
 
-    assert await async_setup_component(hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: entry_data})
+    with patch("homeassistant.components.dsmr.async_setup", return_value=True), patch(
+        "homeassistant.components.dsmr.async_setup_entry", return_value=True
+    ):
+        assert await async_setup_component(
+            hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: entry_data}
+        )
+
     assert not async_add_entities.called
 
     await hass.async_block_till_done()

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -67,10 +67,9 @@ async def test_setup_platform(hass, mock_connection_factory):
         assert await async_setup_component(
             hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: entry_data}
         )
+        await hass.async_block_till_done()
 
     assert not async_add_entities.called
-
-    await hass.async_block_till_done()
 
     # Check config entry
     conf_entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -12,10 +12,11 @@ from itertools import chain, repeat
 
 import pytest
 
-from homeassistant.components.dsmr import sensor
 from homeassistant.components.dsmr.const import DOMAIN
 from homeassistant.components.dsmr.sensor import DerivativeDSMREntity
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ENERGY_KILO_WATT_HOUR, TIME_HOURS, VOLUME_CUBIC_METERS
+from homeassistant.setup import async_setup_component
 
 import tests.async_mock
 from tests.async_mock import DEFAULT, MagicMock, Mock
@@ -53,16 +54,14 @@ async def test_setup_platform(hass, mock_connection_factory):
     async_add_entities = MagicMock()
 
     entry_data = {
+        "platform": DOMAIN,
         "port": "/dev/ttyUSB0",
         "dsmr_version": "2.2",
         "precision": 4,
         "reconnect_interval": 30,
     }
 
-    result = await sensor.async_setup_platform(
-        hass, entry_data, async_add_entities, None
-    )
-    assert not result
+    assert await async_setup_component(hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: entry_data})
     assert not async_add_entities.called
 
     await hass.async_block_till_done()

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -49,10 +49,7 @@ def mock_connection_factory(monkeypatch):
 
 
 async def test_setup_platform(hass, mock_connection_factory):
-    """Test invalid device config."""
-    # mock_device = MagicMock()
-    # hass.data[DATA_NETWORK] = MagicMock()
-    # hass.data[zwave.DATA_DEVICES] = {456: mock_device}
+    """Test setup of platform."""
     async_add_entities = MagicMock()
 
     entry_data = {

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -12,13 +12,12 @@ from itertools import chain, repeat
 
 import pytest
 
-from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.dsmr.sensor import DerivativeDSMREntity
 from homeassistant.const import ENERGY_KILO_WATT_HOUR, TIME_HOURS, VOLUME_CUBIC_METERS
 
 import tests.async_mock
 from tests.async_mock import DEFAULT, Mock
-from tests.common import assert_setup_component
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -58,7 +57,12 @@ async def test_default_setup(hass, mock_connection_factory):
     )
     from dsmr_parser.objects import CosemObject, MBusObject
 
-    config = {"platform": "dsmr"}
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
 
     telegram = {
         CURRENT_ELECTRICITY_USAGE: CosemObject(
@@ -73,9 +77,14 @@ async def test_default_setup(hass, mock_connection_factory):
         ),
     }
 
-    with assert_setup_component(1):
-        await async_setup_component(hass, "sensor", {"sensor": config})
-        await hass.async_block_till_done()
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -106,6 +115,10 @@ async def test_default_setup(hass, mock_connection_factory):
     gas_consumption = hass.states.get("sensor.gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
+
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"
 
 
 async def test_derivative():
@@ -158,7 +171,12 @@ async def test_v4_meter(hass, mock_connection_factory):
     )
     from dsmr_parser.objects import CosemObject, MBusObject
 
-    config = {"platform": "dsmr", "dsmr_version": "4"}
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "4",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
 
     telegram = {
         HOURLY_GAS_METER_READING: MBusObject(
@@ -170,9 +188,14 @@ async def test_v4_meter(hass, mock_connection_factory):
         ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
     }
 
-    with assert_setup_component(1):
-        await async_setup_component(hass, "sensor", {"sensor": config})
-        await hass.async_block_till_done()
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -191,6 +214,10 @@ async def test_v4_meter(hass, mock_connection_factory):
     gas_consumption = hass.states.get("sensor.gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
+
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"
 
 
 async def test_v5_meter(hass, mock_connection_factory):
@@ -203,7 +230,12 @@ async def test_v5_meter(hass, mock_connection_factory):
     )
     from dsmr_parser.objects import CosemObject, MBusObject
 
-    config = {"platform": "dsmr", "dsmr_version": "5"}
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
 
     telegram = {
         HOURLY_GAS_METER_READING: MBusObject(
@@ -215,9 +247,14 @@ async def test_v5_meter(hass, mock_connection_factory):
         ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
     }
 
-    with assert_setup_component(1):
-        await async_setup_component(hass, "sensor", {"sensor": config})
-        await hass.async_block_till_done()
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -237,6 +274,10 @@ async def test_v5_meter(hass, mock_connection_factory):
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
 
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"
+
 
 async def test_belgian_meter(hass, mock_connection_factory):
     """Test if Belgian meter is correctly parsed."""
@@ -248,7 +289,12 @@ async def test_belgian_meter(hass, mock_connection_factory):
     )
     from dsmr_parser.objects import CosemObject, MBusObject
 
-    config = {"platform": "dsmr", "dsmr_version": "5B"}
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5B",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
 
     telegram = {
         BELGIUM_HOURLY_GAS_METER_READING: MBusObject(
@@ -260,9 +306,14 @@ async def test_belgian_meter(hass, mock_connection_factory):
         ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
     }
 
-    with assert_setup_component(1):
-        await async_setup_component(hass, "sensor", {"sensor": config})
-        await hass.async_block_till_done()
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -282,6 +333,10 @@ async def test_belgian_meter(hass, mock_connection_factory):
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
 
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"
+
 
 async def test_belgian_meter_low(hass, mock_connection_factory):
     """Test if Belgian meter is correctly parsed."""
@@ -290,13 +345,23 @@ async def test_belgian_meter_low(hass, mock_connection_factory):
     from dsmr_parser.obis_references import ELECTRICITY_ACTIVE_TARIFF
     from dsmr_parser.objects import CosemObject
 
-    config = {"platform": "dsmr", "dsmr_version": "5B"}
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5B",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
 
     telegram = {ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0002", "unit": ""}])}
 
-    with assert_setup_component(1):
-        await async_setup_component(hass, "sensor", {"sensor": config})
-        await hass.async_block_till_done()
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -311,26 +376,50 @@ async def test_belgian_meter_low(hass, mock_connection_factory):
     assert power_tariff.state == "low"
     assert power_tariff.attributes.get("unit_of_measurement") == ""
 
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"
+
 
 async def test_tcp(hass, mock_connection_factory):
     """If proper config provided TCP connection should be made."""
     (connection_factory, transport, protocol) = mock_connection_factory
 
-    config = {"platform": "dsmr", "host": "localhost", "port": 1234}
+    entry_data = {
+        "host": "localhost",
+        "port": "1234",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
 
-    with assert_setup_component(1):
-        await async_setup_component(hass, "sensor", {"sensor": config})
-        await hass.async_block_till_done()
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert connection_factory.call_args_list[0][0][0] == "localhost"
     assert connection_factory.call_args_list[0][0][1] == "1234"
+
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"
 
 
 async def test_connection_errors_retry(hass, monkeypatch, mock_connection_factory):
     """Connection should be retried on error during setup."""
     (connection_factory, transport, protocol) = mock_connection_factory
 
-    config = {"platform": "dsmr", "reconnect_interval": 0}
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 0,
+    }
 
     # override the mock to have it fail the first time and succeed after
     first_fail_connection_factory = tests.async_mock.AsyncMock(
@@ -342,17 +431,35 @@ async def test_connection_errors_retry(hass, monkeypatch, mock_connection_factor
         "homeassistant.components.dsmr.sensor.create_dsmr_reader",
         first_fail_connection_factory,
     )
-    await async_setup_component(hass, "sensor", {"sensor": config})
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     # wait for sleep to resolve
     await hass.async_block_till_done()
     assert first_fail_connection_factory.call_count >= 2, "connecting not retried"
 
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"
+
 
 async def test_reconnect(hass, monkeypatch, mock_connection_factory):
     """If transport disconnects, the connection should be retried."""
     (connection_factory, transport, protocol) = mock_connection_factory
-    config = {"platform": "dsmr", "reconnect_interval": 0}
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 0,
+    }
 
     # mock waiting coroutine while connection lasts
     closed = asyncio.Event()
@@ -365,7 +472,13 @@ async def test_reconnect(hass, monkeypatch, mock_connection_factory):
 
     protocol.wait_closed = wait_closed
 
-    await async_setup_component(hass, "sensor", {"sensor": config})
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert connection_factory.call_count == 1
@@ -382,3 +495,7 @@ async def test_reconnect(hass, monkeypatch, mock_connection_factory):
     assert connection_factory.call_count >= 2, "connecting not retried"
     # setting it so teardown can be successful
     closed.set()
+
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+
+    assert mock_entry.state == "not_loaded"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
DSMR integration uses platform setup. To migrate it to UI, in this first PR, yaml platform setup is imported into ConfigEntry.

I will add device validation and config flow in a separate PR to limit PR sizes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
