### PR TITLE
Improve ozw websocket response when node is not found

### DIFF
--- a/homeassistant/components/ozw/websocket_api.py
+++ b/homeassistant/components/ozw/websocket_api.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from openzwavemqtt.const import EVENT_NODE_ADDED, EVENT_NODE_CHANGED, CommandClass
+from openzwavemqtt.const import EVENT_NODE_ADDED, EVENT_NODE_CHANGED
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
@@ -45,7 +45,6 @@ def async_register_api(hass):
     websocket_api.async_register_command(hass, websocket_node_status)
     websocket_api.async_register_command(hass, websocket_node_statistics)
     websocket_api.async_register_command(hass, websocket_refresh_node_info)
-    websocket_api.async_register_command(hass, websocket_get_config_values)
 
 
 @websocket_api.websocket_command({vol.Required(TYPE): "ozw/get_instances"})
@@ -287,26 +286,3 @@ def websocket_refresh_node_info(hass, connection, msg):
     instance = manager.get_instance(msg[OZW_INSTANCE])
     instance.refresh_node(msg[NODE_ID])
     connection.send_result(msg["id"])
-
-
-@websocket_api.require_admin
-@websocket_api.websocket_command(
-    {
-        vol.Required(TYPE): "ozw/get_config_values",
-        vol.Optional(OZW_INSTANCE, default=1): vol.Coerce(int),
-        vol.Required(NODE_ID): vol.Coerce(int),
-    }
-)
-def websocket_get_config_values(hass, connection, msg):
-    """Fetch configuration values for a node."""
-
-    manager = hass.data[DOMAIN][MANAGER]
-
-    configs = (
-        manager.get_instance(msg[OZW_INSTANCE])
-        .get_node(msg[NODE_ID])
-        .get_instance(1)
-        .get_command_class(CommandClass.CONFIGURATION)
-    )
-
-    connection.send_result(msg[ID], configs)

--- a/tests/components/ozw/test_websocket_api.py
+++ b/tests/components/ozw/test_websocket_api.py
@@ -1,5 +1,6 @@
 """Test OpenZWave Websocket API."""
 
+from homeassistant.components import websocket_api
 from homeassistant.components.ozw.websocket_api import (
     ATTR_IS_AWAKE,
     ATTR_IS_BEAMING,
@@ -68,8 +69,13 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     assert result[ATTR_NODE_SPECIFIC_STRING] == "Binary Power Switch"
     assert result[ATTR_NEIGHBORS] == [1, 33, 36, 37, 39]
 
+    await client.send_json({ID: 7, TYPE: "ozw/node_status", NODE_ID: 999})
+    msg = await client.receive_json()
+    result = msg["error"]
+    assert result["code"] == websocket_api.const.ERR_NOT_FOUND
+
     # Test node statistics
-    await client.send_json({ID: 7, TYPE: "ozw/node_statistics", NODE_ID: 39})
+    await client.send_json({ID: 8, TYPE: "ozw/node_statistics", NODE_ID: 39})
     msg = await client.receive_json()
     result = msg["result"]
 
@@ -87,13 +93,18 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     assert result["received_unsolicited"] == 3546
 
     # Test node metadata
-    await client.send_json({ID: 8, TYPE: "ozw/node_metadata", NODE_ID: 39})
+    await client.send_json({ID: 9, TYPE: "ozw/node_metadata", NODE_ID: 39})
     msg = await client.receive_json()
     result = msg["result"]
     assert result["metadata"]["ProductPic"] == "images/aeotec/zwa002.png"
 
+    await client.send_json({ID: 10, TYPE: "ozw/node_metadata", NODE_ID: 999})
+    msg = await client.receive_json()
+    result = msg["error"]
+    assert result["code"] == websocket_api.const.ERR_NOT_FOUND
+
     # Test network statistics
-    await client.send_json({ID: 9, TYPE: "ozw/network_statistics"})
+    await client.send_json({ID: 11, TYPE: "ozw/network_statistics"})
     msg = await client.receive_json()
     result = msg["result"]
     assert result["readCnt"] == 92220
@@ -101,7 +112,7 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     assert result["node_count"] == 5
 
     # Test get nodes
-    await client.send_json({ID: 10, TYPE: "ozw/get_nodes"})
+    await client.send_json({ID: 12, TYPE: "ozw/get_nodes"})
     msg = await client.receive_json()
     result = msg["result"]
     assert len(result) == 5

--- a/tests/components/ozw/test_websocket_api.py
+++ b/tests/components/ozw/test_websocket_api.py
@@ -1,6 +1,5 @@
 """Test OpenZWave Websocket API."""
 
-from homeassistant.components import websocket_api
 from homeassistant.components.ozw.websocket_api import (
     ATTR_IS_AWAKE,
     ATTR_IS_BEAMING,
@@ -20,6 +19,7 @@ from homeassistant.components.ozw.websocket_api import (
     OZW_INSTANCE,
     TYPE,
 )
+from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
 
 from .common import MQTTMessage, setup_ozw
 
@@ -72,7 +72,7 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     await client.send_json({ID: 7, TYPE: "ozw/node_status", NODE_ID: 999})
     msg = await client.receive_json()
     result = msg["error"]
-    assert result["code"] == websocket_api.const.ERR_NOT_FOUND
+    assert result["code"] == ERR_NOT_FOUND
 
     # Test node statistics
     await client.send_json({ID: 8, TYPE: "ozw/node_statistics", NODE_ID: 39})
@@ -101,7 +101,7 @@ async def test_websocket_api(hass, generic_data, hass_ws_client):
     await client.send_json({ID: 10, TYPE: "ozw/node_metadata", NODE_ID: 999})
     msg = await client.receive_json()
     result = msg["error"]
-    assert result["code"] == websocket_api.const.ERR_NOT_FOUND
+    assert result["code"] == ERR_NOT_FOUND
 
     # Test network statistics
     await client.send_json({ID: 11, TYPE: "ozw/network_statistics"})


### PR DESCRIPTION
## Proposed change
This PR updates the node_status and node_metadata functions for the OZW websocket API to return a not_found error if the node is not found.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
