### PR TITLE
Add shorthand notation for Template conditions

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -52,26 +52,32 @@ ConditionCheckerType = Callable[[HomeAssistant, TemplateVarsType], bool]
 
 
 async def async_from_config(
-    hass: HomeAssistant, config: ConfigType, config_validation: bool = True
+    hass: HomeAssistant,
+    config: Union[ConfigType, Template],
+    config_validation: bool = True,
 ) -> ConditionCheckerType:
     """Turn a condition configuration into a method.
 
     Should be run on the event loop.
     """
+    if isinstance(config, Template):
+        # We got a condition template, wrap it in a configuration to pass along.
+        config = {
+            CONF_CONDITION: "template",
+            CONF_VALUE_TEMPLATE: config,
+        }
+        condition = "template"
+    else:
+        condition = cast(str, config.get(CONF_CONDITION))
+
     for fmt in (ASYNC_FROM_CONFIG_FORMAT, FROM_CONFIG_FORMAT):
-        factory = getattr(
-            sys.modules[__name__], fmt.format(config.get(CONF_CONDITION)), None
-        )
+        factory = getattr(sys.modules[__name__], fmt.format(condition), None)
 
         if factory:
             break
 
     if factory is None:
-        raise HomeAssistantError(
-            'Invalid condition "{}" specified {}'.format(
-                config.get(CONF_CONDITION), config
-            )
-        )
+        raise HomeAssistantError(f'Invalid condition "{condition}" specified {config}')
 
     # Check for partials to properly determine if coroutine function
     check_factory = factory
@@ -563,9 +569,12 @@ async def async_device_from_config(
 
 
 async def async_validate_condition_config(
-    hass: HomeAssistant, config: ConfigType
-) -> ConfigType:
+    hass: HomeAssistant, config: Union[ConfigType, Template]
+) -> Union[ConfigType, Template]:
     """Validate config."""
+    if isinstance(config, Template):
+        return config
+
     condition = config[CONF_CONDITION]
     if condition in ("and", "not", "or"):
         conditions = []
@@ -576,6 +585,7 @@ async def async_validate_condition_config(
 
     if condition == "device":
         config = cv.DEVICE_CONDITION_SCHEMA(config)
+        assert not isinstance(config, Template)
         platform = await async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], "condition"
         )

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -66,10 +66,8 @@ async def async_from_config(
             CONF_CONDITION: "template",
             CONF_VALUE_TEMPLATE: config,
         }
-        condition = "template"
-    else:
-        condition = cast(str, config.get(CONF_CONDITION))
 
+    condition = config.get(CONF_CONDITION)
     for fmt in (ASYNC_FROM_CONFIG_FORMAT, FROM_CONFIG_FORMAT):
         factory = getattr(sys.modules[__name__], fmt.format(condition), None)
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1018,20 +1018,25 @@ DEVICE_CONDITION_BASE_SCHEMA = vol.Schema(
 
 DEVICE_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
 
-CONDITION_SCHEMA: vol.Schema = key_value_schemas(
-    CONF_CONDITION,
-    {
-        "numeric_state": NUMERIC_STATE_CONDITION_SCHEMA,
-        "state": STATE_CONDITION_SCHEMA,
-        "sun": SUN_CONDITION_SCHEMA,
-        "template": TEMPLATE_CONDITION_SCHEMA,
-        "time": TIME_CONDITION_SCHEMA,
-        "zone": ZONE_CONDITION_SCHEMA,
-        "and": AND_CONDITION_SCHEMA,
-        "or": OR_CONDITION_SCHEMA,
-        "not": NOT_CONDITION_SCHEMA,
-        "device": DEVICE_CONDITION_SCHEMA,
-    },
+CONDITION_SCHEMA: vol.Schema = vol.Schema(
+    vol.Any(
+        key_value_schemas(
+            CONF_CONDITION,
+            {
+                "numeric_state": NUMERIC_STATE_CONDITION_SCHEMA,
+                "state": STATE_CONDITION_SCHEMA,
+                "sun": SUN_CONDITION_SCHEMA,
+                "template": TEMPLATE_CONDITION_SCHEMA,
+                "time": TIME_CONDITION_SCHEMA,
+                "zone": ZONE_CONDITION_SCHEMA,
+                "and": AND_CONDITION_SCHEMA,
+                "or": OR_CONDITION_SCHEMA,
+                "not": NOT_CONDITION_SCHEMA,
+                "device": DEVICE_CONDITION_SCHEMA,
+            },
+        ),
+        dynamic_template,
+    )
 )
 
 TRIGGER_SCHEMA = vol.All(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -935,7 +935,10 @@ class Script:
         await asyncio.shield(self._async_stop(update_state))
 
     async def _async_get_condition(self, config):
-        config_cache_key = frozenset((k, str(v)) for k, v in config.items())
+        if isinstance(config, template.Template):
+            config_cache_key = config.template
+        else:
+            config_cache_key = frozenset((k, str(v)) for k, v in config.items())
         cond = self._config_cache.get(config_cache_key)
         if not cond:
             cond = await condition.async_from_config(self._hass, config, False)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -232,6 +232,31 @@ async def test_two_conditions_with_and(hass, calls):
     assert len(calls) == 1
 
 
+async def test_shorthand_conditions_template(hass, calls):
+    """Test shorthand nation form in conditions."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": [{"platform": "event", "event_type": "test_event"}],
+                "condition": "{{ is_state('test.entity', 'hello') }}",
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    hass.states.async_set("test.entity", "hello")
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_set("test.entity", "goodbye")
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
 async def test_automation_list_setting(hass, calls):
     """Event is not a valid condition."""
     assert await async_setup_component(

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -127,10 +127,7 @@ async def test_or_condition_with_template(hass):
         {
             "condition": "or",
             "conditions": [
-                {
-                    "condition": "template",
-                    "value_template": '{{ states.sensor.temperature.state == "100" }}',
-                },
+                {'{{ states.sensor.temperature.state == "100" }}'},
                 {
                     "condition": "numeric_state",
                     "entity_id": "sensor.temperature",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a shorthand notation for using Templates directly as conditions. This PR is based on an idea by @pnbruckner in PR #38290. This PR takes a broader approach by allowing shorthand template conditions across the board by making it part of the condition schema.

Basically it allows for:

```yaml
conditions: {{ template }}
```

Or combined in a list of conditions:

```yaml
conditions:
  - {{ template }}
  - condition: state
    ...
```

More examples:

```yaml
automation:
  - alias: test
    trigger:
      ...
    condition: "{{ is_state('input_boolean.go', 'on') }}"
    action:
      ...
```

```yaml
automation:
  - alias: test
    trigger:
      ...
    condition:
      - "{{ is_state('input_boolean.go', 'on') }}"
      - condition: state
        ...
      - "{{ is_state('input_boolean.stop', 'off') }}"
    action:
      ...
```

```yaml
- choose:
    - conditions: "{{ trigger.to_state.state == 'home' }}"
      sequence:
        - ...
    - conditions: 
        - "{{ trigger.to_state.state == 'office' }}"
        - condition: state
          ...
      sequence:
        - ...
```

```yaml
- repeat:
    while: "{{ is_state('input_boolean.go', 'on') }}"
    sequence:
      - ...
- repeat:
    while: 
      - "{{ is_state('input_boolean.go', 'on') }}"
      - condition: state
        ...
    sequence:
      - ...
```

```yaml
- condition: not
  conditions: "{{ is_state('input_boolean.go', 'on') }}"
```

```yaml
- condition: or
  conditions:
    - "{{ is_state('input_boolean.go', 'on') }}"
    - condition: state
      ...
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14413

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
