### PR TITLE
Disable Met.no hourly weather by default

### DIFF
--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -104,7 +104,6 @@ class MetWeather(CoordinatorEntity, WeatherEntity):
         self._config = config
         self._is_metric = is_metric
         self._hourly = hourly
-        self._name_appendix = "-hourly" if hourly else ""
 
     @property
     def track_home(self):
@@ -114,23 +113,34 @@ class MetWeather(CoordinatorEntity, WeatherEntity):
     @property
     def unique_id(self):
         """Return unique ID."""
+        name_appendix = ""
+        if self._hourly:
+            name_appendix = "-hourly"
         if self.track_home:
-            return f"home{self._name_appendix}"
+            return f"home{name_appendix}"
 
-        return f"{self._config[CONF_LATITUDE]}-{self._config[CONF_LONGITUDE]}{self._name_appendix}"
+        return f"{self._config[CONF_LATITUDE]}-{self._config[CONF_LONGITUDE]}{name_appendix}"
 
     @property
     def name(self):
         """Return the name of the sensor."""
         name = self._config.get(CONF_NAME)
+        name_appendix = ""
+        if self._hourly:
+            name_appendix = " Hourly"
 
         if name is not None:
-            return f"{name}{self._name_appendix}"
+            return f"{name}{name_appendix}"
 
         if self.track_home:
-            return f"{self.hass.config.location_name}{self._name_appendix}"
+            return f"{self.hass.config.location_name}{name_appendix}"
 
-        return f"{DEFAULT_NAME}{self._name_appendix}"
+        return f"{DEFAULT_NAME}{name_appendix}"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return not self._hourly
 
     @property
     def condition(self):

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -1,12 +1,26 @@
 """Test Met weather entity."""
 
+from homeassistant.components.met import DOMAIN
+from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
+
 
 async def test_tracking_home(hass, mock_weather):
     """Test we track home."""
     await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids("weather")) == 2
+    assert len(hass.states.async_entity_ids("weather")) == 1
     assert len(mock_weather.mock_calls) == 4
+
+    # Test the hourly sensor is disabled by default
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    state = hass.states.get("weather.test_home_hourly")
+    assert state is None
+
+    entry = registry.async_get("weather.test_home_hourly")
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by == "integration"
 
     # Test we track config
     await hass.config.async_update(latitude=10, longitude=20)
@@ -21,6 +35,17 @@ async def test_tracking_home(hass, mock_weather):
 
 async def test_not_tracking_home(hass, mock_weather):
     """Test when we not track home."""
+
+    # Pre-create registry entry for disabled by default hourly weather
+    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry.async_get_or_create(
+        WEATHER_DOMAIN,
+        DOMAIN,
+        "10-20-hourly",
+        suggested_object_id="somewhere_hourly",
+        disabled_by=None,
+    )
+
     await hass.config_entries.flow.async_init(
         "met",
         context={"source": "user"},

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -276,4 +276,4 @@ async def test_onboarding_core_sets_up_met(hass, hass_storage, hass_client):
     assert resp.status == 200
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids("weather")) == 2
+    assert len(hass.states.async_entity_ids("weather")) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Met.no is set up by default on new installations. With recent changes, this brings in a second weather sensor with an hourly forecast. This looks confusing when seeing the Home Assistant frontend the first time. You'll be greeted by 2 big weather cards that look the same but aren't (daily vs hourly, but that might not be clear on first sight).

This PR adjust 2 things:

- The hourly entity is disabled by default in the registry (but can be enabled by the user).
- The hourly now gets a proper name. Instead of "Home-hourly" it becomes "Home Hourly".

These changes are not breaking for existing users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
