### PR TITLE
Support reloading the smtp notify platform

### DIFF
--- a/homeassistant/components/smtp/__init__.py
+++ b/homeassistant/components/smtp/__init__.py
@@ -1,1 +1,4 @@
 """The smtp component."""
+
+DOMAIN = "smtp"
+PLATFORMS = ["notify"]

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -26,7 +26,10 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.reload import setup_reload_service
 import homeassistant.util.dt as dt_util
+
+from . import DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,6 +70,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_service(hass, config, discovery_info=None):
     """Get the mail notification service."""
+    setup_reload_service(hass, DOMAIN, PLATFORMS)
     mail_service = MailNotificationService(
         config.get(CONF_SERVER),
         config.get(CONF_PORT),

--- a/homeassistant/components/smtp/services.yaml
+++ b/homeassistant/components/smtp/services.yaml
@@ -1,0 +1,2 @@
+reload:
+  description: Reload smtp notify services.

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -122,7 +122,9 @@ async def test_reload_notify(hass):
         "fixtures",
         "smtp/configuration.yaml",
     )
-    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path), patch(
+        "homeassistant.components.smtp.notify.MailNotificationService.connection_is_valid"
+    ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_RELOAD,

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -1,8 +1,14 @@
 """The tests for the notify smtp platform."""
+from os import path
 import re
 import unittest
 
+from homeassistant import config as hass_config
+import homeassistant.components.notify as notify
+from homeassistant.components.smtp import DOMAIN
 from homeassistant.components.smtp.notify import MailNotificationService
+from homeassistant.const import SERVICE_RELOAD
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
 from tests.common import get_test_home_assistant
@@ -85,3 +91,49 @@ class TestNotifySmtp(unittest.TestCase):
             "Test msg", data={"html": html, "images": ["test.jpg"]}
         )
         assert "Content-Type: multipart/related" in msg
+
+
+async def test_reload_notify(hass):
+    """Verify we can reload the notify service."""
+
+    with patch(
+        "homeassistant.components.smtp.notify.MailNotificationService.connection_is_valid"
+    ):
+        assert await async_setup_component(
+            hass,
+            notify.DOMAIN,
+            {
+                notify.DOMAIN: [
+                    {
+                        "name": DOMAIN,
+                        "platform": DOMAIN,
+                        "recipient": "test@example.com",
+                        "sender": "test@example.com",
+                    },
+                ]
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert hass.services.has_service(notify.DOMAIN, DOMAIN)
+
+    yaml_path = path.join(
+        _get_fixtures_base_path(),
+        "fixtures",
+        "smtp/configuration.yaml",
+    )
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert not hass.services.has_service(notify.DOMAIN, DOMAIN)
+    assert hass.services.has_service(notify.DOMAIN, "smtp_reloaded")
+
+
+def _get_fixtures_base_path():
+    return path.dirname(path.dirname(path.dirname(__file__)))

--- a/tests/fixtures/smtp/configuration.yaml
+++ b/tests/fixtures/smtp/configuration.yaml
@@ -1,0 +1,5 @@
+notify:
+  - name: smtp_reloaded
+    platform: smtp
+    sender: test@example.com
+    recipient: test@example.com


### PR DESCRIPTION
Requires https://github.com/home-assistant/core/pull/39527

WTH: https://community.home-assistant.io/t/why-the-heck-is-a-restart-needed-for-each-an-every-change-to-configuration-yaml/219630/10?u=bdraco

- [x] Frontend PR: https://github.com/home-assistant/frontend/pull/6759
- [x] Services.yaml:

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Support reloading the smtp notify platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
