### PR TITLE
Add rfxtrx device connection validation when importing

### DIFF
--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -418,7 +418,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         device = import_config[CONF_DEVICE]
 
         try:
-            if import_config[CONF_HOST] is not None:
+            if host is not None:
                 await self.async_validate_rfx(host=host, port=port)
             else:
                 await self.async_validate_rfx(device=device)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -412,6 +412,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured(import_config)
             else:
                 self._abort_if_unique_id_configured()
+
+        host = import_config[CONF_HOST]
+        port = import_config[CONF_PORT]
+        device = import_config[CONF_DEVICE]
+
+        try:
+            if import_config[CONF_HOST] is not None:
+                await self.async_validate_rfx(host=host, port=port)
+            else:
+                await self.async_validate_rfx(device=device)
+        except CannotConnect:
+            return self.async_abort(reason="cannot_connect")
+
         return self.async_create_entry(title="RFXTRX", data=import_config)
 
     async def async_validate_rfx(self, host=None, port=None, device=None):

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -2,7 +2,8 @@
   "title": "Rfxtrx",
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Already configured. Only a single configuration possible."
+            "already_configured": "Already configured. Only a single configuration possible.",
+            "cannot_connect": "Failed to connect"
         },
         "error": {
             "cannot_connect": "Failed to connect"

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -10,6 +10,15 @@ from homeassistant.util.dt import utcnow
 from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+RFXTRX_DATA = {
+    "device": "abcd",
+    "host": None,
+    "port": None,
+    "automatic_add": False,
+    "debug": False,
+    "devices": {},
+}
+
 
 @pytest.fixture(autouse=True, name="rfxtrx")
 async def rfxtrx_fixture(hass):
@@ -37,14 +46,8 @@ async def rfxtrx_fixture(hass):
 @pytest.fixture(name="rfxtrx_automatic")
 async def rfxtrx_automatic_fixture(hass, rfxtrx):
     """Fixture that starts up with automatic additions."""
-    entry_data = {
-        "device": "abcd",
-        "host": None,
-        "port": None,
-        "automatic_add": True,
-        "debug": False,
-        "devices": {},
-    }
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["automatic_add"] = True
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -10,14 +10,17 @@ from homeassistant.util.dt import utcnow
 from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-RFXTRX_DATA = {
-    "device": "abcd",
-    "host": None,
-    "port": None,
-    "automatic_add": False,
-    "debug": False,
-    "devices": {},
-}
+
+def create_rfx_test_cfg(device="abcd", automatic_add=False, devices=None):
+    """Create rfxtrx config entry data."""
+    return {
+        "device": device,
+        "host": None,
+        "port": None,
+        "automatic_add": automatic_add,
+        "debug": False,
+        "devices": devices,
+    }
 
 
 @pytest.fixture(autouse=True, name="rfxtrx")
@@ -46,8 +49,7 @@ async def rfxtrx_fixture(hass):
 @pytest.fixture(name="rfxtrx_automatic")
 async def rfxtrx_automatic_fixture(hass, rfxtrx):
     """Fixture that starts up with automatic additions."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["automatic_add"] = True
+    entry_data = create_rfx_test_cfg(automatic_add=True, devices={})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -4,11 +4,11 @@ from datetime import timedelta
 import pytest
 
 from homeassistant.components import rfxtrx
-from homeassistant.setup import async_setup_component
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.util.dt import utcnow
 
 from tests.async_mock import patch
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture(autouse=True, name="rfxtrx")
@@ -37,12 +37,19 @@ async def rfxtrx_fixture(hass):
 @pytest.fixture(name="rfxtrx_automatic")
 async def rfxtrx_automatic_fixture(hass, rfxtrx):
     """Fixture that starts up with automatic additions."""
+    entry_data = {
+        "device": "abcd",
+        "host": None,
+        "port": None,
+        "automatic_add": True,
+        "debug": False,
+        "devices": {},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "automatic_add": True}},
-    )
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
     yield rfxtrx

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
-from tests.components.rfxtrx.conftest import RFXTRX_DATA
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 EVENT_SMOKE_DETECTOR_PANIC = "08200300a109000670"
 EVENT_SMOKE_DETECTOR_NO_PANIC = "08200300a109000770"
@@ -22,8 +22,7 @@ EVENT_AC_118CDEA_2_ON = "0b1100100118cdea02010f70"
 
 async def test_one(hass, rfxtrx):
     """Test with 1 sensor."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1100cd0213c7f230010f71": {}}
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f230010f71": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -39,14 +38,15 @@ async def test_one(hass, rfxtrx):
 
 async def test_one_pt2262(hass, rfxtrx):
     """Test with 1 sensor."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0913000022670e013970": {
-            "data_bits": 4,
-            "command_on": 0xE,
-            "command_off": 0x7,
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013970": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            }
         }
-    }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -71,8 +71,9 @@ async def test_one_pt2262(hass, rfxtrx):
 
 async def test_pt2262_unconfigured(hass, rfxtrx):
     """Test with discovery for PT2262."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0913000022670e013970": {}, "09130000226707013970": {}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0913000022670e013970": {}, "09130000226707013970": {}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -103,8 +104,7 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1100cd0213c7f230010f71": {}}
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f230010f71": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -117,12 +117,13 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
 async def test_several(hass, rfxtrx):
     """Test with 3."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0b1100cd0213c7f230010f71": {},
-        "0b1100100118cdea02010f70": {},
-        "0b1100101118cdea02010f70": {},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1100cd0213c7f230010f71": {},
+            "0b1100100118cdea02010f70": {},
+            "0b1100101118cdea02010f70": {},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -174,8 +175,7 @@ async def test_off_delay_restore(hass, rfxtrx):
         ],
     )
 
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {EVENT_AC_118CDEA_2_ON: {"off_delay": 5}}
+    entry_data = create_rfx_test_cfg(devices={EVENT_AC_118CDEA_2_ON: {"off_delay": 5}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -191,8 +191,9 @@ async def test_off_delay_restore(hass, rfxtrx):
 
 async def test_off_delay(hass, rfxtrx, timestep):
     """Test with discovery."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1100100118cdea02010f70": {"off_delay": 5}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100100118cdea02010f70": {"off_delay": 5}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -282,19 +283,20 @@ async def test_light(hass, rfxtrx_automatic):
 
 async def test_pt2262_duplicate_id(hass, rfxtrx):
     """Test with 1 sensor."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0913000022670e013970": {
-            "data_bits": 4,
-            "command_on": 0xE,
-            "command_off": 0x7,
-        },
-        "09130000226707013970": {
-            "data_bits": 4,
-            "command_on": 0xE,
-            "command_off": 0x7,
-        },
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013970": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            },
+            "09130000226707013970": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            },
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import RFXTRX_DATA
 
 EVENT_SMOKE_DETECTOR_PANIC = "08200300a109000670"
 EVENT_SMOKE_DETECTOR_NO_PANIC = "08200300a109000770"
@@ -17,15 +18,6 @@ EVENT_LIGHT_DETECTOR_LIGHT = "08200100a109001570"
 EVENT_LIGHT_DETECTOR_DARK = "08200100a109001470"
 
 EVENT_AC_118CDEA_2_ON = "0b1100100118cdea02010f70"
-
-RFXTRX_DATA = {
-    "device": "abcd",
-    "host": None,
-    "port": None,
-    "automatic_add": False,
-    "debug": False,
-    "devices": {},
-}
 
 
 async def test_one(hass, rfxtrx):

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -1,11 +1,11 @@
 """The tests for the Rfxtrx sensor platform."""
 import pytest
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
 
 EVENT_SMOKE_DETECTOR_PANIC = "08200300a109000670"
 EVENT_SMOKE_DETECTOR_NO_PANIC = "08200300a109000770"
@@ -18,14 +18,25 @@ EVENT_LIGHT_DETECTOR_DARK = "08200100a109001470"
 
 EVENT_AC_118CDEA_2_ON = "0b1100100118cdea02010f70"
 
+RFXTRX_DATA = {
+    "device": "abcd",
+    "host": None,
+    "port": None,
+    "automatic_add": False,
+    "debug": False,
+    "devices": {},
+}
+
 
 async def test_one(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f230010f71": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1100cd0213c7f230010f71": {}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.ac_213c7f2_48")
@@ -36,22 +47,19 @@ async def test_one(hass, rfxtrx):
 
 async def test_one_pt2262(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013970": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    }
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0913000022670e013970": {
+            "data_bits": 4,
+            "command_on": 0xE,
+            "command_off": 0x7,
+        }
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -71,19 +79,13 @@ async def test_one_pt2262(hass, rfxtrx):
 
 async def test_pt2262_unconfigured(hass, rfxtrx):
     """Test with discovery for PT2262."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013970": {},
-                    "09130000226707013970": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0913000022670e013970": {}, "09130000226707013970": {}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -109,11 +111,13 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f230010f71": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1100cd0213c7f230010f71": {}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -121,20 +125,17 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
 async def test_several(hass, rfxtrx):
     """Test with 3."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {},
-                    "0b1100100118cdea02010f70": {},
-                    "0b1100101118cdea02010f70": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0b1100cd0213c7f230010f71": {},
+        "0b1100100118cdea02010f70": {},
+        "0b1100101118cdea02010f70": {},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.ac_213c7f2_48")
@@ -181,16 +182,13 @@ async def test_off_delay_restore(hass, rfxtrx):
         ],
     )
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {EVENT_AC_118CDEA_2_ON: {"off_delay": 5}},
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {EVENT_AC_118CDEA_2_ON: {"off_delay": 5}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -201,16 +199,13 @@ async def test_off_delay_restore(hass, rfxtrx):
 
 async def test_off_delay(hass, rfxtrx, timestep):
     """Test with discovery."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {"0b1100100118cdea02010f70": {"off_delay": 5}},
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1100100118cdea02010f70": {"off_delay": 5}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -295,27 +290,24 @@ async def test_light(hass, rfxtrx_automatic):
 
 async def test_pt2262_duplicate_id(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013970": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    },
-                    "09130000226707013970": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    },
-                },
-            }
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0913000022670e013970": {
+            "data_bits": 4,
+            "command_on": 0xE,
+            "command_off": 0x7,
         },
-    )
+        "09130000226707013970": {
+            "data_bits": 4,
+            "command_on": 0xE,
+            "command_off": 0x7,
+        },
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -3,19 +3,22 @@ from unittest.mock import call
 
 import pytest
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import RFXTRX_DATA
 
 
 async def test_one_cover(hass, rfxtrx):
     """Test with 1 cover."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1400cd0213c7f20d010f51": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")
@@ -57,11 +60,13 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1400cd0213c7f20d010f51": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -69,20 +74,17 @@ async def test_state_restore(hass, rfxtrx, state):
 
 async def test_several_covers(hass, rfxtrx):
     """Test with 3 covers."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1400cd0213c7f20d010f51": {},
-                    "0A1400ADF394AB010D0060": {},
-                    "09190000009ba8010100": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
+        "0A1400ADF394AB010D0060": {"signal_repetitions": 1},
+        "09190000009ba8010100": {"signal_repetitions": 1},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")
@@ -118,19 +120,16 @@ async def test_discover_covers(hass, rfxtrx_automatic):
 
 async def test_duplicate_cover(hass, rfxtrx):
     """Test with 2 duplicate covers."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1400cd0213c7f20d010f51": {},
-                    "0b1400cd0213c7f20d010f50": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
+        "0b1400cd0213c7f20d010f50": {"signal_repetitions": 1},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("cover.lightwaverf_siemens_0213c7_242")

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -7,13 +7,14 @@ from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
-from tests.components.rfxtrx.conftest import RFXTRX_DATA
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_one_cover(hass, rfxtrx):
     """Test with 1 cover."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -60,8 +61,9 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -74,12 +76,13 @@ async def test_state_restore(hass, rfxtrx, state):
 
 async def test_several_covers(hass, rfxtrx):
     """Test with 3 covers."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
-        "0A1400ADF394AB010D0060": {"signal_repetitions": 1},
-        "09190000009ba8010100": {"signal_repetitions": 1},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
+            "0A1400ADF394AB010D0060": {"signal_repetitions": 1},
+            "09190000009ba8010100": {"signal_repetitions": 1},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -120,11 +123,12 @@ async def test_discover_covers(hass, rfxtrx_automatic):
 
 async def test_duplicate_cover(hass, rfxtrx):
     """Test with 2 duplicate covers."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
-        "0b1400cd0213c7f20d010f50": {"signal_repetitions": 1},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
+            "0b1400cd0213c7f20d010f50": {"signal_repetitions": 1},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,10 +1,13 @@
 """The tests for the Rfxtrx component."""
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.core import callback
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import call
+from tests.common import MockConfigEntry
+from tests.components.rfxtrx.conftest import RFXTRX_DATA
 
 
 async def test_valid_config(hass):
@@ -55,21 +58,20 @@ async def test_invalid_config(hass):
 
 async def test_fire_event(hass, rfxtrx):
     """Test fire event."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "/dev/serial/by-id/usb"
-                + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-                "automatic_add": True,
-                "devices": {
-                    "0b1100cd0213c7f210010f51": {"fire_event": True},
-                    "0716000100900970": {"fire_event": True},
-                },
-            }
-        },
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["device"] = (
+        "/dev/serial/by-id/usb" + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0"
     )
+    entry_data["automatic_add"] = True
+    entry_data["devices"] = {
+        "0b1100cd0213c7f210010f51": {"fire_event": True},
+        "0716000100900970": {"fire_event": True},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -108,9 +110,13 @@ async def test_fire_event(hass, rfxtrx):
 
 async def test_send(hass, rfxtrx):
     """Test configuration."""
-    assert await async_setup_component(
-        hass, "rfxtrx", {"rfxtrx": {"device": "/dev/null"}}
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["device"] = "/dev/null"
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -7,7 +7,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.async_mock import call
 from tests.common import MockConfigEntry
-from tests.components.rfxtrx.conftest import RFXTRX_DATA
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_valid_config(hass):
@@ -58,15 +58,14 @@ async def test_invalid_config(hass):
 
 async def test_fire_event(hass, rfxtrx):
     """Test fire event."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["device"] = (
-        "/dev/serial/by-id/usb" + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0"
+    entry_data = create_rfx_test_cfg(
+        device=("/dev/serial/by-id/usb" + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0"),
+        automatic_add=True,
+        devices={
+            "0b1100cd0213c7f210010f51": {"fire_event": True},
+            "0716000100900970": {"fire_event": True},
+        },
     )
-    entry_data["automatic_add"] = True
-    entry_data["devices"] = {
-        "0b1100cd0213c7f210010f51": {"fire_event": True},
-        "0716000100900970": {"fire_event": True},
-    }
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -110,8 +109,7 @@ async def test_fire_event(hass, rfxtrx):
 
 async def test_send(hass, rfxtrx):
     """Test configuration."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["device"] = "/dev/null"
+    entry_data = create_rfx_test_cfg(device="/dev/null", devices={})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -59,7 +59,7 @@ async def test_invalid_config(hass):
 async def test_fire_event(hass, rfxtrx):
     """Test fire event."""
     entry_data = create_rfx_test_cfg(
-        device=("/dev/serial/by-id/usb" + "-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0"),
+        device="/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
         automatic_add=True,
         devices={
             "0b1100cd0213c7f210010f51": {"fire_event": True},

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -4,19 +4,22 @@ from unittest.mock import call
 import pytest
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import RFXTRX_DATA
 
 
 async def test_one_light(hass, rfxtrx):
     """Test with 1 light."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210020f51": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("light.ac_213c7f2_16")
@@ -95,11 +98,13 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
         hass, [State(entity_id, state, attributes={ATTR_BRIGHTNESS: brightness})]
     )
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210020f51": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -108,20 +113,17 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
 
 async def test_several_lights(hass, rfxtrx):
     """Test with 3 lights."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230020f71": {},
-                    "0b1100100118cdea02020f70": {},
-                    "0b1100101118cdea02050f70": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0b1100cd0213c7f230020f71": {"signal_repetitions": 1},
+        "0b1100100118cdea02020f70": {"signal_repetitions": 1},
+        "0b1100101118cdea02050f70": {"signal_repetitions": 1},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -160,18 +162,15 @@ async def test_several_lights(hass, rfxtrx):
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -8,13 +8,14 @@ from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
-from tests.components.rfxtrx.conftest import RFXTRX_DATA
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_one_light(hass, rfxtrx):
     """Test with 1 light."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -98,8 +99,9 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
         hass, [State(entity_id, state, attributes={ATTR_BRIGHTNESS: brightness})]
     )
 
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -113,12 +115,13 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
 
 async def test_several_lights(hass, rfxtrx):
     """Test with 3 lights."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0b1100cd0213c7f230020f71": {"signal_repetitions": 1},
-        "0b1100100118cdea02020f70": {"signal_repetitions": 1},
-        "0b1100101118cdea02050f70": {"signal_repetitions": 1},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1100cd0213c7f230020f71": {"signal_repetitions": 1},
+            "0b1100100118cdea02020f70": {"signal_repetitions": 1},
+            "0b1100101118cdea02050f70": {"signal_repetitions": 1},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -162,10 +165,9 @@ async def test_several_lights(hass, rfxtrx):
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -1,19 +1,23 @@
 """The tests for the Rfxtrx sensor platform."""
 import pytest
 
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.const import TEMP_CELSIUS, UNIT_PERCENTAGE
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import RFXTRX_DATA
 
 
 async def test_default_config(hass, rfxtrx):
     """Test with 0 sensor."""
-    await async_setup_component(
-        hass, "sensor", {"sensor": {"platform": "rfxtrx", "devices": {}}}
-    )
+    entry_data = RFXTRX_DATA.copy()
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
@@ -21,11 +25,13 @@ async def test_default_config(hass, rfxtrx):
 
 async def test_one_sensor(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0a52080705020095220269": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0a52080705020095220269": {}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02_temperature")
@@ -49,11 +55,13 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0a520801070100b81b0279": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0a520801070100b81b0279": {}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -61,11 +69,13 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
 async def test_one_sensor_no_datatype(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0a52080705020095220269": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0a52080705020095220269": {}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     base_id = "sensor.wt260_wt260h_wt440h_wt450_wt450h_05_02"
@@ -104,19 +114,16 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
 
 async def test_several_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0a52080705020095220269": {},
-                    "0a520802060100ff0e0269": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0a52080705020095220269": {},
+        "0a520802060100ff0e0269": {},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -244,19 +251,16 @@ async def test_discover_sensor(hass, rfxtrx_automatic):
 
 async def test_update_of_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0a52080705020095220269": {},
-                    "0a520802060100ff0e0269": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0a52080705020095220269": {},
+        "0a520802060100ff0e0269": {},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -290,23 +294,20 @@ async def test_update_of_sensors(hass, rfxtrx):
 
 async def test_rssi_sensor(hass, rfxtrx):
     """Test with 1 sensor."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0913000022670e013b70": {
-                        "data_bits": 4,
-                        "command_on": 0xE,
-                        "command_off": 0x7,
-                    },
-                    "0b1100cd0213c7f230010f71": {},
-                },
-            }
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0913000022670e013b70": {
+            "data_bits": 4,
+            "command_on": 0xE,
+            "command_off": 0x7,
         },
-    )
+        "0b1100cd0213c7f230010f71": {},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
     await hass.async_start()
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -7,12 +7,12 @@ from homeassistant.const import TEMP_CELSIUS, UNIT_PERCENTAGE
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
-from tests.components.rfxtrx.conftest import RFXTRX_DATA
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 
 async def test_default_config(hass, rfxtrx):
     """Test with 0 sensor."""
-    entry_data = RFXTRX_DATA.copy()
+    entry_data = create_rfx_test_cfg(devices={})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -25,8 +25,7 @@ async def test_default_config(hass, rfxtrx):
 
 async def test_one_sensor(hass, rfxtrx):
     """Test with 1 sensor."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0a52080705020095220269": {}}
+    entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -55,8 +54,7 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0a520801070100b81b0279": {}}
+    entry_data = create_rfx_test_cfg(devices={"0a520801070100b81b0279": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -69,8 +67,7 @@ async def test_state_restore(hass, rfxtrx, state, event):
 
 async def test_one_sensor_no_datatype(hass, rfxtrx):
     """Test with 1 sensor."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0a52080705020095220269": {}}
+    entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -114,11 +111,12 @@ async def test_one_sensor_no_datatype(hass, rfxtrx):
 
 async def test_several_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0a52080705020095220269": {},
-        "0a520802060100ff0e0269": {},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0a52080705020095220269": {},
+            "0a520802060100ff0e0269": {},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -251,11 +249,12 @@ async def test_discover_sensor(hass, rfxtrx_automatic):
 
 async def test_update_of_sensors(hass, rfxtrx):
     """Test with 3 sensors."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0a52080705020095220269": {},
-        "0a520802060100ff0e0269": {},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0a52080705020095220269": {},
+            "0a520802060100ff0e0269": {},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -294,15 +293,16 @@ async def test_update_of_sensors(hass, rfxtrx):
 
 async def test_rssi_sensor(hass, rfxtrx):
     """Test with 1 sensor."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0913000022670e013b70": {
-            "data_bits": 4,
-            "command_on": 0xE,
-            "command_off": 0x7,
-        },
-        "0b1100cd0213c7f230010f71": {},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013b70": {
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            },
+            "0b1100cd0213c7f230010f71": {},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -5,9 +5,9 @@ import pytest
 
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from tests.common import mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache
+from tests.components.rfxtrx.conftest import RFXTRX_DATA
 
 EVENT_RFY_ENABLE_SUN_AUTO = "081a00000301010113"
 EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
@@ -15,11 +15,13 @@ EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
 
 async def test_one_switch(hass, rfxtrx):
     """Test with 1 switch."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210010f51": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.ac_213c7f2_16")
@@ -55,11 +57,13 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {"rfxtrx": {"device": "abcd", "devices": {"0b1100cd0213c7f210010f51": {}}}},
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == state
@@ -67,20 +71,17 @@ async def test_state_restore(hass, rfxtrx, state):
 
 async def test_several_switches(hass, rfxtrx):
     """Test with 3 switches."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {},
-                    "0b1100100118cdea02010f70": {},
-                    "0b1100101118cdea02010f70": {},
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0b1100cd0213c7f230010f71": {"signal_repetitions": 1},
+        "0b1100100118cdea02010f70": {"signal_repetitions": 1},
+        "0b1100101118cdea02010f70": {"signal_repetitions": 1},
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.ac_213c7f2_48")
@@ -102,18 +103,15 @@ async def test_several_switches(hass, rfxtrx):
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {
-                    "0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}
-                },
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {
+        "0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}
+    }
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -156,16 +154,13 @@ async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
 
 async def test_unknown_event_code(hass, rfxtrx):
     """Test with 3 switches."""
-    assert await async_setup_component(
-        hass,
-        "rfxtrx",
-        {
-            "rfxtrx": {
-                "device": "abcd",
-                "devices": {"1234567890": {}},
-            }
-        },
-    )
+    entry_data = RFXTRX_DATA.copy()
+    entry_data["devices"] = {"1234567890": {"signal_repetitions": 1}}
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     conf_entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -7,7 +7,7 @@ from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
-from tests.components.rfxtrx.conftest import RFXTRX_DATA
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 EVENT_RFY_ENABLE_SUN_AUTO = "081a00000301010113"
 EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
@@ -15,8 +15,9 @@ EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
 
 async def test_one_switch(hass, rfxtrx):
     """Test with 1 switch."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -57,8 +58,9 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -71,12 +73,13 @@ async def test_state_restore(hass, rfxtrx, state):
 
 async def test_several_switches(hass, rfxtrx):
     """Test with 3 switches."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0b1100cd0213c7f230010f71": {"signal_repetitions": 1},
-        "0b1100100118cdea02010f70": {"signal_repetitions": 1},
-        "0b1100101118cdea02010f70": {"signal_repetitions": 1},
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1100cd0213c7f230010f71": {"signal_repetitions": 1},
+            "0b1100100118cdea02010f70": {"signal_repetitions": 1},
+            "0b1100101118cdea02010f70": {"signal_repetitions": 1},
+        }
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -103,10 +106,9 @@ async def test_several_switches(hass, rfxtrx):
 @pytest.mark.parametrize("repetitions", [1, 3])
 async def test_repetitions(hass, rfxtrx, repetitions):
     """Test signal repetitions."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {
-        "0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}
-    }
+    entry_data = create_rfx_test_cfg(
+        devices={"0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}}
+    )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -154,8 +156,7 @@ async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
 
 async def test_unknown_event_code(hass, rfxtrx):
     """Test with 3 switches."""
-    entry_data = RFXTRX_DATA.copy()
-    entry_data["devices"] = {"1234567890": {"signal_repetitions": 1}}
+    entry_data = create_rfx_test_cfg(devices={"1234567890": {"signal_repetitions": 1}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR targets a different branch that updates rfxtrx integration to have UI config/options (see #39117)

This PR implements connection validation when importing rfxtrx configuration. Furthermore tests are refactored to use `MockConfigEntry`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
