### PR TITLE
Allow separate URL for REST switch state

### DIFF
--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -30,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_BODY_OFF = "body_off"
 CONF_BODY_ON = "body_on"
 CONF_IS_ON_TEMPLATE = "is_on_template"
+CONF_STATE_RESOURCE = "state_resource"
 
 DEFAULT_METHOD = "post"
 DEFAULT_BODY_OFF = "OFF"
@@ -43,6 +44,7 @@ SUPPORT_REST_METHODS = ["post", "put"]
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_RESOURCE): cv.url,
+        vol.Optional(CONF_STATE_RESOURCE): cv.url,
         vol.Optional(CONF_HEADERS): {cv.string: cv.string},
         vol.Optional(CONF_BODY_OFF, default=DEFAULT_BODY_OFF): cv.template,
         vol.Optional(CONF_BODY_ON, default=DEFAULT_BODY_ON): cv.template,
@@ -73,6 +75,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     resource = config.get(CONF_RESOURCE)
+    state_resource = config.get(CONF_STATE_RESOURCE) or resource
     verify_ssl = config.get(CONF_VERIFY_SSL)
 
     auth = None
@@ -91,6 +94,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         switch = RestSwitch(
             name,
             resource,
+            state_resource,
             method,
             headers,
             auth,
@@ -122,6 +126,7 @@ class RestSwitch(SwitchEntity):
         self,
         name,
         resource,
+        state_resource,
         method,
         headers,
         auth,
@@ -135,6 +140,7 @@ class RestSwitch(SwitchEntity):
         self._state = None
         self._name = name
         self._resource = resource
+        self._state_resource = state_resource
         self._method = method
         self._headers = headers
         self._auth = auth
@@ -213,7 +219,7 @@ class RestSwitch(SwitchEntity):
 
         with async_timeout.timeout(self._timeout):
             req = await websession.get(
-                self._resource, auth=self._auth, headers=self._headers
+                self._state_resource, auth=self._auth, headers=self._headers
             )
             text = await req.text()
 

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -99,6 +99,7 @@ class TestRestSwitch:
         self.name = "foo"
         self.method = "post"
         self.resource = "http://localhost/"
+        self.state_resource = self.resource
         self.headers = {"Content-type": "application/json"}
         self.auth = None
         self.body_on = Template("on", self.hass)
@@ -106,6 +107,7 @@ class TestRestSwitch:
         self.switch = rest.RestSwitch(
             self.name,
             self.resource,
+            self.state_resource,
             self.method,
             self.headers,
             self.auth,

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -4,7 +4,17 @@ import asyncio
 import aiohttp
 
 import homeassistant.components.rest.switch as rest
-from homeassistant.const import HTTP_INTERNAL_SERVER_ERROR
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    CONF_HEADERS,
+    CONF_NAME,
+    CONF_PLATFORM,
+    CONF_RESOURCE,
+    CONTENT_TYPE_JSON,
+    HTTP_INTERNAL_SERVER_ERROR,
+    HTTP_NOT_FOUND,
+    HTTP_OK,
+)
 from homeassistant.helpers.template import Template
 from homeassistant.setup import setup_component
 
@@ -25,7 +35,7 @@ class TestRestSwitchSetup:
     def test_setup_missing_config(self):
         """Test setup with configuration missing required entries."""
         assert not asyncio.run_coroutine_threadsafe(
-            rest.async_setup_platform(self.hass, {"platform": "rest"}, None),
+            rest.async_setup_platform(self.hass, {CONF_PLATFORM: rest.DOMAIN}, None),
             self.hass.loop,
         ).result()
 
@@ -33,7 +43,9 @@ class TestRestSwitchSetup:
         """Test setup with resource missing schema."""
         assert not asyncio.run_coroutine_threadsafe(
             rest.async_setup_platform(
-                self.hass, {"platform": "rest", "resource": "localhost"}, None
+                self.hass,
+                {CONF_PLATFORM: rest.DOMAIN, CONF_RESOURCE: "localhost"},
+                None,
             ),
             self.hass.loop,
         ).result()
@@ -43,7 +55,9 @@ class TestRestSwitchSetup:
         aioclient_mock.get("http://localhost", exc=aiohttp.ClientError)
         assert not asyncio.run_coroutine_threadsafe(
             rest.async_setup_platform(
-                self.hass, {"platform": "rest", "resource": "http://localhost"}, None
+                self.hass,
+                {CONF_PLATFORM: rest.DOMAIN, CONF_RESOURCE: "http://localhost"},
+                None,
             ),
             self.hass.loop,
         ).result()
@@ -53,41 +67,70 @@ class TestRestSwitchSetup:
         aioclient_mock.get("http://localhost", exc=asyncio.TimeoutError())
         assert not asyncio.run_coroutine_threadsafe(
             rest.async_setup_platform(
-                self.hass, {"platform": "rest", "resource": "http://localhost"}, None
+                self.hass,
+                {CONF_PLATFORM: rest.DOMAIN, CONF_RESOURCE: "http://localhost"},
+                None,
             ),
             self.hass.loop,
         ).result()
 
     def test_setup_minimum(self, aioclient_mock):
         """Test setup with minimum configuration."""
-        aioclient_mock.get("http://localhost", status=200)
-        with assert_setup_component(1, "switch"):
+        aioclient_mock.get("http://localhost", status=HTTP_OK)
+        with assert_setup_component(1, SWITCH_DOMAIN):
             assert setup_component(
                 self.hass,
-                "switch",
-                {"switch": {"platform": "rest", "resource": "http://localhost"}},
+                SWITCH_DOMAIN,
+                {
+                    SWITCH_DOMAIN: {
+                        CONF_PLATFORM: rest.DOMAIN,
+                        CONF_RESOURCE: "http://localhost",
+                    }
+                },
             )
         assert aioclient_mock.call_count == 1
 
     def test_setup(self, aioclient_mock):
         """Test setup with valid configuration."""
-        aioclient_mock.get("http://localhost", status=200)
+        aioclient_mock.get("http://localhost", status=HTTP_OK)
         assert setup_component(
             self.hass,
-            "switch",
+            SWITCH_DOMAIN,
             {
-                "switch": {
-                    "platform": "rest",
-                    "name": "foo",
-                    "resource": "http://localhost",
-                    "headers": {"Content-type": "application/json"},
-                    "body_on": "custom on text",
-                    "body_off": "custom off text",
+                SWITCH_DOMAIN: {
+                    CONF_PLATFORM: rest.DOMAIN,
+                    CONF_NAME: "foo",
+                    CONF_RESOURCE: "http://localhost",
+                    CONF_HEADERS: {"Content-type": CONTENT_TYPE_JSON},
+                    rest.CONF_BODY_ON: "custom on text",
+                    rest.CONF_BODY_OFF: "custom off text",
                 }
             },
         )
         assert aioclient_mock.call_count == 1
-        assert_setup_component(1, "switch")
+        assert_setup_component(1, SWITCH_DOMAIN)
+
+    def test_setup_with_state_resource(self, aioclient_mock):
+        """Test setup with valid configuration."""
+        aioclient_mock.get("http://localhost", status=HTTP_NOT_FOUND)
+        aioclient_mock.get("http://localhost/state", status=HTTP_OK)
+        assert setup_component(
+            self.hass,
+            SWITCH_DOMAIN,
+            {
+                SWITCH_DOMAIN: {
+                    CONF_PLATFORM: rest.DOMAIN,
+                    CONF_NAME: "foo",
+                    CONF_RESOURCE: "http://localhost",
+                    rest.CONF_STATE_RESOURCE: "http://localhost/state",
+                    CONF_HEADERS: {"Content-type": "application/json"},
+                    rest.CONF_BODY_ON: "custom on text",
+                    rest.CONF_BODY_OFF: "custom off text",
+                }
+            },
+        )
+        assert aioclient_mock.call_count == 1
+        assert_setup_component(1, SWITCH_DOMAIN)
 
 
 class TestRestSwitch:
@@ -133,7 +176,7 @@ class TestRestSwitch:
 
     def test_turn_on_success(self, aioclient_mock):
         """Test turn_on."""
-        aioclient_mock.post(self.resource, status=200)
+        aioclient_mock.post(self.resource, status=HTTP_OK)
         asyncio.run_coroutine_threadsafe(
             self.switch.async_turn_on(), self.hass.loop
         ).result()
@@ -162,7 +205,7 @@ class TestRestSwitch:
 
     def test_turn_off_success(self, aioclient_mock):
         """Test turn_off."""
-        aioclient_mock.post(self.resource, status=200)
+        aioclient_mock.post(self.resource, status=HTTP_OK)
         asyncio.run_coroutine_threadsafe(
             self.switch.async_turn_off(), self.hass.loop
         ).result()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I ran into a switch device with a REST API which reports the current state on a different URL than the command URL. This allows to use a separate URL resource for the status updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
switch:
  - platform: rest
    resource: http://10.0.10.2:8080/api/<KEY>/lights/6/state
    state_resource: http://10.0.10.2:8080/api/<KEY>/lights/6
    name: Bedroom Fan
    body_on: '{"speed": 1}'
    body_off: '{"speed": 0}'
    is_on_template: '{{ value_json.state.speed|int > 0 }}'
    method: PUT
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14392

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
