### PR TITLE
Fix rain retrival for OWM

### DIFF
--- a/homeassistant/components/openweathermap/sensor.py
+++ b/homeassistant/components/openweathermap/sensor.py
@@ -165,15 +165,16 @@ class OpenWeatherMapSensor(Entity):
                 self._state = data.get_clouds()
             elif self.type == "rain":
                 rain = data.get_rain()
-                if "3h" in rain:
-                    self._state = round(rain["3h"], 0)
+                if "1h" in rain:
+                    self._state = round(rain["1h"], 0)
                     self._unit_of_measurement = "mm"
                 else:
                     self._state = "not raining"
                     self._unit_of_measurement = ""
             elif self.type == "snow":
-                if data.get_snow():
-                    self._state = round(data.get_snow(), 0)
+                snow = data.get_snow()
+                if "1h" in snow:
+                    self._state = round(snow["1h"], 0)
                     self._unit_of_measurement = "mm"
                 else:
                     self._state = "not snowing"

--- a/homeassistant/components/openweathermap/weather.py
+++ b/homeassistant/components/openweathermap/weather.py
@@ -203,18 +203,16 @@ class OpenWeatherMapWeather(WeatherEntity):
                     }
                 )
             else:
+                rain = entry.get_rain().get("1h")
+                if rain is not None:
+                    rain = round(rain, 1)
                 data.append(
                     {
                         ATTR_FORECAST_TIME: entry.get_reference_time("unix") * 1000,
                         ATTR_FORECAST_TEMP: entry.get_temperature("celsius").get(
                             "temp"
                         ),
-                        ATTR_FORECAST_PRECIPITATION: (
-                            round(entry.get_rain().get("3h"), 1)
-                            if entry.get_rain().get("3h") is not None
-                            and (round(entry.get_rain().get("3h"), 1) > 0)
-                            else None
-                        ),
+                        ATTR_FORECAST_PRECIPITATION: rain,
                         ATTR_FORECAST_CONDITION: [
                             k
                             for k, v in CONDITION_CLASSES.items()


### PR DESCRIPTION
Currently, the OWM integration always shows "not raining" for entity owm_rain. I guess, this is due to an api change (current version is 2.5, also used by pyowm).

As documented in the OWM API (https://openweathermap.org/api/one-call-api), rain and snow are reported on a 1h basis:

```
current.rain
    current.rain.1h (where available) Rain volume for last hour, mm
current.snow
    current.snow.1h (where available) Snow volume for last hour, mm
```

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Update rain handling in the open weather map integration.


## Type of change
Fix rain calculation

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
