### PR TITLE
Add connection validation on import for dsmr integration

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -1,13 +1,84 @@
 """Config flow for DSMR integration."""
+import asyncio
+from functools import partial
 import logging
 from typing import Any, Dict, Optional
 
-from homeassistant import config_entries
+from dsmr_parser import obis_references as obis_ref
+from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
+import serial
+
+from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST, CONF_PORT
 
 from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class DSMRConnection:
+    """Test the connection to DSMR and receive telegram to read serial ids."""
+
+    def __init__(self, host, port, dsmr_version):
+        """Initialize."""
+        self._host = host
+        self._port = port
+        self._dsmr_version = dsmr_version
+        self._telegram = {}
+
+    def equipment_identifier(self):
+        """Equipment identifier."""
+        if obis_ref.EQUIPMENT_IDENTIFIER in self._telegram:
+            dsmr_object = self._telegram[obis_ref.EQUIPMENT_IDENTIFIER]
+            return getattr(dsmr_object, "value", None)
+
+    def equipment_identifier_gas(self):
+        """Equipment identifier gas."""
+        if obis_ref.EQUIPMENT_IDENTIFIER_GAS in self._telegram:
+            dsmr_object = self._telegram[obis_ref.EQUIPMENT_IDENTIFIER_GAS]
+            return getattr(dsmr_object, "value", None)
+
+    async def validate_connect(self, hass: core.HomeAssistant) -> bool:
+        """Test if we can validate connection with the device."""
+
+        def update_telegram(telegram):
+            self._telegram = telegram
+
+            transport.close()
+
+        if self._host is None:
+            reader_factory = partial(
+                create_dsmr_reader,
+                self._port,
+                self._dsmr_version,
+                update_telegram,
+                loop=hass.loop,
+            )
+        else:
+            reader_factory = partial(
+                create_tcp_dsmr_reader,
+                self._host,
+                self._port,
+                self._dsmr_version,
+                update_telegram,
+                loop=hass.loop,
+            )
+
+        try:
+            transport, protocol = await hass.loop.create_task(reader_factory())
+        except (
+            serial.serialutil.SerialException,
+            ConnectionRefusedError,
+            TimeoutError,
+            asyncio.TimeoutError,
+        ):
+            _LOGGER.exception("Error connecting to DSMR")
+            return False
+
+        if transport:
+            await protocol.wait_closed()
+
+        return True
 
 
 class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -162,6 +162,9 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         data = {**import_config, **info}
 
+        await self.async_set_unique_id(info[CONF_SERIAL_ID])
+        self._abort_if_unique_id_configured(data)
+
         return self.async_create_entry(title=name, data=data)
 
 

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -81,10 +81,9 @@ class DSMRConnection:
                 async with timeout(30):
                     await protocol.wait_closed()
             except asyncio.TimeoutError:
+                # Timeout (no data received), close transport and return True (if telegram is empty, will result in CannotCommunicate error)
                 transport.close()
                 await protocol.wait_closed()
-                return False
-
         return True
 
 

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -83,7 +83,7 @@ class DSMRConnection:
 
 async def _validate_dsmr_connection(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect."""
-    conn = DSMRConnection(data[CONF_HOST], data[CONF_PORT], data[CONF_DSMR_VERSION])
+    conn = DSMRConnection(data.get(CONF_HOST), data[CONF_PORT], data[CONF_DSMR_VERSION])
 
     if not await conn.validate_connect(hass):
         raise CannotConnect

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -144,6 +144,10 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         host = import_config.get(CONF_HOST)
         port = import_config[CONF_PORT]
 
+        status = self._abort_if_host_port_configured(port, host, import_config)
+        if status is not None:
+            return status
+
         try:
             info = await _validate_dsmr_connection(self.hass, import_config)
         except CannotConnect:
@@ -151,16 +155,12 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except CannotCommunicate:
             return self.async_abort(reason="cannot_communicate")
 
-        data = {**import_config, **info}
-
-        status = self._abort_if_host_port_configured(port, host, data)
-        if status is not None:
-            return status
-
         if host is not None:
             name = f"{host}:{port}"
         else:
             name = port
+
+        data = {**import_config, **info}
 
         return self.async_create_entry(title=name, data=data)
 

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -91,6 +91,7 @@ async def _validate_dsmr_connection(hass: core.HomeAssistant, data):
     equipment_identifier = conn.equipment_identifier()
     equipment_identifier_gas = conn.equipment_identifier_gas()
 
+    # Check only for equipment identifier in case no gas meter is connected
     if equipment_identifier is None:
         raise CannotCommunicate
 

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -8,6 +8,9 @@ CONF_DSMR_VERSION = "dsmr_version"
 CONF_RECONNECT_INTERVAL = "reconnect_interval"
 CONF_PRECISION = "precision"
 
+CONF_SERIAL_ID = "serial_id"
+CONF_SERIAL_ID_GAS = "serial_id_gas"
+
 DEFAULT_DSMR_VERSION = "2.2"
 DEFAULT_PORT = "/dev/ttyUSB0"
 DEFAULT_PRECISION = 3

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -10,7 +10,6 @@ import serial
 from homeassistant import config_entries, setup
 from homeassistant.components.dsmr import DOMAIN
 
-import tests.async_mock
 from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
 
@@ -20,8 +19,8 @@ SERIAL_DATA = {"serial_id": "12345678", "serial_id_gas": "123456789"}
 @pytest.fixture
 def mock_connection_factory(monkeypatch):
     """Mock the create functions for serial and TCP Asyncio connections."""
-    transport = tests.async_mock.Mock(spec=asyncio.Transport)
-    protocol = tests.async_mock.Mock(spec=DSMRProtocol)
+    transport = Mock(spec=asyncio.Transport)
+    protocol = Mock(spec=DSMRProtocol)
 
     async def connection_factory(*args, **kwargs):
         """Return mocked out Asyncio classes."""

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -61,8 +61,13 @@ async def test_setup_platform(hass, mock_connection_factory):
         "reconnect_interval": 30,
     }
 
+    serial_data = {"serial_id": "1234", "serial_id_gas": "5678"}
+
     with patch("homeassistant.components.dsmr.async_setup", return_value=True), patch(
         "homeassistant.components.dsmr.async_setup_entry", return_value=True
+    ), patch(
+        "homeassistant.components.dsmr.config_flow._validate_dsmr_connection",
+        return_value=serial_data,
     ):
         assert await async_setup_component(
             hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: entry_data}
@@ -79,7 +84,7 @@ async def test_setup_platform(hass, mock_connection_factory):
     entry = conf_entries[0]
 
     assert entry.state == "loaded"
-    assert entry.data == entry_data
+    assert entry.data == {**entry_data, **serial_data}
 
 
 async def test_default_setup(hass, mock_connection_factory):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR implements device connection validation upon import for dsmr integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
