### PR TITLE
Fix some more usages of asynctest

### DIFF
--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -4,7 +4,6 @@ from os import path
 import tempfile
 from unittest import mock
 
-from asynctest.mock import patch
 import pytest
 
 from homeassistant import config as hass_config
@@ -18,6 +17,8 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
 )
 from homeassistant.setup import async_setup_component
+
+from tests.async_mock import patch
 
 
 @pytest.fixture

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -1,7 +1,6 @@
 """Tests for deCONZ config flow."""
 import asyncio
 
-from asynctest.mock import patch
 import pydeconz
 
 from homeassistant import data_entry_flow
@@ -21,6 +20,8 @@ from homeassistant.components.deconz.const import (
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 
 from .test_gateway import API_KEY, BRIDGEID, setup_deconz_integration
+
+from tests.async_mock import patch
 
 
 async def test_flow_discovered_bridges(hass, aioclient_mock):

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -1,8 +1,6 @@
 """The tests for the Group Light platform."""
 from os import path
 
-from asynctest.mock import patch
-
 from homeassistant import config as hass_config
 from homeassistant.components.group import DOMAIN, SERVICE_RELOAD
 import homeassistant.components.group.light as group
@@ -34,7 +32,7 @@ from homeassistant.const import (
 from homeassistant.setup import async_setup_component
 
 import tests.async_mock
-from tests.async_mock import MagicMock
+from tests.async_mock import MagicMock, patch
 
 
 async def test_default_state(hass):

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -1,5 +1,4 @@
 """The tests for the time_pattern automation."""
-from asynctest.mock import patch
 import pytest
 import voluptuous as vol
 
@@ -8,6 +7,7 @@ import homeassistant.components.homeassistant.triggers.time_pattern as time_patt
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from tests.async_mock import patch
 from tests.common import async_fire_time_changed, async_mock_service, mock_component
 from tests.components.automation import common
 

--- a/tests/components/min_max/test_sensor.py
+++ b/tests/components/min_max/test_sensor.py
@@ -3,8 +3,6 @@ from os import path
 import statistics
 import unittest
 
-from asynctest.mock import patch
-
 from homeassistant import config as hass_config
 from homeassistant.components.min_max import DOMAIN
 from homeassistant.const import (
@@ -18,6 +16,7 @@ from homeassistant.const import (
 )
 from homeassistant.setup import async_setup_component, setup_component
 
+from tests.async_mock import patch
 from tests.common import get_test_home_assistant
 
 

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -4,7 +4,6 @@ from copy import copy
 from os import path
 import unittest
 
-from asynctest.mock import patch
 from voluptuous.error import MultipleInvalid
 
 from homeassistant import config as hass_config
@@ -23,6 +22,7 @@ from homeassistant.const import (
 )
 from homeassistant.setup import async_setup_component
 
+from tests.async_mock import patch
 from tests.common import get_test_home_assistant, mock_service
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
asynctest sneaked in again in a couple of places. Fixed it again to prevent warnings in Python 3.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
