### PR TITLE
Add template filter timedelta

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1,7 +1,7 @@
 """Template helper methods for rendering strings with Home Assistant data."""
 import base64
 import collections.abc
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import wraps
 import json
 import logging
@@ -1026,6 +1026,17 @@ def relative_time(value):
     return dt_util.get_age(value)
 
 
+def timedelta_seconds(value):
+    """
+    Take seconds as an integer and return a timedelta.
+
+    If the input is not an integer the input will be returned unmodified.
+    """
+    if not isinstance(value, int):
+        return value
+    return timedelta(seconds=value)
+
+
 def urlencode(value):
     """Urlencode dictionary and return as UTF-8 string."""
     return urllib_urlencode(value).encode("utf-8")
@@ -1087,6 +1098,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["utcnow"] = dt_util.utcnow
         self.globals["as_timestamp"] = forgiving_as_timestamp
         self.globals["relative_time"] = relative_time
+        self.globals["timedelta_seconds"] = timedelta_seconds
         self.globals["strptime"] = strptime
         self.globals["urlencode"] = urlencode
         if hass is None:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1026,17 +1026,6 @@ def relative_time(value):
     return dt_util.get_age(value)
 
 
-def timedelta_seconds(value):
-    """
-    Take seconds as an integer and return a timedelta.
-
-    If the input is not an integer the input will be returned unmodified.
-    """
-    if not isinstance(value, int):
-        return value
-    return timedelta(seconds=value)
-
-
 def urlencode(value):
     """Urlencode dictionary and return as UTF-8 string."""
     return urllib_urlencode(value).encode("utf-8")
@@ -1098,7 +1087,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["utcnow"] = dt_util.utcnow
         self.globals["as_timestamp"] = forgiving_as_timestamp
         self.globals["relative_time"] = relative_time
-        self.globals["timedelta_seconds"] = timedelta_seconds
+        self.globals["timedelta"] = timedelta
         self.globals["strptime"] = strptime
         self.globals["urlencode"] = urlencode
         if hass is None:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -883,42 +883,56 @@ def test_relative_time(mock_is_safe, hass):
     "homeassistant.helpers.template.TemplateEnvironment.is_safe_callable",
     return_value=True,
 )
-def test_timedelta_seconds(mock_is_safe, hass):
+def test_timedelta(mock_is_safe, hass):
     """Test relative_time method."""
     now = datetime.strptime("2000-01-01 10:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z")
     with patch("homeassistant.util.dt.now", return_value=now):
         assert (
             "0:02:00"
             == template.Template(
-                "{{timedelta_seconds(120)}}",
+                "{{timedelta(seconds=120)}}",
                 hass,
             ).async_render()
         )
         assert (
             "1 day, 0:00:00"
             == template.Template(
-                "{{timedelta_seconds(86400)}}",
+                "{{timedelta(seconds=86400)}}",
+                hass,
+            ).async_render()
+        )
+        assert (
+            "1 day, 4:00:00"
+            == template.Template(
+                "{{timedelta(days=1, hours=4)}}",
                 hass,
             ).async_render()
         )
         assert (
             "1 hour"
             == template.Template(
-                "{{relative_time(now() - timedelta_seconds(3600))}}",
+                "{{relative_time(now() - timedelta(seconds=3600))}}",
                 hass,
             ).async_render()
         )
         assert (
             "1 day"
             == template.Template(
-                "{{relative_time(now() - timedelta_seconds(86400))}}",
+                "{{relative_time(now() - timedelta(seconds=86400))}}",
                 hass,
             ).async_render()
         )
         assert (
             "1 day"
             == template.Template(
-                "{{relative_time(now() - timedelta_seconds(86401))}}",
+                "{{relative_time(now() - timedelta(seconds=86401))}}",
+                hass,
+            ).async_render()
+        )
+        assert (
+            "15 days"
+            == template.Template(
+                "{{relative_time(now() - timedelta(weeks=2, days=1))}}",
                 hass,
             ).async_render()
         )

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -883,6 +883,51 @@ def test_relative_time(mock_is_safe, hass):
     "homeassistant.helpers.template.TemplateEnvironment.is_safe_callable",
     return_value=True,
 )
+def test_timedelta_seconds(mock_is_safe, hass):
+    """Test relative_time method."""
+    now = datetime.strptime("2000-01-01 10:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z")
+    with patch("homeassistant.util.dt.now", return_value=now):
+        assert (
+            "0:02:00"
+            == template.Template(
+                "{{timedelta_seconds(120)}}",
+                hass,
+            ).async_render()
+        )
+        assert (
+            "1 day, 0:00:00"
+            == template.Template(
+                "{{timedelta_seconds(86400)}}",
+                hass,
+            ).async_render()
+        )
+        assert (
+            "1 hour"
+            == template.Template(
+                "{{relative_time(now() - timedelta_seconds(3600))}}",
+                hass,
+            ).async_render()
+        )
+        assert (
+            "1 day"
+            == template.Template(
+                "{{relative_time(now() - timedelta_seconds(86400))}}",
+                hass,
+            ).async_render()
+        )
+        assert (
+            "1 day"
+            == template.Template(
+                "{{relative_time(now() - timedelta_seconds(86401))}}",
+                hass,
+            ).async_render()
+        )
+
+
+@patch(
+    "homeassistant.helpers.template.TemplateEnvironment.is_safe_callable",
+    return_value=True,
+)
 def test_utcnow(mock_is_safe, hass):
     """Test utcnow method."""
     now = dt_util.utcnow()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add template filter `timedelta` to create a timedelta object from seconds. This can be used when sensors report a duration and can be converted into readable text when combined with `relative_time()`, e.g.:

    {{ relative_time(now() - timedelta(seconds=3600)) }}


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14384 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
