### PR TITLE
Guard for spotify items without type

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -440,13 +440,13 @@ def build_item_response(spotify, user, payload):
         items = [item["album"] for item in media.get("items", [])]
     elif media_content_type == "current_user_saved_tracks":
         media = spotify.current_user_saved_tracks(limit=BROWSE_LIMIT)
-        items = media.get("items", [])
+        items = [item["track"] for item in media.get("items", [])]
     elif media_content_type == "current_user_saved_shows":
         media = spotify.current_user_saved_shows(limit=BROWSE_LIMIT)
-        items = media.get("items", [])
+        items = [item["show"] for item in media.get("items", [])]
     elif media_content_type == "current_user_recently_played":
         media = spotify.current_user_recently_played(limit=BROWSE_LIMIT)
-        items = media.get("items", [])
+        items = [item["track"] for item in media.get("items", [])]
     elif media_content_type == "current_user_top_artists":
         media = spotify.current_user_top_artists(limit=BROWSE_LIMIT)
         items = media.get("items", [])
@@ -474,7 +474,7 @@ def build_item_response(spotify, user, payload):
         items = media.get("albums", {}).get("items", [])
     elif media_content_type == MEDIA_TYPE_PLAYLIST:
         media = spotify.playlist(media_content_id)
-        items = media.get("tracks", {}).get("items", [])
+        items = [item["track"] for item in media.get("tracks", {}).get("items", [])]
     elif media_content_type == MEDIA_TYPE_ALBUM:
         media = spotify.album(media_content_id)
         items = media.get("tracks", {}).get("items", [])
@@ -546,12 +546,6 @@ def item_payload(item):
 
     Used by async_browse_media.
     """
-    if MEDIA_TYPE_TRACK in item:
-        item = item[MEDIA_TYPE_TRACK]
-    elif MEDIA_TYPE_SHOW in item:
-        item = item[MEDIA_TYPE_SHOW]
-    elif MEDIA_TYPE_ARTIST in item:
-        item = item[MEDIA_TYPE_ARTIST]
 
     can_expand = item["type"] not in [
         MEDIA_TYPE_TRACK,

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -437,7 +437,7 @@ def build_item_response(spotify, user, payload):
         items = media.get("artists", {}).get("items", [])
     elif media_content_type == "current_user_saved_albums":
         media = spotify.current_user_saved_albums(limit=BROWSE_LIMIT)
-        items = media.get("items", [])
+        items = [item["album"] for item in media.get("items", [])]
     elif media_content_type == "current_user_saved_tracks":
         media = spotify.current_user_saved_tracks(limit=BROWSE_LIMIT)
         items = media.get("items", [])
@@ -528,7 +528,7 @@ def build_item_response(spotify, user, payload):
         "media_content_id": media_content_id,
         "media_content_type": media_content_type,
         "can_play": media_content_type in PLAYABLE_MEDIA_TYPES,
-        "children": [item_payload(item) for item in items if "type" in item],
+        "children": [item_payload(item) for item in items],
         "can_expand": True,
     }
 
@@ -552,8 +552,6 @@ def item_payload(item):
         item = item[MEDIA_TYPE_SHOW]
     elif MEDIA_TYPE_ARTIST in item:
         item = item[MEDIA_TYPE_ARTIST]
-    elif MEDIA_TYPE_ALBUM in item and item["type"] != MEDIA_TYPE_TRACK:
-        item = item[MEDIA_TYPE_ALBUM]
 
     can_expand = item["type"] not in [
         MEDIA_TYPE_TRACK,

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -528,7 +528,7 @@ def build_item_response(spotify, user, payload):
         "media_content_id": media_content_id,
         "media_content_type": media_content_type,
         "can_play": media_content_type in PLAYABLE_MEDIA_TYPES,
-        "children": [item_payload(item) for item in items],
+        "children": [item_payload(item) for item in items if "type" in item],
         "can_expand": True,
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Guard for Spotify media browse items without type.

Fixes #39778

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
