### PR TITLE
Handle Kodi shutdown

### DIFF
--- a/homeassistant/components/kodi/manifest.json
+++ b/homeassistant/components/kodi/manifest.json
@@ -2,7 +2,7 @@
   "domain": "kodi",
   "name": "Kodi",
   "documentation": "https://www.home-assistant.io/integrations/kodi",
-  "requirements": ["pykodi==0.1.2"],
+  "requirements": ["pykodi==0.1.3"],
   "codeowners": [
     "@OnFreund"
   ],

--- a/homeassistant/components/kodi/manifest.json
+++ b/homeassistant/components/kodi/manifest.json
@@ -2,7 +2,7 @@
   "domain": "kodi",
   "name": "Kodi",
   "documentation": "https://www.home-assistant.io/integrations/kodi",
-  "requirements": ["pykodi==0.1.3"],
+  "requirements": ["pykodi==0.2.0"],
   "codeowners": [
     "@OnFreund"
   ],

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -325,10 +325,9 @@ class KodiEntity(MediaPlayerEntity):
         self._app_properties["muted"] = data["muted"]
         self.async_write_ha_state()
 
-    @callback
-    def async_on_quit(self, sender, data):
+    async def async_on_quit(self, sender, data):
         """Reset the player state on quit action."""
-        self.hass.async_create_task(self._clear_connection())
+        await self._clear_connection()
 
     async def _clear_connection(self, close=True):
         self._reset_state()

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -330,7 +330,6 @@ class KodiEntity(MediaPlayerEntity):
         """Reset the player state on quit action."""
         self.hass.async_create_task(self._clear_connection())
 
-    @callback
     async def _clear_connection(self, close=True):
         self._reset_state()
         self.async_write_ha_state()
@@ -394,7 +393,6 @@ class KodiEntity(MediaPlayerEntity):
             await self._connection.connect()
             self._on_ws_connected()
         except (jsonrpc_base.jsonrpc.TransportError, CannotConnectError):
-            _LOGGER.info("Unable to connect to Kodi via websocket")
             _LOGGER.debug("Unable to connect to Kodi via websocket", exc_info=True)
             await self._clear_connection(False)
 
@@ -402,7 +400,6 @@ class KodiEntity(MediaPlayerEntity):
         try:
             await self._kodi.ping()
         except (jsonrpc_base.jsonrpc.TransportError, CannotConnectError):
-            _LOGGER.info("Unable to ping  Kodi via websocket")
             _LOGGER.debug("Unable to ping Kodi via websocket", exc_info=True)
             await self._clear_connection()
 

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -5,6 +5,7 @@ import logging
 import re
 
 import jsonrpc_base
+from pykodi import CannotConnectError
 import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
@@ -327,8 +328,14 @@ class KodiEntity(MediaPlayerEntity):
     @callback
     def async_on_quit(self, sender, data):
         """Reset the player state on quit action."""
+        self.hass.async_create_task(self._clear_connection())
+
+    @callback
+    async def _clear_connection(self, close=True):
         self._reset_state()
-        self.hass.async_create_task(self._connection.close())
+        self.async_write_ha_state()
+        if close:
+            await self._connection.close()
 
     @property
     def unique_id(self):
@@ -386,14 +393,25 @@ class KodiEntity(MediaPlayerEntity):
         try:
             await self._connection.connect()
             self._on_ws_connected()
-        except jsonrpc_base.jsonrpc.TransportError:
+        except (jsonrpc_base.jsonrpc.TransportError, CannotConnectError):
             _LOGGER.info("Unable to connect to Kodi via websocket")
             _LOGGER.debug("Unable to connect to Kodi via websocket", exc_info=True)
+            await self._clear_connection(False)
+
+    async def _ping(self):
+        try:
+            await self._kodi.ping()
+        except (jsonrpc_base.jsonrpc.TransportError, CannotConnectError):
+            _LOGGER.info("Unable to ping  Kodi via websocket")
+            _LOGGER.debug("Unable to ping Kodi via websocket", exc_info=True)
+            await self._clear_connection()
 
     async def _async_connect_websocket_if_disconnected(self, *_):
         """Reconnect the websocket if it fails."""
         if not self._connection.connected:
             await self._async_ws_connect()
+        else:
+            await self._ping()
 
     @callback
     def _register_ws_callbacks(self):
@@ -464,7 +482,7 @@ class KodiEntity(MediaPlayerEntity):
     @property
     def should_poll(self):
         """Return True if entity has to be polled for state."""
-        return (not self._connection.can_subscribe) or (not self._connection.connected)
+        return not self._connection.can_subscribe
 
     @property
     def volume_level(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1431,7 +1431,7 @@ pyitachip2ir==0.0.7
 pykira==0.1.1
 
 # homeassistant.components.kodi
-pykodi==0.1.3
+pykodi==0.2.0
 
 # homeassistant.components.kwb
 pykwb==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1431,7 +1431,7 @@ pyitachip2ir==0.0.7
 pykira==0.1.1
 
 # homeassistant.components.kodi
-pykodi==0.1.2
+pykodi==0.1.3
 
 # homeassistant.components.kwb
 pykwb==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -692,7 +692,7 @@ pyisy==2.0.2
 pykira==0.1.1
 
 # homeassistant.components.kodi
-pykodi==0.1.3
+pykodi==0.2.0
 
 # homeassistant.components.lastfm
 pylast==3.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -692,7 +692,7 @@ pyisy==2.0.2
 pykira==0.1.1
 
 # homeassistant.components.kodi
-pykodi==0.1.2
+pykodi==0.1.3
 
 # homeassistant.components.lastfm
 pylast==3.3.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle kodi shutdowns. If it's a graceful shutdown, and we're on websocket, the HA state will immediately change to off. If it's an ungraceful shutdown, or we're not on websocket (hence polling), it can take a few minutes.
This does not handle the case where Kodi is off when starting HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39788
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
