### PR TITLE
Add new Plex movie lookup method for media_player.play_media

### DIFF
--- a/homeassistant/components/plex/errors.py
+++ b/homeassistant/components/plex/errors.py
@@ -16,3 +16,7 @@ class ServerNotSpecified(PlexException):
 
 class ShouldUpdateConfigEntry(PlexException):
     """Config entry data is out of date and should be updated."""
+
+
+class MediaNotFound(PlexException):
+    """Media lookup failed for a given search query."""

--- a/homeassistant/components/plex/media_search.py
+++ b/homeassistant/components/plex/media_search.py
@@ -23,7 +23,7 @@ def lookup_movie(library_section, **kwargs):
         return None
 
     if not movies:
-        raise MediaNotFound(f"Movie {title}")
+        raise MediaNotFound(f"Movie {title}") from None
 
     if len(movies) > 1:
         exact_matches = [x for x in movies if x.title.lower() == title.lower()]
@@ -47,25 +47,25 @@ def lookup_tv(library_section, **kwargs):
     except KeyError:
         _LOGGER.error("Must specify 'show_name' for this search")
         return None
-    except NotFound:
-        raise MediaNotFound(f"Show {show_name}")
+    except NotFound as err:
+        raise MediaNotFound(f"Show {show_name}") from err
 
     if not season_number:
         return show
 
     try:
         season = show.season(int(season_number))
-    except NotFound:
-        raise MediaNotFound(f"Season {season_number} of {show_name}")
+    except NotFound as err:
+        raise MediaNotFound(f"Season {season_number} of {show_name}") from err
 
     if not episode_number:
         return season
 
     try:
         return season.episode(episode=int(episode_number))
-    except NotFound:
+    except NotFound as err:
         episode = f"S{str(season_number).zfill(2)}E{str(episode_number).zfill(2)}"
-        raise MediaNotFound(f"Episode {episode} of {show_name}")
+        raise MediaNotFound(f"Episode {episode} of {show_name}") from err
 
 
 def lookup_music(library_section, **kwargs):
@@ -80,22 +80,22 @@ def lookup_music(library_section, **kwargs):
     except KeyError:
         _LOGGER.error("Must specify 'artist_name' for this search")
         return None
-    except NotFound:
-        raise MediaNotFound(f"Artist {artist_name}")
+    except NotFound as err:
+        raise MediaNotFound(f"Artist {artist_name}") from err
 
     if album_name:
         try:
             album = artist.album(album_name)
-        except NotFound:
-            raise MediaNotFound(f"Album {album_name} by {artist_name}")
+        except NotFound as err:
+            raise MediaNotFound(f"Album {album_name} by {artist_name}") from err
 
         if track_name:
             try:
                 return album.track(track_name)
-            except NotFound:
+            except NotFound as err:
                 raise MediaNotFound(
                     f"Track {track_name} on {album_name} by {artist_name}"
-                )
+                ) from err
 
         if track_number:
             for track in album.tracks():
@@ -104,13 +104,13 @@ def lookup_music(library_section, **kwargs):
 
             raise MediaNotFound(
                 f"Track {track_number} on {album_name} by {artist_name}"
-            )
+            ) from None
         return album
 
     if track_name:
         try:
             return artist.get(track_name)
-        except NotFound:
-            raise MediaNotFound(f"Track {track_name} by {artist_name}")
+        except NotFound as err:
+            raise MediaNotFound(f"Track {track_name} by {artist_name}") from err
 
     return artist

--- a/homeassistant/components/plex/media_search.py
+++ b/homeassistant/components/plex/media_search.py
@@ -1,0 +1,116 @@
+"""Helper methods to search for Plex media."""
+import logging
+
+from plexapi.exceptions import BadRequest, NotFound
+
+from .errors import MediaNotFound
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def lookup_movie(library_section, **kwargs):
+    """Find a specific movie and return a Plex media object."""
+    try:
+        title = kwargs["title"]
+    except KeyError:
+        _LOGGER.error("Must specify 'title' for this search")
+        return None
+
+    try:
+        movies = library_section.search(**kwargs, libtype="movie", maxresults=3)
+    except BadRequest as err:
+        _LOGGER.error("Invalid search payload provided: %s", err)
+        return None
+
+    if not movies:
+        raise MediaNotFound(f"Movie {title}")
+
+    if len(movies) > 1:
+        exact_matches = [x for x in movies if x.title.lower() == title.lower()]
+        if len(exact_matches) == 1:
+            return exact_matches[0]
+        match_list = [f"{x.title} ({x.year})" for x in movies]
+        _LOGGER.warning("Multiple matches found during search: %s", match_list)
+        return None
+
+    return movies[0]
+
+
+def lookup_tv(library_section, **kwargs):
+    """Find TV media and return a Plex media object."""
+    season_number = kwargs.get("season_number")
+    episode_number = kwargs.get("episode_number")
+
+    try:
+        show_name = kwargs["show_name"]
+        show = library_section.get(show_name)
+    except KeyError:
+        _LOGGER.error("Must specify 'show_name' for this search")
+        return None
+    except NotFound:
+        raise MediaNotFound(f"Show {show_name}")
+
+    if not season_number:
+        return show
+
+    try:
+        season = show.season(int(season_number))
+    except NotFound:
+        raise MediaNotFound(f"Season {season_number} of {show_name}")
+
+    if not episode_number:
+        return season
+
+    try:
+        return season.episode(episode=int(episode_number))
+    except NotFound:
+        episode = f"S{str(season_number).zfill(2)}E{str(episode_number).zfill(2)}"
+        raise MediaNotFound(f"Episode {episode} of {show_name}")
+
+
+def lookup_music(library_section, **kwargs):
+    """Search for music and return a Plex media object."""
+    album_name = kwargs.get("album_name")
+    track_name = kwargs.get("track_name")
+    track_number = kwargs.get("track_number")
+
+    try:
+        artist_name = kwargs["artist_name"]
+        artist = library_section.get(artist_name)
+    except KeyError:
+        _LOGGER.error("Must specify 'artist_name' for this search")
+        return None
+    except NotFound:
+        raise MediaNotFound(f"Artist {artist_name}")
+
+    if album_name:
+        try:
+            album = artist.album(album_name)
+        except NotFound:
+            raise MediaNotFound(f"Album {album_name} by {artist_name}")
+
+        if track_name:
+            try:
+                return album.track(track_name)
+            except NotFound:
+                raise MediaNotFound(
+                    f"Track {track_name} on {album_name} by {artist_name}"
+                )
+
+        if track_number:
+            for track in album.tracks():
+                if int(track.index) == int(track_number):
+                    return track
+
+            raise MediaNotFound(
+                f"Track {track_number} on {album_name} by {artist_name}"
+            )
+        return album
+
+    if track_name:
+        try:
+            return artist.get(track_name)
+        except NotFound:
+            raise MediaNotFound(f"Track {track_name} by {artist_name}")
+
+    return artist

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -185,7 +185,7 @@ class PlexServer:
                         if _update_plexdirect_hostname():
                             config_entry_update_needed = True
                         else:
-                            raise Unauthorized(
+                            raise Unauthorized(  # pylint: disable=raise-missing-from
                                 "New certificate cannot be validated with provided token"
                             )
                     else:

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -518,8 +518,8 @@ class PlexServer:
                 except KeyError:
                     _LOGGER.error("Must specify 'video_name' for this search")
                     return None
-                except NotFound:
-                    raise MediaNotFound(f"Video {video_name}")
+                except NotFound as err:
+                    raise MediaNotFound(f"Video {video_name}") from err
         except MediaNotFound as failed_item:
             _LOGGER.error("%s not found in %s", failed_item, library_name)
             return None

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -185,7 +185,7 @@ class PlexServer:
                         if _update_plexdirect_hostname():
                             config_entry_update_needed = True
                         else:
-                            raise Unauthorized(  # pylint: disable=raise-missing-from
+                            raise Unauthorized(
                                 "New certificate cannot be validated with provided token"
                             )
                     else:
@@ -630,7 +630,7 @@ class PlexServer:
                 if len(exact_matches) == 1:
                     return exact_matches[0]
                 match_list = [f"{x.title} ({x.year})" for x in movies]
-                _LOGGER.warning("Multiple matches found during search:", match_list)
+                _LOGGER.warning("Multiple matches found during search: %s", match_list)
                 return None
 
             return movies[0]

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -614,7 +614,8 @@ class PlexServer:
             except BadRequest as err:
                 _LOGGER.error("Invalid search payload provided: %s", err)
                 return None
-            except NotFound:
+
+            if not movies:
                 _LOGGER.error(
                     "Movie '%s' not found in '%s'",
                     kwargs["title"],

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -398,6 +398,11 @@ class MockPlexLibrarySection:
         """Mock the key identifier property."""
         return str(id(self.title))
 
+    def search(self, **kwargs):
+        """Mock the LibrarySection search method."""
+        if kwargs.get("libtype") == "movie":
+            return self.all()
+
     def update(self):
         """Mock the update call."""
         pass
@@ -406,11 +411,12 @@ class MockPlexLibrarySection:
 class MockPlexMediaItem:
     """Mock a Plex Media instance."""
 
-    def __init__(self, title, mediatype="video"):
+    def __init__(self, title, mediatype="video", year=2020):
         """Initialize the object."""
         self.title = str(title)
         self.type = mediatype
         self.thumbUrl = "http://1.2.3.4/thumb.png"
+        self.year = year
         self._children = []
 
     def __iter__(self):

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -1,7 +1,7 @@
 """Tests for Plex server."""
 import copy
 
-from plexapi.exceptions import NotFound
+from plexapi.exceptions import BadRequest, NotFound
 from requests.exceptions import RequestException
 
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
@@ -9,6 +9,7 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     MEDIA_TYPE_EPISODE,
+    MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_PLAYLIST,
     MEDIA_TYPE_VIDEO,
@@ -32,6 +33,7 @@ from .mock_classes import (
     MockPlexArtist,
     MockPlexLibrary,
     MockPlexLibrarySection,
+    MockPlexMediaItem,
     MockPlexSeason,
     MockPlexServer,
     MockPlexShow,
@@ -454,7 +456,7 @@ async def test_media_lookups(hass):
             is None
         )
 
-    # Movie searches
+    # Legacy Movie searches
     assert loaded_server.lookup_media(MEDIA_TYPE_VIDEO, video_name="Movie") is None
     assert loaded_server.lookup_media(MEDIA_TYPE_VIDEO, library_name="Movies") is None
     assert loaded_server.lookup_media(
@@ -467,3 +469,47 @@ async def test_media_lookups(hass):
             )
             is None
         )
+
+    # Movie searches
+    assert loaded_server.lookup_media(MEDIA_TYPE_MOVIE, title="Movie") is None
+    assert loaded_server.lookup_media(MEDIA_TYPE_MOVIE, library_name="Movies") is None
+    assert loaded_server.lookup_media(
+        MEDIA_TYPE_MOVIE, library_name="Movies", title="Movie"
+    )
+    with patch.object(MockPlexLibrarySection, "search", side_effect=BadRequest):
+        assert (
+            loaded_server.lookup_media(
+                MEDIA_TYPE_MOVIE, library_name="Movies", title="Not a Movie"
+            )
+            is None
+        )
+    with patch.object(MockPlexLibrarySection, "search", side_effect=NotFound):
+        assert (
+            loaded_server.lookup_media(
+                MEDIA_TYPE_MOVIE, library_name="Movies", title="Not a Movie"
+            )
+            is None
+        )
+
+    similar_movies = []
+    for title in "Duplicate Movie", "Duplicate Movie 2":
+        similar_movies.append(MockPlexMediaItem(title))
+    with patch.object(
+        loaded_server.library.section("Movies"), "search", return_value=similar_movies
+    ):
+        found_media = loaded_server.lookup_media(
+            MEDIA_TYPE_MOVIE, library_name="Movies", title="Duplicate Movie"
+        )
+    assert found_media.title == "Duplicate Movie"
+
+    duplicate_movies = []
+    for title in "Duplicate Movie - Original", "Duplicate Movie - Remake":
+        duplicate_movies.append(MockPlexMediaItem(title))
+    with patch.object(
+        loaded_server.library.section("Movies"), "search", return_value=duplicate_movies
+    ):
+        assert (
+            loaded_server.lookup_media(
+                MEDIA_TYPE_MOVIE, library_name="Movies", title="Duplicate Movie"
+            )
+        ) is None

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -483,7 +483,7 @@ async def test_media_lookups(hass):
             )
             is None
         )
-    with patch.object(MockPlexLibrarySection, "search", side_effect=NotFound):
+    with patch.object(MockPlexLibrarySection, "search", return_value=[]):
         assert (
             loaded_server.lookup_media(
                 MEDIA_TYPE_MOVIE, library_name="Movies", title="Not a Movie"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on a discussion in https://community.home-assistant.io/t/plex-media-content-id-looks-like-it-only-supports-video-right-now/218805.

The old method to find specific movies in the `media_player.play_media` service relied on an exact match of the movie's title. This worked for many cases, but does not account for movies that share a title, such as remakes. This PR adds explicit handling for `MEDIA_TYPE_MOVIE` for movies (instead of the old `MEDIA_TYPE_VIDEO`). In addition to searching with `title` (with partial matching), it now allows more powerful searching with the following optional keys:
* `unwatched`: Restrict search to unwatched items only (True, False)
* `actor`: Restrict search for movies that include a specific actor
* `collection`: Restrict search within a named Plex collection
* `contentRating`: Restrict search to a specific content rating ("PG", "R")
* `country`: Restrict search to a specific country of origin
* `decade`: Restrict search to a specific decade ("1960", "2010")
* `director`: Restrict search to a specific director
* `genre`: Restrict search to a specific genre ("Animation", "Drama", "Sci-Fi")
* `resolution`: Restrict search to a specific video resolution (480, 720, 1080, "4k")
* `year`: Restrict search to a specific year

The behavior should be similar to the legacy method when only the `title` key is provided. If there are multiple matches, these will be described in the log.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14378

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
