### PR TITLE
Add Config Flow to bmw_connected_drive

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -102,7 +102,15 @@ omit =
     homeassistant/components/bme280/sensor.py
     homeassistant/components/bme680/sensor.py
     homeassistant/components/bmp280/sensor.py
-    homeassistant/components/bmw_connected_drive/*
+    homeassistant/components/bmw_connected_drive/__init__.py
+    homeassistant/components/bmw_connected_drive/binary_sensor.py
+    homeassistant/components/bmw_connected_drive/device_tracker.py
+    homeassistant/components/bmw_connected_drive/lock.py
+    homeassistant/components/bmw_connected_drive/notify.py
+    homeassistant/components/bmw_connected_drive/sensor.py
+    homeassistant/components/bom/camera.py
+    homeassistant/components/bom/sensor.py
+    homeassistant/components/bom/weather.py
     homeassistant/components/braviatv/__init__.py
     homeassistant/components/braviatv/const.py
     homeassistant/components/braviatv/media_player.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -108,9 +108,6 @@ omit =
     homeassistant/components/bmw_connected_drive/lock.py
     homeassistant/components/bmw_connected_drive/notify.py
     homeassistant/components/bmw_connected_drive/sensor.py
-    homeassistant/components/bom/camera.py
-    homeassistant/components/bom/sensor.py
-    homeassistant/components/bom/weather.py
     homeassistant/components/braviatv/__init__.py
     homeassistant/components/braviatv/const.py
     homeassistant/components/braviatv/media_player.py

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -197,8 +197,10 @@ def setup_account(entry: ConfigEntry, hass, name: str) -> "BMWConnectedDriveAcco
         vin = call.data[ATTR_VIN]
         vehicle = None
         # Double check for read_only accounts as another account could create the services
-        for account in filter(lambda account: not account.read_only, hass.data[DOMAIN]):
-            vehicle = account.get_vehicle(vin)
+        for entity in filter(
+            lambda entity: not entity.read_only, hass.data[DOMAIN].values()
+        ):
+            vehicle = entity.account.get_vehicle(vin)
         if not vehicle:
             _LOGGER.error("Could not find a vehicle for VIN %s", vin)
             return

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -1,29 +1,36 @@
 """Reads vehicle status from BMW connected drive portal."""
+import asyncio
 import logging
+import weakref
 
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.country_selector import get_region_from_name
 import voluptuous as vol
 
+from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+
+from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY, CONF_REGION, CONF_USE_LOCATION
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "bmw_connected_drive"
-CONF_REGION = "region"
-CONF_READ_ONLY = "read_only"
 ATTR_VIN = "vin"
 
 ACCOUNT_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_REGION): vol.Any("north_america", "china", "rest_of_world"),
-        vol.Optional(CONF_READ_ONLY, default=False): cv.boolean,
+        vol.Required(CONF_REGION): vol.In(CONF_ALLOWED_REGIONS),
+        vol.Optional(CONF_READ_ONLY): cv.boolean,
     }
 )
 
@@ -45,48 +52,155 @@ _SERVICE_MAP = {
 }
 
 
-def setup(hass, config: dict):
-    """Set up the BMW connected drive components."""
-    accounts = []
-    for name, account_config in config[DOMAIN].items():
-        accounts.append(setup_account(account_config, hass, name))
-
-    hass.data[DOMAIN] = accounts
-
-    def _update_all(call) -> None:
-        """Update all BMW accounts."""
-        for cd_account in hass.data[DOMAIN]:
-            cd_account.update()
-
-    # Service to manually trigger updates for all accounts.
-    hass.services.register(DOMAIN, SERVICE_UPDATE_STATE, _update_all)
-
-    _update_all(None)
-
-    for component in BMW_COMPONENTS:
-        discovery.load_platform(hass, component, DOMAIN, {}, config)
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the BMW Connected Drive component from configuration.yaml."""
+    if DOMAIN in config:
+        for entry_config in list(config[DOMAIN].values()):
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": "import"}, data=entry_config
+                )
+            )
 
     return True
 
 
-def setup_account(account_config: dict, hass, name: str) -> "BMWConnectedDriveAccount":
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up BMW Connected Drive from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    # Convert data to dict to remove settings that are now stored as options
+    entry.data = dict(entry.data)
+    default_options = {
+        CONF_READ_ONLY: entry.data.pop(CONF_READ_ONLY, False),
+        CONF_USE_LOCATION: False,
+    }
+
+    # Create options based on user input if no options are stored
+    if list(entry.options) != list(default_options):
+        default_options.update(entry.options)
+        entry.options = default_options
+        hass.config_entries.async_update_entry(entry, options=entry.options)
+
+    try:
+        account = await hass.async_add_executor_job(
+            setup_account, entry, hass, entry.data[CONF_USERNAME]
+        )
+        await hass.async_add_executor_job(account.update)
+    except Exception:
+        raise ConfigEntryNotReady
+
+    hass.data[DOMAIN][entry.entry_id] = account
+
+    async def _async_update_all(service_call=None):
+        """Update all BMW accounts."""
+        await hass.async_add_executor_job(_update_all)
+
+        return True
+
+    def _update_all() -> None:
+        """Update all BMW accounts."""
+        for cd_account in list(hass.data[DOMAIN].values()):
+            cd_account.update()
+
+    # Add update listener for config entry changes (options)
+    if weakref.ref(update_listener) not in entry.update_listeners:
+        entry.add_update_listener(update_listener)
+
+    # Service to manually trigger updates for all accounts.
+    hass.services.async_register(DOMAIN, SERVICE_UPDATE_STATE, _async_update_all)
+
+    await _async_update_all()
+
+    for platform in BMW_COMPONENTS:
+        if platform != "notify":
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(entry, platform)
+            )
+
+    hass.async_create_task(
+        discovery.async_load_platform(hass, "notify", DOMAIN, {}, entry.data)
+    )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in BMW_COMPONENTS
+                if component != "notify"
+            ]
+        )
+    )
+
+    # Only remove services if it is the last account and not read only
+    if len(hass.data[DOMAIN]) == 1 and not hass.data[DOMAIN][entry.entry_id].read_only:
+        services = list(_SERVICE_MAP) + [SERVICE_UPDATE_STATE]
+        unload_services = all(
+            await asyncio.gather(
+                *[
+                    hass.async_add_executor_job(hass.services.remove, DOMAIN, service)
+                    for service in services
+                ]
+            )
+        )
+    else:
+        unload_services = True
+
+    # Remove notify services
+    unload_notify = unload_services = all(
+        await asyncio.gather(
+            *[
+                hass.async_add_executor_job(
+                    hass.services.remove,
+                    NOTIFY_DOMAIN,
+                    slugify(f"{DOMAIN}_{vehicle.name}"),
+                )
+                for vehicle in hass.data[DOMAIN][entry.entry_id].account.vehicles
+            ]
+        )
+    )
+
+    if all([unload_ok, unload_services, unload_notify]):
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok
+
+
+async def update_listener(hass, config_entry):
+    """Handle options update."""
+    await hass.config_entries.async_reload(config_entry.entry_id)
+
+
+def setup_account(entry: ConfigEntry, hass, name: str) -> "BMWConnectedDriveAccount":
     """Set up a new BMWConnectedDriveAccount based on the config."""
-    username = account_config[CONF_USERNAME]
-    password = account_config[CONF_PASSWORD]
-    region = account_config[CONF_REGION]
-    read_only = account_config[CONF_READ_ONLY]
+    username = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+    region = entry.data[CONF_REGION]
+    read_only = entry.options[CONF_READ_ONLY]
+    use_location = entry.options[CONF_USE_LOCATION]
 
     _LOGGER.debug("Adding new account %s", name)
-    cd_account = BMWConnectedDriveAccount(username, password, region, name, read_only)
+
+    pos = (
+        (hass.config.latitude, hass.config.longitude) if use_location else (None, None)
+    )
+    cd_account = BMWConnectedDriveAccount(
+        username, password, region, name, read_only, pos[0], pos[1]
+    )
 
     def execute_service(call):
-        """Execute a service for a vehicle.
-
-        This must be a member function as we need access to the cd_account
-        object here.
-        """
+        """Execute a service for a vehicle."""
         vin = call.data[ATTR_VIN]
-        vehicle = cd_account.account.get_vehicle(vin)
+        vehicle = None
+        # Double check for read_only accounts as another account could create the services
+        for account in [
+            account for account in hass.data[DOMAIN] if not account.read_only
+        ]:
+            vehicle = account.get_vehicle(vin)
         if not vehicle:
             _LOGGER.error("Could not find a vehicle for VIN %s", vin)
             return
@@ -118,7 +232,14 @@ class BMWConnectedDriveAccount:
     """Representation of a BMW vehicle."""
 
     def __init__(
-        self, username: str, password: str, region_str: str, name: str, read_only
+        self,
+        username: str,
+        password: str,
+        region_str: str,
+        name: str,
+        read_only: bool,
+        lat=None,
+        lon=None,
     ) -> None:
         """Initialize account."""
         region = get_region_from_name(region_str)
@@ -127,6 +248,12 @@ class BMWConnectedDriveAccount:
         self.account = ConnectedDriveAccount(username, password, region)
         self.name = name
         self._update_listeners = []
+
+        # Set observer position once for older cars to be in range for
+        # GPS position (pre-7/2014, <2km) and get new data from API
+        if lat and lon:
+            self.account.set_observer_position(lat, lon)
+            self.account.update_vehicle_states()
 
     def update(self, *_):
         """Update the state of all vehicles.

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -320,7 +320,6 @@ class BMWConnectedDriveBaseEntity(Entity):
         """Return info for device registry."""
         return {
             "identifiers": {(DOMAIN, self._vehicle.vin)},
-            "sw_version": self._vehicle.vin,
             "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
             "model": self._vehicle.name,
             "manufacturer": self._vehicle.attributes.get("brand"),

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -87,8 +87,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             setup_account, entry, hass, entry.data[CONF_USERNAME]
         )
         await hass.async_add_executor_job(account.update)
-    except Exception:
-        raise ConfigEntryNotReady
+    except Exception as ex:
+        raise ConfigEntryNotReady from ex
 
     hass.data[DOMAIN][entry.entry_id] = account
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -1,16 +1,15 @@
 """Reads vehicle status from BMW connected drive portal."""
 import asyncio
 import logging
-import weakref
 
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.country_selector import get_region_from_name
 import voluptuous as vol
 
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
@@ -19,7 +18,13 @@ from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY, CONF_REGION, CONF_USE_LOCATION
+from .const import (
+    CONF_ACCOUNT,
+    CONF_ALLOWED_REGIONS,
+    CONF_READ_ONLY,
+    CONF_REGION,
+    CONF_USE_LOCATION,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +44,10 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: {cv.string: ACCOUNT_SCHEMA}}, extra=vol.ALLO
 
 SERVICE_SCHEMA = vol.Schema({vol.Required(ATTR_VIN): cv.string})
 
+DEFAULT_OPTIONS = {
+    CONF_READ_ONLY: False,
+    CONF_USE_LOCATION: False,
+}
 
 BMW_PLATFORMS = ["binary_sensor", "device_tracker", "lock", "notify", "sensor"]
 UPDATE_INTERVAL = 5  # in minutes
@@ -52,46 +61,47 @@ _SERVICE_MAP = {
     "find_vehicle": "trigger_remote_vehicle_finder",
 }
 
+UNDO_UPDATE_LISTENER = "undo_update_listener"
+
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the BMW Connected Drive component from configuration.yaml."""
     if DOMAIN in config:
-        for entry_config in list(config[DOMAIN].values()):
+        for entry_config in config[DOMAIN].values():
             hass.async_create_task(
                 hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": "import"}, data=entry_config
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry_config
                 )
             )
 
     return True
 
 
+@callback
+def _async_migrate_options_from_data_if_missing(hass, entry):
+    data = dict(entry.data)
+    options = DEFAULT_OPTIONS.copy()
+
+    if CONF_READ_ONLY in data or list(options) != list(DEFAULT_OPTIONS):
+        options[CONF_READ_ONLY] = data.pop(CONF_READ_ONLY, False)
+
+        options.update(dict(entry.options))
+
+        hass.config_entries.async_update_entry(entry, data=data, options=options)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up BMW Connected Drive from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    # Convert data to dict to remove settings that are now stored as options
-    entry.data = dict(entry.data)
-    default_options = {
-        CONF_READ_ONLY: entry.data.pop(CONF_READ_ONLY, False),
-        CONF_USE_LOCATION: False,
-    }
-
-    # Create options based on user input if no options are stored
-    if list(entry.options) != list(default_options):
-        default_options.update(entry.options)
-        entry.options = default_options
-        hass.config_entries.async_update_entry(entry, options=entry.options)
+    _async_migrate_options_from_data_if_missing(hass, entry)
 
     try:
         account = await hass.async_add_executor_job(
             setup_account, entry, hass, entry.data[CONF_USERNAME]
         )
-        await hass.async_add_executor_job(account.update)
-    except Exception as ex:
+    except OSError as ex:
         raise ConfigEntryNotReady from ex
-
-    hass.data[DOMAIN][entry.entry_id] = account
 
     async def _async_update_all(service_call=None):
         """Update all BMW accounts."""
@@ -101,12 +111,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     def _update_all() -> None:
         """Update all BMW accounts."""
-        for cd_account in hass.data[DOMAIN].values():
-            cd_account.update()
+        for entry in hass.data[DOMAIN].values():
+            entry[CONF_ACCOUNT].update()
 
     # Add update listener for config entry changes (options)
-    if weakref.ref(update_listener) not in entry.update_listeners:
-        entry.add_update_listener(update_listener)
+    undo_listener = entry.add_update_listener(update_listener)
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        CONF_ACCOUNT: account,
+        UNDO_UPDATE_LISTENER: undo_listener,
+    }
 
     # Service to manually trigger updates for all accounts.
     hass.services.async_register(DOMAIN, SERVICE_UPDATE_STATE, _async_update_all)
@@ -139,35 +153,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     # Only remove services if it is the last account and not read only
-    if len(hass.data[DOMAIN]) == 1 and not hass.data[DOMAIN][entry.entry_id].read_only:
+    if (
+        len(hass.data[DOMAIN]) == 1
+        and not hass.data[DOMAIN][entry.entry_id][CONF_ACCOUNT].read_only
+    ):
         services = list(_SERVICE_MAP) + [SERVICE_UPDATE_STATE]
-        unload_services = all(
-            await asyncio.gather(
-                *[
-                    hass.async_add_executor_job(hass.services.remove, DOMAIN, service)
-                    for service in services
-                ]
-            )
-        )
-    else:
-        unload_services = True
+        for service in services:
+            hass.services.async_remove(DOMAIN, service)
 
-    # Remove notify services
-    unload_notify = all(
-        await asyncio.gather(
-            *[
-                hass.async_add_executor_job(
-                    hass.services.remove,
-                    NOTIFY_DOMAIN,
-                    slugify(f"{DOMAIN}_{vehicle.name}"),
-                )
-                for vehicle in hass.data[DOMAIN][entry.entry_id].account.vehicles
-            ]
-        )
-    )
+    for vehicle in hass.data[DOMAIN][entry.entry_id][CONF_ACCOUNT].account.vehicles:
+        hass.services.async_remove(NOTIFY_DOMAIN, slugify(f"{DOMAIN}_{vehicle.name}"))
 
-    if all([unload_ok, unload_services, unload_notify]):
+    if unload_ok:
+        hass.data[DOMAIN][entry.entry_id][UNDO_UPDATE_LISTENER]()
         hass.data[DOMAIN].pop(entry.entry_id)
+
     return unload_ok
 
 
@@ -199,9 +199,10 @@ def setup_account(entry: ConfigEntry, hass, name: str) -> "BMWConnectedDriveAcco
         vehicle = None
         # Double check for read_only accounts as another account could create the services
         for entity in filter(
-            lambda entity: not entity.read_only, hass.data[DOMAIN].values()
+            lambda entity: not entity[CONF_ACCOUNT].read_only,
+            hass.data[DOMAIN].values(),
         ):
-            vehicle = entity.account.get_vehicle(vin)
+            vehicle = entity[CONF_ACCOUNT].account.get_vehicle(vin)
         if not vehicle:
             _LOGGER.error("Could not find a vehicle for VIN %s", vin)
             return
@@ -225,6 +226,9 @@ def setup_account(entry: ConfigEntry, hass, name: str) -> "BMWConnectedDriveAcco
         minute=range(now.minute % UPDATE_INTERVAL, 60, UPDATE_INTERVAL),
         second=now.second,
     )
+
+    # Initialize
+    cd_account.update()
 
     return cd_account
 
@@ -300,6 +304,14 @@ class BMWConnectedDriveBaseEntity(Entity):
             "model": self._vehicle.name,
             "manufacturer": self._vehicle.attributes.get("brand"),
         }
+
+    @property
+    def should_poll(self):
+        """Do not poll this class.
+
+        Updates are triggered from BMWConnectedDriveAccount.
+        """
+        return False
 
     def update_callback(self):
         """Schedule a state update."""

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -66,15 +66,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWConnectedDriveSensor(BinarySensorEntity, BMWConnectedDriveBaseEntity):
+class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, BinarySensorEntity):
     """Representation of a BMW vehicle binary sensor."""
 
     def __init__(
         self, account, vehicle, attribute: str, sensor_name, device_class, icon
     ):
         """Initialize sensor."""
-        self._account = account
-        self._vehicle = vehicle
+        super().__init__(account, vehicle)
+
         self._attribute = attribute
         self._name = f"{self._vehicle.name} {self._attribute}"
         self._unique_id = f"{self._vehicle.vin}-{self._attribute}"

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import LENGTH_KILOMETERS
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import CONF_ACCOUNT
+from .const import CONF_ACCOUNT, DATA_ENTRIES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ SENSOR_TYPES_ELEC.update(SENSOR_TYPES)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the BMW ConnectedDrive binary sensors from config entry."""
-    account = hass.data[BMW_DOMAIN][config_entry.entry_id][CONF_ACCOUNT]
+    account = hass.data[BMW_DOMAIN][DATA_ENTRIES][config_entry.entry_id][CONF_ACCOUNT]
     entities = []
 
     for vehicle in account.account.vehicles:

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -41,30 +41,29 @@ SENSOR_TYPES_ELEC = {
 SENSOR_TYPES_ELEC.update(SENSOR_TYPES)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the BMW sensors."""
-    accounts = hass.data[BMW_DOMAIN]
-    _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the BMW ConnectedDrive binary sensors from config entry."""
+    account = hass.data[BMW_DOMAIN][config_entry.entry_id]
     devices = []
-    for account in accounts:
-        for vehicle in account.account.vehicles:
-            if vehicle.has_hv_battery:
-                _LOGGER.debug("BMW with a high voltage battery")
-                for key, value in sorted(SENSOR_TYPES_ELEC.items()):
-                    if key in vehicle.available_attributes:
-                        device = BMWConnectedDriveSensor(
-                            account, vehicle, key, value[0], value[1], value[2]
-                        )
-                        devices.append(device)
-            elif vehicle.has_internal_combustion_engine:
-                _LOGGER.debug("BMW with an internal combustion engine")
-                for key, value in sorted(SENSOR_TYPES.items()):
-                    if key in vehicle.available_attributes:
-                        device = BMWConnectedDriveSensor(
-                            account, vehicle, key, value[0], value[1], value[2]
-                        )
-                        devices.append(device)
-    add_entities(devices, True)
+
+    for vehicle in account.account.vehicles:
+        if vehicle.has_hv_battery:
+            _LOGGER.debug("BMW with a high voltage battery")
+            for key, value in sorted(SENSOR_TYPES_ELEC.items()):
+                if key in vehicle.available_attributes:
+                    device = BMWConnectedDriveSensor(
+                        account, vehicle, key, value[0], value[1], value[2]
+                    )
+                    devices.append(device)
+        elif vehicle.has_internal_combustion_engine:
+            _LOGGER.debug("BMW with an internal combustion engine")
+            for key, value in sorted(SENSOR_TYPES.items()):
+                if key in vehicle.available_attributes:
+                    device = BMWConnectedDriveSensor(
+                        account, vehicle, key, value[0], value[1], value[2]
+                    )
+                    devices.append(device)
+    async_add_entities(devices, True)
 
 
 class BMWConnectedDriveSensor(BinarySensorEntity):
@@ -83,6 +82,17 @@ class BMWConnectedDriveSensor(BinarySensorEntity):
         self._device_class = device_class
         self._icon = icon
         self._state = None
+
+    @property
+    def device_info(self) -> dict:
+        """Return info for device registry."""
+        return {
+            "identifiers": {(BMW_DOMAIN, self._vehicle.vin)},
+            "sw_version": self._vehicle.vin,
+            "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
+            "model": self._vehicle.name,
+            "manufacturer": self._vehicle.attributes.get("brand"),
+        }
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -9,10 +9,10 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_PROBLEM,
     BinarySensorEntity,
 )
-from homeassistant.const import ATTR_ATTRIBUTION, LENGTH_KILOMETERS
+from homeassistant.const import LENGTH_KILOMETERS
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import ATTRIBUTION, CONF_ACCOUNT
+from .const import CONF_ACCOUNT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -112,10 +112,7 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, BinarySensorEntity):
     def device_state_attributes(self):
         """Return the state attributes of the binary sensor."""
         vehicle_state = self._vehicle.state
-        result = {
-            "car": self._vehicle.name,
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-        }
+        result = self._attrs.copy()
 
         if self._attribute == "lids":
             for lid in vehicle_state.lids:

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import ATTR_ATTRIBUTION, LENGTH_KILOMETERS
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import ATTRIBUTION
+from .const import ATTRIBUTION, CONF_ACCOUNT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,8 +43,8 @@ SENSOR_TYPES_ELEC.update(SENSOR_TYPES)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the BMW ConnectedDrive binary sensors from config entry."""
-    account = hass.data[BMW_DOMAIN][config_entry.entry_id]
-    devices = []
+    account = hass.data[BMW_DOMAIN][config_entry.entry_id][CONF_ACCOUNT]
+    entities = []
 
     for vehicle in account.account.vehicles:
         if vehicle.has_hv_battery:
@@ -54,7 +54,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     device = BMWConnectedDriveSensor(
                         account, vehicle, key, value[0], value[1], value[2]
                     )
-                    devices.append(device)
+                    entities.append(device)
         elif vehicle.has_internal_combustion_engine:
             _LOGGER.debug("BMW with an internal combustion engine")
             for key, value in sorted(SENSOR_TYPES.items()):
@@ -62,8 +62,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     device = BMWConnectedDriveSensor(
                         account, vehicle, key, value[0], value[1], value[2]
                     )
-                    devices.append(device)
-    async_add_entities(devices, True)
+                    entities.append(device)
+    async_add_entities(entities, True)
 
 
 class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, BinarySensorEntity):
@@ -82,14 +82,6 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, BinarySensorEntity):
         self._device_class = device_class
         self._icon = icon
         self._state = None
-
-    @property
-    def should_poll(self) -> bool:
-        """Return False.
-
-        Data update is triggered from BMWConnectedDriveEntity.
-        """
-        return False
 
     @property
     def unique_id(self):

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import ATTR_ATTRIBUTION, LENGTH_KILOMETERS
 
-from . import DOMAIN as BMW_DOMAIN
+from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
 from .const import ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWConnectedDriveSensor(BinarySensorEntity):
+class BMWConnectedDriveSensor(BinarySensorEntity, BMWConnectedDriveBaseEntity):
     """Representation of a BMW vehicle binary sensor."""
 
     def __init__(
@@ -82,17 +82,6 @@ class BMWConnectedDriveSensor(BinarySensorEntity):
         self._device_class = device_class
         self._icon = icon
         self._state = None
-
-    @property
-    def device_info(self) -> dict:
-        """Return info for device registry."""
-        return {
-            "identifiers": {(BMW_DOMAIN, self._vehicle.vin)},
-            "sw_version": self._vehicle.vin,
-            "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
-            "model": self._vehicle.name,
-            "manufacturer": self._vehicle.attributes.get("brand"),
-        }
 
     @property
     def should_poll(self) -> bool:
@@ -215,14 +204,3 @@ class BMWConnectedDriveSensor(BinarySensorEntity):
                 f"{service_type} distance"
             ] = f"{distance} {self.hass.config.units.length_unit}"
         return result
-
-    def update_callback(self):
-        """Schedule a state update."""
-        self.schedule_update_ha_state(True)
-
-    async def async_added_to_hass(self):
-        """Add callback after being added to hass.
-
-        Show latest data after startup.
-        """
-        self._account.add_update_listener(self.update_callback)

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -47,10 +47,10 @@ async def validate_input(hass: core.HomeAssistant, data):
             setup_account, entry, hass, entry.data[CONF_USERNAME]
         )
         await hass.async_add_executor_job(account.update)
-    except OSError:
-        raise InvalidAuth
-    except Exception:
-        raise CannotConnect
+    except OSError as ex:
+        raise InvalidAuth from ex
+    except Exception as ex:
+        raise CannotConnect from ex
 
     # Return info that you want to store in the config entry.
     return {"title": f"{data[CONF_USERNAME]}{data.get(CONF_SOURCE, '')}"}

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -1,0 +1,142 @@
+"""Config flow for BMW ConnectedDrive integration."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_PASSWORD, CONF_SOURCE, CONF_USERNAME
+from homeassistant.core import callback
+
+from . import DOMAIN, setup_account
+from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY, CONF_REGION, CONF_USE_LOCATION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_REGION): vol.In(CONF_ALLOWED_REGIONS),
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+
+    entry = config_entries.ConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        title=data[CONF_USERNAME],
+        data=data,
+        source=config_entries.SOURCE_IGNORE,
+        connection_class=config_entries.CONN_CLASS_CLOUD_POLL,
+        options={
+            CONF_READ_ONLY: data.get(CONF_READ_ONLY, False),
+            CONF_USE_LOCATION: False,
+        },
+        system_options={},
+    )
+
+    try:
+        account = await hass.async_add_executor_job(
+            setup_account, entry, hass, entry.data[CONF_USERNAME]
+        )
+        await hass.async_add_executor_job(account.update)
+    except OSError:
+        raise InvalidAuth
+    except Exception:
+        raise CannotConnect
+
+    # Return info that you want to store in the config entry.
+    return {"title": f"{data[CONF_USERNAME]}{data.get(CONF_SOURCE, '')}"}
+
+
+class BMWConnectedDriveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for BMW ConnectedDrive."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            unique_id = f"{user_input[CONF_REGION]}-{user_input[CONF_USERNAME]}"
+
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
+
+            try:
+                info = await validate_input(self.hass, user_input)
+                # pylint: disable=no-member
+                if self.context[CONF_SOURCE] == config_entries.SOURCE_IMPORT:
+                    info["title"] = f"{info['title']} (configuration.yaml)"
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, user_input):
+        """Handle import."""
+        return await self.async_step_user(user_input)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Return a BWM ConnectedDrive option flow."""
+        return BMWConnectedDriveOptionsFlow(config_entry)
+
+
+class BMWConnectedDriveOptionsFlow(config_entries.OptionsFlow):
+    """Handle a option flow for BMW ConnectedDrive."""
+
+    def __init__(self, config_entry):
+        """Initialize BMW ConnectedDrive option flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        return await self.async_step_account_options()
+
+    async def async_step_account_options(self, user_input=None):
+        """Handle the initial step."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+        return self.async_show_form(
+            step_id="account_options",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_READ_ONLY,
+                        default=self.config_entry.options.get(CONF_READ_ONLY, False),
+                    ): bool,
+                    vol.Optional(
+                        CONF_USE_LOCATION,
+                        default=self.config_entry.options.get(CONF_USE_LOCATION, False),
+                    ): bool,
+                }
+            ),
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_SOURCE, CONF_USERNAME
 from homeassistant.core import callback
 
-from . import DOMAIN
+from . import DOMAIN  # pylint: disable=unused-import
 from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY, CONF_REGION, CONF_USE_LOCATION
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -37,8 +37,6 @@ async def validate_input(hass: core.HomeAssistant, data):
             get_region_from_name(data[CONF_REGION]),
         )
     except OSError as ex:
-        raise InvalidAuth from ex
-    except Exception as ex:
         raise CannotConnect from ex
 
     # Return info that you want to store in the config entry.
@@ -65,8 +63,6 @@ class BMWConnectedDriveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                errors["base"] = "invalid_auth"
 
             if info:
                 return self.async_create_entry(title=info["title"], data=user_input)
@@ -121,7 +117,3 @@ class BMWConnectedDriveOptionsFlow(config_entries.OptionsFlow):
 
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(exceptions.HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -69,10 +69,6 @@ class BMWConnectedDriveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_auth"
 
             if info:
-                # pylint: disable=no-member
-                if self.context[CONF_SOURCE] == config_entries.SOURCE_IMPORT:
-                    info["title"] = f"{info['title']} (configuration.yaml)"
-
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -1,2 +1,7 @@
 """Const file for the BMW Connected Drive integration."""
 ATTRIBUTION = "Data provided by BMW Connected Drive"
+
+CONF_REGION = "region"
+CONF_ALLOWED_REGIONS = ["china", "north_america", "rest_of_world"]
+CONF_READ_ONLY = "read_only"
+CONF_USE_LOCATION = "use_location"

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -7,3 +7,6 @@ CONF_READ_ONLY = "read_only"
 CONF_USE_LOCATION = "use_location"
 
 CONF_ACCOUNT = "account"
+
+DATA_HASS_CONFIG = "hass_config"
+DATA_ENTRIES = "entries"

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -5,3 +5,5 @@ CONF_REGION = "region"
 CONF_ALLOWED_REGIONS = ["china", "north_america", "rest_of_world"]
 CONF_READ_ONLY = "read_only"
 CONF_USE_LOCATION = "use_location"
+
+CONF_ACCOUNT = "account"

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -32,7 +32,9 @@ class BMWDeviceTracker(TrackerEntity):
         self._account = account
         self._vehicle = vehicle
         self._unique_id = vehicle.vin
-        self._location = vehicle.state.gps_position
+        self._location = (
+            vehicle.state.gps_position if vehicle.state.gps_position else (None, None)
+        )
         self._name = vehicle.name
 
     @property

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -1,51 +1,101 @@
 """Device tracker for BMW Connected Drive vehicles."""
 import logging
 
-from homeassistant.util import slugify
+from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
 
 from . import DOMAIN as BMW_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_scanner(hass, config, see, discovery_info=None):
-    """Set up the BMW tracker."""
-    accounts = hass.data[BMW_DOMAIN]
-    _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
-    for account in accounts:
-        for vehicle in account.account.vehicles:
-            tracker = BMWDeviceTracker(see, vehicle)
-            account.add_update_listener(tracker.update)
-            tracker.update()
-    return True
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the BMW ConnectedDrive tracker from config entry."""
+    account = hass.data[BMW_DOMAIN][config_entry.entry_id]
+    devices = []
+
+    for vehicle in account.account.vehicles:
+        if vehicle.state.is_vehicle_tracking_enabled:
+            devices.append(BMWDeviceTracker(account, vehicle))
+        else:
+            _LOGGER.info(
+                "Tracking is disabled for vehicle %s (%s)", vehicle.name, vehicle.vin
+            )
+    async_add_entities(devices, True)
 
 
-class BMWDeviceTracker:
+class BMWDeviceTracker(TrackerEntity):
     """BMW Connected Drive device tracker."""
 
-    def __init__(self, see, vehicle):
+    def __init__(self, account, vehicle):
         """Initialize the Tracker."""
-        self._see = see
-        self.vehicle = vehicle
+        self._account = account
+        self._vehicle = vehicle
+        self._unique_id = vehicle.vin
+        self._location = vehicle.state.gps_position
+        self._name = vehicle.name
 
-    def update(self) -> None:
-        """Update the device info.
+    @property
+    def latitude(self):
+        """Return latitude value of the device."""
+        return self._location[0]
 
-        Only update the state in Home Assistant if tracking in
-        the car is enabled.
-        """
-        dev_id = slugify(self.vehicle.name)
+    @property
+    def longitude(self):
+        """Return longitude value of the device."""
+        return self._location[1]
 
-        if not self.vehicle.state.is_vehicle_tracking_enabled:
-            _LOGGER.debug("Tracking is disabled for vehicle %s", dev_id)
-            return
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
 
-        _LOGGER.debug("Updating %s", dev_id)
-        attrs = {"vin": self.vehicle.vin}
-        self._see(
-            dev_id=dev_id,
-            host_name=self.vehicle.name,
-            gps=self.vehicle.state.gps_position,
-            attributes=attrs,
-            icon="mdi:car",
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return self._unique_id
+
+    @property
+    def device_info(self) -> dict:
+        """Return info for device registry."""
+        return {
+            "identifiers": {(BMW_DOMAIN, self._vehicle.vin)},
+            "sw_version": self._vehicle.vin,
+            "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
+            "model": self._vehicle.name,
+            "manufacturer": self._vehicle.attributes.get("brand"),
+        }
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return SOURCE_TYPE_GPS
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:car"
+
+    @property
+    def force_update(self):
+        """All updates do not need to be written to the state machine."""
+        return False
+
+    def update(self):
+        """Update state of the decvice tracker."""
+        self._location = (
+            self._vehicle.state.gps_position
+            if self._vehicle.state.is_vehicle_tracking_enabled
+            else (None, None)
         )
+
+    def update_callback(self):
+        """Schedule a state update."""
+        self.schedule_update_ha_state(True)
+
+    async def async_added_to_hass(self):
+        """Add callback after being added to hass.
+
+        Show latest data after startup.
+        """
+        self._account.add_update_listener(self.update_callback)

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -17,9 +17,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     for vehicle in account.account.vehicles:
         entities.append(BMWDeviceTracker(account, vehicle))
-        _LOGGER.info(
-            "Tracking is disabled for vehicle %s (%s)", vehicle.name, vehicle.vin
-        )
+        if not vehicle.state.is_vehicle_tracking_enabled:
+            _LOGGER.info(
+                "Tracking is (currently) disabled for vehicle %s (%s), defaulting to unknown.",
+                vehicle.name,
+                vehicle.vin,
+            )
     async_add_entities(entities, True)
 
 

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 
-from . import DOMAIN as BMW_DOMAIN
+from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWDeviceTracker(TrackerEntity):
+class BMWDeviceTracker(TrackerEntity, BMWConnectedDriveBaseEntity):
     """BMW Connected Drive device tracker."""
 
     def __init__(self, account, vehicle):
@@ -58,17 +58,6 @@ class BMWDeviceTracker(TrackerEntity):
         return self._unique_id
 
     @property
-    def device_info(self) -> dict:
-        """Return info for device registry."""
-        return {
-            "identifiers": {(BMW_DOMAIN, self._vehicle.vin)},
-            "sw_version": self._vehicle.vin,
-            "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
-            "model": self._vehicle.name,
-            "manufacturer": self._vehicle.attributes.get("brand"),
-        }
-
-    @property
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
         return SOURCE_TYPE_GPS
@@ -90,14 +79,3 @@ class BMWDeviceTracker(TrackerEntity):
             if self._vehicle.state.is_vehicle_tracking_enabled
             else (None, None)
         )
-
-    def update_callback(self):
-        """Schedule a state update."""
-        self.schedule_update_ha_state(True)
-
-    async def async_added_to_hass(self):
-        """Add callback after being added to hass.
-
-        Show latest data after startup.
-        """
-        self._account.add_update_listener(self.update_callback)

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -24,13 +24,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWDeviceTracker(TrackerEntity, BMWConnectedDriveBaseEntity):
+class BMWDeviceTracker(BMWConnectedDriveBaseEntity, TrackerEntity):
     """BMW Connected Drive device tracker."""
 
     def __init__(self, account, vehicle):
         """Initialize the Tracker."""
-        self._account = account
-        self._vehicle = vehicle
+        super().__init__(account, vehicle)
+
         self._unique_id = vehicle.vin
         self._location = (
             vehicle.state.gps_position if vehicle.state.gps_position else (None, None)

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -19,7 +19,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities.append(BMWDeviceTracker(account, vehicle))
         if not vehicle.state.is_vehicle_tracking_enabled:
             _LOGGER.info(
-                "Tracking is (currently) disabled for vehicle %s (%s), defaulting to unknown.",
+                "Tracking is (currently) disabled for vehicle %s (%s), defaulting to unknown",
                 vehicle.name,
                 vehicle.vin,
             )

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -16,12 +16,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     entities = []
 
     for vehicle in account.account.vehicles:
-        if vehicle.state.is_vehicle_tracking_enabled:
-            entities.append(BMWDeviceTracker(account, vehicle))
-        else:
-            _LOGGER.info(
-                "Tracking is disabled for vehicle %s (%s)", vehicle.name, vehicle.vin
-            )
+        # if vehicle.state.is_vehicle_tracking_enabled:
+        entities.append(BMWDeviceTracker(account, vehicle))
+        # else:
+        #     _LOGGER.info(
+        #         "Tracking is disabled for vehicle %s (%s)", vehicle.name, vehicle.vin
+        #     )
     async_add_entities(entities, True)
 
 

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -5,23 +5,24 @@ from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
+from .const import CONF_ACCOUNT
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the BMW ConnectedDrive tracker from config entry."""
-    account = hass.data[BMW_DOMAIN][config_entry.entry_id]
-    devices = []
+    account = hass.data[BMW_DOMAIN][config_entry.entry_id][CONF_ACCOUNT]
+    entities = []
 
     for vehicle in account.account.vehicles:
         if vehicle.state.is_vehicle_tracking_enabled:
-            devices.append(BMWDeviceTracker(account, vehicle))
+            entities.append(BMWDeviceTracker(account, vehicle))
         else:
             _LOGGER.info(
                 "Tracking is disabled for vehicle %s (%s)", vehicle.name, vehicle.vin
             )
-    async_add_entities(devices, True)
+    async_add_entities(entities, True)
 
 
 class BMWDeviceTracker(BMWConnectedDriveBaseEntity, TrackerEntity):

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -5,14 +5,14 @@ from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import CONF_ACCOUNT
+from .const import CONF_ACCOUNT, DATA_ENTRIES
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the BMW ConnectedDrive tracker from config entry."""
-    account = hass.data[BMW_DOMAIN][config_entry.entry_id][CONF_ACCOUNT]
+    account = hass.data[BMW_DOMAIN][DATA_ENTRIES][config_entry.entry_id][CONF_ACCOUNT]
     entities = []
 
     for vehicle in account.account.vehicles:

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -16,12 +16,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     entities = []
 
     for vehicle in account.account.vehicles:
-        # if vehicle.state.is_vehicle_tracking_enabled:
         entities.append(BMWDeviceTracker(account, vehicle))
-        # else:
-        #     _LOGGER.info(
-        #         "Tracking is disabled for vehicle %s (%s)", vehicle.name, vehicle.vin
-        #     )
+        _LOGGER.info(
+            "Tracking is disabled for vehicle %s (%s)", vehicle.name, vehicle.vin
+        )
     async_add_entities(entities, True)
 
 

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -68,9 +68,10 @@ class BMWLock(BMWConnectedDriveBaseEntity, LockEntity):
     def is_locked(self):
         """Return true if lock is locked."""
         if self.door_lock_state_available:
-            return self._state == STATE_LOCKED
+            result = self._state == STATE_LOCKED
         else:
-            return None
+            result = None
+        return result
 
     def lock(self, **kwargs):
         """Lock the car."""

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -7,7 +7,7 @@ from homeassistant.components.lock import LockEntity
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import CONF_ACCOUNT
+from .const import CONF_ACCOUNT, DATA_ENTRIES
 
 DOOR_LOCK_STATE = "door_lock_state"
 _LOGGER = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the BMW ConnectedDrive binary sensors from config entry."""
-    account = hass.data[BMW_DOMAIN][config_entry.entry_id][CONF_ACCOUNT]
+    account = hass.data[BMW_DOMAIN][DATA_ENTRIES][config_entry.entry_id][CONF_ACCOUNT]
     entities = []
 
     if not account.read_only:

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -25,13 +25,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWLock(LockEntity, BMWConnectedDriveBaseEntity):
+class BMWLock(BMWConnectedDriveBaseEntity, LockEntity):
     """Representation of a BMW vehicle lock."""
 
     def __init__(self, account, vehicle, attribute: str, sensor_name):
         """Initialize the lock."""
-        self._account = account
-        self._vehicle = vehicle
+        super().__init__(account, vehicle)
+
         self._attribute = attribute
         self._name = f"{self._vehicle.name} {self._attribute}"
         self._unique_id = f"{self._vehicle.vin}-{self._attribute}"

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -6,7 +6,7 @@ from bimmer_connected.state import LockState
 from homeassistant.components.lock import LockEntity
 from homeassistant.const import ATTR_ATTRIBUTION, STATE_LOCKED, STATE_UNLOCKED
 
-from . import DOMAIN as BMW_DOMAIN
+from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
 from .const import ATTRIBUTION
 
 DOOR_LOCK_STATE = "door_lock_state"
@@ -25,7 +25,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWLock(LockEntity):
+class BMWLock(LockEntity, BMWConnectedDriveBaseEntity):
     """Representation of a BMW vehicle lock."""
 
     def __init__(self, account, vehicle, attribute: str, sensor_name):
@@ -40,17 +40,6 @@ class BMWLock(LockEntity):
         self.door_lock_state_available = (
             DOOR_LOCK_STATE in self._vehicle.available_attributes
         )
-
-    @property
-    def device_info(self) -> dict:
-        """Return info for device registry."""
-        return {
-            "identifiers": {(BMW_DOMAIN, self._vehicle.vin)},
-            "sw_version": self._vehicle.vin,
-            "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
-            "model": self._vehicle.name,
-            "manufacturer": self._vehicle.attributes.get("brand"),
-        }
 
     @property
     def should_poll(self):
@@ -117,14 +106,3 @@ class BMWLock(LockEntity):
             if vehicle_state.door_lock_state in [LockState.LOCKED, LockState.SECURED]
             else STATE_UNLOCKED
         )
-
-    def update_callback(self):
-        """Schedule a state update."""
-        self.schedule_update_ha_state(True)
-
-    async def async_added_to_hass(self):
-        """Add callback after being added to hass.
-
-        Show latest data after startup.
-        """
-        self._account.add_update_listener(self.update_callback)

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -4,10 +4,10 @@ import logging
 from bimmer_connected.state import LockState
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.const import ATTR_ATTRIBUTION, STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import ATTRIBUTION, CONF_ACCOUNT
+from .const import CONF_ACCOUNT
 
 DOOR_LOCK_STATE = "door_lock_state"
 _LOGGER = logging.getLogger(__name__)
@@ -55,10 +55,8 @@ class BMWLock(BMWConnectedDriveBaseEntity, LockEntity):
     def device_state_attributes(self):
         """Return the state attributes of the lock."""
         vehicle_state = self._vehicle.state
-        result = {
-            "car": self._vehicle.name,
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-        }
+        result = self._attrs.copy()
+
         if self.door_lock_state_available:
             result["door_lock_state"] = vehicle_state.door_lock_state.value
             result["last_update_reason"] = vehicle_state.last_update_reason

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -3,5 +3,6 @@
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
   "requirements": ["bimmer_connected==0.7.13"],
-  "codeowners": ["@gerard33", "@rikroe"]
+  "codeowners": ["@gerard33", "@rikroe"],
+  "config_flow": true
 }

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the BMW notification service."""
-    accounts = hass.data[BMW_DOMAIN]
+    accounts = list(hass.data[BMW_DOMAIN].values())
     _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
     svc = BMWNotificationService()
     svc.setup(accounts)

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -10,7 +10,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import ATTR_LATITUDE, ATTR_LOCATION, ATTR_LONGITUDE, ATTR_NAME
 
-from . import DOMAIN as BMW_DOMAIN
+from . import DATA_HASS_CONFIG, DOMAIN as BMW_DOMAIN
 from .const import CONF_ACCOUNT
 
 ATTR_LAT = "lat"
@@ -24,7 +24,11 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the BMW notification service."""
-    accounts = [entry[CONF_ACCOUNT] for entry in hass.data[BMW_DOMAIN].values()]
+    accounts = [
+        e[CONF_ACCOUNT]
+        for k, e in hass.data[BMW_DOMAIN].items()
+        if k != DATA_HASS_CONFIG
+    ]
     _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
     svc = BMWNotificationService()
     svc.setup(accounts)

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the BMW notification service."""
-    accounts = list(hass.data[BMW_DOMAIN].values())
+    accounts = hass.data[BMW_DOMAIN].values()
     _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
     svc = BMWNotificationService()
     svc.setup(accounts)

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -11,6 +11,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import ATTR_LATITUDE, ATTR_LOCATION, ATTR_LONGITUDE, ATTR_NAME
 
 from . import DOMAIN as BMW_DOMAIN
+from .const import CONF_ACCOUNT
 
 ATTR_LAT = "lat"
 ATTR_LOCATION_ATTRIBUTES = ["street", "city", "postal_code", "country"]
@@ -23,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the BMW notification service."""
-    accounts = hass.data[BMW_DOMAIN].values()
+    accounts = [entry[CONF_ACCOUNT] for entry in hass.data[BMW_DOMAIN].values()]
     _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
     svc = BMWNotificationService()
     svc.setup(accounts)

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -10,8 +10,8 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import ATTR_LATITUDE, ATTR_LOCATION, ATTR_LONGITUDE, ATTR_NAME
 
-from . import DATA_HASS_CONFIG, DOMAIN as BMW_DOMAIN
-from .const import CONF_ACCOUNT
+from . import DOMAIN as BMW_DOMAIN
+from .const import CONF_ACCOUNT, DATA_ENTRIES
 
 ATTR_LAT = "lat"
 ATTR_LOCATION_ATTRIBUTES = ["street", "city", "postal_code", "country"]
@@ -24,11 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the BMW notification service."""
-    accounts = [
-        e[CONF_ACCOUNT]
-        for k, e in hass.data[BMW_DOMAIN].items()
-        if k != DATA_HASS_CONFIG
-    ]
+    accounts = [e[CONF_ACCOUNT] for e in hass.data[BMW_DOMAIN][DATA_ENTRIES].values()]
     _LOGGER.debug("Found BMW accounts: %s", ", ".join([a.name for a in accounts]))
     svc = BMWNotificationService()
     svc.setup(accounts)

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 
-from . import DOMAIN as BMW_DOMAIN
+from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
 from .const import ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWConnectedDriveSensor(Entity):
+class BMWConnectedDriveSensor(Entity, BMWConnectedDriveBaseEntity):
     """Representation of a BMW vehicle sensor."""
 
     def __init__(self, account, vehicle, attribute: str, attribute_info):
@@ -81,17 +81,6 @@ class BMWConnectedDriveSensor(Entity):
         self._name = f"{self._vehicle.name} {self._attribute}"
         self._unique_id = f"{self._vehicle.vin}-{self._attribute}"
         self._attribute_info = attribute_info
-
-    @property
-    def device_info(self) -> dict:
-        """Return info for device registry."""
-        return {
-            "identifiers": {(BMW_DOMAIN, self._vehicle.vin)},
-            "sw_version": self._vehicle.vin,
-            "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
-            "model": self._vehicle.name,
-            "manufacturer": self._vehicle.attributes.get("brand"),
-        }
 
     @property
     def should_poll(self) -> bool:
@@ -163,14 +152,3 @@ class BMWConnectedDriveSensor(Entity):
             self._state = round(value_converted)
         else:
             self._state = getattr(vehicle_state, self._attribute)
-
-    def update_callback(self):
-        """Schedule a state update."""
-        self.schedule_update_ha_state(True)
-
-    async def async_added_to_hass(self):
-        """Add callback after being added to hass.
-
-        Show latest data after startup.
-        """
-        self._account.add_update_listener(self.update_callback)

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -4,7 +4,6 @@ import logging
 from bimmer_connected.state import ChargingState
 
 from homeassistant.const import (
-    ATTR_ATTRIBUTION,
     CONF_UNIT_SYSTEM_IMPERIAL,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
@@ -17,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import ATTRIBUTION, CONF_ACCOUNT
+from .const import CONF_ACCOUNT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -118,14 +117,6 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, Entity):
         """Get the unit of measurement."""
         unit = self._attribute_info.get(self._attribute, [None, None])[1]
         return unit
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the sensor."""
-        return {
-            "car": self._vehicle.name,
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-        }
 
     def update(self) -> None:
         """Read new state data from the library."""

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -69,13 +69,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(devices, True)
 
 
-class BMWConnectedDriveSensor(Entity, BMWConnectedDriveBaseEntity):
+class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, Entity):
     """Representation of a BMW vehicle sensor."""
 
     def __init__(self, account, vehicle, attribute: str, attribute_info):
         """Initialize BMW vehicle sensor."""
-        self._vehicle = vehicle
-        self._account = account
+        super().__init__(account, vehicle)
+
         self._attribute = attribute
         self._state = None
         self._name = f"{self._vehicle.name} {self._attribute}"

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import ATTRIBUTION
+from .const import ATTRIBUTION, CONF_ACCOUNT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,14 +50,13 @@ ATTR_TO_HA_IMPERIAL = {
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the BMW ConnectedDrive sensors from config entry."""
-
     if hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL:
         attribute_info = ATTR_TO_HA_IMPERIAL
     else:
         attribute_info = ATTR_TO_HA_METRIC
 
-    account = hass.data[BMW_DOMAIN][config_entry.entry_id]
-    devices = []
+    account = hass.data[BMW_DOMAIN][config_entry.entry_id][CONF_ACCOUNT]
+    entities = []
 
     for vehicle in account.account.vehicles:
         for attribute_name in vehicle.drive_train_attributes:
@@ -65,8 +64,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 device = BMWConnectedDriveSensor(
                     account, vehicle, attribute_name, attribute_info
                 )
-                devices.append(device)
-    async_add_entities(devices, True)
+                entities.append(device)
+    async_add_entities(entities, True)
 
 
 class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, Entity):
@@ -81,14 +80,6 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, Entity):
         self._name = f"{self._vehicle.name} {self._attribute}"
         self._unique_id = f"{self._vehicle.vin}-{self._attribute}"
         self._attribute_info = attribute_info
-
-    @property
-    def should_poll(self) -> bool:
-        """Return False.
-
-        Data update is triggered from BMWConnectedDriveEntity.
-        """
-        return False
 
     @property
     def unique_id(self):

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import DOMAIN as BMW_DOMAIN, BMWConnectedDriveBaseEntity
-from .const import CONF_ACCOUNT
+from .const import CONF_ACCOUNT, DATA_ENTRIES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     else:
         attribute_info = ATTR_TO_HA_METRIC
 
-    account = hass.data[BMW_DOMAIN][config_entry.entry_id][CONF_ACCOUNT]
+    account = hass.data[BMW_DOMAIN][DATA_ENTRIES][config_entry.entry_id][CONF_ACCOUNT]
     entities = []
 
     for vehicle in account.account.vehicles:

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -1,30 +1,27 @@
 {
-  "title": "BMW ConnectedDrive",
   "config": {
     "step": {
       "user": {
-        "title": "Connect to BMW ConnectedDrive",
         "data": {
-          "username": "Email",
-          "password": "Password",
+          "username": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]",
           "region": "ConnectedDrive Region",
           "read_only": "Read-only"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect, please try again",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   },
   "options": {
     "step": {
       "account_options": {
-        "title": "BMW ConnectedDrive settings",
         "data": {
           "read_only": "Read-only (only sensors and notify, no execution of services, no lock)",
           "use_location": "Use Home Assistant location for car location polls (required for non i3/i8 vehicles produced before 7/2014)"

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -5,15 +5,13 @@
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "region": "ConnectedDrive Region",
-          "read_only": "Read-only"
+          "region": "ConnectedDrive Region"
         }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -1,0 +1,35 @@
+{
+  "title": "BMW ConnectedDrive",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to BMW ConnectedDrive",
+        "data": {
+          "username": "Email",
+          "password": "Password",
+          "region": "ConnectedDrive Region",
+          "read_only": "Read-only"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please try again",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "account_options": {
+        "title": "BMW ConnectedDrive settings",
+        "data": {
+          "read_only": "Read-only (only sensors and notify, no execution of services, no lock)",
+          "use_location": "Use Home Assistant location for car location polls (required for non i3/i8 vehicles produced before 7/2014)"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "data": {
-          "username": "[%key:common::config_flow::data::email%]",
+          "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "region": "ConnectedDrive Region",
           "read_only": "Read-only"

--- a/homeassistant/components/bmw_connected_drive/translations/en.json
+++ b/homeassistant/components/bmw_connected_drive/translations/en.json
@@ -5,8 +5,7 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "invalid_auth": "Invalid authentication"
         },
         "step": {
             "user": {

--- a/homeassistant/components/bmw_connected_drive/translations/en.json
+++ b/homeassistant/components/bmw_connected_drive/translations/en.json
@@ -1,0 +1,35 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect, please try again",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "password": "Password",
+                    "read_only": "Read-only",
+                    "region": "ConnectedDrive Region",
+                    "username": "Email"
+                },
+                "title": "Connect to BMW ConnectedDrive"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "account_options": {
+                "data": {
+                    "read_only": "Read-only (only sensors and notify, no execution of services, no lock)",
+                    "use_location": "Use Home Assistant location for car location polls (required for non i3/i8 vehicles produced before 7/2014)"
+                },
+                "title": "BMW ConnectedDrive settings"
+            }
+        }
+    },
+    "title": "BMW ConnectedDrive"
+}

--- a/homeassistant/components/bmw_connected_drive/translations/en.json
+++ b/homeassistant/components/bmw_connected_drive/translations/en.json
@@ -1,10 +1,10 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Account is already configured"
         },
         "error": {
-            "cannot_connect": "Failed to connect, please try again",
+            "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
@@ -15,8 +15,7 @@
                     "read_only": "Read-only",
                     "region": "ConnectedDrive Region",
                     "username": "Email"
-                },
-                "title": "Connect to BMW ConnectedDrive"
+                }
             }
         }
     },
@@ -26,10 +25,8 @@
                 "data": {
                     "read_only": "Read-only (only sensors and notify, no execution of services, no lock)",
                     "use_location": "Use Home Assistant location for car location polls (required for non i3/i8 vehicles produced before 7/2014)"
-                },
-                "title": "BMW ConnectedDrive settings"
+                }
             }
         }
-    },
-    "title": "BMW ConnectedDrive"
+    }
 }

--- a/homeassistant/components/bmw_connected_drive/translations/en.json
+++ b/homeassistant/components/bmw_connected_drive/translations/en.json
@@ -14,7 +14,7 @@
                     "password": "Password",
                     "read_only": "Read-only",
                     "region": "ConnectedDrive Region",
-                    "username": "Email"
+                    "username": "Username"
                 }
             }
         }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -29,6 +29,7 @@ FLOWS = [
     "azure_devops",
     "blebox",
     "blink",
+    "bmw_connected_drive",
     "bond",
     "braviatv",
     "broadlink",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -192,7 +192,7 @@ base36==0.1.1
 bellows==0.21.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.7.7
+bimmer_connected==0.7.8
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -192,7 +192,7 @@ base36==0.1.1
 bellows==0.21.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.7.8
+bimmer_connected==0.7.12
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -192,7 +192,7 @@ base36==0.1.1
 bellows==0.21.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.7.12
+bimmer_connected==0.7.13
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -191,6 +191,9 @@ base36==0.1.1
 # homeassistant.components.zha
 bellows==0.21.0
 
+# homeassistant.components.bmw_connected_drive
+bimmer_connected==0.7.7
+
 # homeassistant.components.blebox
 blebox_uniapi==1.3.2
 

--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the for the BMW Connected Drive integration."""

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -1,0 +1,77 @@
+"""Test the for the BMW Connected Drive config flow."""
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.bmw_connected_drive.config_flow import DOMAIN
+from homeassistant.components.bmw_connected_drive.const import CONF_REGION
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from tests.async_mock import patch
+
+FIXTURE_USER_INPUT = {
+    CONF_USERNAME: "user@domain.com",
+    CONF_PASSWORD: "p4ssw0rd",
+    CONF_REGION: "rest_of_world",
+}
+FIXTURE_COMPLETE_ENTRY = FIXTURE_USER_INPUT.copy()
+FIXTURE_IMPORT_ENTRY = FIXTURE_USER_INPUT.copy()
+
+
+async def test_show_form(hass):
+    """Test that the form is served with no input."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_connection_error(hass):
+    """Test we show user form on Atag connection error."""
+
+    with patch(
+        "bimmer_connected.account.ConnectedDriveAccount._get_oauth_token",
+        side_effect=OSError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_full_user_flow_implementation(hass):
+    """Test registering an integration and finishing flow works."""
+    with patch(
+        "bimmer_connected.account.ConnectedDriveAccount._get_vehicles", return_value=[],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == FIXTURE_COMPLETE_ENTRY[CONF_USERNAME]
+        assert result["data"] == FIXTURE_COMPLETE_ENTRY
+
+
+async def test_full_config_flow_implementation(hass):
+    """Test registering an integration and finishing flow works."""
+    with patch(
+        "bimmer_connected.account.ConnectedDriveAccount._get_vehicles", return_value=[],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=FIXTURE_USER_INPUT,
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert (
+            result["title"]
+            == FIXTURE_IMPORT_ENTRY[CONF_USERNAME] + " (configuration.yaml)"
+        )
+        assert result["data"] == FIXTURE_IMPORT_ENTRY

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -82,38 +82,28 @@ async def test_connection_error(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_general_error(hass):
-    """Test we show user form on BMW connected drive connection error."""
-
-    with patch(
-        "homeassistant.config_entries.ConfigEntry",
-        side_effect=Exception,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=FIXTURE_USER_INPUT,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "unknown"}
-
-
 async def test_full_user_flow_implementation(hass):
     """Test registering an integration and finishing flow works."""
     with patch(
         "bimmer_connected.account.ConnectedDriveAccount._get_vehicles",
         return_value=[],
-    ):
-        result = await hass.config_entries.flow.async_init(
+    ), patch(
+        "homeassistant.components.bmw_connected_drive.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.bmw_connected_drive.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
             data=FIXTURE_USER_INPUT,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == FIXTURE_COMPLETE_ENTRY[CONF_USERNAME]
-        assert result["data"] == FIXTURE_COMPLETE_ENTRY
+        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result2["title"] == FIXTURE_COMPLETE_ENTRY[CONF_USERNAME]
+        assert result2["data"] == FIXTURE_COMPLETE_ENTRY
+
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_full_config_flow_implementation(hass):
@@ -121,7 +111,12 @@ async def test_full_config_flow_implementation(hass):
     with patch(
         "bimmer_connected.account.ConnectedDriveAccount._get_vehicles",
         return_value=[],
-    ):
+    ), patch(
+        "homeassistant.components.bmw_connected_drive.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.bmw_connected_drive.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
@@ -135,13 +130,21 @@ async def test_full_config_flow_implementation(hass):
         )
         assert result["data"] == FIXTURE_IMPORT_ENTRY
 
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
+
 
 async def test_options_flow_implementation(hass):
     """Test config flow options."""
     with patch(
         "bimmer_connected.account.ConnectedDriveAccount._get_vehicles",
         return_value=[],
-    ):
+    ), patch(
+        "homeassistant.components.bmw_connected_drive.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.bmw_connected_drive.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
         config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
         config_entry.add_to_hass(hass)
 
@@ -156,9 +159,13 @@ async def test_options_flow_implementation(hass):
             result["flow_id"],
             user_input={CONF_READ_ONLY: False, CONF_USE_LOCATION: False},
         )
+        await hass.async_block_till_done()
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"] == {
             CONF_READ_ONLY: False,
             CONF_USE_LOCATION: False,
         }
+
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -124,10 +124,7 @@ async def test_full_config_flow_implementation(hass):
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert (
-            result["title"]
-            == FIXTURE_IMPORT_ENTRY[CONF_USERNAME] + " (configuration.yaml)"
-        )
+        assert result["title"] == FIXTURE_IMPORT_ENTRY[CONF_USERNAME]
         assert result["data"] == FIXTURE_IMPORT_ENTRY
 
         assert len(mock_setup.mock_calls) == 1

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -46,30 +46,15 @@ async def test_show_form(hass):
     assert result["step_id"] == "user"
 
 
-async def test_auth_error(hass):
+async def test_connection_error(hass):
     """Test we show user form on BMW connected drive connection error."""
+
+    def _mock_get_oauth_token(*args, **kwargs):
+        pass
 
     with patch(
         "bimmer_connected.account.ConnectedDriveAccount._get_oauth_token",
         side_effect=OSError,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=FIXTURE_USER_INPUT,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "invalid_auth"}
-
-
-async def test_connection_error(hass):
-    """Test we show user form on BMW connected drive connection error."""
-
-    with patch(
-        "bimmer_connected.account.ConnectedDriveAccount._get_oauth_token",
-        side_effect=Exception,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
BMW Connected Drive has been migrated to config flows. Your old entries from configuration.yaml are used __once__ for initial setup. It is recommended to rename the device_tracker of your car(s) in config/known_devices.yaml (you can e.g. add `_old` to the entity name) before updating, otherwise a second device tracker entity (ending with `_2`) per car will be created. After updating, the entity can be removed from known_devices as that will no longer be used.


## Proposed change
> This PR contains the same code as #35732 where I miserably failed to rebase correctly. For some discussion and first reviews, please refer to #35732.

This PR adds a config flow to `bmw_connected_drive`. The existing `configuration.yaml` is loaded initially. The device tracker update was required to allow for config flows. Non-mandatory options can be configured from an option flow.
All platforms now only require to distinguish between the different vehicles of an account, as multiple accounts are stored in different config entries. 

This PR also adds information to the device registry where possible. To make it easy to distighuish between cars, I am using the vehicle identification number (VIN) as firmware (due to the lack of another displayed field in the device registry).

Not in scope of this PR (but planned): Creating a `BMWConnectedDriveBaseEntity` to be used in all platforms in combination with `DataUpdateCoordinator`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Existing entries are imported once and can be deleted afterwards in favor of config flows.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29976 due to rewritten device tracker
- This PR is related to issue: includes a fix from #14464 for older vehicles
- Link to documentation pull request: home-assistant/home-assistant.io#13471

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] home-assistant/home-assistant.io#13471

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io