### PR TITLE
Numeric state condition can also accept input_number entity ID

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -167,8 +167,8 @@ async def async_not_from_config(
 def numeric_state(
     hass: HomeAssistant,
     entity: Union[None, str, State],
-    below: Optional[float] = None,
-    above: Optional[float] = None,
+    below: Optional[Union[float, str]] = None,
+    above: Optional[Union[float, str]] = None,
     value_template: Optional[Template] = None,
     variables: TemplateVarsType = None,
 ) -> bool:
@@ -188,8 +188,8 @@ def numeric_state(
 def async_numeric_state(
     hass: HomeAssistant,
     entity: Union[None, str, State],
-    below: Optional[float] = None,
-    above: Optional[float] = None,
+    below: Optional[Union[float, str]] = None,
+    above: Optional[Union[float, str]] = None,
     value_template: Optional[Template] = None,
     variables: TemplateVarsType = None,
     attribute: Optional[str] = None,
@@ -229,11 +229,29 @@ def async_numeric_state(
         )
         return False
 
-    if below is not None and fvalue >= below:
-        return False
+    if below is not None:
+        if isinstance(below, str):
+            below_entity = hass.states.get(below)
+            if (
+                not below_entity
+                or below_entity.state in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+                or fvalue >= float(below_entity.state)
+            ):
+                return False
+        elif fvalue >= below:
+            return False
 
-    if above is not None and fvalue <= above:
-        return False
+    if above is not None:
+        if isinstance(above, str):
+            above_entity = hass.states.get(above)
+            if (
+                not above_entity
+                or above_entity.state in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+                or fvalue <= float(above_entity.state)
+            ):
+                return False
+        elif fvalue <= above:
+            return False
 
     return True
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -906,8 +906,12 @@ NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
             vol.Required(CONF_CONDITION): "numeric_state",
             vol.Required(CONF_ENTITY_ID): entity_ids,
             vol.Optional(CONF_ATTRIBUTE): str,
-            CONF_BELOW: vol.Coerce(float),
-            CONF_ABOVE: vol.Coerce(float),
+            CONF_BELOW: vol.Any(
+                vol.Coerce(float), vol.All(str, entity_domain("input_number"))
+            ),
+            CONF_ABOVE: vol.Any(
+                vol.Coerce(float), vol.All(str, entity_domain("input_number"))
+            ),
             vol.Optional(CONF_VALUE_TEMPLATE): template,
         }
     ),

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.async_mock import patch
@@ -416,6 +417,62 @@ async def test_numberic_state_attribute(hass):
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": None})
     assert not test(hass)
+
+
+async def test_numeric_state_using_input_number(hass):
+    """Test numeric_state conditions using input_number entities."""
+    await async_setup_component(
+        hass,
+        "input_number",
+        {
+            "input_number": {
+                "low": {"min": 0, "max": 255, "initial": 10},
+                "high": {"min": 0, "max": 255, "initial": 100},
+            }
+        },
+    )
+
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "numeric_state",
+                    "entity_id": "sensor.temperature",
+                    "below": "input_number.high",
+                    "above": "input_number.low",
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set("sensor.temperature", 42)
+    assert test(hass)
+
+    hass.states.async_set("sensor.temperature", 10)
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature", 100)
+    assert not test(hass)
+
+    await hass.services.async_call(
+        "input_number",
+        "set_value",
+        {
+            "entity_id": "input_number.high",
+            "value": 101,
+        },
+        blocking=True,
+    )
+    assert test(hass)
+
+    assert not condition.async_numeric_state(
+        hass, entity="sensor.temperature", below="input_number.not_exist"
+    )
+    assert not condition.async_numeric_state(
+        hass, entity="sensor.temperature", above="input_number.not_exist"
+    )
 
 
 async def test_zone_multiple_entities(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the possibility to use `input_number` entities with the `numeric_state` conditions.

For example:

```yaml
- condition: numeric_state
  entity_id: climate.living_room_thermostat
  attribute: temperature
  above: input_number.temperature_threshold_low
  below: input_number.temperature_threshold_high
```
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14403

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
