### PR TITLE
Fix setup of ONVIF devices without snapshot capability

### DIFF
--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -127,6 +127,8 @@ async def _get_snapshot_auth(hass, device, entry):
         return HTTP_DIGEST_AUTHENTICATION
 
     snapshot_uri = await device.async_get_snapshot_uri(device.profiles[0])
+    if not snapshot_uri:
+        return HTTP_DIGEST_AUTHENTICATION
     auth = HTTPDigestAuth(device.username, device.password)
 
     def _get():

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -217,7 +217,7 @@ class ONVIFDevice:
                 raise fault
 
             LOGGER.debug(
-                "Couldn't get network interfaces from ONVIF deivice '%s'. Error: %s",
+                "Couldn't get network interfaces from ONVIF device '%s'. Error: %s",
                 self.name,
                 fault,
             )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes setup of devices without snapshot capability:

```
Traceback (most recent call last):
  File "[...]/homeassistant/config_entries.py", line 228, in async_setup
    result = await component.async_setup_entry(hass, self)  # type: ignore
  File "[...]/homeassistant/components/onvif/__init__.py", line 86, in async_setup_entry
    await async_populate_snapshot_auth(hass, device, entry)
  File "[...]/homeassistant/components/onvif/__init__.py", line 156, in async_populate_snapshot_auth
    auth = await _get_snapshot_auth(hass, device, entry)
  File "[...]/homeassistant/components/onvif/__init__.py", line 140, in _get_snapshot_auth
    response = await hass.async_add_executor_job(_get)
  File "[...]/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "[...]/homeassistant/components/onvif/__init__.py", line 137, in _get
    return requests.get(snapshot_uri, timeout=1, auth=auth)
  File "[...]/lib/python3.7/site-packages/requests/api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "[...]/lib/python3.7/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "[...]/lib/python3.7/site-packages/requests/sessions.py", line 516, in request
    prep = self.prepare_request(req)
  File "[...]/lib/python3.7/site-packages/requests/sessions.py", line 459, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "[...]/lib/python3.7/site-packages/requests/models.py", line 314, in prepare
    self.prepare_url(url, params)
  File "[...]/lib/python3.7/site-packages/requests/models.py", line 388, in prepare_url
    raise MissingSchema(error)
requests.exceptions.MissingSchema: Invalid URL 'None': No schema supplied. Perhaps you meant http://None?
```

Returning digest here seems a bit dirty/possibly confusing to me, but it mirrors what happens if username/password is missing. Cleaner could be to return `None` and test for existence of the `CONF_SNAPSHOT_AUTH` key in config instead of a truthy value for it, but maybe that's a bit out of scope for this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
