### PR TITLE
Fix netatmo browse_media return type

### DIFF
--- a/homeassistant/components/netatmo/media_source.py
+++ b/homeassistant/components/netatmo/media_source.py
@@ -1,5 +1,6 @@
 """Netatmo Media Source Implementation."""
 import datetime as dt
+import logging
 import re
 from typing import Optional, Tuple
 
@@ -17,6 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 
 from .const import DATA_CAMERAS, DATA_EVENTS, DOMAIN, MANUFACTURER
 
+_LOGGER = logging.getLogger(__name__)
 MIME_TYPE = "application/x-mpegURL"
 
 
@@ -99,6 +101,9 @@ class NetatmoSource(MediaSource):
         )
 
         if not media.can_play and not media.can_expand:
+            _LOGGER.debug(
+                "Camera %s with event %s without media url found", camera_id, event_id
+            )
             raise IncompatibleMediaSource
 
         if not media.can_expand:

--- a/homeassistant/components/netatmo/media_source.py
+++ b/homeassistant/components/netatmo/media_source.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 from homeassistant.components.media_player.const import MEDIA_TYPE_VIDEO
 from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.components.media_source.const import MEDIA_MIME_TYPES
-from homeassistant.components.media_source.error import Unresolvable
+from homeassistant.components.media_source.error import MediaSourceError, Unresolvable
 from homeassistant.components.media_source.models import (
     BrowseMediaSource,
     MediaSource,
@@ -18,6 +18,10 @@ from homeassistant.core import HomeAssistant, callback
 from .const import DATA_CAMERAS, DATA_EVENTS, DOMAIN, MANUFACTURER
 
 MIME_TYPE = "application/x-mpegURL"
+
+
+class IncompatibleMediaSource(MediaSourceError):
+    """Incompatible media source attributes."""
 
 
 async def async_get_media_source(hass: HomeAssistant):
@@ -44,7 +48,7 @@ class NetatmoSource(MediaSource):
 
     async def async_browse_media(
         self, item: MediaSourceItem, media_types: Tuple[str] = MEDIA_MIME_TYPES
-    ) -> Optional[BrowseMediaSource]:
+    ) -> BrowseMediaSource:
         """Return media."""
         try:
             source, camera_id, event_id = async_parse_identifier(item)
@@ -55,7 +59,7 @@ class NetatmoSource(MediaSource):
 
     def _browse_media(
         self, source: str, camera_id: str, event_id: int
-    ) -> Optional[BrowseMediaSource]:
+    ) -> BrowseMediaSource:
         """Browse media."""
         if camera_id and camera_id not in self.events:
             raise BrowseError("Camera does not exist.")
@@ -67,7 +71,7 @@ class NetatmoSource(MediaSource):
 
     def _build_item_response(
         self, source: str, camera_id: str, event_id: int = None
-    ) -> Optional[BrowseMediaSource]:
+    ) -> BrowseMediaSource:
         if event_id and event_id in self.events[camera_id]:
             created = dt.datetime.fromtimestamp(event_id)
             thumbnail = self.events[camera_id][event_id].get("snapshot", {}).get("url")
@@ -95,7 +99,7 @@ class NetatmoSource(MediaSource):
         )
 
         if not media.can_play and not media.can_expand:
-            return None
+            raise IncompatibleMediaSource
 
         if not media.can_expand:
             return media
@@ -109,7 +113,10 @@ class NetatmoSource(MediaSource):
                     media.children.append(child)
         else:
             for eid in self.events[camera_id]:
-                child = self._build_item_response(source, camera_id, eid)
+                try:
+                    child = self._build_item_response(source, camera_id, eid)
+                except IncompatibleMediaSource:
+                    continue
                 if child:
                     media.children.append(child)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- `MediaSource.async_browse_media` must return a `BrowseMediaSource`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
