### PR TITLE
Add support for learning RF commands with Broadlink remotes

### DIFF
--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -69,9 +69,7 @@ SERVICE_SEND_SCHEMA = COMMAND_SCHEMA.extend(
 SERVICE_LEARN_SCHEMA = COMMAND_SCHEMA.extend(
     {
         vol.Required(ATTR_DEVICE): vol.All(cv.string, vol.Length(min=1)),
-        vol.Optional(ATTR_COMMAND_TYPE, default=COMMAND_TYPES[0]): vol.In(
-            COMMAND_TYPES
-        ),
+        vol.Optional(ATTR_COMMAND_TYPE, default=COMMAND_TYPE_IR): vol.In(COMMAND_TYPES),
         vol.Optional(ATTR_ALTERNATIVE, default=False): cv.boolean,
     }
 )
@@ -353,7 +351,11 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 except (ReadError, StorageError):
                     continue
                 return b64encode(code).decode("utf8")
-            raise TimeoutError("No code received")
+
+            raise TimeoutError(
+                "No infrared code received within "
+                f"{LEARNING_TIMEOUT.seconds} seconds"
+            )
 
         finally:
             self.hass.components.persistent_notification.async_dismiss(
@@ -388,7 +390,10 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 await self._device.async_request(
                     self._device.api.cancel_sweep_frequency
                 )
-                raise TimeoutError("No radiofrequency found")
+                raise TimeoutError(
+                    "No radiofrequency found within "
+                    f"{LEARNING_TIMEOUT.seconds} seconds"
+                )
 
         finally:
             self.hass.components.persistent_notification.async_dismiss(
@@ -419,7 +424,11 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 except (ReadError, StorageError):
                     continue
                 return b64encode(code).decode("utf8")
-            raise TimeoutError("No code received")
+
+            raise TimeoutError(
+                "No radiofrequency code received within "
+                f"{LEARNING_TIMEOUT.seconds} seconds"
+            )
 
         finally:
             self.hass.components.persistent_notification.async_dismiss(

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -18,6 +18,7 @@ import voluptuous as vol
 from homeassistant.components.remote import (
     ATTR_ALTERNATIVE,
     ATTR_COMMAND,
+    ATTR_COMMAND_TYPE,
     ATTR_DELAY_SECS,
     ATTR_DEVICE,
     ATTR_NUM_REPEATS,
@@ -40,6 +41,10 @@ from .helpers import data_packet, import_device
 _LOGGER = logging.getLogger(__name__)
 
 LEARNING_TIMEOUT = timedelta(seconds=30)
+
+INFRARED = "ir"
+RADIOFREQUENCY = "rf"
+COMMAND_TYPES = [INFRARED, RADIOFREQUENCY]
 
 CODE_STORAGE_VERSION = 1
 FLAG_STORAGE_VERSION = 1
@@ -64,6 +69,9 @@ SERVICE_SEND_SCHEMA = COMMAND_SCHEMA.extend(
 SERVICE_LEARN_SCHEMA = COMMAND_SCHEMA.extend(
     {
         vol.Required(ATTR_DEVICE): vol.All(cv.string, vol.Length(min=1)),
+        vol.Optional(ATTR_COMMAND_TYPE, default=COMMAND_TYPES[0]): vol.In(
+            COMMAND_TYPES
+        ),
         vol.Optional(ATTR_ALTERNATIVE, default=False): cv.boolean,
     }
 )
@@ -266,11 +274,11 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 await self._device.async_request(self._device.api.send_data, code)
 
             except (AuthorizationError, NetworkTimeoutError, OSError) as err:
-                _LOGGER.error("Failed to send '%s': %s", command, err)
+                _LOGGER.error("Failed to send '%s': %s", cmd, err)
                 break
 
             except BroadlinkException as err:
-                _LOGGER.error("Failed to send '%s': %s", command, err)
+                _LOGGER.error("Failed to send '%s': %s", cmd, err)
                 should_delay = False
                 continue
 
@@ -284,6 +292,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         """Learn a list of commands from a remote."""
         kwargs = SERVICE_LEARN_SCHEMA(kwargs)
         commands = kwargs[ATTR_COMMAND]
+        command_type = kwargs[ATTR_COMMAND_TYPE]
         device = kwargs[ATTR_DEVICE]
         toggle = kwargs[ATTR_ALTERNATIVE]
 
@@ -293,13 +302,18 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
             )
             return
 
+        learn_command = (
+            self._async_learn_ir_command
+            if command_type == INFRARED
+            else self._async_learn_rf_command
+        )
         should_store = False
 
         for command in commands:
             try:
-                code = await self._async_learn_command(command)
+                code = await learn_command(command)
                 if toggle:
-                    code = [code, await self._async_learn_command(command)]
+                    code = [code, await learn_command(command)]
 
             except (AuthorizationError, NetworkTimeoutError, OSError) as err:
                 _LOGGER.error("Failed to learn '%s': %s", command, err)
@@ -315,8 +329,8 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         if should_store:
             await self._code_storage.async_save(self._codes)
 
-    async def _async_learn_command(self, command):
-        """Learn a command from a remote."""
+    async def _async_learn_ir_command(self, command):
+        """Learn an infrared command."""
         try:
             await self._device.async_request(self._device.api.enter_learning)
 
@@ -336,10 +350,74 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 await asyncio.sleep(1)
                 try:
                     code = await self._device.async_request(self._device.api.check_data)
-
                 except (ReadError, StorageError):
                     continue
+                return b64encode(code).decode("utf8")
+            raise TimeoutError("No code received")
 
+        finally:
+            self.hass.components.persistent_notification.async_dismiss(
+                notification_id="learn_command"
+            )
+
+    async def _async_learn_rf_command(self, command):
+        """Learn a radiofrequency command."""
+        try:
+            await self._device.async_request(self._device.api.sweep_frequency)
+
+        except (BroadlinkException, OSError) as err:
+            _LOGGER.debug("Failed to sweep frequency: %s", err)
+            raise
+
+        self.hass.components.persistent_notification.async_create(
+            f"Press and hold the '{command}' button.",
+            title="Sweep frequency",
+            notification_id="sweep_frequency",
+        )
+
+        try:
+            start_time = utcnow()
+            while (utcnow() - start_time) < LEARNING_TIMEOUT:
+                await asyncio.sleep(1)
+                found = await self._device.async_request(
+                    self._device.api.check_frequency
+                )
+                if found:
+                    break
+            else:
+                await self._device.async_request(
+                    self._device.api.cancel_sweep_frequency
+                )
+                raise TimeoutError("No radiofrequency found")
+
+        finally:
+            self.hass.components.persistent_notification.async_dismiss(
+                notification_id="sweep_frequency"
+            )
+
+        await asyncio.sleep(1)
+
+        try:
+            await self._device.async_request(self._device.api.find_rf_packet)
+
+        except (BroadlinkException, OSError) as err:
+            _LOGGER.debug("Failed to enter learning mode: %s", err)
+            raise
+
+        self.hass.components.persistent_notification.async_create(
+            f"Press the '{command}' button again.",
+            title="Learn command",
+            notification_id="learn_command",
+        )
+
+        try:
+            start_time = utcnow()
+            while (utcnow() - start_time) < LEARNING_TIMEOUT:
+                await asyncio.sleep(1)
+                try:
+                    code = await self._device.async_request(self._device.api.check_data)
+                except (ReadError, StorageError):
+                    continue
                 return b64encode(code).decode("utf8")
             raise TimeoutError("No code received")
 

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -42,9 +42,9 @@ _LOGGER = logging.getLogger(__name__)
 
 LEARNING_TIMEOUT = timedelta(seconds=30)
 
-INFRARED = "ir"
-RADIOFREQUENCY = "rf"
-COMMAND_TYPES = [INFRARED, RADIOFREQUENCY]
+COMMAND_TYPE_IR = "ir"
+COMMAND_TYPE_RF = "rf"
+COMMAND_TYPES = [COMMAND_TYPE_IR, COMMAND_TYPE_RF]
 
 CODE_STORAGE_VERSION = 1
 FLAG_STORAGE_VERSION = 1
@@ -304,7 +304,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
 
         learn_command = (
             self._async_learn_ir_command
-            if command_type == INFRARED
+            if command_type == COMMAND_TYPE_IR
             else self._async_learn_rf_command
         )
         should_store = False

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -302,11 +302,11 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
             )
             return
 
-        learn_command = (
-            self._async_learn_ir_command
-            if command_type == COMMAND_TYPE_IR
-            else self._async_learn_rf_command
-        )
+        if command_type == COMMAND_TYPE_IR:
+            learn_command = self._async_learn_ir_command
+        else:
+            learn_command = self._async_learn_rf_command
+
         should_store = False
 
         for command in commands:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for learning RF commands with Broadlink devices. These are the proposed changes:
- Create a method for learning RF commands. This method will be called when the user specifies `command_type: rf` in `remote.learn_command` service.
- The method for learning IR commands remains as a default option. The user can also make it explicit by calling `remote.learn_command` with `command_type: ir`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
script:
  learn_car_lock:
    sequence:
      - service: remote.learn_command
        data:
          entity_id: remote.garage
          device: car
          command: unlock
          command_type: rf
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/37055 https://github.com/mjg59/python-broadlink/issues/358
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14398

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
