### PR TITLE
Add get_migration_config to zwave websocket api

### DIFF
--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -10,6 +10,7 @@ from homeassistant.core import callback
 from .const import (
     CONF_AUTOHEAL,
     CONF_DEBUG,
+    CONF_NETWORK_KEY,
     CONF_POLLING_INTERVAL,
     CONF_USB_STICK_PATH,
     DATA_NETWORK,
@@ -46,8 +47,23 @@ def websocket_get_config(hass, connection, msg):
     )
 
 
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required(TYPE): "zwave/get_migration_config"})
+def websocket_get_migration_config(hass, connection, msg):
+    """Get Z-Wave configuration for migration."""
+    config = hass.data[DATA_ZWAVE_CONFIG]
+    connection.send_result(
+        msg[ID],
+        {
+            CONF_USB_STICK_PATH: config[CONF_USB_STICK_PATH],
+            CONF_NETWORK_KEY: config[CONF_NETWORK_KEY],
+        },
+    )
+
+
 @callback
 def async_load_websocket_api(hass):
     """Set up the web socket API."""
     websocket_api.async_register_command(hass, websocket_network_status)
     websocket_api.async_register_command(hass, websocket_get_config)
+    websocket_api.async_register_command(hass, websocket_get_migration_config)

--- a/tests/components/zwave/test_websocket_api.py
+++ b/tests/components/zwave/test_websocket_api.py
@@ -2,6 +2,7 @@
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.zwave.const import (
     CONF_AUTOHEAL,
+    CONF_NETWORK_KEY,
     CONF_POLLING_INTERVAL,
     CONF_USB_STICK_PATH,
 )
@@ -19,6 +20,7 @@ async def test_zwave_ws_api(hass, mock_openzwave, hass_ws_client):
                 CONF_AUTOHEAL: False,
                 CONF_USB_STICK_PATH: "/dev/zwave",
                 CONF_POLLING_INTERVAL: 6000,
+                CONF_NETWORK_KEY: "0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST",
             }
         },
     )
@@ -35,3 +37,13 @@ async def test_zwave_ws_api(hass, mock_openzwave, hass_ws_client):
     assert result[CONF_USB_STICK_PATH] == "/dev/zwave"
     assert not result[CONF_AUTOHEAL]
     assert result[CONF_POLLING_INTERVAL] == 6000
+
+    await client.send_json({ID: 6, TYPE: "zwave/get_migration_config"})
+    msg = await client.receive_json()
+    result = msg["result"]
+
+    assert result[CONF_USB_STICK_PATH] == "/dev/zwave"
+    assert (
+        result[CONF_NETWORK_KEY]
+        == "0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST, 0xTE, 0xST"
+    )


### PR DESCRIPTION
## Proposed change
Adds a get_migration_config function to the `zwave` websocket api, which will return the USB path and network key to the frontend for the zwave -> ozw migration wizard

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
