### PR TITLE
Use media state to better represent roku state

### DIFF
--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -191,6 +191,14 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    def media_position_updated_at(self):
+        """When was the position of the current playing media valid.."""
+        if self.coordinator.data.media:
+            return self.coordinator.data.media.at
+
+        return None
+
+    @property
     def source(self) -> str:
         """Return the current input source."""
         if self.coordinator.data.app is not None:

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -192,7 +192,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
     @property
     def media_position_updated_at(self):
-        """When was the position of the current playing media valid.."""
+        """When was the position of the current playing media valid."""
         if self.coordinator.data.media:
             return self.coordinator.data.media.at
 

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -78,6 +78,16 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
         self._unique_id = unique_id
 
+    def _is_media_playback_trackable(self) -> bool:
+        """Detect if we have enough media data to track playback."""
+        if self.coordinator.data.media.live:
+            return False
+
+        return (
+           self.coordinator.data.media
+           and self.coordinator.data.media.duration > 0
+        ):
+
     @property
     def unique_id(self) -> str:
         """Return the unique ID for this entity."""
@@ -177,7 +187,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_duration(self):
         """Duration of current playing media in seconds."""
-        if self.coordinator.data.media:
+        if _is_media_playback_trackable():
            return self.coordinator.data.media.duration
 
         return None
@@ -185,7 +195,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        if self.coordinator.data.media:
+        if _is_media_playback_trackable():
            return self.coordinator.data.media.position
 
         return None
@@ -193,7 +203,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        if self.coordinator.data.media:
+        if _is_media_playback_trackable():
             return self.coordinator.data.media.at
 
         return None

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -86,10 +86,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         ):
             return False
 
-        return (
-           self.coordinator.data.media
-           and self.coordinator.data.media.duration > 0
-        ):
+        return self.coordinator.data.media.duration > 0
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -22,6 +22,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import (
     STATE_HOME,
     STATE_IDLE,
+    STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
     STATE_STANDBY,
@@ -100,11 +101,14 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         if self.coordinator.data.app.name == "Roku":
             return STATE_HOME
 
-        if self.coordinator.data.media and self.coordinator.data.media.paused:
-            return STATE_PAUSED
+        if self.coordinator.data.media:
+            if self.coordinator.data.media.paused:
+                return STATE_PAUSED
+            else:
+                return STATE_PLAYING
 
         if self.coordinator.data.app.name:
-            return STATE_PLAYING
+            return STATE_ON
 
         return None
 
@@ -167,6 +171,22 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
         if self.coordinator.data.channel.program_title is not None:
             return self.coordinator.data.channel.program_title
+
+        return None
+
+    @property
+    def media_duration(self):
+        """Duration of current playing media in seconds."""
+        if self.coordinator.data.media:
+           return self.coordinator.data.media.duration
+
+        return None
+
+    @property
+    def media_position(self):
+        """Position of current playing media in seconds."""
+        if self.coordinator.data.media:
+           return self.coordinator.data.media.position
 
         return None
 

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -78,7 +78,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
         self._unique_id = unique_id
 
-    def _is_media_playback_trackable(self) -> bool:
+    def _media_playback_trackable(self) -> bool:
         """Detect if we have enough media data to track playback."""
         if (
             self.coordinator.data.media is None
@@ -190,7 +190,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_duration(self):
         """Duration of current playing media in seconds."""
-        if _is_media_playback_trackable():
+        if _media_playback_trackable():
            return self.coordinator.data.media.duration
 
         return None
@@ -198,7 +198,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        if _is_media_playback_trackable():
+        if _media_playback_trackable():
            return self.coordinator.data.media.position
 
         return None
@@ -206,7 +206,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        if _is_media_playback_trackable():
+        if _media_playback_trackable():
             return self.coordinator.data.media.at
 
         return None

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -111,8 +111,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         if self.coordinator.data.media:
             if self.coordinator.data.media.paused:
                 return STATE_PAUSED
-            else:
-                return STATE_PLAYING
+            return STATE_PLAYING
 
         if self.coordinator.data.app.name:
             return STATE_ON

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -80,7 +80,10 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
     def _is_media_playback_trackable(self) -> bool:
         """Detect if we have enough media data to track playback."""
-        if self.coordinator.data.media.live:
+        if (
+            self.coordinator.data.media is None
+            or self.coordinator.data.media.live
+        ):
             return False
 
         return (

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -184,7 +184,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_duration(self):
         """Duration of current playing media in seconds."""
-        if _media_playback_trackable():
+        if self._media_playback_trackable():
             return self.coordinator.data.media.duration
 
         return None
@@ -192,7 +192,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        if _media_playback_trackable():
+        if self._media_playback_trackable():
             return self.coordinator.data.media.position
 
         return None
@@ -200,7 +200,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @property
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        if _media_playback_trackable():
+        if self._media_playback_trackable():
             return self.coordinator.data.media.at
 
         return None

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -80,10 +80,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
     def _media_playback_trackable(self) -> bool:
         """Detect if we have enough media data to track playback."""
-        if (
-            self.coordinator.data.media is None
-            or self.coordinator.data.media.live
-        ):
+        if self.coordinator.data.media is None or self.coordinator.data.media.live:
             return False
 
         return self.coordinator.data.media.duration > 0
@@ -188,7 +185,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     def media_duration(self):
         """Duration of current playing media in seconds."""
         if _media_playback_trackable():
-           return self.coordinator.data.media.duration
+            return self.coordinator.data.media.duration
 
         return None
 
@@ -196,7 +193,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     def media_position(self):
         """Position of current playing media in seconds."""
         if _media_playback_trackable():
-           return self.coordinator.data.media.position
+            return self.coordinator.data.media.position
 
         return None
 

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -210,7 +210,7 @@ async def test_attributes_app(
     await setup_integration(hass, aioclient_mock, app="netflix")
 
     state = hass.states.get(MAIN_ENTITY_ID)
-    assert state.state == STATE_PLAYING
+    assert state.state == STATE_ON
 
     assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_APP
     assert state.attributes.get(ATTR_APP_ID) == "12"

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -228,7 +228,7 @@ async def test_attributes_app_media_paused(
     assert state.state == STATE_PAUSED
 
     assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_APP
-    assert state.attributes.get(ATTR_MEDIA_DURATION) == 650
+    assert state.attributes.get(ATTR_MEDIA_DURATION) == 6496
     assert state.attributes.get(ATTR_MEDIA_POSITION) == 314
     assert state.attributes.get(ATTR_APP_ID) == "74519"
     assert state.attributes.get(ATTR_APP_NAME) == "Pluto TV - It's Free TV"
@@ -264,7 +264,7 @@ async def test_tv_attributes(
     )
 
     state = hass.states.get(TV_ENTITY_ID)
-    assert state.state == STATE_PLAYING
+    assert state.state == STATE_ON
 
     assert state.attributes.get(ATTR_APP_ID) == "tvinput.dtv"
     assert state.attributes.get(ATTR_APP_NAME) == "Antenna TV"

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -229,7 +229,7 @@ async def test_attributes_app_media_playing(
 
     assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_APP
     assert state.attributes.get(ATTR_MEDIA_DURATION) == 6496
-    assert state.attributes.get(ATTR_MEDIA_POSITION) == 388
+    assert state.attributes.get(ATTR_MEDIA_POSITION) == 38
     assert state.attributes.get(ATTR_APP_ID) == "74519"
     assert state.attributes.get(ATTR_APP_NAME) == "Pluto TV - It's Free TV"
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Pluto TV - It's Free TV"

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -10,6 +10,8 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CHANNEL,
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_DURATION,
+    ATTR_MEDIA_POSITION,
     ATTR_MEDIA_TITLE,
     ATTR_MEDIA_VOLUME_MUTED,
     DOMAIN as MP_DOMAIN,
@@ -43,6 +45,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_UP,
     STATE_HOME,
     STATE_IDLE,
+    STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
     STATE_STANDBY,
@@ -225,6 +228,8 @@ async def test_attributes_app_media_paused(
     assert state.state == STATE_PAUSED
 
     assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_APP
+    assert state.attributes.get(ATTR_MEDIA_DURATION) == 650
+    assert state.attributes.get(ATTR_MEDIA_POSITION) == 314
     assert state.attributes.get(ATTR_APP_ID) == "74519"
     assert state.attributes.get(ATTR_APP_NAME) == "Pluto TV - It's Free TV"
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Pluto TV - It's Free TV"

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -218,6 +218,23 @@ async def test_attributes_app(
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Netflix"
 
 
+async def test_attributes_app_media_playing(
+    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test attributes for app with playing media."""
+    await setup_integration(hass, aioclient_mock, app="pluto", media_state="play")
+
+    state = hass.states.get(MAIN_ENTITY_ID)
+    assert state.state == STATE_PLAYING
+
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_APP
+    assert state.attributes.get(ATTR_MEDIA_DURATION) == 6496
+    assert state.attributes.get(ATTR_MEDIA_POSITION) == 388
+    assert state.attributes.get(ATTR_APP_ID) == "74519"
+    assert state.attributes.get(ATTR_APP_NAME) == "Pluto TV - It's Free TV"
+    assert state.attributes.get(ATTR_INPUT_SOURCE) == "Pluto TV - It's Free TV"
+
+
 async def test_attributes_app_media_paused(
     hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
 ) -> None:
@@ -229,7 +246,7 @@ async def test_attributes_app_media_paused(
 
     assert state.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_APP
     assert state.attributes.get(ATTR_MEDIA_DURATION) == 6496
-    assert state.attributes.get(ATTR_MEDIA_POSITION) == 314
+    assert state.attributes.get(ATTR_MEDIA_POSITION) == 313
     assert state.attributes.get(ATTR_APP_ID) == "74519"
     assert state.attributes.get(ATTR_APP_NAME) == "Pluto TV - It's Free TV"
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Pluto TV - It's Free TV"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Roku state now better aligns with media playback. Previously, if an app was open, the state would be "playing" even if you were just browsing the app interface. This has been adjusted to be represented as "on". When Roku reports media playback in progress, the state "playing" will be used. This improves compatibility with exposing entities to alexa, google assistant, and homekit.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
