### PR TITLE
Support fnmatch (glob matching) in group entities list

### DIFF
--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -107,7 +107,7 @@ def _glob_to_re(glob: str) -> Pattern[str]:
     return re.compile(fnmatch.translate(glob))
 
 
-def _test_against_patterns(patterns: List[Pattern[str]], entity_id: str) -> bool:
+def test_against_patterns(patterns: List[Pattern[str]], entity_id: str) -> bool:
     """Test entity against list of patterns, true if any match."""
     for pattern in patterns:
         if pattern.match(entity_id):
@@ -144,7 +144,7 @@ def generate_filter(
         return (
             entity_id in include_e
             or domain in include_d
-            or bool(include_eg and _test_against_patterns(include_eg, entity_id))
+            or bool(include_eg and test_against_patterns(include_eg, entity_id))
         )
 
     def entity_excluded(domain: str, entity_id: str) -> bool:
@@ -152,7 +152,7 @@ def generate_filter(
         return (
             entity_id in exclude_e
             or domain in exclude_d
-            or bool(exclude_eg and _test_against_patterns(exclude_eg, entity_id))
+            or bool(exclude_eg and test_against_patterns(exclude_eg, entity_id))
         )
 
     # Case 1 - no includes or excludes - pass all entities
@@ -194,11 +194,9 @@ def generate_filter(
             if domain in include_d:
                 return not (
                     entity_id in exclude_e
-                    or bool(
-                        exclude_eg and _test_against_patterns(exclude_eg, entity_id)
-                    )
+                    or bool(exclude_eg and test_against_patterns(exclude_eg, entity_id))
                 )
-            if _test_against_patterns(include_eg, entity_id):
+            if test_against_patterns(include_eg, entity_id):
                 return not entity_excluded(domain, entity_id)
             return entity_id in include_e
 
@@ -217,7 +215,7 @@ def generate_filter(
             """Return filter function for case 4b."""
             domain = split_entity_id(entity_id)[0]
             if domain in exclude_d or (
-                exclude_eg and _test_against_patterns(exclude_eg, entity_id)
+                exclude_eg and test_against_patterns(exclude_eg, entity_id)
             ):
                 return entity_id in include_e
             return entity_id not in exclude_e

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -175,6 +175,28 @@ def test_entity_ids():
     assert schema("sensor.LIGHT, light.kitchen ") == ["sensor.light", "light.kitchen"]
 
 
+def test_glob_entity_ids():
+    """Test entity ID validation with globs."""
+    schema = vol.Schema(cv.glob_entity_ids)
+
+    options = (
+        "invalid_entity",
+        "sensor.light,sensor_*",
+        ["invalid_entity"],
+        ["sensor.light", "sensor_[i]nvalid"],
+        ["sensor.l[!o]ght,sensor_invalid"],
+    )
+    for value in options:
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    options = ([], ["sensor.light"], "sensor.light")
+    for value in options:
+        schema(value)
+
+    assert schema("sensor.LIGHT, light.kitchen ") == ["sensor.light", "light.kitchen"]
+
+
 def test_entity_domain():
     """Test entity domain validation."""
     schema = vol.Schema(cv.entity_domain("sensor"))

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -1,8 +1,11 @@
 """The tests for the EntityFilter component."""
+import re
+
 from homeassistant.helpers.entityfilter import (
     FILTER_SCHEMA,
     INCLUDE_EXCLUDE_FILTER_SCHEMA,
     generate_filter,
+    test_against_patterns as against_patterns,
 )
 
 
@@ -248,3 +251,11 @@ def test_filter_schema_include_exclude():
     }
     filt = INCLUDE_EXCLUDE_FILTER_SCHEMA(conf)
     assert filt.config == conf
+
+
+def test_test_against_patterns():
+    """Verify test_against_patterns checks all patterns."""
+    patterns = [re.compile(r"a\.a"), re.compile(r"b\..*")]
+    assert against_patterns(patterns, "a.a") is True
+    assert against_patterns(patterns, "a.b") is False
+    assert against_patterns(patterns, "b.a") is True


### PR DESCRIPTION
https://community.home-assistant.io/t/why-the-heck-dont-we-have-templates-glob-for-groups/224693/3

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support fnmatch (glob matching) in group entities list

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
