### PR TITLE
Migrate config entry for rfxtrx integration

### DIFF
--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -404,6 +404,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured(import_config)
             else:
                 self._abort_if_unique_id_configured()
+
+        host = import_config[CONF_HOST]
+        port = import_config[CONF_PORT]
+        device = import_config[CONF_DEVICE]
+
+        try:
+            if import_config[CONF_HOST] is not None:
+                await self.async_validate_rfx(host=host, port=port)
+            else:
+                await self.async_validate_rfx(device=device)
+        except CannotConnect:
+            return self.async_abort(reason="cannot_connect")
+
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -137,7 +137,8 @@ class OptionsFlow(config_entries.OptionsFlow):
         options = {
             vol.Optional(CONF_DEBUG, default=self._config_entry.data[CONF_DEBUG]): bool,
             vol.Optional(
-                CONF_AUTOMATIC_ADD, default=self._config_entry.data[CONF_AUTOMATIC_ADD],
+                CONF_AUTOMATIC_ADD,
+                default=self._config_entry.data[CONF_AUTOMATIC_ADD],
             ): bool,
             vol.Optional(CONF_EVENT_CODE): str,
             vol.Optional(CONF_DEVICE): vol.In(devices),
@@ -338,7 +339,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {vol.Required(CONF_HOST): str, vol.Required(CONF_PORT): int}
         )
         return self.async_show_form(
-            step_id="setup_network", data_schema=schema, errors=errors,
+            step_id="setup_network",
+            data_schema=schema,
+            errors=errors,
         )
 
     async def async_step_setup_serial(self, user_input=None):
@@ -365,15 +368,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
         list_of_ports = {}
         for port in ports:
-            list_of_ports[port.device] = (
-                f"{port}, s/n: {port.serial_number or 'n/a'}"
-                + (f" - {port.manufacturer}" if port.manufacturer else "")
+            list_of_ports[
+                port.device
+            ] = f"{port}, s/n: {port.serial_number or 'n/a'}" + (
+                f" - {port.manufacturer}" if port.manufacturer else ""
             )
         list_of_ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
 
         schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(list_of_ports)})
         return self.async_show_form(
-            step_id="setup_serial", data_schema=schema, errors=errors,
+            step_id="setup_serial",
+            data_schema=schema,
+            errors=errors,
         )
 
     async def async_step_setup_serial_manual_path(self, user_input=None):
@@ -392,19 +398,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema({vol.Required(CONF_DEVICE): str})
         return self.async_show_form(
-            step_id="setup_serial_manual_path", data_schema=schema, errors=errors,
+            step_id="setup_serial_manual_path",
+            data_schema=schema,
+            errors=errors,
         )
 
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
-        entry = await self.async_set_unique_id(DOMAIN)
-        if entry:
-            if CONF_DEVICES not in entry.data:
-                # In version 0.113, devices key was not written to config entry. Update the entry with import data
-                self._abort_if_unique_id_configured(import_config)
-            else:
-                self._abort_if_unique_id_configured()
-        return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):
         """Create data for rfxtrx entry."""

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -399,11 +399,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         entry = await self.async_set_unique_id(DOMAIN)
         # In version 0.113 devices is not stored in entry.data, to be safe update data for all VERSION=1 entries
-        if entry.version == 1:
-            entry.version = 2
-            self._abort_if_unique_id_configured(import_config)
-        else:
-            self._abort_if_unique_id_configured()
+        if entry:
+            if entry.version == 1:
+                entry.version = 2
+                self._abort_if_unique_id_configured(import_config)
+            else:
+                self._abort_if_unique_id_configured()
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -297,7 +297,7 @@ class OptionsFlow(config_entries.OptionsFlow):
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for RFXCOM RFXtrx."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     async def async_step_user(self, user_input=None):
@@ -397,8 +397,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured()
+        entry = await self.async_set_unique_id(DOMAIN)
+        # In version 0.113 devices is not stored in entry.data, to be safe update data for all VERSION=1 entries
+        if entry.version == 1:
+            entry.version = 2
+            self._abort_if_unique_id_configured(import_config)
+        else:
+            self._abort_if_unique_id_configured()
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -404,19 +404,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured(import_config)
             else:
                 self._abort_if_unique_id_configured()
-
-        host = import_config[CONF_HOST]
-        port = import_config[CONF_PORT]
-        device = import_config[CONF_DEVICE]
-
-        try:
-            if import_config[CONF_HOST] is not None:
-                await self.async_validate_rfx(host=host, port=port)
-            else:
-                await self.async_validate_rfx(device=device)
-        except CannotConnect:
-            return self.async_abort(reason="cannot_connect")
-
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -405,6 +405,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
+        entry = await self.async_set_unique_id(DOMAIN)
+        if entry:
+            if CONF_DEVICES not in entry.data:
+                # In version 0.113, devices key was not written to config entry. Update the entry with import data
+                self._abort_if_unique_id_configured(import_config)
+            else:
+                self._abort_if_unique_id_configured()
+        return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):
         """Create data for rfxtrx entry."""

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -297,7 +297,7 @@ class OptionsFlow(config_entries.OptionsFlow):
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for RFXCOM RFXtrx."""
 
-    VERSION = 2
+    VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     async def async_step_user(self, user_input=None):
@@ -398,10 +398,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
         entry = await self.async_set_unique_id(DOMAIN)
-        # In version 0.113 devices is not stored in entry.data, to be safe update data for all VERSION=1 entries
         if entry:
-            if entry.version == 1:
-                entry.version = 2
+            if CONF_DEVICES not in entry.data:
+                # In version 0.113, devices key was not written to config entry. Update the entry with import data
                 self._abort_if_unique_id_configured(import_config)
             else:
                 self._abort_if_unique_id_configured()

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -50,7 +50,8 @@ async def test_setup_network(connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Network"},
+        result["flow_id"],
+        {"type": "Network"},
     )
 
     assert result["type"] == "form"
@@ -96,7 +97,8 @@ async def test_setup_serial(com_mock, connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -140,7 +142,8 @@ async def test_setup_serial_manual(com_mock, connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -187,7 +190,8 @@ async def test_setup_network_fail(connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Network"},
+        result["flow_id"],
+        {"type": "Network"},
     )
 
     assert result["type"] == "form"
@@ -221,7 +225,8 @@ async def test_setup_serial_fail(com_mock, connect_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -253,7 +258,8 @@ async def test_setup_serial_manual_fail(com_mock, hass):
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"type": "Serial"},
+        result["flow_id"],
+        {"type": "Serial"},
     )
 
     assert result["type"] == "form"
@@ -328,37 +334,6 @@ async def test_import_update(hass):
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-
-
-async def test_import_migrate(hass):
-    """Test we can import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
-        unique_id=DOMAIN,
-    )
-    entry.add_to_hass(hass)
-
-    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                "host": None,
-                "port": None,
-                "device": "/dev/tty123",
-                "debug": True,
-                "automatic_add": True,
-                "devices": {},
-            },
-        )
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
-
-    assert entry.data["devices"] == {}
 
 
 async def test_options_global(hass):

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -277,15 +277,24 @@ async def test_setup_serial_manual_fail(com_mock, hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_import(hass):
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
+    serial_connect,
+)
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
+    return_value=None,
+)
+async def test_import_serial(connect_mock, hass):
     """Test we can import."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
-    )
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
+        )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "RFXTRX"
@@ -295,6 +304,50 @@ async def test_import(hass):
         "device": "/dev/tty123",
         "debug": False,
     }
+
+
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport.connect",
+    return_value=None,
+)
+async def test_import_network(connect_mock, hass):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={"host": "localhost", "port": 1234, "device": None, "debug": False},
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "RFXTRX"
+    assert result["data"] == {
+        "host": "localhost",
+        "port": 1234,
+        "device": None,
+        "debug": False,
+    }
+
+
+@patch(
+    "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport.connect",
+    side_effect=OSError,
+)
+async def test_import_network_connection_fail(connect_mock, hass):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={"host": "localhost", "port": 1234, "device": None, "debug": False},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_import_update(hass):
@@ -330,9 +383,7 @@ async def test_import_migrate(hass):
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.config_entries.ConfigEntries.async_reload", return_value=True
-    ):
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
@@ -345,6 +396,8 @@ async def test_import_migrate(hass):
                 "devices": {},
             },
         )
+
+    await hass.async_block_till_done()
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -305,6 +305,7 @@ async def test_import_update(hass):
         domain=DOMAIN,
         data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
         unique_id=DOMAIN,
+        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -313,6 +314,31 @@ async def test_import_update(hass):
         context={"source": config_entries.SOURCE_IMPORT},
         data={"host": None, "port": None, "device": "/dev/tty123", "debug": True},
     )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_migrate(hass):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
+        unique_id=DOMAIN,
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={"host": None, "port": None, "device": "/dev/tty123", "debug": True},
+        )
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
@@ -333,6 +359,7 @@ async def test_options_global(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -368,6 +395,7 @@ async def test_options_add_device(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -437,6 +465,7 @@ async def test_options_add_remove_device(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -526,6 +555,7 @@ async def test_options_add_and_configure_device(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=2,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -327,7 +327,6 @@ async def test_import_migrate(hass):
         domain=DOMAIN,
         data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
         unique_id=DOMAIN,
-        version=1,
     )
     entry.add_to_hass(hass)
 
@@ -337,13 +336,20 @@ async def test_import_migrate(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={"host": None, "port": None, "device": "/dev/tty123", "debug": True},
+            data={
+                "host": None,
+                "port": None,
+                "device": "/dev/tty123",
+                "debug": True,
+                "automatic_add": True,
+                "devices": {},
+            },
         )
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
 
-    assert entry.version == 2
+    assert entry.data["devices"] == {}
 
 
 async def test_options_global(hass):
@@ -361,7 +367,6 @@ async def test_options_global(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
-        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -397,7 +402,6 @@ async def test_options_add_device(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
-        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -467,7 +471,6 @@ async def test_options_add_remove_device(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
-        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -557,7 +560,6 @@ async def test_options_add_and_configure_device(hass):
             "devices": {},
         },
         unique_id=DOMAIN,
-        version=2,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -330,9 +330,7 @@ async def test_import_migrate(hass):
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.config_entries.ConfigEntries.async_reload", return_value=True
-    ):
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -343,6 +343,8 @@ async def test_import_migrate(hass):
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
 
+    assert entry.version == 2
+
 
 async def test_options_global(hass):
     """Test if we can set global options."""

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -336,6 +336,37 @@ async def test_import_update(hass):
     assert result["reason"] == "already_configured"
 
 
+async def test_import_migrate(hass):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "host": None,
+                "port": None,
+                "device": "/dev/tty123",
+                "debug": True,
+                "automatic_add": True,
+                "devices": {},
+            },
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+    assert entry.data["devices"] == {}
+
+
 async def test_options_global(hass):
     """Test if we can set global options."""
     await setup.async_setup_component(hass, "persistent_notification", {})

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -303,16 +303,27 @@ async def test_import_update(hass):
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"host": None, "port": None, "device": "/dev/tty123", "debug": False},
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "devices": {},
+        },
         unique_id=DOMAIN,
-        version=2,
     )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
-        data={"host": None, "port": None, "device": "/dev/tty123", "debug": True},
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": True,
+            "devices": {},
+        },
     )
 
     assert result["type"] == "abort"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR targets a different branch that updates rfxtrx integration to have UI config/options (see #39117)

In HA 0.113, the data stored in the ConfigEntry was limited. Since 0.114, additional data is stored in the ConfigEntry. If a user wants to migrate from 0.113 to the version options/conflig flow will land in, the ConfigEntry won't be updated and entry is incomplete. To prevent that, a one-time import is done if devices key is missing from entry data

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
