### PR TITLE
Force token expires_in to float

### DIFF
--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -80,11 +80,7 @@ class AbstractOAuth2Implementation(ABC):
         """Refresh a token and update expires info."""
         new_token = await self._async_refresh_token(token)
         # Force int for non-compliant oauth2 providers
-        try:
-            new_token["expires_in"] = int(new_token["expires_in"])
-        except ValueError as err:
-            _LOGGER.warning("Error converting expires_in to int: %s", err)
-            return token
+        new_token["expires_in"] = int(new_token["expires_in"])
         new_token["expires_at"] = time.time() + new_token["expires_in"]
         return new_token
 

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -257,7 +257,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
     ) -> Dict[str, Any]:
         """Create config entry from external data."""
         token = await self.flow_impl.async_resolve_external_data(self.external_data)
-        token["expires_at"] = time.time() + token["expires_in"]
+        token["expires_at"] = time.time() + cast(float, token["expires_in"])
 
         self.logger.info("Successfully authenticated")
 

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -25,6 +25,8 @@ from homeassistant.helpers.network import get_url
 
 from .aiohttp_client import async_get_clientsession
 
+_LOGGER = logging.getLogger(__name__)
+
 DATA_JWT_SECRET = "oauth2_jwt_secret"
 DATA_VIEW_REGISTERED = "oauth2_view_reg"
 DATA_IMPLEMENTATIONS = "oauth2_impl"
@@ -257,11 +259,11 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
     ) -> Dict[str, Any]:
         """Create config entry from external data."""
         token = await self.flow_impl.async_resolve_external_data(self.external_data)
-        # Force float for non-compliant oauth2 providers
+        # Force int for non-compliant oauth2 providers
         try:
-            token["expires_in"] = float(token["expires_in"])
-        except ValueError:
-            pass
+            token["expires_in"] = int(token["expires_in"])
+        except ValueError as err:
+            _LOGGER.warning("Error converting expires_in to int: %s", err)
         token["expires_at"] = time.time() + token["expires_in"]
 
         self.logger.info("Successfully authenticated")

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -84,6 +84,7 @@ class AbstractOAuth2Implementation(ABC):
             new_token["expires_in"] = int(new_token["expires_in"])
         except ValueError as err:
             _LOGGER.warning("Error converting expires_in to int: %s", err)
+            return token
         new_token["expires_at"] = time.time() + new_token["expires_in"]
         return new_token
 

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -257,7 +257,12 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
     ) -> Dict[str, Any]:
         """Create config entry from external data."""
         token = await self.flow_impl.async_resolve_external_data(self.external_data)
-        token["expires_at"] = time.time() + cast(float, token["expires_in"])
+        # Force float for non-compliant oauth2 providers
+        try:
+            token["expires_in"] = float(token["expires_in"])
+        except ValueError:
+            pass
+        token["expires_at"] = time.time() + token["expires_in"]
 
         self.logger.info("Successfully authenticated")
 

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -128,6 +128,62 @@ async def test_abort_if_authorization_timeout(hass, flow_handler, local_impl):
     assert result["reason"] == "authorize_url_timeout"
 
 
+async def test_abort_if_oauth_error(
+    hass, flow_handler, local_impl, aiohttp_client, aioclient_mock, current_request
+):
+    """Check bad oauth token."""
+    await async_process_ha_core_config(
+        hass,
+        {"external_url": "https://example.com"},
+    )
+
+    flow_handler.async_register_implementation(hass, local_impl)
+    config_entry_oauth2_flow.async_register_implementation(
+        hass, TEST_DOMAIN, MockOAuth2Implementation()
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pick_implementation"
+
+    # Pick implementation
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"implementation": TEST_DOMAIN}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+    assert result["url"] == (
+        f"{AUTHORIZE_URL}?response_type=code&client_id={CLIENT_ID}"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}&scope=read+write"
+    )
+
+    client = await aiohttp_client(hass.http.app)
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": REFRESH_TOKEN,
+            "access_token": ACCESS_TOKEN_1,
+            "type": "bearer",
+            "expires_in": "badnumber",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "oauth_error"
+
+
 async def test_step_discovery(hass, flow_handler, local_impl):
     """Check flow triggers from discovery."""
     await async_process_ha_core_config(

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -327,6 +327,31 @@ async def test_full_flow(
     )
 
 
+async def test_local_refresh_token_bad_response(hass, local_impl, aioclient_mock):
+    """Test bad refresh token."""
+    aioclient_mock.post(
+        TOKEN_URL, json={"access_token": ACCESS_TOKEN_2, "expires_in": "badnumber"}
+    )
+
+    token = {
+        "refresh_token": REFRESH_TOKEN,
+        "access_token": ACCESS_TOKEN_1,
+        "type": "bearer",
+        "expires_in": "badnumber",
+    }
+
+    new_tokens = await local_impl.async_refresh_token(token)
+
+    assert new_tokens == token
+    assert len(aioclient_mock.mock_calls) == 1
+    assert aioclient_mock.mock_calls[0][2] == {
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "grant_type": "refresh_token",
+        "refresh_token": REFRESH_TOKEN,
+    }
+
+
 async def test_local_refresh_token(hass, local_impl, aioclient_mock):
     """Test we can refresh token."""
     aioclient_mock.post(

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -327,31 +327,6 @@ async def test_full_flow(
     )
 
 
-async def test_local_refresh_token_bad_response(hass, local_impl, aioclient_mock):
-    """Test bad refresh token."""
-    aioclient_mock.post(
-        TOKEN_URL, json={"access_token": ACCESS_TOKEN_2, "expires_in": "badnumber"}
-    )
-
-    token = {
-        "refresh_token": REFRESH_TOKEN,
-        "access_token": ACCESS_TOKEN_1,
-        "type": "bearer",
-        "expires_in": "badnumber",
-    }
-
-    new_tokens = await local_impl.async_refresh_token(token)
-
-    assert new_tokens == token
-    assert len(aioclient_mock.mock_calls) == 1
-    assert aioclient_mock.mock_calls[0][2] == {
-        "client_id": CLIENT_ID,
-        "client_secret": CLIENT_SECRET,
-        "grant_type": "refresh_token",
-        "refresh_token": REFRESH_TOKEN,
-    }
-
-
 async def test_local_refresh_token(hass, local_impl, aioclient_mock):
     """Test we can refresh token."""
     aioclient_mock.post(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The API I am currently looking at does not conform with standards and returns `expires_in` as a `str` which causes this line to error. This enforces that `expires_in` is always a float.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
