### PR TITLE
Do not default Pilight lights to max brightness

### DIFF
--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -71,8 +71,8 @@ class PilightLight(PilightBaseDevice, LightEntity):
             # By creating a percentage
             percentage = self._brightness / 255
             # Then calulate the dimmer range (aka ammount of available brightness steps).
-            range = self._dimlevel_max - self._dimlevel_min
+            dimrange = self._dimlevel_max - self._dimlevel_min
             # Finaly calculate the pilight brightness, adding dimlevel_min back in to ensure the minimum is always reaced.
-            dimlevel = int(percentage * range + self._dimlevel_min)
+            dimlevel = int(percentage * dimrange + self._dimlevel_min)
 
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -67,6 +67,9 @@ class PilightLight(PilightBaseDevice, LightEntity):
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
             """Calculate pilight brightness (a 0 to 15 range), by basing a percentage on the min and max dimlevel"""
-            dimlevel = int((self._brightness / 255) * (self._dimlevel_max - self._dimlevel_min) + self._dimlevel_min)
-        
+            dimlevel = int(
+                (self._brightness / 255) * (self._dimlevel_max - self._dimlevel_min)
+                + self._dimlevel_min
+            )
+
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -70,9 +70,9 @@ class PilightLight(PilightBaseDevice, LightEntity):
             # Calculate pilight brightness (as a range of 0 to 15)
             # By creating a percentage
             percentage = self._brightness / 255
-            # Then calulate the dimmer range (aka ammount of available brightness steps).
+            # Then calculate the dimmer range (aka amount of available brightness steps).
             dimrange = self._dimlevel_max - self._dimlevel_min
-            # Finaly calculate the pilight brightness, adding dimlevel_min back in to ensure the minimum is always reaced.
+            # Finally calculate the pilight brightness, adding dimlevel_min back in to ensure the minimum is always reaced.
             dimlevel = int(percentage * dimrange + self._dimlevel_min)
 
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -61,12 +61,12 @@ class PilightLight(PilightBaseDevice, LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the switch on by calling pilight.send service with on code."""
-        """Set the brightness only if needed, this will allow the switch to keep is old brightness level."""
+        # Set the brightness only if needed, this will allow the switch to keep is old brightness level.
         dimlevel = None
 
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
-            """Calculate pilight brightness (a 0 to 15 range), by basing a percentage on the min and max dimlevel"""
+            # Calculate pilight brightness (a 0 to 15 range), by basing a percentage on the min and max dimlevel
             dimlevel = int(
                 (self._brightness / 255) * (self._dimlevel_max - self._dimlevel_min)
                 + self._dimlevel_min

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -72,7 +72,7 @@ class PilightLight(PilightBaseDevice, LightEntity):
             percentage = self._brightness / 255
             # Then calculate the dimmer range (aka amount of available brightness steps).
             dimrange = self._dimlevel_max - self._dimlevel_min
-            # Finally calculate the pilight brightness, adding dimlevel_min back in to ensure the minimum is always reaced.
+            # Finally calculate the pilight brightness, adding dimlevel_min back in to ensure the minimum is always reached.
             dimlevel = int(percentage * dimrange + self._dimlevel_min)
 
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -61,15 +61,18 @@ class PilightLight(PilightBaseDevice, LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the switch on by calling pilight.send service with on code."""
-        # Set the brightness only if needed, this will allow the switch to keep is old brightness level.
-        dimlevel = None
-
+        # Update brightness only if provided as an argument, this will allow the switch to keep its previous brightness level.
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
-            # Calculate pilight brightness (a 0 to 15 range), by basing a percentage on the min and max dimlevel
-            dimlevel = int(
-                (self._brightness / 255) * (self._dimlevel_max - self._dimlevel_min)
-                + self._dimlevel_min
-            )
+
+        dimlevel = None
+        if self._brightness is not None:
+            # Calculate pilight brightness (as a range of 0 to 15), 
+            # By creating a percentage
+            percentage = self._brightness / 255
+            # Then calulate the dimmer range (aka ammount of available brightness steps).
+            range = self._dimlevel_max - self._dimlevel_min
+            # Finaly calculate the pilight brightness, adding dimlevel_min back in to ensure the minimum is always reaced.
+            dimlevel = int(percentage * range + self._dimlevel_min)
 
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -61,7 +61,8 @@ class PilightLight(PilightBaseDevice, LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the switch on by calling pilight.send service with on code."""
-        # Update brightness only if provided as an argument, this will allow the switch to keep its previous brightness level.
+        # Update brightness only if provided as an argument.
+        # This will allow the switch to keep its previous brightness level.
         dimlevel = None
 
         if ATTR_BRIGHTNESS in kwargs:

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -62,11 +62,11 @@ class PilightLight(PilightBaseDevice, LightEntity):
     def turn_on(self, **kwargs):
         """Turn the switch on by calling pilight.send service with on code."""
         # Update brightness only if provided as an argument, this will allow the switch to keep its previous brightness level.
+        dimlevel = None
+
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
 
-        dimlevel = None
-        if self._brightness is not None:
             # Calculate pilight brightness (as a range of 0 to 15)
             # By creating a percentage
             percentage = self._brightness / 255

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -73,7 +73,8 @@ class PilightLight(PilightBaseDevice, LightEntity):
             percentage = self._brightness / 255
             # Then calculate the dimmer range (aka amount of available brightness steps).
             dimrange = self._dimlevel_max - self._dimlevel_min
-            # Finally calculate the pilight brightness, adding dimlevel_min back in to ensure the minimum is always reached.
+            # Finally calculate the pilight brightness.
+            # We add dimlevel_min back in to ensure the minimum is always reached.
             dimlevel = int(percentage * dimrange + self._dimlevel_min)
 
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -61,7 +61,12 @@ class PilightLight(PilightBaseDevice, LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the switch on by calling pilight.send service with on code."""
-        self._brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-        dimlevel = int(self._brightness / (255 / self._dimlevel_max))
+        """Set the brightness only if needed, this will allow the switch to keep is old brightness level."""
+        dimlevel = None
 
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
+            """Calculate pilight brightness (a 0 to 15 range), by basing a percentage on the min and max dimlevel"""
+            dimlevel = int((self._brightness / 255) * (self._dimlevel_max - self._dimlevel_min) + self._dimlevel_min)
+        
         self.set_state(turn_on=True, dimlevel=dimlevel)

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -67,7 +67,7 @@ class PilightLight(PilightBaseDevice, LightEntity):
 
         dimlevel = None
         if self._brightness is not None:
-            # Calculate pilight brightness (as a range of 0 to 15), 
+            # Calculate pilight brightness (as a range of 0 to 15)
             # By creating a percentage
             percentage = self._brightness / 255
             # Then calulate the dimmer range (aka ammount of available brightness steps).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Lights using the pilight integration will now turn on to the last used brightness instead of its maximum brightness.

If you want to retain you lights turning on to its maximum brightness you can set the default intensity in the light_profiles.csv file.
The steps to set this up:
1. In the your main `config` folder (where you'll find `configuration.yaml`) create a new file called 'light_profiles.csv'
2. For each of lights add an line with its entity id and the brightness you want, as a value from 0 to 255.

Example:
```
light.<deviceentityid>.default,0,0,255
```

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Right now when turning on a light using the pilight integration it will default to its maximum brightness unless a brightness was selected by the user. 
This change will let pilight send a basic "switch on" command and will send the brightness value only if it was specified.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
- platform: pilight
  lights:
    TestLight:
      dimlevel_min: 4
      dimlevel_max: 10
      on_code:
        protocol: kaku_dimmer
        unit: 0
        id: 1337001
        'on': 1
      off_code:
        protocol: kaku_dimmer
        unit: 0
        id: 1337001
        'off': 1
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This change was based of looking at the Hue integration.
But be aware that it is not possible to query the current brightness of a light in 433mhz protocols.

- This PR fixes or closes issue: no associated issues.
- This PR is related to issue: no associated issues.
- Link to documentation pull request: (pending)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] ~~The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.~~
- [ ] ~~New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.~~
- [ ] ~~Untested files have been added to `.coveragerc`.~~

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
