### PR TITLE
Add a duration function to templates helper

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1026,6 +1026,24 @@ def relative_time(value):
     return dt_util.get_age(value)
 
 
+def duration(value):
+    """
+    Take a datetime and return its duration since now in seconds.
+
+    If the date is in the future it will return a negative number.
+
+    If the input is not a datetime object the input will be returned unmodified.
+    """
+
+    if not isinstance(value, datetime):
+        return value
+    if not value.tzinfo:
+        value = dt_util.as_local(value)
+    if dt_util.now() < value:
+        return value
+    return dt_util.as_timestamp(dt_util.now()) - dt_util.as_timestamp(value)
+
+
 def urlencode(value):
     """Urlencode dictionary and return as UTF-8 string."""
     return urllib_urlencode(value).encode("utf-8")
@@ -1071,6 +1089,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["bitwise_and"] = bitwise_and
         self.filters["bitwise_or"] = bitwise_or
         self.filters["ord"] = ord
+        self.filters["duration"] = duration
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -1091,6 +1110,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["relative_time"] = relative_time
         self.globals["strptime"] = strptime
         self.globals["urlencode"] = urlencode
+        self.globals["duration"] = duration
         if hass is None:
             return
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1031,16 +1031,12 @@ def duration(value):
     Take a datetime and return its duration since now in seconds.
 
     If the date is in the future it will return a negative number.
-
-    If the input is not a datetime object the input will be returned unmodified.
     """
 
     if not isinstance(value, datetime):
-        return value
+        raise TypeError("Expected value to be a datetime")
     if not value.tzinfo:
         value = dt_util.as_local(value)
-    if dt_util.now() < value:
-        return value
     return dt_util.as_timestamp(dt_util.now()) - dt_util.as_timestamp(value)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a `duration` helper function (both global and filter) which works similarly to `relative_time`, but always returns the number of seconds respective to now(). In essence it is a shorter version of the often repeated (at least for me) pattern of:
```{{ as_timestamp(now()) - as_timestamp(states.binary_sensor.test.last_changed) }}```
Instead it becomes:
```{{ states.binary_sensor.test.last_changed | duration }}```
or
```{{ duration(states.binary_sensor.test.last_changed) }}```
which is mostly helpful in conditions. Basically it helps where `for` can not be used (although it obviously won't update on the condition itself).

I wasn't sure what to name it, so I'm open to suggestions! Also wasn't sure if I could just add a helper function, but I didn't know where to ask, so I figured this was the quickest way...
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
- input_boolean:
  - test1
  - test2

- platform: template
  sensors:
    test:
      value_template: >-
        {% if states.input_boolean.test1.last_changed | duration > 60 and
              states('input_boolean.test2', "on") 
        %}
        state1
        {% else %}
        state2
       {% endif %}
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
