### PR TITLE
Add camera support to synology_dsm

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -830,6 +830,7 @@ omit =
     homeassistant/components/synology/camera.py
     homeassistant/components/synology_chat/notify.py
     homeassistant/components/synology_dsm/__init__.py
+    homeassistant/components/synology_dsm/camera.py
     homeassistant/components/synology_dsm/binary_sensor.py
     homeassistant/components/synology_dsm/sensor.py
     homeassistant/components/synology_srm/device_tracker.py

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -188,7 +188,6 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Unload Synology DSM sensors."""
-    entry_data = hass.data[DOMAIN][entry.unique_id]
     unload_ok = all(
         await asyncio.gather(
             *[
@@ -199,6 +198,7 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     )
 
     if unload_ok:
+        entry_data = hass.data[DOMAIN][entry.unique_id]
         entry_data[UNDO_UPDATE_LISTENER]()
         await entry_data[SYNO_API].async_unload()
         hass.data[DOMAIN].pop(entry.unique_id)

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -10,6 +10,7 @@ from synology_dsm.api.core.utilization import SynoCoreUtilization
 from synology_dsm.api.dsm.information import SynoDSMInformation
 from synology_dsm.api.dsm.network import SynoDSMNetwork
 from synology_dsm.api.storage.storage import SynoStorage
+from synology_dsm.api.surveillance_station import SynoSurveillanceStation
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -45,7 +46,6 @@ from .const import (
     ENTITY_ICON,
     ENTITY_NAME,
     ENTITY_UNIT,
-    PLATFORMS,
     STORAGE_DISK_BINARY_SENSORS,
     STORAGE_DISK_SENSORS,
     STORAGE_VOL_SENSORS,
@@ -177,7 +177,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
             entry, data={**entry.data, CONF_MAC: network.macs}
         )
 
-    for platform in PLATFORMS:
+    for platform in _async_platforms(api):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
@@ -187,17 +187,17 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Unload Synology DSM sensors."""
+    entry_data = hass.data[DOMAIN][entry.unique_id]
     unload_ok = all(
         await asyncio.gather(
             *[
                 hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in PLATFORMS
+                for platform in _async_platforms(entry_data[SYNO_API])
             ]
         )
     )
 
     if unload_ok:
-        entry_data = hass.data[DOMAIN][entry.unique_id]
         entry_data[UNDO_UPDATE_LISTENER]()
         await entry_data[SYNO_API].async_unload()
         hass.data[DOMAIN].pop(entry.unique_id)
@@ -208,6 +208,15 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
 async def _async_update_listener(hass: HomeAssistantType, entry: ConfigEntry):
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+@callback
+def _async_platforms(api):
+    """Return the platforms to be set up / unloaded."""
+    platforms = ["binary_sensor", "sensor"]
+    if api._with_surveillance_station:
+        platforms.append("camera")
+    return platforms
 
 
 class SynoApi:
@@ -225,12 +234,14 @@ class SynoApi:
         self.security: SynoCoreSecurity = None
         self.storage: SynoStorage = None
         self.utilisation: SynoCoreUtilization = None
+        self.surveillance_station: SynoSurveillanceStation = None
 
         # Should we fetch them
         self._fetching_entities = {}
         self._with_security = True
         self._with_storage = True
         self._with_utilisation = True
+        self._with_surveillance_station = True
 
         self._unsub_dispatcher = None
 
@@ -248,6 +259,11 @@ class SynoApi:
             self._entry.data[CONF_PASSWORD],
             self._entry.data[CONF_SSL],
             device_token=self._entry.data.get("device_token"),
+        )
+
+        await self._hass.async_add_executor_job(self.dsm.discover_apis)
+        self._with_surveillance_station = bool(
+            self.dsm.apis.get(SynoSurveillanceStation.CAMERA_API_KEY)
         )
 
         self._async_setup_api_requests()
@@ -294,6 +310,9 @@ class SynoApi:
         self._with_utilisation = bool(
             self._fetching_entities.get(SynoCoreUtilization.API_KEY)
         )
+        self._with_surveillance_station = bool(
+            self._fetching_entities.get(SynoSurveillanceStation.CAMERA_API_KEY)
+        )
 
         # Reset not used API
         if not self._with_security:
@@ -307,6 +326,10 @@ class SynoApi:
         if not self._with_utilisation:
             self.dsm.reset(self.utilisation)
             self.utilisation = None
+
+        if not self._with_surveillance_station:
+            self.dsm.reset(self.surveillance_station)
+            self.surveillance_station = None
 
     def _fetch_device_configuration(self):
         """Fetch initial device config."""
@@ -323,6 +346,9 @@ class SynoApi:
 
         if self._with_utilisation:
             self.utilisation = self.dsm.utilisation
+
+        if self._with_surveillance_station:
+            self.surveillance_station = self.dsm.surveillance_station
 
     async def async_unload(self):
         """Stop interacting with the NAS and prepare for removal from hass."""
@@ -345,6 +371,8 @@ class SynologyDSMEntity(Entity):
         entity_info: Dict[str, str],
     ):
         """Initialize the Synology DSM entity."""
+        super().__init__()
+
         self._api = api
         self._api_key = entity_type.split(":")[0]
         self.entity_type = entity_type.split(":")[-1]

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -46,6 +46,7 @@ from .const import (
     ENTITY_ICON,
     ENTITY_NAME,
     ENTITY_UNIT,
+    PLATFORMS,
     STORAGE_DISK_BINARY_SENSORS,
     STORAGE_DISK_SENSORS,
     STORAGE_VOL_SENSORS,
@@ -177,7 +178,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
             entry, data={**entry.data, CONF_MAC: network.macs}
         )
 
-    for platform in _async_platforms(api):
+    for platform in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
@@ -192,7 +193,7 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
         await asyncio.gather(
             *[
                 hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in _async_platforms(entry_data[SYNO_API])
+                for platform in PLATFORMS
             ]
         )
     )
@@ -208,15 +209,6 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
 async def _async_update_listener(hass: HomeAssistantType, entry: ConfigEntry):
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-@callback
-def _async_platforms(api):
-    """Return the platforms to be set up / unloaded."""
-    platforms = ["binary_sensor", "sensor"]
-    if api._with_surveillance_station:
-        platforms.append("camera")
-    return platforms
 
 
 class SynoApi:

--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -29,7 +29,8 @@ async def async_setup_entry(
 
     api = hass.data[DOMAIN][entry.unique_id][SYNO_API]
 
-    entities = []
+    if SynoSurveillanceStation.CAMERA_API_KEY not in api.dsm.apis:
+        return True
 
     surveillance_station = api.surveillance_station
     await hass.async_add_executor_job(surveillance_station.update)
@@ -91,7 +92,6 @@ class SynoDSMCamera(SynologyDSMEntity, Camera):
 
     async def stream_source(self) -> str:
         """Return the source of the stream."""
-        _LOGGER.debug(self._camera.live_view.rtsp)
         return self._camera.live_view.rtsp
 
     def enable_motion_detection(self):

--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -1,5 +1,4 @@
 """Support for Synology DSM cameras."""
-import logging
 from typing import Dict
 
 from synology_dsm.api.surveillance_station import SynoSurveillanceStation
@@ -18,8 +17,6 @@ from .const import (
     ENTITY_UNIT,
     SYNO_API,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -47,7 +44,7 @@ class SynoDSMCamera(SynologyDSMEntity, Camera):
         """Initialize a Synology camera."""
         super().__init__(
             api,
-            f"{SynoSurveillanceStation.CAMERA_API_KEY}:{camera.name}",
+            f"{SynoSurveillanceStation.CAMERA_API_KEY}:{camera.id}",
             {
                 ENTITY_NAME: camera.name,
                 ENTITY_CLASS: None,
@@ -56,16 +53,13 @@ class SynoDSMCamera(SynologyDSMEntity, Camera):
                 ENTITY_UNIT: None,
             },
         )
-        self._unique_id = f"{self._api.information.serial}_{SynoSurveillanceStation.CAMERA_API_KEY}_{camera.id}"
         self._camera = camera
 
     @property
     def device_info(self) -> Dict[str, any]:
         """Return the device information."""
         return {
-            "identifiers": {
-                (DOMAIN, f"{self._api.information.serial}/{self._camera.id}")
-            },
+            "identifiers": {(DOMAIN, self._api.information.serial, self._camera.id)},
             "name": self.name,
             "model": self._camera.model,
             "via_device": (DOMAIN, self._api.information.serial),

--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -1,0 +1,103 @@
+"""Support for Synology DSM cameras."""
+import logging
+from typing import Dict
+
+from synology_dsm.api.surveillance_station import SynoSurveillanceStation
+
+from homeassistant.components.camera import SUPPORT_STREAM, Camera
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import SynologyDSMEntity
+from .const import (
+    DOMAIN,
+    ENTITY_CLASS,
+    ENTITY_ENABLE,
+    ENTITY_ICON,
+    ENTITY_NAME,
+    ENTITY_UNIT,
+    SYNO_API,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up the Synology NAS binary sensor."""
+
+    api = hass.data[DOMAIN][entry.unique_id][SYNO_API]
+
+    entities = []
+
+    surveillance_station = api.surveillance_station
+    await hass.async_add_executor_job(surveillance_station.update)
+    cameras = surveillance_station.get_all_cameras()
+    entities = [SynoDSMCamera(api, camera) for camera in cameras]
+
+    async_add_entities(entities)
+
+
+class SynoDSMCamera(SynologyDSMEntity, Camera):
+    """Representation a Synology camera."""
+
+    def __init__(self, api, camera):
+        """Initialize a Synology camera."""
+        super().__init__(
+            api,
+            f"{SynoSurveillanceStation.CAMERA_API_KEY}:{camera.name}",
+            {
+                ENTITY_NAME: camera.name,
+                ENTITY_CLASS: None,
+                ENTITY_ICON: None,
+                ENTITY_ENABLE: True,
+                ENTITY_UNIT: None,
+            },
+        )
+        self._unique_id = f"{self._api.information.serial}_{SynoSurveillanceStation.CAMERA_API_KEY}_{camera.id}"
+        self._camera = camera
+
+    @property
+    def device_info(self) -> Dict[str, any]:
+        """Return the device information."""
+        return {
+            "identifiers": {
+                (DOMAIN, f"{self._api.information.serial}/{self._camera.id}")
+            },
+            "name": self.name,
+            "model": self._camera.model,
+            "via_device": (DOMAIN, self._api.information.serial),
+        }
+
+    @property
+    def supported_features(self) -> int:
+        """Return supported features of this camera."""
+        return SUPPORT_STREAM
+
+    @property
+    def is_recording(self):
+        """Return true if the device is recording."""
+        return self._camera.is_recording
+
+    @property
+    def motion_detection_enabled(self):
+        """Return the camera motion detection status."""
+        return self._camera.is_motion_detection_enabled
+
+    def camera_image(self) -> bytes:
+        """Return bytes of camera image."""
+        return self._api.surveillance_station.get_camera_image(self._camera.id)
+
+    async def stream_source(self) -> str:
+        """Return the source of the stream."""
+        _LOGGER.debug(self._camera.live_view.rtsp)
+        return self._camera.live_view.rtsp
+
+    def enable_motion_detection(self):
+        """Enable motion detection in the camera."""
+        self._api.surveillance_station.enable_motion_detection(self._camera.id)
+
+    def disable_motion_detection(self):
+        """Disable motion detection in camera."""
+        self._api.surveillance_station.disable_motion_detection(self._camera.id)

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
 )
 
 DOMAIN = "synology_dsm"
+PLATFORMS = ["binary_sensor", "camera", "sensor"]
 
 # Entry keys
 SYNO_API = "syno_api"

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
 )
 
 DOMAIN = "synology_dsm"
-PLATFORMS = ["binary_sensor", "sensor"]
 
 # Entry keys
 SYNO_API = "syno_api"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds camera support to the `synology_dsm` integration. After this integration, we should deprecated the `synology` integration since that is no longer needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29931, fixes #36999
- This PR is related to issue: #35475
- Link to documentation pull request: home-assistant/home-assistant.io#14467

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
