### PR TITLE
Add systemmonitor check for mandatory "arg" of sensors

### DIFF
--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -157,7 +157,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             # Check if argument is required. If yes, but none was provided, log an error.
             if SENSOR_TYPES[resource[CONF_TYPE]][4] is True:
                 _LOGGER.error(
-                    f"Mandatory 'arg' is missing for 'type' {resource[CONF_TYPE]}."
+                    "Mandatory 'arg' is missing for sensor type '%s'.",
+                    resource[CONF_TYPE],
                 )
                 continue
 

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -96,12 +96,12 @@ SENSOR_TYPES = {
 def check_required_arg(value):
     """Validate that the required "arg" for the sensor types that need it are set."""
     for sensor in value:
-        type = sensor.get(CONF_TYPE)
-        arg = sensor.get(CONF_ARG)
+        sensor_type = sensor.get(CONF_TYPE)
+        sensor_arg = sensor.get(CONF_ARG)
 
-        if arg is None and SENSOR_TYPES[type][4] is True:
+        if sensor_arg is None and SENSOR_TYPES[sensor_type][4] is True:
             raise vol.RequiredFieldInvalid(
-                f"Mandatory 'arg' is missing for sensor type '{type}'."
+                f"Mandatory 'arg' is missing for sensor type '{sensor_type}'."
             )
 
     return value

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -35,41 +35,61 @@ if sys.maxsize > 2 ** 32:
 else:
     CPU_ICON = "mdi:cpu-32-bit"
 
+# Schema: [name, unit of measurement, icon, device class, flag if mandatory arg]
 SENSOR_TYPES = {
-    "disk_free": ["Disk free", DATA_GIBIBYTES, "mdi:harddisk", None],
-    "disk_use": ["Disk use", DATA_GIBIBYTES, "mdi:harddisk", None],
-    "disk_use_percent": ["Disk use (percent)", PERCENTAGE, "mdi:harddisk", None],
-    "ipv4_address": ["IPv4 address", "", "mdi:server-network", None],
-    "ipv6_address": ["IPv6 address", "", "mdi:server-network", None],
-    "last_boot": ["Last boot", "", "mdi:clock", "timestamp"],
-    "load_15m": ["Load (15m)", " ", "mdi:memory", None],
-    "load_1m": ["Load (1m)", " ", "mdi:memory", None],
-    "load_5m": ["Load (5m)", " ", "mdi:memory", None],
-    "memory_free": ["Memory free", DATA_MEBIBYTES, "mdi:memory", None],
-    "memory_use": ["Memory use", DATA_MEBIBYTES, "mdi:memory", None],
-    "memory_use_percent": ["Memory use (percent)", PERCENTAGE, "mdi:memory", None],
-    "network_in": ["Network in", DATA_MEBIBYTES, "mdi:server-network", None],
-    "network_out": ["Network out", DATA_MEBIBYTES, "mdi:server-network", None],
-    "packets_in": ["Packets in", " ", "mdi:server-network", None],
-    "packets_out": ["Packets out", " ", "mdi:server-network", None],
+    "disk_free": ["Disk free", DATA_GIBIBYTES, "mdi:harddisk", None, False],
+    "disk_use": ["Disk use", DATA_GIBIBYTES, "mdi:harddisk", None, False],
+    "disk_use_percent": [
+        "Disk use (percent)",
+        PERCENTAGE,
+        "mdi:harddisk",
+        None,
+        False,
+    ],
+    "ipv4_address": ["IPv4 address", "", "mdi:server-network", None, True],
+    "ipv6_address": ["IPv6 address", "", "mdi:server-network", None, True],
+    "last_boot": ["Last boot", "", "mdi:clock", "timestamp", False],
+    "load_15m": ["Load (15m)", " ", CPU_ICON, None, False],
+    "load_1m": ["Load (1m)", " ", CPU_ICON, None, False],
+    "load_5m": ["Load (5m)", " ", CPU_ICON, None, False],
+    "memory_free": ["Memory free", DATA_MEBIBYTES, "mdi:memory", None, False],
+    "memory_use": ["Memory use", DATA_MEBIBYTES, "mdi:memory", None, False],
+    "memory_use_percent": [
+        "Memory use (percent)",
+        PERCENTAGE,
+        "mdi:memory",
+        None,
+        False,
+    ],
+    "network_in": ["Network in", DATA_MEBIBYTES, "mdi:server-network", None, True],
+    "network_out": ["Network out", DATA_MEBIBYTES, "mdi:server-network", None, True],
+    "packets_in": ["Packets in", " ", "mdi:server-network", None, True],
+    "packets_out": ["Packets out", " ", "mdi:server-network", None, True],
     "throughput_network_in": [
         "Network throughput in",
         DATA_RATE_MEGABYTES_PER_SECOND,
         "mdi:server-network",
         None,
+        True,
     ],
     "throughput_network_out": [
         "Network throughput out",
         DATA_RATE_MEGABYTES_PER_SECOND,
         "mdi:server-network",
-        None,
+        True,
     ],
-    "process": ["Process", " ", CPU_ICON, None],
-    "processor_use": ["Processor use", PERCENTAGE, CPU_ICON, None],
-    "processor_temperature": ["Processor temperature", TEMP_CELSIUS, CPU_ICON, None],
-    "swap_free": ["Swap free", DATA_MEBIBYTES, "mdi:harddisk", None],
-    "swap_use": ["Swap use", DATA_MEBIBYTES, "mdi:harddisk", None],
-    "swap_use_percent": ["Swap use (percent)", PERCENTAGE, "mdi:harddisk", None],
+    "process": ["Process", " ", CPU_ICON, None, True],
+    "processor_use": ["Processor use", PERCENTAGE, CPU_ICON, None, False],
+    "processor_temperature": [
+        "Processor temperature",
+        TEMP_CELSIUS,
+        CPU_ICON,
+        None,
+        False,
+    ],
+    "swap_free": ["Swap free", DATA_MEBIBYTES, "mdi:harddisk", None, True],
+    "swap_use": ["Swap use", DATA_MEBIBYTES, "mdi:harddisk", None, False],
+    "swap_use_percent": ["Swap use (percent)", PERCENTAGE, "mdi:harddisk", None, False],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -133,6 +153,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 resource[CONF_ARG] = "/"
             else:
                 resource[CONF_ARG] = ""
+
+            # Check if argument is required. If yes, but none was provided, log an error.
+            if SENSOR_TYPES[resource[CONF_TYPE]][4] is True:
+                _LOGGER.error(
+                    f"Mandatory 'arg' is missing for 'type' {resource[CONF_TYPE]}."
+                )
+                continue
 
         # Verify if we can retrieve CPU / processor temperatures.
         # If not, do not create the entity and add a warning to the log

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -96,10 +96,10 @@ SENSOR_TYPES = {
 def check_required_arg(value):
     """Validate that the required "arg" for the sensor types that need it are set."""
     for sensor in value:
-        sensor_type = sensor.get(CONF_TYPE)
+        sensor_type = sensor[CONF_TYPE]
         sensor_arg = sensor.get(CONF_ARG)
 
-        if sensor_arg is None and SENSOR_TYPES[sensor_type][4] is True:
+        if sensor_arg is None and SENSOR_TYPES[sensor_type][4]:
             raise vol.RequiredFieldInvalid(
                 f"Mandatory 'arg' is missing for sensor type '{sensor_type}'."
             )
@@ -111,7 +111,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_RESOURCES, default={CONF_TYPE: "disk_use"}): vol.All(
             cv.ensure_list,
-            check_required_arg,
             [
                 vol.Schema(
                     {
@@ -120,6 +119,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     }
                 )
             ],
+            check_required_arg,
         )
     }
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not really a breaking change, since the overall logic did not change. Arguments that were previously mandatory for sensors of this integration are still mandatory and optional arguments remain optional.

However, we now enforce those mandatory arguments to be present, since otherwise this integration creates entities that cannot do anything, e.g. the sensor for IPv4 addresses cannot do anything if no network interface is specified from which to take the IP.

If the integration fails to load, check the log to see which arguments are missing in your configuration. The documentation also has been updated to clearly show which arguments are mandatory.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the integration schema cannot enforce the "arg" to be mandatory in the configuration, since for some sensors it is, for others not though. In a documentation PR that was just merged (https://github.com/home-assistant/home-assistant.io/pull/14400) I added documentation to make the users aware in which scenarios the "arg" is required. This PR now adds a coding check that will log an error if it is missing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
  - platform: systemmonitor
    resources:
      - type: ipv4_address
```

Will create this log entry:
```2020-09-09 10:28:16 ERROR (MainThread) [homeassistant.config] Invalid config for [sensor.systemmonitor]: Mandatory 'arg' is missing for sensor type 'ipv4_address'. for dictionary value @ data['resources']. Got [OrderedDict([('type', 'disk_use_percent')]), OrderedDict([('type', 'disk_use'), ('arg', '/')]), OrderedDict([('type', 'disk_free'), ('arg', '/')]), OrderedDict([('type', 'disk_use_percent'), ('arg', '/boot')]), OrderedDict([('type', 'disk_use'), ('arg', '/boot')]), OrderedDict([('type', 'disk_free'), ('arg', '/boot')]), OrderedDict([('type', 'memory_use_percent')]), OrderedDict([('type', 'swap_use_percent')]), OrderedDict([('type', 'last_boot')]), OrderedDict([('type', 'processor_temperature.... (See /home/pi/.homeassistant/configuration.yaml, line 81). Please check the docs at https://www.home-assistant.io/integrations/systemmonitor```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
