### PR TITLE
Time condition can also accept an input_datetime Entity ID

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -956,8 +956,8 @@ TIME_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_CONDITION): "time",
-            "before": time,
-            "after": time,
+            "before": vol.Any(time, vol.All(str, entity_domain("input_datetime"))),
+            "after": vol.Any(time, vol.All(str, entity_domain("input_datetime"))),
             "weekday": weekdays,
         }
     ),

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.async_mock import patch
@@ -226,29 +227,115 @@ async def test_time_window(hass):
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=3),
     ):
-        assert not condition.time(after=sixam, before=sixpm)
-        assert condition.time(after=sixpm, before=sixam)
+        assert not condition.time(hass, after=sixam, before=sixpm)
+        assert condition.time(hass, after=sixpm, before=sixam)
 
     with patch(
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=9),
     ):
-        assert condition.time(after=sixam, before=sixpm)
-        assert not condition.time(after=sixpm, before=sixam)
+        assert condition.time(hass, after=sixam, before=sixpm)
+        assert not condition.time(hass, after=sixpm, before=sixam)
 
     with patch(
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=15),
     ):
-        assert condition.time(after=sixam, before=sixpm)
-        assert not condition.time(after=sixpm, before=sixam)
+        assert condition.time(hass, after=sixam, before=sixpm)
+        assert not condition.time(hass, after=sixpm, before=sixam)
 
     with patch(
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=21),
     ):
-        assert not condition.time(after=sixam, before=sixpm)
-        assert condition.time(after=sixpm, before=sixam)
+        assert not condition.time(hass, after=sixam, before=sixpm)
+        assert condition.time(hass, after=sixpm, before=sixam)
+
+
+async def test_time_using_input_datetime(hass):
+    """Test time conditions using input_datetime entities."""
+    await async_setup_component(
+        hass,
+        "input_datetime",
+        {
+            "input_datetime": {
+                "am": {"has_date": True, "has_time": True},
+                "pm": {"has_date": True, "has_time": True},
+            }
+        },
+    )
+
+    await hass.services.async_call(
+        "input_datetime",
+        "set_datetime",
+        {
+            "entity_id": "input_datetime.am",
+            "datetime": str(
+                dt.now()
+                .replace(hour=6, minute=0, second=0, microsecond=0)
+                .replace(tzinfo=None)
+            ),
+        },
+        blocking=True,
+    )
+
+    await hass.services.async_call(
+        "input_datetime",
+        "set_datetime",
+        {
+            "entity_id": "input_datetime.pm",
+            "datetime": str(
+                dt.now()
+                .replace(hour=18, minute=0, second=0, microsecond=0)
+                .replace(tzinfo=None)
+            ),
+        },
+        blocking=True,
+    )
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt.now().replace(hour=3),
+    ):
+        assert not condition.time(
+            hass, after="input_datetime.am", before="input_datetime.pm"
+        )
+        assert condition.time(
+            hass, after="input_datetime.pm", before="input_datetime.am"
+        )
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt.now().replace(hour=9),
+    ):
+        assert condition.time(
+            hass, after="input_datetime.am", before="input_datetime.pm"
+        )
+        assert not condition.time(
+            hass, after="input_datetime.pm", before="input_datetime.am"
+        )
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt.now().replace(hour=15),
+    ):
+        assert condition.time(
+            hass, after="input_datetime.am", before="input_datetime.pm"
+        )
+        assert not condition.time(
+            hass, after="input_datetime.pm", before="input_datetime.am"
+        )
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt.now().replace(hour=21),
+    ):
+        assert not condition.time(
+            hass, after="input_datetime.am", before="input_datetime.pm"
+        )
+        assert condition.time(
+            hass, after="input_datetime.pm", before="input_datetime.am"
+        )
 
 
 async def test_if_numeric_state_not_raise_on_unavailable(hass):

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -337,6 +337,9 @@ async def test_time_using_input_datetime(hass):
             hass, after="input_datetime.pm", before="input_datetime.am"
         )
 
+    assert not condition.time(hass, after="input_datetime.not_existing")
+    assert not condition.time(hass, before="input_datetime.not_existing")
+
 
 async def test_if_numeric_state_not_raise_on_unavailable(hass):
     """Test numeric_state doesn't raise on unavailable/unknown state."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

It is currently hard to work with values from `input_datetime` which requires the use of templates like his:

```yaml
- condition: template
  value_template: "{{ states('sensor.time') == (state_attr('input_datetime.house_silent_hours_end', 'timestamp') | int | timestamp_custom('%H:%M', False)) }}"
```

This PR allows for:

```yaml
- condition: time
  after: input_datetime.house_silent_hours_end
```

or even:

```yaml
- condition: time
  after: input_datetime.house_silent_hours_start
  before: input_datetime.house_silent_hours_end
```

Followup of #38698, which introduced this possibility for time triggers. This PR makes this feature more consistent by allowing the same for the time condition.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14404

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
