### PR TITLE
Add config flow to epson and fix timeouts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -127,6 +127,7 @@ homeassistant/components/enocean/* @bdurrer
 homeassistant/components/entur_public_transport/* @hfurubotten
 homeassistant/components/environment_canada/* @michaeldavie
 homeassistant/components/ephember/* @ttroy50
+homeassistant/components/epson/* @pszafer
 homeassistant/components/epsonworkforce/* @ThaStealth
 homeassistant/components/eq3btsmart/* @rytilahti
 homeassistant/components/esphome/* @OttoWinter

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass, entry.data[CONF_HOST], entry.data[CONF_PORT]
         )
     except CannotConnect:
-        _LOGGER.warning(f"Cannot connect to projector {entry.data[CONF_HOST]}")
+        _LOGGER.warning("Cannot connect to projector %s.", entry.data[CONF_HOST])
         return False
     hass.data[DOMAIN][entry.entry_id] = projector
     for component in PLATFORMS:

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -41,8 +41,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             ]
         )
     )
-    hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER]()
     if unload_ok:
+        listener = hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER]
+        listener()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
@@ -51,5 +52,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def update_listener(hass, entry):
     """Handle options update."""
     async_dispatcher_send(
-        hass, SIGNAL_CONFIG_OPTIONS_UPDATE.format(entry.entry_id), entry.options
+        hass, f"{SIGNAL_CONFIG_OPTIONS_UPDATE} {entry.entry_id}", entry.options
     )

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass, entry.data[CONF_HOST], entry.data[CONF_PORT]
         )
     except CannotConnect:
-        _LOGGER.warning("Cannot connect to projector %s.", entry.data[CONF_HOST])
+        _LOGGER.warning("Cannot connect to projector %s", entry.data[CONF_HOST])
         return False
     hass.data[DOMAIN][entry.entry_id] = projector
     for component in PLATFORMS:

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -1,1 +1,40 @@
-"""The epson component."""
+"""The epson integration."""
+import asyncio
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+PLATFORMS = ["media_player"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the epson component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up epson from a config entry."""
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -31,24 +31,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors = {}
         if user_input is not None:
-            if self.host_already_configured(user_input[CONF_HOST]):
-                return self.async_abort(reason="already_configured")
             try:
                 await validate_projector(
                     self.hass, user_input[CONF_HOST], user_input[CONF_PORT]
                 )
-                name = user_input.pop(CONF_NAME)
-                await self.async_set_unique_id(name)
-                return self.async_create_entry(title=name, data=user_input)
+                return self.async_create_entry(
+                    title=user_input.pop(CONF_NAME), data=user_input
+                )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
-
-    def host_already_configured(self, host):
-        """See if we already have a entry matching user input configured."""
-        existing_hosts = {
-            entry.data[CONF_HOST] for entry in self._async_current_entries()
-        }
-        return host in existing_hosts

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -1,0 +1,113 @@
+"""Config flow for epson integration."""
+import logging
+
+import epson_projector as epson
+from epson_projector.const import POWER
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL
+from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN, TIMEOUT_SCALE
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Optional(CONF_NAME, default=DOMAIN): str,
+        vol.Optional(CONF_PORT, default=80): int,
+        vol.Optional(CONF_SSL, default=False): bool,
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    # TODO validate the data can be used to set up a connection.
+
+    # If your PyPI package is not built with async, pass your methods
+    # to the executor:
+    # await hass.async_add_executor_job(
+    #     your_validate_func, data["username"], data["password"]
+    # )
+
+    epson_proj = epson.Projector(
+        data[CONF_HOST],
+        websession=async_get_clientsession(hass, verify_ssl=data.get(CONF_SSL, False)),
+        port=data[CONF_PORT],
+    )
+
+    _power = await epson_proj.get_property(POWER)
+
+    if not _power:
+        raise CannotConnect
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for epson."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Epson options flow."""
+        return EpsonOptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                await validate_input(self.hass, user_input)
+                return self.async_create_entry(
+                    title=user_input.pop(CONF_NAME), data=user_input
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class EpsonOptionsFlowHandler(config_entries.OptionsFlow):
+    """Config flow options for Epson."""
+
+    def __init__(self, config_entry):
+        """Initialize Epson options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        return await self.async_step_user()
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        TIMEOUT_SCALE,
+                        default=self.config_entry.options.get(TIMEOUT_SCALE, 1.0),
+                    ): float
+                }
+            ),
+        )

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -17,9 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Optional(CONF_NAME, default=DOMAIN): str,
-        vol.Optional(CONF_PORT, default=80): int,
-        vol.Optional(CONF_SSL, default=False): bool,
+        vol.Required(CONF_NAME, default=DOMAIN): str,
+        vol.Required(CONF_PORT, default=80): int,
+        vol.Required(CONF_SSL, default=False): bool,
     }
 )
 
@@ -52,6 +52,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         """Epson options flow."""
         return EpsonOptionsFlowHandler(config_entry)
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -1,44 +1,20 @@
 """Config flow for epson integration."""
-import epson_projector as epson
-from epson_projector.const import POWER
 import voluptuous as vol
 
-from homeassistant import config_entries, core, exceptions
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PORT,
-    CONF_SSL,
-    STATE_UNAVAILABLE,
-)
-from homeassistant.core import callback
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 
-from .const import DOMAIN, TIMEOUT_SCALE
+from . import validate_projector
+from .const import DOMAIN
+from .exceptions import CannotConnect
 
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_NAME, default=DOMAIN): str,
         vol.Required(CONF_PORT, default=80): int,
-        vol.Required(CONF_SSL, default=False): bool,
     }
 )
-
-
-async def validate_input(hass: core.HomeAssistant, data):
-    """Validate the user input allows us to connect.
-
-    Data has the keys from DATA_SCHEMA with values provided by the user.
-    """
-    epson_proj = epson.Projector(
-        data[CONF_HOST],
-        websession=async_get_clientsession(hass, verify_ssl=data.get(CONF_SSL, False)),
-        port=data[CONF_PORT],
-    )
-    _power = await epson_proj.get_property(POWER)
-    if not _power or _power == STATE_UNAVAILABLE:
-        raise CannotConnect
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -46,12 +22,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Epson options flow."""
-        return EpsonOptionsFlowHandler(config_entry)
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
@@ -64,10 +34,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if self.host_already_configured(user_input[CONF_HOST]):
                 return self.async_abort(reason="already_configured")
             try:
-                await validate_input(self.hass, user_input)
-                return self.async_create_entry(
-                    title=user_input.pop(CONF_NAME), data=user_input
+                await validate_projector(
+                    self.hass, user_input[CONF_HOST], user_input[CONF_PORT]
                 )
+                name = user_input.pop(CONF_NAME)
+                await self.async_set_unique_id(name)
+                return self.async_create_entry(title=name, data=user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
         return self.async_show_form(
@@ -80,36 +52,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             entry.data[CONF_HOST] for entry in self._async_current_entries()
         }
         return host in existing_hosts
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class EpsonOptionsFlowHandler(config_entries.OptionsFlow):
-    """Config flow options for Epson."""
-
-    def __init__(self, config_entry):
-        """Initialize Epson options flow."""
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
-        """Manage the options."""
-        return await self.async_step_user()
-
-    async def async_step_user(self, user_input=None):
-        """Handle a flow initialized by the user."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        TIMEOUT_SCALE,
-                        default=self.config_entry.options.get(TIMEOUT_SCALE, 1.0),
-                    ): vol.All(vol.Coerce(float), vol.Range(min=1))
-                }
-            ),
-        )

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -107,7 +107,7 @@ class EpsonOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required(
                         TIMEOUT_SCALE,
                         default=self.config_entry.options.get(TIMEOUT_SCALE, 1.0),
-                    ): float
+                    ): vol.And(vol.Coerce(float), vol.Range(min=0))
                 }
             ),
         )

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -29,14 +29,6 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
-    # TODO validate the data can be used to set up a connection.
-
-    # If your PyPI package is not built with async, pass your methods
-    # to the executor:
-    # await hass.async_add_executor_job(
-    #     your_validate_func, data["username"], data["password"]
-    # )
-
     epson_proj = epson.Projector(
         data[CONF_HOST],
         websession=async_get_clientsession(hass, verify_ssl=data.get(CONF_SSL, False)),
@@ -63,7 +55,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
-        print("dzialałm?")
         errors = {}
         if user_input is not None:
             try:

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -107,7 +107,7 @@ class EpsonOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required(
                         TIMEOUT_SCALE,
                         default=self.config_entry.options.get(TIMEOUT_SCALE, 1.0),
-                    ): vol.And(vol.Coerce(float), vol.Range(min=0))
+                    ): vol.All(vol.Coerce(float), vol.Range(min=1))
                 }
             ),
         )

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -63,6 +63,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
+        print("dzialałm?")
         errors = {}
         if user_input is not None:
             try:

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -11,3 +11,5 @@ DEFAULT_NAME = "EPSON Projector"
 SUPPORT_CMODE = 33001
 
 TIMEOUT_SCALE = "timeout_scale"
+UPDATE_LISTENER = "update_listener"
+SIGNAL_CONFIG_OPTIONS_UPDATE = "epson_config_options_update {}"

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -12,4 +12,4 @@ SUPPORT_CMODE = 33001
 
 TIMEOUT_SCALE = "timeout_scale"
 UPDATE_LISTENER = "update_listener"
-SIGNAL_CONFIG_OPTIONS_UPDATE = "epson_config_options_update {}"
+SIGNAL_CONFIG_OPTIONS_UPDATE = "epson_config_options_update"

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -1,10 +1,13 @@
-"""Constants for the Epson projector component."""
+"""Constants for the epson integration."""
+
 DOMAIN = "epson"
 SERVICE_SELECT_CMODE = "select_cmode"
 
 ATTR_CMODE = "cmode"
 
-DATA_EPSON = "epson"
+DATA_EPSON = "epson_entities"
 DEFAULT_NAME = "EPSON Projector"
 
 SUPPORT_CMODE = 33001
+
+TIMEOUT_SCALE = "timeout_scale"

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -5,11 +5,4 @@ SERVICE_SELECT_CMODE = "select_cmode"
 
 ATTR_CMODE = "cmode"
 
-DATA_EPSON = "epson_entities"
 DEFAULT_NAME = "EPSON Projector"
-
-SUPPORT_CMODE = 33001
-
-TIMEOUT_SCALE = "timeout_scale"
-UPDATE_LISTENER = "update_listener"
-SIGNAL_CONFIG_OPTIONS_UPDATE = "epson_config_options_update"

--- a/homeassistant/components/epson/exceptions.py
+++ b/homeassistant/components/epson/exceptions.py
@@ -1,0 +1,6 @@
+"""The errors of Epson integration."""
+from homeassistant import exceptions
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/epson/manifest.json
+++ b/homeassistant/components/epson/manifest.json
@@ -3,6 +3,6 @@
   "name": "epson",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/epson",
-  "requirements": ["epson-projector==0.2.1"],
+  "requirements": ["epson-projector==0.2.2"],
   "codeowners": ["@pszafer"]
 }

--- a/homeassistant/components/epson/manifest.json
+++ b/homeassistant/components/epson/manifest.json
@@ -1,7 +1,8 @@
 {
   "domain": "epson",
-  "name": "Epson",
+  "name": "epson",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/epson",
-  "requirements": ["epson-projector==0.1.3"],
-  "codeowners": []
+  "requirements": ["epson-projector==0.2.1"],
+  "codeowners": ["@pszafer"]
 }

--- a/homeassistant/components/epson/manifest.json
+++ b/homeassistant/components/epson/manifest.json
@@ -3,6 +3,6 @@
   "name": "epson",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/epson",
-  "requirements": ["epson-projector==0.2.2"],
+  "requirements": ["epson-projector==0.2.3"],
   "codeowners": ["@pszafer"]
 }

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -92,7 +92,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Bosch thermostat from a config entry."""
+    """Set up the Epson projector from a config entry."""
 
     timeout_scale = config_entry.options.get(TIMEOUT_SCALE, 1.0)
     epson_proj = EpsonProjector(
@@ -150,8 +150,7 @@ async def update_listener(hass, entry):
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Bosch Thermostat Platform."""
-    pass
+    """Set up the Epson projector."""
 
 
 class EpsonProjector(MediaPlayerEntity):
@@ -236,6 +235,7 @@ class EpsonProjector(MediaPlayerEntity):
         """Turn off epson."""
         if self._state == STATE_ON:
             await self._projector.send_command(TURN_OFF)
+            self._state = STATE_OFF
 
     @property
     def source_list(self):

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -36,6 +36,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_STEP,
 )
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,
@@ -151,6 +152,11 @@ async def update_listener(hass, entry):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Epson projector."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
 
 
 class EpsonProjector(MediaPlayerEntity):

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -108,11 +108,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if entity_ids:
             devices = [
                 device
-                for device in hass.data[DATA_EPSON]
+                for device in hass.data[DOMAIN][config_entry.entry_id][DATA_EPSON]
                 if device.entity_id in entity_ids
             ]
         else:
-            devices = hass.data[DATA_EPSON]
+            devices = hass.data[DOMAIN][config_entry.entry_id][DATA_EPSON]
         for device in devices:
             if service.service == SERVICE_SELECT_CMODE:
                 cmode = service.data.get(ATTR_CMODE)
@@ -180,7 +180,7 @@ class EpsonProjector(MediaPlayerEntity):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                SIGNAL_CONFIG_OPTIONS_UPDATE.format(self._entry_id),
+                f"{SIGNAL_CONFIG_OPTIONS_UPDATE} {self._entry_id}",
                 self.update_options,
             )
         )

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -107,6 +107,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Bosch thermostat from a config entry."""
+    print("OJOJOJOJO")
 
     timeout_scale = config_entry.options.get(TIMEOUT_SCALE, 1.0)
     epson_proj = EpsonProjector(
@@ -183,6 +184,7 @@ class EpsonProjector(MediaPlayerEntity):
         self._volume = None
         self._state = None
         self._entry_id = entry_id
+        print("init")
         print(self.source_list)
         print(self.source)
 
@@ -225,6 +227,8 @@ class EpsonProjector(MediaPlayerEntity):
     @property
     def name(self):
         """Return the name of the device."""
+        print("name")
+        print(self._name)
         return self._name
 
     @property

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -29,11 +29,14 @@ import voluptuous as vol
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
+    SUPPORT_PLAY,
+    SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.const import (
@@ -66,6 +69,18 @@ from .const import (
 SIGNAL_CONFIG_OPTIONS_UPDATE = "epson_config_options_update {}"
 
 _LOGGER = logging.getLogger(__name__)
+
+
+SUPPORT_ONKYO = (
+    SUPPORT_VOLUME_SET
+    | SUPPORT_VOLUME_MUTE
+    | SUPPORT_VOLUME_STEP
+    | SUPPORT_TURN_ON
+    | SUPPORT_TURN_OFF
+    | SUPPORT_SELECT_SOURCE
+    | SUPPORT_PLAY
+    | SUPPORT_PLAY_MEDIA
+)
 
 SUPPORT_EPSON = (
     SUPPORT_TURN_ON
@@ -168,10 +183,13 @@ class EpsonProjector(MediaPlayerEntity):
         self._volume = None
         self._state = None
         self._entry_id = entry_id
+        print(self.source_list)
+        print(self.source)
 
     async def async_update(self):
         """Update state of device."""
         is_turned_on = await self._projector.get_property(POWER)
+        is_turned_on = "01"
         _LOGGER.debug("Projector status: %s", is_turned_on)
         if is_turned_on and is_turned_on == EPSON_CODES[POWER]:
             self._state = STATE_ON
@@ -182,10 +200,12 @@ class EpsonProjector(MediaPlayerEntity):
             volume = await self._projector.get_property(VOLUME)
             if volume:
                 self._volume = volume
+            print("ustawione!")
         elif is_turned_on == BUSY:
             self._state = STATE_ON
         else:
             self._state = STATE_OFF
+        print("działam")
 
     async def async_added_to_hass(self):
         """Use lifecycle hooks."""
@@ -220,7 +240,7 @@ class EpsonProjector(MediaPlayerEntity):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        return SUPPORT_EPSON
+        return SUPPORT_ONKYO
 
     async def async_turn_on(self):
         """Turn on epson."""
@@ -253,7 +273,10 @@ class EpsonProjector(MediaPlayerEntity):
 
     async def async_select_source(self, source):
         """Select input source."""
+        print("wybieram source")
         selected_source = INV_SOURCES[source]
+        print("mam source")
+        print(selected_source)
         await self._projector.send_command(selected_source)
 
     async def async_mute_volume(self, mute):

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -172,7 +172,7 @@ class EpsonProjector(MediaPlayerEntity):
     async def async_update(self):
         """Update state of device."""
         is_turned_on = await self._projector.get_property(POWER)
-        _LOGGER.debug("Project turn on/off status: %s", is_turned_on)
+        _LOGGER.debug("Projector status: %s", is_turned_on)
         if is_turned_on and is_turned_on == EPSON_CODES[POWER]:
             self._state = STATE_ON
             cmode = await self._projector.get_property(CMODE)

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -106,8 +106,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Bosch thermostat from a config entry."""
-    print("OJOJOJOJO")
+    """Set up the Epson from a config entry."""
 
     timeout_scale = config_entry.options.get(TIMEOUT_SCALE, 1.0)
     epson_proj = EpsonProjector(
@@ -165,7 +164,7 @@ async def update_listener(hass, entry):
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Bosch Thermostat Platform."""
+    """Set up the Epson Platform."""
     pass
 
 
@@ -184,14 +183,10 @@ class EpsonProjector(MediaPlayerEntity):
         self._volume = None
         self._state = None
         self._entry_id = entry_id
-        print("init")
-        print(self.source_list)
-        print(self.source)
 
     async def async_update(self):
         """Update state of device."""
         is_turned_on = await self._projector.get_property(POWER)
-        is_turned_on = "01"
         _LOGGER.debug("Projector status: %s", is_turned_on)
         if is_turned_on and is_turned_on == EPSON_CODES[POWER]:
             self._state = STATE_ON
@@ -202,12 +197,10 @@ class EpsonProjector(MediaPlayerEntity):
             volume = await self._projector.get_property(VOLUME)
             if volume:
                 self._volume = volume
-            print("ustawione!")
         elif is_turned_on == BUSY:
             self._state = STATE_ON
         else:
             self._state = STATE_OFF
-        print("działam")
 
     async def async_added_to_hass(self):
         """Use lifecycle hooks."""
@@ -227,8 +220,6 @@ class EpsonProjector(MediaPlayerEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        print("name")
-        print(self._name)
         return self._name
 
     @property
@@ -277,10 +268,7 @@ class EpsonProjector(MediaPlayerEntity):
 
     async def async_select_source(self, source):
         """Select input source."""
-        print("wybieram source")
         selected_source = INV_SOURCES[source]
-        print("mam source")
-        print(selected_source)
         await self._projector.send_command(selected_source)
 
     async def async_mute_volume(self, mute):

--- a/homeassistant/components/epson/strings.json
+++ b/homeassistant/components/epson/strings.json
@@ -5,9 +5,8 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "name": "Name",
-          "port": "[%key:common::config_flow::data::port%]",
-          "ssl": "Use SSL"
+          "name": "[%key:common::config_flow::data::name%]",
+          "port": "[%key:common::config_flow::data::port%]"
         }
       }
     },
@@ -16,17 +15,6 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-    }
-  },
-  "options": {
-    "step": {
-      "user": {
-        "title": "Epson Options",
-        "description": "Epson projectors sometimes have delay responding. Default timeouts are turn_on - 40s, off - 10s, source-5s, rest-3s. You can multiply this time by setting timeout scale eg. 1.5.",
-        "data": {
-          "timeout_scale": "Timeout scale"
-        }
-      }
     }
   }
 }

--- a/homeassistant/components/epson/strings.json
+++ b/homeassistant/components/epson/strings.json
@@ -12,9 +12,7 @@
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/epson/strings.json
+++ b/homeassistant/components/epson/strings.json
@@ -1,0 +1,34 @@
+{
+  "title": "Epson Projector",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "name": "Name",
+          "port": "[%key:common::config_flow::data::port%]",
+          "ssl": "Use SSL (not tested)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Epson Options",
+        "description": "Epson projectors sometimes have delay responding. Default timeouts are turn_on - 40s, off - 10s, source-5s, rest-3s. You can multiply this time by setting timeout scale eg. 1.5.",
+        "data": {
+          "timeout_scale": "Timeout scale"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/epson/strings.json
+++ b/homeassistant/components/epson/strings.json
@@ -7,7 +7,7 @@
           "host": "[%key:common::config_flow::data::host%]",
           "name": "Name",
           "port": "[%key:common::config_flow::data::port%]",
-          "ssl": "Use SSL (not tested)"
+          "ssl": "Use SSL"
         }
       }
     },

--- a/homeassistant/components/epson/translations/en.json
+++ b/homeassistant/components/epson/translations/en.json
@@ -1,0 +1,34 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        },
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "unknown": "[%key:common::config_flow::error::unknown%]"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "[%key:common::config_flow::data::host%]",
+                    "name": "Name",
+                    "port": "[%key:common::config_flow::data::port%]",
+                    "ssl": "Use SSL (not tested)"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "user": {
+                "data": {
+                    "timeout_scale": "Timeout scale"
+                },
+                "description": "Epson projectors sometimes have delay responding. Default timeouts are turn_on - 40s, off - 10s, source-5s, rest-3s. You can multiply this time by setting timeout scale eg. 1.5.",
+                "title": "Epson Options"
+            }
+        }
+    },
+    "title": "Epson Projector"
+}

--- a/homeassistant/components/epson/translations/en.json
+++ b/homeassistant/components/epson/translations/en.json
@@ -1,30 +1,18 @@
 {
     "config": {
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+            "already_configured": "Device is already configured"
         },
         "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+            "cannot_connect": "Failed to connect"
         },
         "step": {
             "user": {
                 "data": {
-                    "host": "[%key:common::config_flow::data::host%]",
+                    "host": "Host",
                     "name": "Name",
-                    "port": "[%key:common::config_flow::data::port%]",
-                    "ssl": "Use SSL (not tested)"
+                    "port": "Port"
                 }
-            }
-        }
-    },
-    "options": {
-        "step": {
-            "user": {
-                "data": {
-                    "timeout_scale": "Timeout scale"
-                },
-                "description": "Epson projectors sometimes have delay responding. Default timeouts are turn_on - 40s, off - 10s, source-5s, rest-3s. You can multiply this time by setting timeout scale eg. 1.5.",
-                "title": "Epson Options"
             }
         }
     },

--- a/homeassistant/components/epson/translations/en.json
+++ b/homeassistant/components/epson/translations/en.json
@@ -4,9 +4,7 @@
             "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         },
         "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-            "unknown": "[%key:common::config_flow::error::unknown%]"
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
         },
         "step": {
             "user": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -55,6 +55,7 @@ FLOWS = [
     "elkm1",
     "emulated_roku",
     "enocean",
+    "epson",
     "esphome",
     "flick_electric",
     "flo",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -565,7 +565,7 @@ envoy_reader==0.16.1
 ephem==3.7.7.0
 
 # homeassistant.components.epson
-epson-projector==0.2.2
+epson-projector==0.2.3
 
 # homeassistant.components.epsonworkforce
 epsonprinter==0.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -565,7 +565,7 @@ envoy_reader==0.16.1
 ephem==3.7.7.0
 
 # homeassistant.components.epson
-epson-projector==0.1.3
+epson-projector==0.2.1
 
 # homeassistant.components.epsonworkforce
 epsonprinter==0.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -565,7 +565,7 @@ envoy_reader==0.16.1
 ephem==3.7.7.0
 
 # homeassistant.components.epson
-epson-projector==0.2.1
+epson-projector==0.2.2
 
 # homeassistant.components.epsonworkforce
 epsonprinter==0.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -296,7 +296,7 @@ enocean==0.50
 ephem==3.7.7.0
 
 # homeassistant.components.epson
-epson-projector==0.2.2
+epson-projector==0.2.3
 
 # homeassistant.components.feedreader
 feedparser-homeassistant==5.2.2.dev1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -295,6 +295,9 @@ enocean==0.50
 # homeassistant.components.season
 ephem==3.7.7.0
 
+# homeassistant.components.epson
+epson-projector==0.2.1
+
 # homeassistant.components.feedreader
 feedparser-homeassistant==5.2.2.dev1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -296,7 +296,7 @@ enocean==0.50
 ephem==3.7.7.0
 
 # homeassistant.components.epson
-epson-projector==0.2.1
+epson-projector==0.2.2
 
 # homeassistant.components.feedreader
 feedparser-homeassistant==5.2.2.dev1

--- a/tests/components/epson/__init__.py
+++ b/tests/components/epson/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the epson integration."""

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -1,16 +1,9 @@
 """Test the epson config flow."""
-from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.epson.const import DOMAIN, TIMEOUT_SCALE
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PORT,
-    CONF_SSL,
-    STATE_UNAVAILABLE,
-)
+from homeassistant import config_entries, setup
+from homeassistant.components.epson.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_UNAVAILABLE
 
 from tests.async_mock import patch
-from tests.common import MockConfigEntry
 
 
 async def test_form(hass):
@@ -24,7 +17,7 @@ async def test_form(hass):
     assert result["step_id"] == config_entries.SOURCE_USER
 
     with patch(
-        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
+        "homeassistant.components.epson.Projector.get_property",
         return_value="04",
     ), patch(
         "homeassistant.components.epson.async_setup", return_value=True
@@ -34,16 +27,11 @@ async def test_form(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_HOST: "1.1.1.1",
-                CONF_NAME: "test-epson",
-                CONF_PORT: 80,
-                CONF_SSL: False,
-            },
+            {CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
         )
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-epson"
-    assert result2["data"] == {CONF_HOST: "1.1.1.1", CONF_PORT: 80, CONF_SSL: False}
+    assert result2["data"] == {CONF_HOST: "1.1.1.1", CONF_PORT: 80}
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -56,75 +44,32 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
+        "homeassistant.components.epson.Projector.get_property",
         return_value=STATE_UNAVAILABLE,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_HOST: "1.1.1.1",
-                CONF_NAME: "test-epson",
-                CONF_PORT: 80,
-                CONF_SSL: False,
-            },
+            {CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_options_flow(hass):
-    """Test EpsonOptionsFlowHandler."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="123456",
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_NAME: "test-epson",
-            CONF_PORT: 80,
-            CONF_SSL: False,
-        },
-    )
-    config_entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
-        return_value="04",
-    ), patch("homeassistant.components.epson.async_setup", return_value=True), patch(
-        "homeassistant.components.epson.async_setup_entry",
-        return_value=True,
-    ):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["step_id"] == "user"
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={TIMEOUT_SCALE: 1.5}
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert config_entry.options == {TIMEOUT_SCALE: 1.5}
-
-
 async def test_import(hass):
     """Test config.yaml import."""
     with patch(
-        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
+        "homeassistant.components.epson.Projector.get_property",
         return_value="04",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                CONF_HOST: "1.1.1.1",
-                CONF_NAME: "test-epson",
-                CONF_PORT: 80,
-                CONF_SSL: False,
-            },
+            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
         )
         assert result["type"] == "create_entry"
         assert result["title"] == "test-epson"
-        assert result["data"] == {CONF_HOST: "1.1.1.1", CONF_PORT: 80, CONF_SSL: False}
+        assert result["data"] == {CONF_HOST: "1.1.1.1", CONF_PORT: 80}
 
 
 async def test_import_cannot_connect(hass):
@@ -134,17 +79,12 @@ async def test_import_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
+        "homeassistant.components.epson.Projector.get_property",
         return_value=STATE_UNAVAILABLE,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_HOST: "1.1.1.1",
-                CONF_NAME: "test-epson",
-                CONF_PORT: 80,
-                CONF_SSL: False,
-            },
+            {CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
         )
 
     assert result2["type"] == "form"
@@ -154,31 +94,21 @@ async def test_import_cannot_connect(hass):
 async def test_import_already_configured(hass):
     """Test config.yaml import."""
     with patch(
-        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
+        "homeassistant.components.epson.Projector.get_property",
         return_value="04",
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                CONF_HOST: "1.1.1.1",
-                CONF_NAME: "test-epson",
-                CONF_PORT: 80,
-                CONF_SSL: False,
-            },
+            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
         )
         assert result["type"] == "create_entry"
         assert result["title"] == "test-epson"
-        assert result["data"] == {CONF_HOST: "1.1.1.1", CONF_PORT: 80, CONF_SSL: False}
+        assert result["data"] == {CONF_HOST: "1.1.1.1", CONF_PORT: 80}
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                CONF_HOST: "1.1.1.1",
-                CONF_NAME: "test-epson",
-                CONF_PORT: 80,
-                CONF_SSL: False,
-            },
+            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
         )
         assert result2["type"] == "abort"
         assert result2["reason"] == "already_configured"

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -21,18 +21,19 @@ async def test_form(hass):
     ), patch(
         "homeassistant.components.epson.async_setup", return_value=True
     ) as mock_setup, patch(
-        "homeassistant.components.epson.async_setup_entry", return_value=True,
+        "homeassistant.components.epson.async_setup_entry",
+        return_value=True,
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1", "name": "test-epson", "port": 80, "ssl": False},
         )
-
+    print("res")
+    print(result2)
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "Name of the device"
+    assert result2["title"] == "test-epson"
     assert result2["data"] == {
         "host": "1.1.1.1",
-        "name": "test-epson",
         "port": 80,
         "ssl": False,
     }

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -1,0 +1,60 @@
+"""Test the epson config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.epson.config_flow import CannotConnect
+from homeassistant.components.epson.const import DOMAIN
+
+from tests.async_mock import patch
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
+        return_value="04",
+    ), patch(
+        "homeassistant.components.epson.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.epson.async_setup_entry", return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "1.1.1.1", "name": "test-epson", "port": 80, "ssl": False},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "name": "test-epson",
+        "port": 80,
+        "ssl": False,
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.epson.config_flow.epson.Projector.get_property",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "1.1.1.1", "name": "test-epson", "port": 80, "ssl": False},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -28,8 +28,6 @@ async def test_form(hass):
             result["flow_id"],
             {"host": "1.1.1.1", "name": "test-epson", "port": 80, "ssl": False},
         )
-    print("res")
-    print(result2)
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-epson"
     assert result2["data"] == {

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -21,6 +21,7 @@ async def test_form(hass):
     )
     assert result["type"] == "form"
     assert result["errors"] == {}
+    assert result["step_id"] == config_entries.SOURCE_USER
 
     with patch(
         "homeassistant.components.epson.config_flow.epson.Projector.get_property",

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -89,26 +89,3 @@ async def test_import_cannot_connect(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
-
-
-async def test_import_already_configured(hass):
-    """Test config.yaml import."""
-    with patch(
-        "homeassistant.components.epson.Projector.get_property",
-        return_value="04",
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
-        )
-        assert result["type"] == "create_entry"
-        assert result["title"] == "test-epson"
-        assert result["data"] == {CONF_HOST: "1.1.1.1", CONF_PORT: 80}
-        result2 = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson", CONF_PORT: 80},
-        )
-        assert result2["type"] == "abort"
-        assert result2["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
Removed SSL option from config as there is no signs that anybody used it with success.

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
- add Config Entry option to Epson projector
- add timeout scale option so component can communicate with slower projectors
- bump new version of epson lib to v0.2.3 - https://github.com/pszafer/epson_projector/releases/tag/v0.2.3

Fixes https://github.com/home-assistant/core/issues/38743
Fixes https://github.com/home-assistant/core/issues/31129
Fixes https://github.com/home-assistant/core/issues/30624

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```
media_player:
  - platform: epson
    host: 192.168.0.123
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: None
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14407

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
