### PR TITLE
Support reloading the telegram notify platform

### DIFF
--- a/homeassistant/components/telegram/__init__.py
+++ b/homeassistant/components/telegram/__init__.py
@@ -1,1 +1,4 @@
 """The telegram component."""
+
+DOMAIN = "telegram"
+PLATFORMS = ["notify"]

--- a/homeassistant/components/telegram/notify.py
+++ b/homeassistant/components/telegram/notify.py
@@ -12,6 +12,9 @@ from homeassistant.components.notify import (
     BaseNotificationService,
 )
 from homeassistant.const import ATTR_LOCATION
+from homeassistant.helpers.reload import setup_reload_service
+
+from . import DOMAIN as TELEGRAM_DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +32,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_CHAT_ID): vol.Coerce
 
 def get_service(hass, config, discovery_info=None):
     """Get the Telegram notification service."""
+
+    setup_reload_service(hass, TELEGRAM_DOMAIN, PLATFORMS)
     chat_id = config.get(CONF_CHAT_ID)
     return TelegramNotificationService(hass, chat_id)
 

--- a/homeassistant/components/telegram/services.yaml
+++ b/homeassistant/components/telegram/services.yaml
@@ -1,0 +1,2 @@
+reload:
+  description: Reload telegram notify services.

--- a/tests/components/telegram/__init__.py
+++ b/tests/components/telegram/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for telegram component."""

--- a/tests/components/telegram/test_notify.py
+++ b/tests/components/telegram/test_notify.py
@@ -1,0 +1,53 @@
+"""The tests for the telegram.notify platform."""
+from os import path
+
+from homeassistant import config as hass_config
+import homeassistant.components.notify as notify
+from homeassistant.components.telegram import DOMAIN
+from homeassistant.const import SERVICE_RELOAD
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import patch
+
+
+async def test_reload_notify(hass):
+    """Verify we can reload the notify service."""
+
+    with patch("homeassistant.components.telegram_bot.async_setup", return_value=True):
+        assert await async_setup_component(
+            hass,
+            notify.DOMAIN,
+            {
+                notify.DOMAIN: [
+                    {
+                        "name": DOMAIN,
+                        "platform": DOMAIN,
+                        "chat_id": 1,
+                    },
+                ]
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert hass.services.has_service(notify.DOMAIN, DOMAIN)
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "telegram/configuration.yaml",
+    )
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert not hass.services.has_service(notify.DOMAIN, DOMAIN)
+    assert hass.services.has_service(notify.DOMAIN, "telegram_reloaded")
+
+
+def _get_fixtures_base_path():
+    return path.dirname(path.dirname(path.dirname(__file__)))

--- a/tests/fixtures/telegram/configuration.yaml
+++ b/tests/fixtures/telegram/configuration.yaml
@@ -1,0 +1,4 @@
+notify:
+  - name: telegram_reloaded
+    platform: telegram
+    chat_id: 2


### PR DESCRIPTION
Requires https://github.com/home-assistant/core/pull/39527

WTH: https://community.home-assistant.io/t/why-the-heck-is-a-restart-needed-for-each-an-every-change-to-configuration-yaml/219630/10?u=bdraco

- [x] Frontend PR: https://github.com/home-assistant/frontend/pull/6759
- [x] Services.yaml:

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Support reloading the telegram notify platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
