### PR TITLE
Support reloading the group notify platform

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -58,7 +58,7 @@ ATTR_ALL = "all"
 SERVICE_SET = "set"
 SERVICE_REMOVE = "remove"
 
-PLATFORMS = ["light", "cover"]
+PLATFORMS = ["light", "cover", "notify"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/group/services.yaml
+++ b/homeassistant/components/group/services.yaml
@@ -1,6 +1,6 @@
 # Describes the format for available group services
 reload:
-  description: Reload group configuration.
+  description: Reload group configuration, entities, and notify services.
 
 set:
   description: Create/Update a user group.

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -102,6 +102,12 @@ class BaseNotificationService:
 
     hass: Optional[HomeAssistantType] = None
 
+    def __init__(self):
+        """Init the notification service."""
+        self._service_name = None
+        self._target_service_name_prefix = None
+        self._registered_targets: Dict = {}
+
     def send_message(self, message, **kwargs):
         """Send a message.
 
@@ -141,10 +147,9 @@ class BaseNotificationService:
         self, service_name: str, target_service_name_prefix: str
     ) -> None:
         """Store the data for the notify service."""
-        # pylint: disable=attribute-defined-outside-init
         self._service_name = service_name
         self._target_service_name_prefix = target_service_name_prefix
-        self._registered_targets: Dict = {}
+        self._registered_targets = {}
 
     async def async_register_services(self) -> None:
         """Create or update the notify services."""

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -211,7 +211,7 @@ class NotifyServiceData:
     target_service_name_prefix
         The prefix used to create new service for tagets.
     targets
-        A dict of targets index by service names.
+        A dict of targets indexed by service names.
     """
 
     service: BaseNotificationService

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -205,7 +205,7 @@ class NotifyServiceData:
     """Class for storing notify service data.
 
     service
-        The NotifyService
+        The NotificationService
     service_name
         The name of the notify service.
     target_service_name_prefix

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -268,13 +268,11 @@ async def async_setup(hass, config):
         service_name = slugify(conf_name or SERVICE_NOTIFY)
 
         await notify_service.async_setup(service_name, target_service_name_prefix)
+        await notify_service.async_register_services()
 
         hass.data[NOTIFY_SERVICES].setdefault(integration_name, []).append(
             notify_service
         )
-
-        await notify_service.async_register_services()
-
         hass.config.components.add(f"{DOMAIN}.{integration_name}")
 
         return True

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -91,12 +91,12 @@ async def _async_unregister_notify_services(hass, data):
     targets = data[TARGETS]
 
     if targets:
-        stale_targets = set(targets)
-        for stale_target_name, target in stale_targets:
-            del targets[stale_target_name]
+        remove_targets = set(targets)
+        for remove_target_name in remove_targets:
+            del targets[remove_target_name]
             hass.services.async_remove(
                 DOMAIN,
-                stale_target_name,
+                remove_target_name,
             )
 
     friendly_name_slug = slugify(data[FRIENDLY_NAME])

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -144,9 +144,13 @@ class BaseNotificationService:
         await self.async_send_message(**kwargs)
 
     async def async_setup(
-        self, service_name: str, target_service_name_prefix: str
+        self,
+        hass: HomeAssistantType,
+        service_name: str,
+        target_service_name_prefix: str,
     ) -> None:
         """Store the data for the notify service."""
+        self.hass = hass
         self._service_name = service_name
         self._target_service_name_prefix = target_service_name_prefix
         self._registered_targets = {}
@@ -258,8 +262,6 @@ async def async_setup(hass, config):
             _LOGGER.exception("Error setting up platform %s", integration_name)
             return
 
-        notify_service.hass = hass
-
         if discovery_info is None:
             discovery_info = {}
 
@@ -267,7 +269,7 @@ async def async_setup(hass, config):
         target_service_name_prefix = conf_name or integration_name
         service_name = slugify(conf_name or SERVICE_NOTIFY)
 
-        await notify_service.async_setup(service_name, target_service_name_prefix)
+        await notify_service.async_setup(hass, service_name, target_service_name_prefix)
         await notify_service.async_register_services()
 
         hass.data[NOTIFY_SERVICES].setdefault(integration_name, []).append(

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -86,6 +86,17 @@ async def async_reset_platform(hass, integration_name):
     del hass.data[NOTIFY_SERVICES][integration_name]
 
 
+def _async_integration_has_notify_services(hass, integration_name):
+    """Determine if an integration has notify services registered."""
+    if (
+        NOTIFY_SERVICES not in hass.data
+        or integration_name not in hass.data[NOTIFY_SERVICES]
+    ):
+        return False
+
+    return True
+
+
 class BaseNotificationService:
     """An abstract class for notification services."""
 
@@ -207,17 +218,6 @@ class NotifyServiceData:
     service_name: str
     target_service_name_prefix: str
     targets: Dict
-
-
-def _async_integration_has_notify_services(hass, integration_name):
-    """Call a method on all notify services for an integration."""
-    if (
-        NOTIFY_SERVICES not in hass.data
-        or integration_name not in hass.data[NOTIFY_SERVICES]
-    ):
-        return False
-
-    return True
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -147,7 +147,7 @@ class BaseNotificationService:
         self._registered_targets: Dict = {}
 
     async def async_register_services(self) -> None:
-        """Create or remove the notify services."""
+        """Create or update the notify services."""
         assert self.hass
 
         if hasattr(self, "targets"):

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -102,12 +102,6 @@ class BaseNotificationService:
 
     hass: Optional[HomeAssistantType] = None
 
-    def __init__(self):
-        """Init the notification service."""
-        self._service_name = None
-        self._target_service_name_prefix = None
-        self._registered_targets: Dict = {}
-
     def send_message(self, message, **kwargs):
         """Send a message.
 
@@ -150,10 +144,11 @@ class BaseNotificationService:
         target_service_name_prefix: str,
     ) -> None:
         """Store the data for the notify service."""
+        # pylint: disable=attribute-defined-outside-init
         self.hass = hass
         self._service_name = service_name
         self._target_service_name_prefix = target_service_name_prefix
-        self._registered_targets = {}
+        self._registered_targets: Dict = {}
 
     async def async_register_services(self) -> None:
         """Create or update the notify services."""

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -282,11 +282,11 @@ async def async_setup(hass, config):
 
         conf_name = p_config.get(CONF_NAME) or discovery_info.get(CONF_NAME)
         target_service_name_prefix = conf_name or integration_name
-        service_name = conf_name or SERVICE_NOTIFY
+        service_name = slugify(conf_name or SERVICE_NOTIFY)
         targets = {}
 
         data = NotifyServiceData(
-            notify_service, slugify(service_name), target_service_name_prefix, targets
+            notify_service, service_name, target_service_name_prefix, targets
         )
         hass.data[NOTIFY_SERVICES].setdefault(integration_name, []).append(data)
 

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -68,9 +68,6 @@ async def _resetup_platform(
 
         root_config[integration_platform].append(p_config)
 
-    if not root_config[integration_platform]:
-        return
-
     component = integration.get_component()
 
     if hasattr(component, "async_reset_platform"):

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -34,29 +34,62 @@ async def async_reload_integration_platforms(
         _LOGGER.error(err)
         return
 
-    for integration_platform in integration_platforms:
-        platform = async_get_platform(hass, integration_name, integration_platform)
-
-        if not platform:
-            continue
-
-        integration = await async_get_integration(hass, integration_platform)
-
-        conf = await conf_util.async_process_component_config(
-            hass, unprocessed_conf, integration
+    tasks = [
+        _resetup_platform(
+            hass, integration_name, integration_platform, unprocessed_conf
         )
+        for integration_platform in integration_platforms
+    ]
 
-        if not conf:
+    await asyncio.gather(*tasks)
+
+
+async def _resetup_platform(
+    hass: HomeAssistantType,
+    integration_name: str,
+    integration_platform: str,
+    unprocessed_conf: Dict,
+) -> None:
+    """Resetup a platform."""
+    integration = await async_get_integration(hass, integration_platform)
+
+    conf = await conf_util.async_process_component_config(
+        hass, unprocessed_conf, integration
+    )
+
+    if not conf:
+        return
+
+    root_config: Dict = {integration_platform: []}
+    # Extract only the config for template, ignore the rest.
+    for p_type, p_config in config_per_platform(conf, integration_platform):
+        if p_type != integration_name:
             continue
 
-        await platform.async_reset()
+        root_config[integration_platform].append(p_config)
 
-        # Extract only the config for template, ignore the rest.
-        for p_type, p_config in config_per_platform(conf, integration_platform):
-            if p_type != integration_name:
-                continue
+    if not root_config[integration_platform]:
+        return
 
-            await platform.async_setup(p_config)  # type: ignore
+    component = integration.get_component()
+
+    if hasattr(component, "async_reset_platform"):
+        # If the integration has its own way to reset
+        # use this method.
+        await component.async_reset_platform(hass, integration_name)  # type: ignore
+        await component.async_setup(hass, root_config)  # type: ignore
+        return
+
+    # If its an entity platform, we use the entity_platform
+    # async_reset method
+    platform = async_get_platform(hass, integration_name, integration_platform)
+    if not platform:
+        return
+
+    await platform.async_reset()
+
+    tasks = [platform.async_setup(p_config) for p_config in root_config[integration_platform]]  # type: ignore
+    await asyncio.gather(*tasks)
 
 
 async def async_integration_yaml_config(

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -683,5 +683,79 @@ async def test_reload(hass):
     assert hass.states.get("light.outside_patio_lights_g") is not None
 
 
+async def test_reload_with_platform_not_setup(hass):
+    """Test the ability to reload lights."""
+    hass.states.async_set("light.bowl", STATE_ON)
+    await async_setup_component(
+        hass,
+        LIGHT_DOMAIN,
+        {
+            LIGHT_DOMAIN: [
+                {"platform": "demo"},
+            ]
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "light.Bowl", "icon": "mdi:work"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "group/configuration.yaml",
+    )
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get("light.light_group") is None
+    assert hass.states.get("light.master_hall_lights_g") is not None
+    assert hass.states.get("light.outside_patio_lights_g") is not None
+
+
+async def test_reload_with_base_integration_platform_not_setup(hass):
+    """Test the ability to reload lights."""
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "light.Bowl", "icon": "mdi:work"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "group/configuration.yaml",
+    )
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get("light.light_group") is None
+    assert hass.states.get("light.master_hall_lights_g") is not None
+    assert hass.states.get("light.outside_patio_lights_g") is not None
+
+
 def _get_fixtures_base_path():
     return path.dirname(path.dirname(path.dirname(__file__)))

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -1,11 +1,14 @@
 """The tests for the notify.group platform."""
 import asyncio
+from os import path
 import unittest
 
+from homeassistant import config as hass_config
 import homeassistant.components.demo.notify as demo
+from homeassistant.components.group import SERVICE_RELOAD
 import homeassistant.components.group.notify as group
 import homeassistant.components.notify as notify
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component, setup_component
 
 from tests.async_mock import MagicMock, patch
 from tests.common import assert_setup_component, get_test_home_assistant
@@ -90,3 +93,58 @@ class TestNotifyGroup(unittest.TestCase):
             "title": "Test notification",
             "data": {"hello": "world", "test": "message"},
         }
+
+
+async def test_reload_notify(hass):
+    """Verify we can reload the notify service."""
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {},
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        notify.DOMAIN,
+        {
+            notify.DOMAIN: [
+                {"name": "demo1", "platform": "demo"},
+                {"name": "demo2", "platform": "demo"},
+                {
+                    "name": "group_notify",
+                    "platform": "group",
+                    "services": [{"service": "demo1"}],
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.services.has_service(notify.DOMAIN, "demo1")
+    assert hass.services.has_service(notify.DOMAIN, "demo2")
+    assert hass.services.has_service(notify.DOMAIN, "group_notify")
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "group/configuration.yaml",
+    )
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            "group",
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert hass.services.has_service(notify.DOMAIN, "demo1")
+    assert hass.services.has_service(notify.DOMAIN, "demo2")
+    assert not hass.services.has_service(notify.DOMAIN, "group_notify")
+    assert hass.services.has_service(notify.DOMAIN, "new_group_notify")
+
+
+def _get_fixtures_base_path():
+    return path.dirname(path.dirname(path.dirname(__file__)))

--- a/tests/fixtures/group/configuration.yaml
+++ b/tests/fixtures/group/configuration.yaml
@@ -9,3 +9,10 @@ light:
     entities:
       - light.outside_patio_lights
       - light.outside_patio_lights_2
+
+notify:
+  - platform: group
+    name: new_group_notify
+    services:
+      - service: demo1
+      - service: demo2

--- a/tests/helpers/test_reload.py
+++ b/tests/helpers/test_reload.py
@@ -13,8 +13,9 @@ from homeassistant.helpers.reload import (
     async_reload_integration_platforms,
     async_setup_reload_service,
 )
+from homeassistant.loader import async_get_integration
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import AsyncMock, Mock, patch
 from tests.common import (
     MockModule,
     MockPlatform,
@@ -107,6 +108,104 @@ async def test_setup_reload_service(hass):
         await hass.async_block_till_done()
 
     assert len(setup_called) == 2
+
+
+async def test_setup_reload_service_when_async_process_component_config_fails(hass):
+    """Test setting up a reload service with the config processing failing."""
+    component_setup = Mock(return_value=True)
+
+    setup_called = []
+
+    async def setup_platform(*args):
+        setup_called.append(args)
+
+    mock_integration(hass, MockModule(DOMAIN, setup=component_setup))
+    mock_integration(hass, MockModule(PLATFORM, dependencies=[DOMAIN]))
+
+    mock_platform = MockPlatform(async_setup_platform=setup_platform)
+    mock_entity_platform(hass, f"{DOMAIN}.{PLATFORM}", mock_platform)
+
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    await component.async_setup({DOMAIN: {"platform": PLATFORM, "sensors": None}})
+    await hass.async_block_till_done()
+    assert component_setup.called
+
+    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert len(setup_called) == 1
+
+    await async_setup_reload_service(hass, PLATFORM, [DOMAIN])
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "helpers/reload_configuration.yaml",
+    )
+    with patch.object(config, "YAML_CONFIG_FILE", yaml_path), patch.object(
+        config, "async_process_component_config", return_value=None
+    ):
+        await hass.services.async_call(
+            PLATFORM,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert len(setup_called) == 1
+
+
+async def test_setup_reload_service_with_platform_that_provides_async_reset_platform(
+    hass,
+):
+    """Test setting up a reload service using a platform that has its own async_reset_platform."""
+    component_setup = AsyncMock(return_value=True)
+
+    setup_called = []
+    async_reset_platform_called = []
+
+    async def setup_platform(*args):
+        setup_called.append(args)
+
+    async def async_reset_platform(*args):
+        async_reset_platform_called.append(args)
+
+    mock_integration(hass, MockModule(DOMAIN, async_setup=component_setup))
+    integration = await async_get_integration(hass, DOMAIN)
+    integration.get_component().async_reset_platform = async_reset_platform
+
+    mock_integration(hass, MockModule(PLATFORM, dependencies=[DOMAIN]))
+
+    mock_platform = MockPlatform(async_setup_platform=setup_platform)
+    mock_entity_platform(hass, f"{DOMAIN}.{PLATFORM}", mock_platform)
+
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    await component.async_setup({DOMAIN: {"platform": PLATFORM, "name": "xyz"}})
+    await hass.async_block_till_done()
+    assert component_setup.called
+
+    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert len(setup_called) == 1
+
+    await async_setup_reload_service(hass, PLATFORM, [DOMAIN])
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "helpers/reload_configuration.yaml",
+    )
+    with patch.object(config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            PLATFORM,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert len(setup_called) == 1
+    assert len(async_reset_platform_called) == 1
 
 
 async def test_async_integration_yaml_config(hass):


### PR DESCRIPTION
WTH: https://community.home-assistant.io/t/why-the-heck-is-a-restart-needed-for-each-an-every-change-to-configuration-yaml/219630/10?u=bdraco

Frontend PR https://github.com/home-assistant/frontend/pull/6759

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support reloading the group notify platform

Add support to resetup notify platforms


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
