### PR TITLE
Bump Plugwise_Smile from 1.1.0 to 1.4.0

### DIFF
--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["Plugwise_Smile==1.1.0"],
+  "requirements": ["Plugwise_Smile==1.4.0a6"],
   "codeowners": ["@CoMPaTech", "@bouwew"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["Plugwise_Smile==1.4.0a6"],
+  "requirements": ["Plugwise_Smile==1.4.0"],
   "codeowners": ["@CoMPaTech", "@bouwew"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -26,7 +26,7 @@ Mastodon.py==1.5.1
 OPi.GPIO==0.4.0
 
 # homeassistant.components.plugwise
-Plugwise_Smile==1.4.0a6
+Plugwise_Smile==1.4.0
 
 # homeassistant.components.essent
 PyEssent==0.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -26,7 +26,7 @@ Mastodon.py==1.5.1
 OPi.GPIO==0.4.0
 
 # homeassistant.components.plugwise
-Plugwise_Smile==1.1.0
+Plugwise_Smile==1.4.0a6
 
 # homeassistant.components.essent
 PyEssent==0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 HAP-python==3.0.0
 
 # homeassistant.components.plugwise
-Plugwise_Smile==1.4.0a6
+Plugwise_Smile==1.4.0
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 HAP-python==3.0.0
 
 # homeassistant.components.plugwise
-Plugwise_Smile==1.1.0
+Plugwise_Smile==1.4.0a6
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2


### PR DESCRIPTION
## Proposed change
Bump version of Plugwise_Smile module to 1.4 - main improvements are removing internal modules as per request by @MartinHjelmare in https://github.com/plugwise/Plugwise-Smile/issues/86 while improving conditions where `unique_id` might have been `None`. This version also improves by using the actual unique hostname (directly from `zeroconf` when discovered or through connecting with the device when set-up manually). Lastly there it provides for new functionality to be incorporated by upcoming PRs for "Plugwise Stretch", a hub to interface zigbee plugs other than those provided with Adam.

Full changelog at https://github.com/plugwise/Plugwise-Smile/blob/master/CHANGELOG.md

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #38388
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.
