### PR TITLE
Axis - Improve naming of some events

### DIFF
--- a/homeassistant/components/axis/binary_sensor.py
+++ b/homeassistant/components/axis/binary_sensor.py
@@ -8,6 +8,10 @@ from axis.event_stream import (
     CLASS_MOTION,
     CLASS_OUTPUT,
     CLASS_SOUND,
+    FenceGuard,
+    LoiteringGuard,
+    MotionGuard,
+    Vmd4,
 )
 
 from homeassistant.components.binary_sensor import (
@@ -103,6 +107,21 @@ class AxisBinarySensor(AxisEventBase, BinarySensorEntity):
             return (
                 f"{self.device.name} {self.device.api.vapix.ports[self.event.id].name}"
             )
+
+        if self.event.CLASS == CLASS_MOTION:
+
+            for event_class, event_data in (
+                (FenceGuard, self.device.api.vapix.fence_guard),
+                (LoiteringGuard, self.device.api.vapix.loitering_guard),
+                (MotionGuard, self.device.api.vapix.motion_guard),
+                (Vmd4, self.device.api.vapix.vmd4),
+            ):
+                if (
+                    isinstance(self.event, event_class)
+                    and event_data
+                    and self.event.id in event_data
+                ):
+                    return f"{self.device.name} {self.event.TYPE} {event_data[self.event.id].name}"
 
         return super().name
 

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
-  "requirements": ["axis==34"],
+  "requirements": ["axis==35"],
   "zeroconf": ["_axis-video._tcp.local."],
   "after_dependencies": ["mqtt"],
   "codeowners": ["@Kane610"]

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
-  "requirements": ["axis==33"],
+  "requirements": ["axis==34"],
   "zeroconf": ["_axis-video._tcp.local."],
   "after_dependencies": ["mqtt"],
   "codeowners": ["@Kane610"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==33
+axis==34
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==34
+axis==35
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -174,7 +174,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==34
+axis==35
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -174,7 +174,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==33
+axis==34
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/tests/components/axis/test_binary_sensor.py
+++ b/tests/components/axis/test_binary_sensor.py
@@ -63,7 +63,7 @@ async def test_binary_sensors(hass):
     assert pir.name == f"{NAME} PIR 0"
     assert pir.attributes["device_class"] == DEVICE_CLASS_MOTION
 
-    vmd4 = hass.states.get(f"binary_sensor.{NAME}_vmd4_camera1profile1")
+    vmd4 = hass.states.get(f"binary_sensor.{NAME}_vmd4_profile_1")
     assert vmd4.state == "on"
-    assert vmd4.name == f"{NAME} VMD4 Camera1Profile1"
+    assert vmd4.name == f"{NAME} VMD4 Profile 1"
     assert vmd4.attributes["device_class"] == DEVICE_CLASS_MOTION

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -5,6 +5,8 @@ from unittest import mock
 
 import axis as axislib
 from axis.api_discovery import URL as API_DISCOVERY_URL
+from axis.applications import URL_LIST as APPLICATIONS_URL
+from axis.applications.vmd4 import URL as VMD4_URL
 from axis.basic_device_info import URL as BASIC_DEVICE_INFO_URL
 from axis.event_stream import OPERATION_INITIALIZED
 from axis.light_control import URL as LIGHT_CONTROL_URL
@@ -79,6 +81,10 @@ API_DISCOVERY_PORT_MANAGEMENT = {
     "name": "IO Port Management",
 }
 
+APPLICATIONS_LIST_RESPONSE = """<reply result="ok">
+ <application Name="vmd" NiceName="AXIS Video Motion Detection" Vendor="Axis Communications" Version="4.2-0" ApplicationID="143440" License="None" Status="Running" ConfigurationPage="local/vmd/config.html" VendorHomePage="http://www.axis.com" />
+</reply>"""
+
 BASIC_DEVICE_INFO_RESPONSE = {
     "apiVersion": "1.1",
     "data": {
@@ -138,6 +144,18 @@ PORT_MANAGEMENT_RESPONSE = {
     },
 }
 
+VMD4_RESPONSE = {
+    "apiVersion": "1.4",
+    "method": "getConfiguration",
+    "context": "Axis library",
+    "data": {
+        "cameras": [{"id": 1, "rotation": 0, "active": True}],
+        "profiles": [
+            {"filters": [], "camera": 1, "triggers": [], "name": "Profile 1", "uid": 1}
+        ],
+    },
+}
+
 BRAND_RESPONSE = """root.Brand.Brand=AXIS
 root.Brand.ProdFullName=AXIS M1065-LW Network Camera
 root.Brand.ProdNbr=M1065-LW
@@ -158,6 +176,7 @@ root.Output.NbrOfOutputs=0
 PROPERTIES_RESPONSE = """root.Properties.API.HTTP.Version=3
 root.Properties.API.Metadata.Metadata=yes
 root.Properties.API.Metadata.Version=1.0
+root.Properties.EmbeddedDevelopment.Version=2.16
 root.Properties.Firmware.BuildDate=Feb 15 2019 09:42
 root.Properties.Firmware.BuildNumber=26
 root.Properties.Firmware.Version=9.10.1
@@ -182,6 +201,8 @@ def vapix_session_request(session, url, **kwargs):
     """Return data based on url."""
     if API_DISCOVERY_URL in url:
         return json.dumps(API_DISCOVERY_RESPONSE)
+    if APPLICATIONS_URL in url:
+        return APPLICATIONS_LIST_RESPONSE
     if BASIC_DEVICE_INFO_URL in url:
         return json.dumps(BASIC_DEVICE_INFO_RESPONSE)
     if LIGHT_CONTROL_URL in url:
@@ -190,6 +211,8 @@ def vapix_session_request(session, url, **kwargs):
         return json.dumps(MQTT_CLIENT_RESPONSE)
     if PORT_MANAGEMENT_URL in url:
         return json.dumps(PORT_MANAGEMENT_RESPONSE)
+    if VMD4_URL in url:
+        return json.dumps(VMD4_RESPONSE)
     if BRAND_URL in url:
         return BRAND_RESPONSE
     if IOPORT_URL in url or INPUT_URL in url or OUTPUT_URL in url:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Initial naming of events from VMD4 and Fence guard are now based on their configured name on the device; 'binary_sensor.m1065-lw_0_vmd4_camera1profile1' is now 'binary_sensor.m1065-lw_0_vmd4_profile_1' or 'profile_1' can be whatever the user chose to name the profile.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Library now calls APIs of applications and this data can be used to improve naming of entities.
Specifically for Fence guard, Loitering guard, Motion guard, VMD4
This also fixes a small issue with parsing users which could break during certain conditions

Library changes: https://github.com/Kane610/axis/compare/v33...v34

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
