### PR TITLE
Skip setup of dependencies if they are already setup

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -71,27 +71,47 @@ async def _async_process_dependencies(
     hass: core.HomeAssistant, config: ConfigType, integration: loader.Integration
 ) -> bool:
     """Ensure all dependencies are set up."""
-    tasks = {
+    dependencies_tasks = {
         dep: hass.loop.create_task(async_setup_component(hass, dep, config))
         for dep in integration.dependencies
+        if dep not in hass.config.components
     }
 
+    after_dependencies_tasks = dict()
     to_be_loaded = hass.data.get(DATA_SETUP_DONE, {})
     for dep in integration.after_dependencies:
-        if dep in to_be_loaded and dep not in hass.config.components:
-            tasks[dep] = hass.loop.create_task(to_be_loaded[dep].wait())
+        if (
+            dep not in dependencies_tasks
+            and dep in to_be_loaded
+            and dep not in hass.config.components
+        ):
+            after_dependencies_tasks[dep] = hass.loop.create_task(
+                to_be_loaded[dep].wait()
+            )
 
-    if not tasks:
+    if not dependencies_tasks and not after_dependencies_tasks:
         return True
 
-    _LOGGER.debug("Dependency %s will wait for %s", integration.domain, list(tasks))
+    if dependencies_tasks:
+        _LOGGER.debug(
+            "Dependency %s will wait for dependencies %s",
+            integration.domain,
+            list(dependencies_tasks),
+        )
+    if after_dependencies_tasks:
+        _LOGGER.debug(
+            "Dependency %s will wait for after dependencies %s",
+            integration.domain,
+            list(after_dependencies_tasks),
+        )
+
     async with hass.timeout.async_freeze(integration.domain):
-        results = await asyncio.gather(*tasks.values())
+        results = await asyncio.gather(
+            *dependencies_tasks.values(), *after_dependencies_tasks.values()
+        )
 
     failed = [
-        domain
-        for idx, domain in enumerate(integration.dependencies)
-        if not results[idx]
+        domain for idx, domain in enumerate(dependencies_tasks) if not results[idx]
     ]
 
     if failed:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`after_dependencies` were checking `hass.config.components`
to see if something was already setup.  We did not do
the same for `dependencies` which resulted in trying
to set them up more then once.

Noticed when `homeassistant.setup` was set to `debug`
logging and many integrations were announcing
waiting on `http` when it was already setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
