### PR TITLE
Fix boolean validation when the value is a float in a string

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -151,6 +151,10 @@ def boolean(value: Any) -> bool:
             return True
         if value in ("0", "false", "no", "off", "disable"):
             return False
+        try:
+            return float(value) != 0
+        except ValueError:
+            pass
     elif isinstance(value, Number):
         # type ignore: https://github.com/python/mypy/issues/3186
         return value != 0  # type: ignore

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -32,10 +32,22 @@ def test_boolean():
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
-    for value in ("true", "On", "1", "YES", "   true  ", "enable", 1, 50, True, 0.1):
+    for value in (
+        "true",
+        "On",
+        "1",
+        "YES",
+        "   true  ",
+        "enable",
+        1,
+        50,
+        True,
+        0.1,
+        "0.1",
+    ):
         assert schema(value)
 
-    for value in ("false", "Off", "0", "NO", "disable", 0, False):
+    for value in ("false", "Off", "0", "NO", "disable", 0, False, "0.00"):
         assert not schema(value)
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1599,26 +1599,34 @@ def test_nested_async_render_to_info_case(hass):
 def test_result_as_boolean(hass):
     """Test converting a template result to a boolean."""
 
-    template.result_as_boolean(True) is True
-    template.result_as_boolean(" 1 ") is True
-    template.result_as_boolean(" true ") is True
-    template.result_as_boolean(" TrUE ") is True
-    template.result_as_boolean(" YeS ") is True
-    template.result_as_boolean(" On ") is True
-    template.result_as_boolean(" Enable ") is True
-    template.result_as_boolean(1) is True
-    template.result_as_boolean(-1) is True
-    template.result_as_boolean(500) is True
+    assert template.result_as_boolean(True) is True
+    assert template.result_as_boolean(" 1 ") is True
+    assert template.result_as_boolean(" true ") is True
+    assert template.result_as_boolean(" TrUE ") is True
+    assert template.result_as_boolean(" YeS ") is True
+    assert template.result_as_boolean(" On ") is True
+    assert template.result_as_boolean(" Enable ") is True
+    assert template.result_as_boolean(1) is True
+    assert template.result_as_boolean(-1) is True
+    assert template.result_as_boolean(500) is True
+    assert template.result_as_boolean(0.5) is True
+    assert template.result_as_boolean("0.5") is True
+    assert template.result_as_boolean(0.389) is True
+    assert template.result_as_boolean("0.389") is True
+    assert template.result_as_boolean(35) is True
+    assert template.result_as_boolean("35") is True
 
-    template.result_as_boolean(False) is False
-    template.result_as_boolean(" 0 ") is False
-    template.result_as_boolean(" false ") is False
-    template.result_as_boolean(" FaLsE ") is False
-    template.result_as_boolean(" no ") is False
-    template.result_as_boolean(" off ") is False
-    template.result_as_boolean(" disable ") is False
-    template.result_as_boolean(0) is False
-    template.result_as_boolean(None) is False
+    assert template.result_as_boolean(False) is False
+    assert template.result_as_boolean(" 0 ") is False
+    assert template.result_as_boolean(" false ") is False
+    assert template.result_as_boolean(" FaLsE ") is False
+    assert template.result_as_boolean(" no ") is False
+    assert template.result_as_boolean(" off ") is False
+    assert template.result_as_boolean(" disable ") is False
+    assert template.result_as_boolean(0) is False
+    assert template.result_as_boolean(0.0) is False
+    assert template.result_as_boolean("0.00") is False
+    assert template.result_as_boolean(None) is False
 
 
 def test_closest_function_to_entity_id(hass):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,7 +202,7 @@ def test_core_config_schema():
 
 def test_customize_dict_schema():
     """Test basic customize config validation."""
-    values = ({ATTR_FRIENDLY_NAME: None}, {ATTR_ASSUMED_STATE: "2"})
+    values = ({ATTR_FRIENDLY_NAME: None}, {ATTR_ASSUMED_STATE: "not_a_number"})
 
     for val in values:
         print(val)


### PR DESCRIPTION
At least one test is expected `"2"` to evaluate to `False` so this has to be a breaking change.

## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix boolean validation when the value is a float in a string.
We had tests to verify `0.1` is `True`, `50` is `True`, and `"1"` is `True` so it seems reasonable
that `"0.1"` should also be `True`.

We are using this for `async_track_template_result` and I just
realized in testing it doesn't work exactly as expected with
Number values cast as strings (usually from templates).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
