### PR TITLE
Expose angle and xy attributes in deCONZ event if present

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -44,4 +44,6 @@ POWER_PLUGS = ["On/Off light", "On/Off plug-in unit", "Smart plug"]
 SIRENS = ["Warning device"]
 SWITCH_TYPES = POWER_PLUGS + SIRENS
 
+CONF_ANGLE = "angle"
 CONF_GESTURE = "gesture"
+CONF_XY = "xy"

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -3,7 +3,7 @@ from homeassistant.const import CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
 from homeassistant.core import callback
 from homeassistant.util import slugify
 
-from .const import CONF_GESTURE, LOGGER
+from .const import CONF_ANGLE, CONF_GESTURE, CONF_XY, LOGGER
 from .deconz_device import DeconzBase
 
 CONF_DECONZ_EVENT = "deconz_event"
@@ -51,6 +51,12 @@ class DeconzEvent(DeconzBase):
 
         if self._device.gesture is not None:
             data[CONF_GESTURE] = self._device.gesture
+
+        if self._device.angle is not None:
+            data[CONF_ANGLE] = self._device.angle
+
+        if self._device.xy is not None:
+            data[CONF_XY] = self._device.xy
 
         self.gateway.hass.bus.async_fire(CONF_DECONZ_EVENT, data)
 

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -40,6 +40,14 @@ SENSORS = {
         "config": {"battery": 100},
         "uniqueid": "00:00:00:00:00:00:00:04-00",
     },
+    "5": {
+        "id": "ZHA remote 1 id",
+        "name": "ZHA remote 1",
+        "type": "ZHASwitch",
+        "state": {"angle": 0, "buttonevent": 1000, "xy": [0.0, 0.0]},
+        "config": {"group": "4,5,6", "reachable": True, "on": True},
+        "uniqueid": "00:00:00:00:00:00:00:05-00",
+    },
 }
 
 
@@ -53,7 +61,7 @@ async def test_deconz_events(hass):
     assert "sensor.switch_2" not in gateway.deconz_ids
     assert "sensor.switch_2_battery_level" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 3
-    assert len(gateway.events) == 4
+    assert len(gateway.events) == 5
 
     switch_1 = hass.states.get("sensor.switch_1")
     assert switch_1 is None
@@ -99,6 +107,20 @@ async def test_deconz_events(hass):
         "unique_id": "00:00:00:00:00:00:00:04",
         "event": 1000,
         "gesture": 0,
+    }
+
+    gateway.api.sensors["5"].update(
+        {"state": {"buttonevent": 6002, "angle": 110, "xy": [0.5982, 0.3897]}}
+    )
+    await hass.async_block_till_done()
+
+    assert len(events) == 4
+    assert events[3].data == {
+        "id": "zha_remote_1",
+        "unique_id": "00:00:00:00:00:00:00:05",
+        "event": 6002,
+        "angle": 110,
+        "xy": [0.5982, 0.3897],
     }
 
     await gateway.async_reset()


### PR DESCRIPTION
## Proposed change

The tint remote control by Müller Licht has a color wheel which always generates the same button event with different values for the `angle` and `xy` attribute. The deCONZ REST API output looks like this for this sensor:

```
{
    "config": {
        "group": "16388,16389,16390",
        "on": true,
        "reachable": true
    },
    "ep": 1,
    "etag": "465eafe48223e2d66be34e0a97cd3cde",
    "lastseen": "2020-09-08T18:06Z",
    "manufacturername": "MLI",
    "mode": 1,
    "modelid": "ZBT-Remote-ALL-RGBW",
    "name": "ZHA Remote K\u00fcche 1",
    "state": {
        "angle": 110,
        "buttonevent": 6002,
        "lastupdated": "2020-09-08T18:07:22.576",
        "xy": [
            0.5982,
            0.3897
        ]
    },
    "swversion": "2.0",
    "type": "ZHASwitch",
    "uniqueid": "00:15:8d:00:03:61:XX:XX-01-1000",
    "e": "changed",
    "id": "12",
    "r": "sensors",
    "t": "event"
}
```

The `angle` and `xy` attributes in `state` are the properties that change when using the color wheel so we need to expose them to Home Assistant in order to do anything useful with the color wheel.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Example entry for `automations.yaml`:

```yaml
- alias: React to color wheel changes
  trigger:
     - platform: event
       event_type: deconz_event
       event_data:
         id: zha_remote_1
         event: 6002
  condition: []
  action:
    - service: light.turn_on
      data:
        xy_color:
          - '{{ trigger.event.data.xy.0 | float }}'
          - '{{ trigger.event.data.xy.1 | float }}'
        entity_id: light.example_color_light_1

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
