### PR TITLE
Fix wrong error message on adding a new HomematicIP Cloud AP

### DIFF
--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -47,6 +47,9 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
                 _LOGGER.info("Connection to HomematicIP Cloud established")
                 return await self.async_step_link()
 
+            _LOGGER.info("Connection to HomematicIP Cloud failed")
+            errors["base"] = "invalid_sgtin_or_pin"
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -34,7 +34,7 @@ class HomematicipAuth:
             self.auth = await self.get_auth(
                 self.hass, self.config.get(HMIPC_HAPID), self.config.get(HMIPC_PIN)
             )
-            return True
+            return self.auth is not None
         except HmipcConnectionError:
             return False
 
@@ -63,7 +63,7 @@ class HomematicipAuth:
                 auth.pin = pin
             await auth.connectionRequest("HomeAssistant")
         except HmipConnectionError:
-            return False
+            return None
         return auth
 
 

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -16,7 +16,7 @@
     },
     "error": {
       "register_failed": "Failed to register, please try again.",
-      "invalid_pin": "Invalid PIN, please try again.",
+      "invalid_sgtin_or_pin": "Invalid SGTIN or PIN, please try again.",
       "press_the_button": "Please press the blue button.",
       "timeout_button": "Blue button press timeout, please try again."
     },

--- a/homeassistant/components/homematicip_cloud/translations/en.json
+++ b/homeassistant/components/homematicip_cloud/translations/en.json
@@ -6,7 +6,7 @@
             "unknown": "Unknown error occurred."
         },
         "error": {
-            "invalid_pin": "Invalid PIN, please try again.",
+            "invalid_sgtin_or_pin": "Invalid SGTIN or PIN, please try again.",
             "press_the_button": "Please press the blue button.",
             "register_failed": "Failed to register, please try again.",
             "timeout_button": "Blue button press timeout, please try again."

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -175,9 +175,7 @@ async def test_auth_create_exception(hass, simple_mock_auth):
         "homeassistant.components.homematicip_cloud.hap.AsyncAuth",
         return_value=simple_mock_auth,
     ):
-        assert await hmip_auth.async_setup()
-        await hass.async_block_till_done()
-        assert not hmip_auth.auth
+        assert not await hmip_auth.async_setup()
 
     with patch(
         "homeassistant.components.homematicip_cloud.hap.AsyncAuth",


### PR DESCRIPTION
## Proposed change
Fix wrong error message on adding a new HomematicIP Cloud AP.
If SGTIN or pin is not correct, then this will be covered with a correct error message


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39505
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
