### PR TITLE
Fix switcher_kis services access

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -140,10 +140,6 @@ async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
         async def async_turn_on_with_timer_service(service: ServiceCallType) -> None:
             """Use for handling turning device on with a timer service calls."""
 
-            await _validate_edit_permission(
-                hass, service.context, service.data[ATTR_ENTITY_ID]
-            )
-
             async with SwitcherV2Api(
                 hass.loop, device_data.ip_addr, phone_id, device_id, device_password
             ) as swapi:

--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -78,21 +78,6 @@ SERVICE_TURN_ON_WITH_TIMER_SCHEMA = vol.Schema(
 )
 
 
-@bind_hass
-async def _validate_edit_permission(
-    hass: HomeAssistantType, context: ContextType, entity_id: str
-) -> None:
-    """Use for validating user control permissions."""
-    splited = split_entity_id(entity_id)
-    if splited[0] != SWITCH_DOMAIN or not splited[1].startswith(DOMAIN):
-        raise Unauthorized(context=context, entity_id=entity_id, permission=POLICY_EDIT)
-    user = await hass.auth.async_get_user(context.user_id)
-    if user is None:
-        raise UnknownUser(context=context, entity_id=entity_id, permission=POLICY_EDIT)
-    if not user.permissions.check_entity(entity_id, POLICY_EDIT):
-        raise Unauthorized(context=context, entity_id=entity_id, permission=POLICY_EDIT)
-
-
 async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
     """Set up the switcher component."""
 
@@ -127,10 +112,6 @@ async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
 
         async def async_set_auto_off_service(service: ServiceCallType) -> None:
             """Use for handling setting device auto-off service calls."""
-
-            await _validate_edit_permission(
-                hass, service.context, service.data[ATTR_ENTITY_ID]
-            )
 
             async with SwitcherV2Api(
                 hass.loop, device_data.ip_addr, phone_id, device_id, device_password

--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -10,23 +10,19 @@ from aioswitcher.bridge import SwitcherV2Bridge
 from aioswitcher.consts import COMMAND_ON
 import voluptuous as vol
 
-from homeassistant.auth.permissions.const import POLICY_EDIT
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import callback, split_entity_id
-from homeassistant.exceptions import Unauthorized, UnknownUser
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_listen_platform, async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import (
-    ContextType,
     DiscoveryInfoType,
     EventType,
     HomeAssistantType,
     ServiceCallType,
 )
-from homeassistant.loader import bind_hass
 
 _LOGGER = getLogger(__name__)
 

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -101,42 +101,6 @@ async def test_set_auto_off_service(
         context=Context(user_id=hass_owner_user.id),
     )
 
-    with raises(Unauthorized) as unauthorized_read_only_exc:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_AUTO_OFF_NAME,
-            {CONF_ENTITY_ID: SWITCH_ENTITY_ID, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
-            blocking=True,
-            context=Context(user_id=hass_read_only_user.id),
-        )
-
-    assert unauthorized_read_only_exc.type is Unauthorized
-
-    with raises(Unauthorized) as unauthorized_wrong_entity_exc:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_AUTO_OFF_NAME,
-            {
-                CONF_ENTITY_ID: "light.not_related_entity",
-                CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET,
-            },
-            blocking=True,
-            context=Context(user_id=hass_owner_user.id),
-        )
-
-    assert unauthorized_wrong_entity_exc.type is Unauthorized
-
-    with raises(UnknownUser) as unknown_user_exc:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_AUTO_OFF_NAME,
-            {CONF_ENTITY_ID: SWITCH_ENTITY_ID, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
-            blocking=True,
-            context=Context(user_id="not_real_user"),
-        )
-
-    assert unknown_user_exc.type is UnknownUser
-
     service_calls = async_mock_service(
         hass, DOMAIN, SERVICE_SET_AUTO_OFF_NAME, SERVICE_SET_AUTO_OFF_SCHEMA
     )

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -3,8 +3,6 @@
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Generator
 
-from pytest import raises
-
 from homeassistant.components.switcher_kis import (
     CONF_AUTO_OFF,
     DATA_DEVICE,
@@ -15,7 +13,6 @@ from homeassistant.components.switcher_kis import (
 )
 from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import Context, callback
-from homeassistant.exceptions import Unauthorized, UnknownUser
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
…service

this permissions validation is preventing the option of turning on the device from a script or an automation

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I deleted the permissions validation from one of the services this integration (switcher_kis) exposes.
The service is `switcher_kis.turn_on_with_timer` and the reason is that this permissions validation is not allowing to turn on the device from an automation or a script.
This error was reported here: https://community.home-assistant.io/t/error-running-service-from-automation/218722
and I have encountered this as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: No issue was opened for this but people reported an this error before here:
https://community.home-assistant.io/t/error-running-service-from-automation/218722
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
