### PR TITLE
State condition can also accept an input_* Entity ID as state value

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -4,6 +4,7 @@ from collections import deque
 from datetime import datetime, timedelta
 import functools as ft
 import logging
+import re
 import sys
 from typing import Any, Callable, Container, List, Optional, Set, Union, cast
 
@@ -47,6 +48,10 @@ FROM_CONFIG_FORMAT = "{}_from_config"
 ASYNC_FROM_CONFIG_FORMAT = "async_{}_from_config"
 
 _LOGGER = logging.getLogger(__name__)
+
+INPUT_ENTITY_ID = re.compile(
+    r"^input_(?:select|text|number|boolean|datetime)\.(?!.+__)(?!_)[\da-z_]+(?<!_)$"
+)
 
 ConditionCheckerType = Callable[[HomeAssistant, TemplateVarsType], bool]
 
@@ -286,13 +291,25 @@ def state(
 
     assert isinstance(entity, State)
 
+    if attribute is None:
+        value = entity.state
+    else:
+        value = str(entity.attributes.get(attribute))
+
     if isinstance(req_state, str):
         req_state = [req_state]
 
-    if attribute is None:
-        is_state = entity.state in req_state
-    else:
-        is_state = str(entity.attributes.get(attribute)) in req_state
+    is_state = False
+    for req_state_value in req_state:
+        state_value = req_state_value
+        if INPUT_ENTITY_ID.match(req_state_value) is not None:
+            state_entity = hass.states.get(req_state_value)
+            if not state_entity:
+                continue
+            state_value = state_entity.state
+        is_state = value == state_value
+        if is_state:
+            break
 
     if for_period is None or not is_state:
         return is_state

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.async_mock import patch
@@ -354,6 +355,83 @@ async def test_state_attribute(hass):
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": None})
     assert not test(hass)
+
+
+async def test_state_using_input_entities(hass):
+    """Test state conditions using input_* entities."""
+    await async_setup_component(
+        hass,
+        "input_text",
+        {
+            "input_text": {
+                "hello": {"initial": "goodbye"},
+            }
+        },
+    )
+
+    await async_setup_component(
+        hass,
+        "input_select",
+        {
+            "input_select": {
+                "hello": {"options": ["cya", "goodbye", "welcome"], "initial": "cya"},
+            }
+        },
+    )
+
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "and",
+            "conditions": [
+                {
+                    "condition": "state",
+                    "entity_id": "sensor.salut",
+                    "state": ["input_text.hello", "input_select.hello", "salut"],
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set("sensor.salut", "goodbye")
+    assert test(hass)
+
+    hass.states.async_set("sensor.salut", "salut")
+    assert test(hass)
+
+    hass.states.async_set("sensor.salut", "hello")
+    assert not test(hass)
+
+    await hass.services.async_call(
+        "input_text",
+        "set_value",
+        {
+            "entity_id": "input_text.hello",
+            "value": "hi",
+        },
+        blocking=True,
+    )
+    assert not test(hass)
+
+    hass.states.async_set("sensor.salut", "hi")
+    assert test(hass)
+
+    hass.states.async_set("sensor.salut", "cya")
+    assert test(hass)
+
+    await hass.services.async_call(
+        "input_select",
+        "select_option",
+        {
+            "entity_id": "input_select.hello",
+            "option": "welcome",
+        },
+        blocking=True,
+    )
+    assert not test(hass)
+
+    hass.states.async_set("sensor.salut", "welcome")
+    assert test(hass)
 
 
 async def test_numeric_state_multiple_entities(hass):

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -387,7 +387,12 @@ async def test_state_using_input_entities(hass):
                 {
                     "condition": "state",
                     "entity_id": "sensor.salut",
-                    "state": ["input_text.hello", "input_select.hello", "salut"],
+                    "state": [
+                        "input_text.hello",
+                        "input_select.hello",
+                        "input_number.not_exist",
+                        "salut",
+                    ],
                 },
             ],
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR allows for using `input_*` entities (helpers) with state conditions as a value.

Examples:

```yaml
- condition: state
  entity_id: sensor.test
  state: input_text.test
```

```yaml
- condition: state
  entity_id: sensor.test
  state: input_select.test
```

```yaml
- condition: state
  entity_id: sensor.test
  state: input_number.test
```

```yaml
- condition: state
  entity_id: light.test
  state: input_boolean.test
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14412

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
