### PR TITLE
Implement device migration function in rfxtrx option flow

### DIFF
--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -464,11 +464,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_validate_rfx(self, host=None, port=None, device=None):
         """Create data for rfxtrx entry."""
-        # success = await self.hass.async_add_executor_job(
-        #    _test_transport, host, port, device
-        # )
-        # if not success:
-        #    raise CannotConnect
+        success = await self.hass.async_add_executor_job(
+            _test_transport, host, port, device
+        )
+        if not success:
+            raise CannotConnect
 
         data = {
             CONF_HOST: host,

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -176,7 +176,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                 await self._async_replace_device(user_input[CONF_REPLACE_DEVICE])
 
                 devices = {self._selected_device_event_code: None}
-
                 self.update_config_data(
                     global_options=self._global_options, devices=devices
                 )

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -316,18 +316,18 @@ class OptionsFlow(config_entries.OptionsFlow):
         new_device_id = "_".join(x for x in new_device_data[CONF_DEVICE_ID])
 
         entity_registry = await async_get_entity_registry(self.hass)
-        entities = async_entries_for_device(entity_registry, old_device)
+        entity_entries = async_entries_for_device(entity_registry, old_device)
         entity_migration_map = {}
-        for entity in entities:
-            unique_id = entity.unique_id
+        for entry in entity_entries:
+            unique_id = entry.unique_id
             new_unique_id = unique_id.replace(old_device_id, new_device_id)
 
             new_entity_id = entity_registry.async_get_entity_id(
-                entity.domain, entity.platform, new_unique_id
+                entry.domain, entry.platform, new_unique_id
             )
 
             if new_entity_id is not None:
-                entity_migration_map[new_entity_id] = entity
+                entity_migration_map[new_entity_id] = entry
 
         for entry in entity_migration_map.values():
             entity_registry.async_remove(entry.entity_id)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -279,19 +279,18 @@ class OptionsFlow(config_entries.OptionsFlow):
                 }
             )
 
-        if isinstance(self._selected_device_object, rfxtrxmod.SensorEvent):
-            devices = {
-                entry.id: entry.name_by_user if entry.name_by_user else entry.name
-                for entry in self._device_entries
-                if self._can_replace_device(entry.id)
-            }
+        devices = {
+            entry.id: entry.name_by_user if entry.name_by_user else entry.name
+            for entry in self._device_entries
+            if self._can_replace_device(entry.id)
+        }
 
-            if devices:
-                data_schema.update(
-                    {
-                        vol.Optional(CONF_REPLACE_DEVICE): vol.In(devices),
-                    }
-                )
+        if devices:
+            data_schema.update(
+                {
+                    vol.Optional(CONF_REPLACE_DEVICE): vol.In(devices),
+                }
+            )
 
         return self.async_show_form(
             step_id="set_device_options",
@@ -349,8 +348,8 @@ class OptionsFlow(config_entries.OptionsFlow):
         event_code = device_data[CONF_EVENT_CODE]
         rfx_obj = get_rfx_object(event_code)
         if (
-            rfx_obj.pkt.packettype == self._selected_device_object.pkt.packettype
-            and rfx_obj.pkt.subtype == self._selected_device_object.pkt.subtype
+            rfx_obj.device.packettype == self._selected_device_object.device.packettype
+            and rfx_obj.device.subtype == self._selected_device_object.device.subtype
             and self._selected_device_event_code != event_code
         ):
             return True

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -300,6 +300,7 @@ class OptionsFlow(config_entries.OptionsFlow):
         )
 
     async def _async_replace_device(self, replace_device):
+        """Migrate properties of a device into another."""
         device_registry = self._device_registry
         old_device_id = self._selected_device_entry_id
         old_entry = device_registry.async_get(old_device_id)

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -8,6 +8,7 @@ CONF_DEBUG = "debug"
 CONF_OFF_DELAY = "off_delay"
 
 CONF_REMOVE_DEVICE = "remove_device"
+CONF_REPLACE_DEVICE = "replace_device"
 
 COMMAND_ON_LIST = [
     "On",

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -56,7 +56,8 @@
           "data_bit": "Number of data bits",
           "command_on": "Data bits value for command on",
           "command_off": "Data bits value for command off",
-          "signal_repetitions": "Number of signal repetitions"
+          "signal_repetitions": "Number of signal repetitions",
+          "replace_device": "Select device to replace"
         },
         "title": "Configure device options"
       }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -30,7 +30,7 @@
       },
       "setup_serial_manual_path": {
         "data": {
-          "device": "Select path"
+          "device": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Path"
       }
@@ -67,7 +67,7 @@
       "invalid_input_2262_on": "Invalid input for command on",
       "invalid_input_2262_off": "Invalid input for command off",
       "invalid_input_off_delay": "Invalid input for off delay",
-      "unknown": "Unexpected error"
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }
 }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,23 +1,17 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Already configured. Only a single configuration possible.",
-            "cannot_connect": "Failed to connect"
+            "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
         },
         "error": {
-            "cannot_connect": "Failed to connect"
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
         },
         "step": {
-            "user": {
-                "data": {
-                    "type": "Connection type"
-                },
-                "title": "Select connection type"
-            },
             "setup_network": {
                 "data": {
-                    "host": "Host",
-                    "port": "Port"
+                    "host": "[%key:common::config_flow::data::host%]",
+                    "port": "[%key:common::config_flow::data::port%]"
                 },
                 "title": "Select connection address"
             },
@@ -32,40 +26,47 @@
                     "device": "Select path"
                 },
                 "title": "Path"
+            },
+            "user": {
+                "data": {
+                    "type": "Connection type"
+                },
+                "title": "Select connection type"
             }
         }
     },
     "options": {
+        "error": {
+            "invalid_event_code": "Invalid event code",
+            "invalid_input_2262_off": "Invalid input for command off",
+            "invalid_input_2262_on": "Invalid input for command on",
+            "invalid_input_off_delay": "Invalid input for off delay",
+            "unknown": "Unexpected error"
+        },
         "step": {
             "prompt_options": {
                 "data": {
-                    "debug": "Enable debugging",
                     "automatic_add": "Enable automatic add",
-                    "event_code": "Enter event code to add",
+                    "debug": "Enable debugging",
                     "device": "Select device to configure",
+                    "event_code": "Enter event code to add",
                     "remove_device": "Select device to delete"
                 },
                 "title": "Rfxtrx Options"
             },
             "set_device_options": {
                 "data": {
+                    "command_off": "Data bits value for command off",
+                    "command_on": "Data bits value for command on",
+                    "data_bit": "Number of data bits",
                     "fire_event": "Enable device event",
                     "off_delay": "Off delay",
                     "off_delay_enabled": "Enable off delay",
-                    "data_bit": "Number of data bits",
-                    "command_on": "Data bits value for command on",
-                    "command_off": "Data bits value for command off",
+                    "replace_device": "Select device to replace",
                     "signal_repetitions": "Number of signal repetitions"
                 },
                 "title": "Configure device options"
             }
-        },
-        "error": {
-            "invalid_event_code": "Invalid event code",
-            "invalid_input_2262_on": "Invalid input for command on",
-            "invalid_input_2262_off": "Invalid input for command off",
-            "invalid_input_off_delay": "Invalid input for off delay",
-            "unknown": "Unexpected error"
         }
     },
     "title": "Rfxtrx"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -1,17 +1,23 @@
 {
     "config": {
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+            "already_configured": "Already configured. Only a single configuration possible.",
+            "cannot_connect": "Failed to connect"
         },
         "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+            "cannot_connect": "Failed to connect"
         },
         "step": {
+            "user": {
+                "data": {
+                    "type": "Connection type"
+                },
+                "title": "Select connection type"
+            },
             "setup_network": {
                 "data": {
-                    "host": "[%key:common::config_flow::data::host%]",
-                    "port": "[%key:common::config_flow::data::port%]"
+                    "host": "Host",
+                    "port": "Port"
                 },
                 "title": "Select connection address"
             },
@@ -26,47 +32,41 @@
                     "device": "Select path"
                 },
                 "title": "Path"
-            },
-            "user": {
-                "data": {
-                    "type": "Connection type"
-                },
-                "title": "Select connection type"
             }
         }
     },
     "options": {
-        "error": {
-            "invalid_event_code": "Invalid event code",
-            "invalid_input_2262_off": "Invalid input for command off",
-            "invalid_input_2262_on": "Invalid input for command on",
-            "invalid_input_off_delay": "Invalid input for off delay",
-            "unknown": "Unexpected error"
-        },
         "step": {
             "prompt_options": {
                 "data": {
-                    "automatic_add": "Enable automatic add",
                     "debug": "Enable debugging",
-                    "device": "Select device to configure",
+                    "automatic_add": "Enable automatic add",
                     "event_code": "Enter event code to add",
+                    "device": "Select device to configure",
                     "remove_device": "Select device to delete"
                 },
                 "title": "Rfxtrx Options"
             },
             "set_device_options": {
                 "data": {
-                    "command_off": "Data bits value for command off",
-                    "command_on": "Data bits value for command on",
-                    "data_bit": "Number of data bits",
                     "fire_event": "Enable device event",
                     "off_delay": "Off delay",
                     "off_delay_enabled": "Enable off delay",
-                    "replace_device": "Select device to replace",
-                    "signal_repetitions": "Number of signal repetitions"
+                    "data_bit": "Number of data bits",
+                    "command_on": "Data bits value for command on",
+                    "command_off": "Data bits value for command off",
+                    "signal_repetitions": "Number of signal repetitions",
+                    "replace_device": "Select device to replace"
                 },
                 "title": "Configure device options"
             }
+        },
+        "error": {
+            "invalid_event_code": "Invalid event code",
+            "invalid_input_2262_on": "Invalid input for command on",
+            "invalid_input_2262_off": "Invalid input for command off",
+            "invalid_input_off_delay": "Invalid input for off delay",
+            "unknown": "Unexpected error"
         }
     },
     "title": "Rfxtrx"

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -617,7 +617,7 @@ async def test_options_add_remove_device(hass):
 
 
 async def test_options_replace_sensor_device(hass):
-    """Test we can replace a device."""
+    """Test we can replace a sensor device."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
@@ -731,31 +731,31 @@ async def test_options_replace_sensor_device(hass):
 
     entity_registry = await async_get_entity_registry(hass)
 
-    rssi_entity = entity_registry.async_get(
+    entry = entity_registry.async_get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_rssi_numeric"
     )
-    assert rssi_entity
-    assert rssi_entity.device_id == new_device
-    humidity_entity = entity_registry.async_get(
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_humidity"
     )
-    assert humidity_entity
-    assert humidity_entity.device_id == new_device
-    humidity_status_entity = entity_registry.async_get(
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_humidity_status"
     )
-    assert humidity_status_entity
-    assert humidity_status_entity.device_id == new_device
-    battery_numeric_entity = entity_registry.async_get(
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_battery_numeric"
     )
-    assert battery_numeric_entity
-    assert battery_numeric_entity.device_id == new_device
-    temperature_entity = entity_registry.async_get(
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_temperature"
     )
-    assert temperature_entity
-    assert temperature_entity.device_id == new_device
+    assert entry
+    assert entry.device_id == new_device
 
     state = hass.states.get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_23_04_rssi_numeric"
@@ -872,15 +872,15 @@ async def test_options_replace_control_device(hass):
 
     entity_registry = await async_get_entity_registry(hass)
 
-    binary_entity = entity_registry.async_get("binary_sensor.ac_118cdea_2")
-    assert binary_entity
-    assert binary_entity.device_id == new_device
-    sensor_entity = entity_registry.async_get("sensor.ac_118cdea_2_rssi_numeric")
-    assert sensor_entity
-    assert sensor_entity.device_id == new_device
-    switch_entity = entity_registry.async_get("switch.ac_118cdea_2")
-    assert switch_entity
-    assert switch_entity.device_id == new_device
+    entry = entity_registry.async_get("binary_sensor.ac_118cdea_2")
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get("sensor.ac_118cdea_2_rssi_numeric")
+    assert entry
+    assert entry.device_id == new_device
+    entry = entity_registry.async_get("switch.ac_118cdea_2")
+    assert entry
+    assert entry.device_id == new_device
 
     state = hass.states.get("binary_sensor.ac_1118cdea_2")
     assert not state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR targets a different branch that updates rfxtrx integration to have UI config/options (see #39117)

Some sensor devices (e.g. Oregon temp/hum sensors) communicating to the rfxtrx device report with a random generated id. These are mostly battery powered sensors which generate an id when batteries are put in. When batteries are replaced they start sending with another randomly generated id.
In ha, a device and entities are created around the id with which a device sends. When the id changes, this creates a new device with new entities in ha. Before 0.113 this was easily solved by replacing the event code in yaml. As the rfxtrx now has unique ids based on the device id, the only way to replace is to remove the old device and change all the names again.
This PR targets to make a migration function to pick a new detected device and migrate it with an existing device to remove the burdon of having to change all the configured entity ids and names.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: NOTE: documentation PR is linked to #39117, for reference it is mentioned here (home-assistant/home-assistant.io#14158)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
