### PR TITLE
Add option to delete multiple rfxtrx devices

### DIFF
--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -285,7 +285,6 @@ class OptionsFlow(config_entries.OptionsFlow):
     @callback
     def update_config_data(self, global_options=None, devices=None):
         """Update data in ConfigEntry."""
-        # entry_data = copy.deepcopy(self._config_entry.data)
         entry_data = self._config_entry.data.copy()
         entry_data[CONF_DEVICES] = copy.deepcopy(self._config_entry.data[CONF_DEVICES])
         if global_options:

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for RFXCOM RFXtrx integration."""
+import copy
 import logging
 import os
 
@@ -284,7 +285,9 @@ class OptionsFlow(config_entries.OptionsFlow):
     @callback
     def update_config_data(self, global_options=None, devices=None):
         """Update data in ConfigEntry."""
+        # entry_data = copy.deepcopy(self._config_entry.data)
         entry_data = self._config_entry.data.copy()
+        entry_data[CONF_DEVICES] = copy.deepcopy(self._config_entry.data[CONF_DEVICES])
         if global_options:
             entry_data.update(global_options)
         if devices:

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import (
     async_entries_for_config_entry,
     async_get_registry,
@@ -90,16 +91,18 @@ class OptionsFlow(config_entries.OptionsFlow):
                 self._selected_device_object = get_rfx_object(event_code)
                 return await self.async_step_set_device_options()
             if CONF_REMOVE_DEVICE in user_input:
-                entry_id = user_input[CONF_REMOVE_DEVICE]
-                device_data = self._get_device_data(entry_id)
+                remove_devices = user_input[CONF_REMOVE_DEVICE]
+                for entry_id in remove_devices:
+                    device_data = self._get_device_data(entry_id)
 
-                event_code = device_data[CONF_EVENT_CODE]
-                device_id = device_data[CONF_DEVICE_ID]
-                self.hass.helpers.dispatcher.async_dispatcher_send(
-                    f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{device_id}"
-                )
-                self._device_registry.async_remove_device(entry_id)
-                devices = {event_code: None}
+                    event_code = device_data[CONF_EVENT_CODE]
+                    device_id = device_data[CONF_DEVICE_ID]
+                    self.hass.helpers.dispatcher.async_dispatcher_send(
+                        f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{device_id}"
+                    )
+                    self._device_registry.async_remove_device(entry_id)
+                    devices = {event_code: None}
+
                 self.update_config_data(
                     global_options=self._global_options, devices=devices
                 )
@@ -142,7 +145,7 @@ class OptionsFlow(config_entries.OptionsFlow):
             ): bool,
             vol.Optional(CONF_EVENT_CODE): str,
             vol.Optional(CONF_DEVICE): vol.In(devices),
-            vol.Optional(CONF_REMOVE_DEVICE): vol.In(devices),
+            vol.Optional(CONF_REMOVE_DEVICE): cv.multi_select(devices),
         }
 
         return self.async_show_form(

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -92,6 +92,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                 return await self.async_step_set_device_options()
             if CONF_REMOVE_DEVICE in user_input:
                 remove_devices = user_input[CONF_REMOVE_DEVICE]
+                devices = {}
                 for entry_id in remove_devices:
                     device_data = self._get_device_data(entry_id)
 
@@ -101,7 +102,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                         f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{device_id}"
                     )
                     self._device_registry.async_remove_device(entry_id)
-                    devices = {event_code: None}
+                    devices[event_code] = None
 
                 self.update_config_data(
                     global_options=self._global_options, devices=devices

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -650,6 +650,16 @@ async def test_options_remove_multiple_devices(hass):
 
     assert len(device_entries) == 3
 
+    def match_device_id(entry):
+        device_id = next(iter(entry.identifiers))[1:]
+        if device_id == ("11", "0", "213c7f2:48"):
+            return True
+        if device_id == ("11", "0", "118cdea:2"):
+            return True
+        return False
+
+    remove_devices = [elem.id for elem in device_entries if match_device_id(elem)]
+
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
     assert result["type"] == "form"
@@ -660,11 +670,7 @@ async def test_options_remove_multiple_devices(hass):
         user_input={
             "debug": False,
             "automatic_add": False,
-            "remove_device": [
-                device_entries[0].id,
-                device_entries[1].id,
-                device_entries[2].id,
-            ],
+            "remove_device": remove_devices,
         },
     )
 
@@ -677,7 +683,7 @@ async def test_options_remove_multiple_devices(hass):
     state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert not state
     state = hass.states.get("binary_sensor.ac_1118cdea_2")
-    assert not state
+    assert state
 
 
 async def test_options_add_and_configure_device(hass):

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -596,7 +596,7 @@ async def test_options_add_remove_device(hass):
         user_input={
             "debug": False,
             "automatic_add": False,
-            "remove_device": device_entries[0].id,
+            "remove_device": [device_entries[0].id],
         },
     )
 
@@ -611,6 +611,63 @@ async def test_options_add_remove_device(hass):
 
     state = hass.states.get("binary_sensor.ac_213c7f2_48")
     assert not state
+
+
+async def test_options_remove_multiple_devices(hass):
+    """Test we can add a device."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": None,
+            "port": None,
+            "device": "/dev/tty123",
+            "debug": False,
+            "automatic_add": False,
+            "devices": {
+                "0b1100cd0213c7f230010f71": {},
+                "0b1100100118cdea02010f70": {},
+                "0b1100101118cdea02010f70": {},
+            },
+        },
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = await async_get_registry(hass)
+    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+
+    assert len(device_entries) == 3
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "prompt_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "debug": False,
+            "automatic_add": False,
+            "remove_device": [device_entries[0].id],
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    await hass.async_block_till_done()
+
+    # assert not entry.data["debug"]
+    # assert not entry.data["automatic_add"]
+
+    # assert "0b1100cd0213c7f230010f71" not in entry.data["devices"]
+
+    # state = hass.states.get("binary_sensor.ac_213c7f2_48")
+    # assert not state
 
 
 async def test_options_add_and_configure_device(hass):

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -626,9 +626,9 @@ async def test_options_remove_multiple_devices(hass):
             "debug": False,
             "automatic_add": False,
             "devices": {
-                "0b1100cd0213c7f230010f71": {},
-                "0b1100100118cdea02010f70": {},
-                "0b1100101118cdea02010f70": {},
+                "0b1100cd0213c7f230010f71": {"device_id": ["11", "0", "213c7f2:48"]},
+                "0b1100100118cdea02010f70": {"device_id": ["11", "0", "118cdea:2"]},
+                "0b1100101118cdea02010f70": {"device_id": ["11", "0", "1118cdea:2"]},
             },
         },
         unique_id=DOMAIN,
@@ -637,6 +637,13 @@ async def test_options_remove_multiple_devices(hass):
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.ac_213c7f2_48")
+    assert state
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
+    assert state
+    state = hass.states.get("binary_sensor.ac_1118cdea_2")
+    assert state
 
     device_registry = await async_get_registry(hass)
     device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
@@ -653,7 +660,11 @@ async def test_options_remove_multiple_devices(hass):
         user_input={
             "debug": False,
             "automatic_add": False,
-            "remove_device": [device_entries[0].id],
+            "remove_device": [
+                device_entries[0].id,
+                device_entries[1].id,
+                device_entries[2].id,
+            ],
         },
     )
 
@@ -661,13 +672,12 @@ async def test_options_remove_multiple_devices(hass):
 
     await hass.async_block_till_done()
 
-    # assert not entry.data["debug"]
-    # assert not entry.data["automatic_add"]
-
-    # assert "0b1100cd0213c7f230010f71" not in entry.data["devices"]
-
-    # state = hass.states.get("binary_sensor.ac_213c7f2_48")
-    # assert not state
+    state = hass.states.get("binary_sensor.ac_213c7f2_48")
+    assert not state
+    state = hass.states.get("binary_sensor.ac_118cdea_2")
+    assert not state
+    state = hass.states.get("binary_sensor.ac_1118cdea_2")
+    assert not state
 
 
 async def test_options_add_and_configure_device(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR targets a different branch that updates rfxtrx integration to have UI config/options (see #39117)

One of the things I came by reading through reactions on changes in rfxtrx which was ability to delete multiple devices in one go. This makes sense, auto detect could potentially detect numerous unwanted devices. With this PR, a number of devices can be selected through the option flow and they will all be deleted at once.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: NOTE: documentation PR is linked to #39117, for reference it is mentioned here (home-assistant/home-assistant.io#14158)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
