### PR TITLE
Update ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -9,6 +9,7 @@ import zigpy_cc.zigbee.application
 import zigpy_deconz.zigbee.application
 import zigpy_xbee.zigbee.application
 import zigpy_zigate.zigbee.application
+import zigpy_znp.zigbee.application
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.climate import DOMAIN as CLIMATE
@@ -177,8 +178,12 @@ class RadioType(enum.Enum):
         "deCONZ = dresden elektronik deCONZ protocol: ConBee I/II, RaspBee I/II",
         zigpy_deconz.zigbee.application.ControllerApplication,
     )
+    znp = (
+        "ZNP = Texas Instruments Z-Stack ZNP protocol: CC253x, CC26x2, CC13x2",
+        zigpy_znp.zigbee.application.ControllerApplication,
+    )
     ti_cc = (
-        "TI_CC = Texas Instruments Z-Stack ZNP protocol: CC253x, CC26x2, CC13x2",
+        "Legacy TI_CC = Texas Instruments Z-Stack ZNP protocol: CC253x, CC26x2, CC13x2",
         zigpy_cc.zigbee.application.ControllerApplication,
     )
     zigate = (

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -170,6 +170,10 @@ POWER_BATTERY_OR_UNKNOWN = "Battery or Unknown"
 class RadioType(enum.Enum):
     """Possible options for radio type."""
 
+    znp = (
+        "ZNP = Texas Instruments Z-Stack ZNP protocol: CC253x, CC26x2, CC13x2",
+        zigpy_znp.zigbee.application.ControllerApplication,
+    )
     ezsp = (
         "EZSP = Silicon Labs EmberZNet protocol: Elelabs, HUSBZB-1, Telegesis",
         bellows.zigbee.application.ControllerApplication,
@@ -177,10 +181,6 @@ class RadioType(enum.Enum):
     deconz = (
         "deCONZ = dresden elektronik deCONZ protocol: ConBee I/II, RaspBee I/II",
         zigpy_deconz.zigbee.application.ControllerApplication,
-    )
-    znp = (
-        "ZNP = Texas Instruments Z-Stack ZNP protocol: CC253x, CC26x2, CC13x2",
-        zigpy_znp.zigbee.application.ControllerApplication,
     )
     ti_cc = (
         "Legacy TI_CC = Texas Instruments Z-Stack ZNP protocol: CC253x, CC26x2, CC13x2",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,14 +4,15 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
-    "bellows==0.18.1",
+    "bellows==0.20.0",
     "pyserial==3.4",
     "zha-quirks==0.0.43",
-    "zigpy-cc==0.5.1",
+    "zigpy-cc==0.5.2",
     "zigpy-deconz==0.9.2",
-    "zigpy==0.22.2",
-    "zigpy-xbee==0.12.1",
-    "zigpy-zigate==0.6.1"
+    "zigpy==0.23.1",
+    "zigpy-xbee==0.13.0",
+    "zigpy-zigate==0.6.1",
+    "zigpy-znp==0.1.0"
   ],
   "codeowners": ["@dmulcahey", "@adminiuga"]
 }

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -11,7 +11,7 @@
     "zigpy-deconz==0.9.2",
     "zigpy==0.23.1",
     "zigpy-xbee==0.13.0",
-    "zigpy-zigate==0.6.1",
+    "zigpy-zigate==0.6.2",
     "zigpy-znp==0.1.0"
   ],
   "codeowners": ["@dmulcahey", "@adminiuga"]

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,15 +4,15 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
-    "bellows==0.20.0",
+    "bellows==0.20.1",
     "pyserial==3.4",
-    "zha-quirks==0.0.43",
+    "zha-quirks==0.0.44",
     "zigpy-cc==0.5.2",
     "zigpy-deconz==0.9.2",
     "zigpy==0.23.1",
     "zigpy-xbee==0.13.0",
     "zigpy-zigate==0.6.2",
-    "zigpy-znp==0.1.0"
+    "zigpy-znp==0.1.1"
   ],
   "codeowners": ["@dmulcahey", "@adminiuga"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2304,7 +2304,7 @@ zigpy-deconz==0.9.2
 zigpy-xbee==0.13.0
 
 # homeassistant.components.zha
-zigpy-zigate==0.6.1
+zigpy-zigate==0.6.2
 
 # homeassistant.components.zha
 zigpy-znp==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -339,7 +339,7 @@ beautifulsoup4==4.9.1
 # beewi_smartclim==0.0.7
 
 # homeassistant.components.zha
-bellows==0.18.1
+bellows==0.20.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.7.7
@@ -2295,19 +2295,22 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-cc==0.5.1
+zigpy-cc==0.5.2
 
 # homeassistant.components.zha
 zigpy-deconz==0.9.2
 
 # homeassistant.components.zha
-zigpy-xbee==0.12.1
+zigpy-xbee==0.13.0
 
 # homeassistant.components.zha
 zigpy-zigate==0.6.1
 
 # homeassistant.components.zha
-zigpy==0.22.2
+zigpy-znp==0.1.0
+
+# homeassistant.components.zha
+zigpy==0.23.1
 
 # homeassistant.components.zoneminder
 zm-py==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -339,7 +339,7 @@ beautifulsoup4==4.9.1
 # beewi_smartclim==0.0.7
 
 # homeassistant.components.zha
-bellows==0.20.0
+bellows==0.20.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.7.7
@@ -2286,7 +2286,7 @@ zengge==0.2
 zeroconf==0.28.4
 
 # homeassistant.components.zha
-zha-quirks==0.0.43
+zha-quirks==0.0.44
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9
@@ -2307,7 +2307,7 @@ zigpy-xbee==0.13.0
 zigpy-zigate==0.6.2
 
 # homeassistant.components.zha
-zigpy-znp==0.1.0
+zigpy-znp==0.1.1
 
 # homeassistant.components.zha
 zigpy==0.23.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -183,7 +183,7 @@ azure-eventhub==5.1.0
 base36==0.1.1
 
 # homeassistant.components.zha
-bellows==0.20.0
+bellows==0.20.1
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.2
@@ -1056,7 +1056,7 @@ yeelight==0.5.3
 zeroconf==0.28.4
 
 # homeassistant.components.zha
-zha-quirks==0.0.43
+zha-quirks==0.0.44
 
 # homeassistant.components.zha
 zigpy-cc==0.5.2
@@ -1071,7 +1071,7 @@ zigpy-xbee==0.13.0
 zigpy-zigate==0.6.2
 
 # homeassistant.components.zha
-zigpy-znp==0.1.0
+zigpy-znp==0.1.1
 
 # homeassistant.components.zha
 zigpy==0.23.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1068,7 +1068,7 @@ zigpy-deconz==0.9.2
 zigpy-xbee==0.13.0
 
 # homeassistant.components.zha
-zigpy-zigate==0.6.1
+zigpy-zigate==0.6.2
 
 # homeassistant.components.zha
 zigpy-znp==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -183,7 +183,7 @@ azure-eventhub==5.1.0
 base36==0.1.1
 
 # homeassistant.components.zha
-bellows==0.18.1
+bellows==0.20.0
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.2
@@ -1059,16 +1059,19 @@ zeroconf==0.28.4
 zha-quirks==0.0.43
 
 # homeassistant.components.zha
-zigpy-cc==0.5.1
+zigpy-cc==0.5.2
 
 # homeassistant.components.zha
 zigpy-deconz==0.9.2
 
 # homeassistant.components.zha
-zigpy-xbee==0.12.1
+zigpy-xbee==0.13.0
 
 # homeassistant.components.zha
 zigpy-zigate==0.6.1
 
 # homeassistant.components.zha
-zigpy==0.22.2
+zigpy-znp==0.1.0
+
+# homeassistant.components.zha
+zigpy==0.23.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump up zha dependencies:
- `bellows==0.20.1`
- `zha-quirks==0.0.44`
- `zigpy==0.23.1`
- `zigpy-cc==0.5.2`
- `zigpy-xbee==0.13.0`
- `zigpy-zigate==0.6.2`
- `zigpy-znp==0.1.1` -- New

Introduce alternative ZNP protocol implementation library `zigpy-znp` Kudos to @puddly for great work. Existing configurations for TI based radios (or TI radios running HA12 version of ZStack) will continue to use `zigpy-cc` library. 
New configurations for TI based radios running ZStack version 3.0 or later will use `zigpy-znp` library by default, but users always have options to configure ZHA integration manually and pick the implementation they like the best. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
