### PR TITLE
An integration to control relays over HTTP

### DIFF
--- a/homeassistant/components/http_inline/__init__.py
+++ b/homeassistant/components/http_inline/__init__.py
@@ -1,0 +1,86 @@
+"""Support for WebController-Relay devices."""
+
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_ID, CONF_NAME
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+
+from .const import (
+    CONF_PATH_PATTERN_READ,
+    CONF_PATH_PATTERN_WRITE,
+    CONF_RELAYS,
+    DEFAULT_NAME,
+    DEFAULT_PATH_PATTERN_READ,
+    DEFAULT_PATH_PATTERN_WRITE,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_PLATFORMS = [
+    "switch",
+]
+
+_SWITCHES_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ID): cv.positive_int,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
+)
+
+HTTP_INLINE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.url,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(
+            CONF_PATH_PATTERN_READ, default=DEFAULT_PATH_PATTERN_READ
+        ): cv.string,
+        vol.Optional(
+            CONF_PATH_PATTERN_WRITE, default=DEFAULT_PATH_PATTERN_WRITE
+        ): cv.string,
+        vol.Required(CONF_RELAYS): _SWITCHES_SCHEMA,
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [HTTP_INLINE_SCHEMA]))},
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Set up the WebController-Relay component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Set up the WebController-Relay component."""
+    _LOGGER.error(entry)
+
+    for platform in SUPPORTED_PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(config_entry, component)
+                for component in SUPPORTED_PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(config_entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/http_inline/config_flow.py
+++ b/homeassistant/components/http_inline/config_flow.py
@@ -1,0 +1,194 @@
+"""Config flow to configure the WebController-Relay integration."""
+
+import logging
+
+import requests
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME, HTTP_OK
+
+from .const import (  # pylint: disable=unused-import
+    CONF_NB_RELAYS,
+    CONF_PATH_PATTERN_READ,
+    CONF_PATH_PATTERN_WRITE,
+    CONF_RELAY_I_NAME_PATTERN,
+    CONF_RELAY_NAMES,
+    DEFAULT_HOST,
+    DEFAULT_NAME,
+    DEFAULT_NB_RELAYS,
+    DEFAULT_PATH_PATTERN_READ,
+    DEFAULT_PATH_PATTERN_WRITE,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HttpInlineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    def __init__(self):
+        """Initialize HTTP_inline config flow."""
+        self._host = None
+        self._name = None
+        self._path_read = None
+        self._path_write = None
+        self._nb_relays = 0
+        self._relay_names = []
+
+    def _global_data_schema(self, user_input=None):
+        if user_input is None:
+            user_input = {}
+
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_HOST, default=user_input.get(CONF_HOST, DEFAULT_HOST)
+                ): str,
+                vol.Required(
+                    CONF_NB_RELAYS,
+                    default=user_input.get(CONF_NB_RELAYS, DEFAULT_NB_RELAYS),
+                ): int,
+                vol.Optional(
+                    CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)
+                ): str,
+                vol.Optional(
+                    CONF_PATH_PATTERN_READ,
+                    default=user_input.get(
+                        CONF_PATH_PATTERN_READ, DEFAULT_PATH_PATTERN_READ
+                    ),
+                ): str,
+                vol.Optional(
+                    CONF_PATH_PATTERN_WRITE,
+                    default=user_input.get(
+                        CONF_PATH_PATTERN_WRITE, DEFAULT_PATH_PATTERN_WRITE
+                    ),
+                ): str,
+            }
+        )
+
+    def _relays_data_schema(self, user_input=None):
+        if user_input is None:
+            user_input = {}
+
+        schema = vol.Schema({})
+        for i in range(0, self._nb_relays):
+            name = CONF_RELAY_I_NAME_PATTERN.format(i)
+            default = f"{self._name} #{i}"
+
+            schema = schema.extend({vol.Optional(name, default=default): str})
+
+        return schema
+
+    def _export(self):
+        return {
+            CONF_HOST: self._host,
+            CONF_NAME: self._name,
+            CONF_PATH_PATTERN_READ: self._path_read,
+            CONF_PATH_PATTERN_WRITE: self._path_write,
+            CONF_NB_RELAYS: self._nb_relays,
+            CONF_RELAY_NAMES: self._relay_names,
+        }
+
+    def _show_global_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user."""
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self._global_data_schema(user_input),
+            errors=errors or {},
+        )
+
+    def _show_relays_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user_bis."""
+        return self.async_show_form(
+            step_id="relay",
+            data_schema=self._relays_data_schema(user_input),
+            errors=errors or {},
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        if user_input is None:
+            return self._show_global_setup_form(user_input, errors)
+
+        await self.async_set_unique_id(user_input[CONF_HOST])
+
+        return await self.async_step_link(user_input)
+
+    async def async_step_link(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        try:
+            request = requests.get(user_input[CONF_HOST], timeout=10)
+            if request.status_code == HTTP_OK:
+                self._host = user_input[CONF_HOST]
+                self._name = user_input.get(CONF_NAME, user_input[CONF_HOST])
+                self._path_read = user_input.get(
+                    CONF_PATH_PATTERN_READ, DEFAULT_PATH_PATTERN_READ
+                )
+                self._path_write = user_input.get(
+                    CONF_PATH_PATTERN_WRITE, DEFAULT_PATH_PATTERN_WRITE
+                )
+                self._nb_relays = user_input[CONF_NB_RELAYS]
+
+                return await self.async_step_relay()
+
+            _LOGGER.error("Server error %d", request.status_code)
+            errors[CONF_HOST] = "Server error"
+
+        except requests.exceptions.MissingSchema:
+            _LOGGER.error(
+                "Missing host or schema in configuration. Add http:// to your URL"
+            )
+            errors[
+                CONF_HOST
+            ] = "Missing host or schema in configuration. Add http:// to your URL"
+
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("No route to device at %s", user_input[CONF_HOST])
+            errors[CONF_HOST] = "No route to device"
+
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Unknown error connecting with server at %s", user_input[CONF_HOST]
+            )
+            errors["base"] = "unknown"
+
+        return self._show_global_setup_form(user_input, errors)
+
+    async def async_step_relay(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        if user_input is None:
+            return self._show_relays_setup_form(user_input, errors)
+
+        self._relay_names = [None] * self._nb_relays
+
+        for i in range(0, self._nb_relays):
+            key = CONF_RELAY_I_NAME_PATTERN.format(i)
+            if key in user_input:
+                self._relay_names[i] = user_input[key]
+            else:
+                return self._show_relays_setup_form(user_input, errors)
+
+        return await self.async_step_import(user_input)
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        if user_input is None:
+            user_input = {}
+
+        data = self._export()
+
+        self.hass.data[DOMAIN] = data
+
+        return self.async_create_entry(title=data[CONF_NAME], data=data)

--- a/homeassistant/components/http_inline/const.py
+++ b/homeassistant/components/http_inline/const.py
@@ -1,0 +1,18 @@
+"""Const for the http_inline integration."""
+
+
+DOMAIN = "http_inline"
+PLATFORMS = ["switch"]
+
+CONF_PATH_PATTERN_READ = "path_read"
+CONF_PATH_PATTERN_WRITE = "path_write"
+CONF_RELAYS = "relays"
+CONF_NB_RELAYS = "nb_relays"
+CONF_RELAY_NAMES = "relay_names"
+CONF_RELAY_I_NAME_PATTERN = "relay_name_{}"
+
+DEFAULT_HOST = "http://webrelay.local"
+DEFAULT_NAME = "http_inline switch"
+DEFAULT_PATH_PATTERN_READ = "/r/{relay_id}"
+DEFAULT_PATH_PATTERN_WRITE = "/w/{relay_id}/{state}"
+DEFAULT_NB_RELAYS = "0"

--- a/homeassistant/components/http_inline/manifest.json
+++ b/homeassistant/components/http_inline/manifest.json
@@ -1,0 +1,8 @@
+{
+    "domain": "http_inline",
+    "name": "HTTP inline",
+    "config_flow": true,
+    "documentation": "https://github.com/1e1/arduino-webcontroller-relay",
+    "codeowners": ["@1e1"],
+    "quality_scale": "silver"
+}

--- a/homeassistant/components/http_inline/strings.json
+++ b/homeassistant/components/http_inline/strings.json
@@ -1,0 +1,61 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "HTTP inline",
+                "description": "Set up a Webcontroller-Relay - https://github.com/1e1/arduino-webcontroller-relay",
+                "data": {
+                    "host": "Host URL",
+                    "name": "Name of the integration",
+                    "path_read": "path URL for reading",
+                    "path_write": "path URL for writing",
+                    "nb_relays": "number of relays"
+                }
+            },
+            "relay": {
+                "title": "HTTP inline - Relays",
+                "description": "list of relaynames",
+                "data": {
+                    "relay_name_0": "#0",
+                    "relay_name_1": "#1",
+                    "relay_name_2": "#2",
+                    "relay_name_3": "#3",
+                    "relay_name_4": "#4",
+                    "relay_name_5": "#5",
+                    "relay_name_6": "#6",
+                    "relay_name_7": "#7",
+                    "relay_name_8": "#8",
+                    "relay_name_9": "#9",
+                    "relay_name_10": "#10",
+                    "relay_name_11": "#11",
+                    "relay_name_12": "#12",
+                    "relay_name_13": "#13",
+                    "relay_name_14": "#14",
+                    "relay_name_15": "#15",
+                    "relay_name_16": "#16",
+                    "relay_name_17": "#17",
+                    "relay_name_18": "#18",
+                    "relay_name_19": "#19",
+                    "relay_name_20": "#20",
+                    "relay_name_21": "#21",
+                    "relay_name_22": "#22",
+                    "relay_name_23": "#23",
+                    "relay_name_24": "#24",
+                    "relay_name_25": "#25",
+                    "relay_name_26": "#26",
+                    "relay_name_27": "#27",
+                    "relay_name_28": "#28",
+                    "relay_name_29": "#29",
+                    "relay_name_30": "#30",
+                    "relay_name_31": "#31"
+                }
+            }
+        },
+        "error": {
+            "unknown": "Unknown error: please retry later"
+        },
+        "abort": {
+            "already_configured": "Host already configured"
+        }
+    }
+}

--- a/homeassistant/components/http_inline/switch.py
+++ b/homeassistant/components/http_inline/switch.py
@@ -1,0 +1,172 @@
+"""Support for an exposed http_inline API of a device."""
+
+import logging
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
+from homeassistant.const import CONF_HOST, CONF_NAME, HTTP_OK
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    CONF_NB_RELAYS,
+    CONF_PATH_PATTERN_READ,
+    CONF_PATH_PATTERN_WRITE,
+    CONF_RELAY_NAMES,
+    CONF_RELAYS,
+    DEFAULT_NAME,
+    DEFAULT_PATH_PATTERN_READ,
+    DEFAULT_PATH_PATTERN_WRITE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_SWITCHES_SCHEMA = vol.Schema({cv.positive_int: cv.string})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.url,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(
+            CONF_PATH_PATTERN_READ, default=DEFAULT_PATH_PATTERN_READ
+        ): cv.string,
+        vol.Optional(
+            CONF_PATH_PATTERN_WRITE, default=DEFAULT_PATH_PATTERN_WRITE
+        ): cv.string,
+        vol.Required(CONF_RELAYS): _SWITCHES_SCHEMA,
+    }
+)
+
+
+def async_setup_platform(hass, config, add_entities, discovery_info=None) -> None:
+    """Set up the http_inline switches."""
+    host = config[CONF_HOST]
+    path_read = config[CONF_PATH_PATTERN_READ]
+    path_write = config[CONF_PATH_PATTERN_WRITE]
+
+    try:
+        requests.get(host, timeout=10)
+    except requests.exceptions.MissingSchema:
+        _LOGGER.error(
+            "Missing host or schema in configuration. Add http:// to your URL"
+        )
+        return
+    except requests.exceptions.ConnectionError:
+        _LOGGER.error("No route to device at %d", host)
+        return
+
+    net_config = {
+        CONF_HOST: host,
+        CONF_PATH_PATTERN_READ: path_read,
+        CONF_PATH_PATTERN_WRITE: path_write,
+    }
+
+    dev = []
+    relays = config[CONF_RELAYS]
+    for relay_id, name in relays.items():
+        dev.append(
+            HttpInlineSwitch(
+                net_config,
+                relay_id,
+                name,
+            )
+        )
+
+    async_add_entities(dev, True)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up WebController-Relay entities based on a config entry."""
+    # name = config_entry.data[CONF_NAME]
+    host = config_entry.data[CONF_HOST]
+    path_read = config_entry.data[CONF_PATH_PATTERN_READ]
+    path_write = config_entry.data[CONF_PATH_PATTERN_WRITE]
+    nb_relays = config_entry.data[CONF_NB_RELAYS]
+    relay_names = config_entry.data[CONF_RELAY_NAMES]
+
+    net_config = {
+        CONF_HOST: host,
+        CONF_PATH_PATTERN_READ: path_read,
+        CONF_PATH_PATTERN_WRITE: path_write,
+    }
+
+    dev = []
+    for i in range(0, nb_relays):
+        dev.append(
+            HttpInlineSwitch(
+                net_config,
+                i,
+                relay_names[i],
+            )
+        )
+
+    async_add_entities(dev, True)
+
+
+class HttpInlineSwitch(SwitchEntity):
+    """Representation of an http_inline switch."""
+
+    def __init__(self, net_config, relay_id, name) -> None:
+        """Initialize the switch."""
+        self._host = net_config[CONF_HOST]
+        self._path_read = net_config[CONF_PATH_PATTERN_READ]
+        self._path_write = net_config[CONF_PATH_PATTERN_WRITE]
+        self._relay_id = relay_id
+        self._name = name
+        self._state = None
+        self._available = True
+
+        self._read()
+
+    @property
+    def name(self) -> str:
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def available(self) -> bool:
+        """Could the device be accessed during the last update call."""
+        return self._available
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        self._write(True)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        self._write(False)
+
+    async def async_update(self):
+        """Get the latest data from http_inline API and update the state."""
+        self._read()
+
+    def _read(self):
+        path = self._path_read
+        path = path.replace("{relay_id}", str(self._relay_id))
+        request = requests.get(self._host + path, timeout=10)
+        if request.status_code != HTTP_OK:
+            _LOGGER.error("Can't set mode")
+            self._available = False
+        else:
+            self._parse_response(request)
+
+    def _write(self, state):
+        path = self._path_write
+        path = path.replace("{relay_id}", str(self._relay_id))
+        path = path.replace("{state}", "1" if state else "0")
+        request = requests.post(self._host + path, timeout=10)
+        if request.status_code == HTTP_OK:
+            self._parse_response(request)
+        else:
+            _LOGGER.error("Can't switch relay %d at %s", self._relay_id, self._host)
+
+    def _parse_response(self, request) -> None:
+        response = request.text
+        data = response.split()
+        self._state = data[0] == "1"

--- a/homeassistant/components/http_inline/translations/en.json
+++ b/homeassistant/components/http_inline/translations/en.json
@@ -1,0 +1,61 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "HTTP inline",
+                "description": "Set up a Webcontroller-Relay - https://github.com/1e1/arduino-webcontroller-relay",
+                "data": {
+                    "host": "Host URL",
+                    "name": "Name of the integration",
+                    "path_read": "path URL for reading",
+                    "path_write": "path URL for writing",
+                    "nb_relays": "number of relays"
+                }
+            },
+            "relay": {
+                "title": "HTTP inline - Relays",
+                "description": "list of relaynames",
+                "data": {
+                    "relay_name_0": "#0",
+                    "relay_name_1": "#1",
+                    "relay_name_2": "#2",
+                    "relay_name_3": "#3",
+                    "relay_name_4": "#4",
+                    "relay_name_5": "#5",
+                    "relay_name_6": "#6",
+                    "relay_name_7": "#7",
+                    "relay_name_8": "#8",
+                    "relay_name_9": "#9",
+                    "relay_name_10": "#10",
+                    "relay_name_11": "#11",
+                    "relay_name_12": "#12",
+                    "relay_name_13": "#13",
+                    "relay_name_14": "#14",
+                    "relay_name_15": "#15",
+                    "relay_name_16": "#16",
+                    "relay_name_17": "#17",
+                    "relay_name_18": "#18",
+                    "relay_name_19": "#19",
+                    "relay_name_20": "#20",
+                    "relay_name_21": "#21",
+                    "relay_name_22": "#22",
+                    "relay_name_23": "#23",
+                    "relay_name_24": "#24",
+                    "relay_name_25": "#25",
+                    "relay_name_26": "#26",
+                    "relay_name_27": "#27",
+                    "relay_name_28": "#28",
+                    "relay_name_29": "#29",
+                    "relay_name_30": "#30",
+                    "relay_name_31": "#31"
+                }
+            }
+        },
+        "error": {
+            "unknown": "Unknown error: please retry later"
+        },
+        "abort": {
+            "already_configured": "Host already configured"
+        }
+    }
+}


### PR DESCRIPTION
(on second thought after https://github.com/home-assistant/core/pull/39343)
It's a NO-REST component to control switches. 
It sends commands by using path only:
  - so the embed webserver parses the first header only... yes, it's very light)
  - any command can be played by a browser


Add the following lines into `configuration.yaml`:
```
switch:
  - platform: http_inline
    host: http://webrelay.local
    relays:
      0:  relayname 1
      1:  relay name 2
      2:  a relay name 3
      30: another relayname 31
      31: and this relayname 32
```

Or use the integration wizard:

1- "user"
  - host
  - number of relays
  - name
  - READ path pattern
  - WRITE path pattern

2- "relay"
  - name 0
  - name 1
  - ...
  - name i

---

You can install an Arduino client from: https://github.com/1e1/arduino-webcontroller-relay

Control a device understanding routes:
- READ:  {host}/r/{relay_id}
- WRITE: {host}/w/{relay_id}/{state:[0-1]}

the response payload is:
"{state} {relay_id} {NC or NO} {pin_id}"

specs: https://raw.githubusercontent.com/1e1/arduino-webcontroller-relay/master/doc/swagger.yml

---

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

none


## Proposed change

1 new component (cf on top)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
switch:
  - platform: http_inline
    host: http://webrelay.local
    relays:
      0:  relayname 1
      1:  relay name 2
      2:  a relay name 3
      30: another relayname 31
      31: and this relayname 32
```

## Additional information

- first draft aborted after discussion https://github.com/home-assistant/core/pull/39343
- swagger of the IoT client: https://raw.githubusercontent.com/1e1/arduino-webcontroller-relay/master/doc/swagger.yml

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
