### PR TITLE
Limit zeroconf discovery to name/macaddress when provided

### DIFF
--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -4,7 +4,11 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
   "requirements": ["axis==35"],
-  "zeroconf": [{"type":"_axis-video._tcp.local.","macaddress":"00408C*"}, {"type":"_axis-video._tcp.local.","macaddress":"ACCC8E*"}, {"type":"_axis-video._tcp.local.","macaddress":"B8A44F*"}],
+  "zeroconf": [
+    {"type":"_axis-video._tcp.local.","macaddress":"00408C*"},
+    {"type":"_axis-video._tcp.local.","macaddress":"ACCC8E*"},
+    {"type":"_axis-video._tcp.local.","macaddress":"B8A44F*"}
+  ],
   "after_dependencies": ["mqtt"],
   "codeowners": ["@Kane610"]
 }

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
   "requirements": ["axis==35"],
-  "zeroconf": [{"type":"_axis-video._tcp.local.","macaddress":"00408C"}, {"type":"_axis-video._tcp.local.","macaddress":"ACCC8E"}, {"type":"_axis-video._tcp.local.","macaddress":"B8A44F"}],
+  "zeroconf": [{"type":"_axis-video._tcp.local.","macaddress":"00408C*"}, {"type":"_axis-video._tcp.local.","macaddress":"ACCC8E*"}, {"type":"_axis-video._tcp.local.","macaddress":"B8A44F*"}],
   "after_dependencies": ["mqtt"],
   "codeowners": ["@Kane610"]
 }

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
   "requirements": ["axis==35"],
-  "zeroconf": ["_axis-video._tcp.local."],
+  "zeroconf": [{"type":"_axis-video._tcp.local.","macaddress":"00408C"}, {"type":"_axis-video._tcp.local.","macaddress":"ACCC8E"}, {"type":"_axis-video._tcp.local.","macaddress":"B8A44F"}],
   "after_dependencies": ["mqtt"],
   "codeowners": ["@Kane610"]
 }

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
   "requirements": ["brother==0.1.17"],
-  "zeroconf": [{"type": "_printer._tcp.local.", "name":"brother"}],
+  "zeroconf": [{"type": "_printer._tcp.local.", "name":"brother*"}],
   "config_flow": true,
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
   "requirements": ["brother==0.1.17"],
-  "zeroconf": ["_printer._tcp.local."],
+  "zeroconf": [{"type": "_printer._tcp.local.", "name":"brother"}],
   "config_flow": true,
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/doorbird/manifest.json
+++ b/homeassistant/components/doorbird/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/doorbird",
   "requirements": ["doorbirdpy==2.1.0"],
   "dependencies": ["http"],
-  "zeroconf": ["_axis-video._tcp.local."],
+  "zeroconf": [{"type":"_axis-video._tcp.local.","macaddress":"1CCAE3"}],
   "codeowners": ["@oblogic7", "@bdraco"],
   "config_flow": true
 }

--- a/homeassistant/components/doorbird/manifest.json
+++ b/homeassistant/components/doorbird/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/doorbird",
   "requirements": ["doorbirdpy==2.1.0"],
   "dependencies": ["http"],
-  "zeroconf": [{"type":"_axis-video._tcp.local.","macaddress":"1CCAE3"}],
+  "zeroconf": [{"type":"_axis-video._tcp.local.","macaddress":"1CCAE3*"}],
   "codeowners": ["@oblogic7", "@bdraco"],
   "config_flow": true
 }

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -4,6 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
   "requirements": ["aioshelly==0.3.1"],
-  "zeroconf": [{"type": "_http._tcp.local.", "name":"shelly"}],
+  "zeroconf": [{"type": "_http._tcp.local.", "name":"shelly*"}],
   "codeowners": ["@balloob", "@bieniu"]
 }

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -4,6 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
   "requirements": ["aioshelly==0.3.1"],
-  "zeroconf": ["_http._tcp.local."],
+  "zeroconf": [{"type": "_http._tcp.local.", "name":"shelly"}],
   "codeowners": ["@balloob", "@bieniu"]
 }

--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -11,6 +11,7 @@
     "@bsmappee"
   ],
   "zeroconf": [
-    "_ssh._tcp.local."
+    {"type":"_ssh._tcp.local.", "name":"smappee1"},
+    {"type":"_ssh._tcp.local.", "name":"smappee2"}
   ]
 }

--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -11,7 +11,7 @@
     "@bsmappee"
   ],
   "zeroconf": [
-    {"type":"_ssh._tcp.local.", "name":"smappee1"},
-    {"type":"_ssh._tcp.local.", "name":"smappee2"}
+    {"type":"_ssh._tcp.local.", "name":"smappee1*"},
+    {"type":"_ssh._tcp.local.", "name":"smappee2*"}
   ]
 }

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -1,5 +1,6 @@
 """Support for exposing Home Assistant via Zeroconf."""
 import asyncio
+import fnmatch
 import ipaddress
 import logging
 import socket
@@ -275,16 +276,14 @@ def setup(hass, config):
                         continue
                     if "macaddress" not in info["properties"]:
                         continue
-                    if (
-                        not info["properties"]["macaddress"]
-                        .upper()
-                        .startswith(entry["macaddress"])
+                    if not fnmatch.fnmatch(
+                        info["properties"]["macaddress"], entry["macaddress"]
                     ):
                         continue
                 if "name" in entry:
                     if "name" not in info:
                         continue
-                    if not info["name"].lower().startswith(entry["name"]):
+                    if not fnmatch.fnmatch(info["name"], entry["name"]):
                         continue
 
             hass.add_job(

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -268,10 +268,28 @@ def setup(hass, config):
                     # likely bad homekit data
                     return
 
-        for domain in zeroconf_types[service_type]:
+        for entry in zeroconf_types[service_type]:
+            if len(entry) > 1:
+                if "macaddress" in entry:
+                    if "properties" not in info:
+                        continue
+                    if "macaddress" not in info["properties"]:
+                        continue
+                    if (
+                        not info["properties"]["macaddress"]
+                        .upper()
+                        .startswith(entry["macaddress"])
+                    ):
+                        continue
+                if "name" in entry:
+                    if "name" not in info:
+                        continue
+                    if not info["name"].lower().startswith(entry["name"]):
+                        continue
+
             hass.add_job(
                 hass.config_entries.flow.async_init(
-                    domain, context={"source": DOMAIN}, data=info
+                    entry["domain"], context={"source": DOMAIN}, data=info
                 )
             )
 

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -19,19 +19,19 @@ ZEROCONF = {
     "_axis-video._tcp.local.": [
         {
             "domain": "axis",
-            "macaddress": "00408C"
+            "macaddress": "00408C*"
         },
         {
             "domain": "axis",
-            "macaddress": "ACCC8E"
+            "macaddress": "ACCC8E*"
         },
         {
             "domain": "axis",
-            "macaddress": "B8A44F"
+            "macaddress": "B8A44F*"
         },
         {
             "domain": "doorbird",
-            "macaddress": "1CCAE3"
+            "macaddress": "1CCAE3*"
         }
     ],
     "_bond._tcp.local.": [
@@ -75,7 +75,7 @@ ZEROCONF = {
     "_http._tcp.local.": [
         {
             "domain": "shelly",
-            "name": "shelly"
+            "name": "shelly*"
         }
     ],
     "_ipp._tcp.local.": [
@@ -109,7 +109,7 @@ ZEROCONF = {
     "_printer._tcp.local.": [
         {
             "domain": "brother",
-            "name": "brother"
+            "name": "brother*"
         }
     ],
     "_spotify-connect._tcp.local.": [
@@ -120,11 +120,11 @@ ZEROCONF = {
     "_ssh._tcp.local.": [
         {
             "domain": "smappee",
-            "name": "smappee1"
+            "name": "smappee1*"
         },
         {
             "domain": "smappee",
-            "name": "smappee2"
+            "name": "smappee2*"
         }
     ],
     "_viziocast._tcp.local.": [

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -7,75 +7,140 @@ To update, run python3 -m script.hassfest
 
 ZEROCONF = {
     "_Volumio._tcp.local.": [
-        "volumio"
+        {
+            "domain": "volumio"
+        }
     ],
     "_api._udp.local.": [
-        "guardian"
+        {
+            "domain": "guardian"
+        }
     ],
     "_axis-video._tcp.local.": [
-        "axis",
-        "doorbird"
+        {
+            "domain": "axis",
+            "macaddress": "00408C"
+        },
+        {
+            "domain": "axis",
+            "macaddress": "ACCC8E"
+        },
+        {
+            "domain": "axis",
+            "macaddress": "B8A44F"
+        },
+        {
+            "domain": "doorbird",
+            "macaddress": "1CCAE3"
+        }
     ],
     "_bond._tcp.local.": [
-        "bond"
+        {
+            "domain": "bond"
+        }
     ],
     "_daap._tcp.local.": [
-        "forked_daapd"
+        {
+            "domain": "forked_daapd"
+        }
     ],
     "_dkapi._tcp.local.": [
-        "daikin"
+        {
+            "domain": "daikin"
+        }
     ],
     "_elg._tcp.local.": [
-        "elgato"
+        {
+            "domain": "elgato"
+        }
     ],
     "_esphomelib._tcp.local.": [
-        "esphome"
+        {
+            "domain": "esphome"
+        }
     ],
     "_googlecast._tcp.local.": [
-        "cast"
+        {
+            "domain": "cast"
+        }
     ],
     "_hap._tcp.local.": [
-        "homekit_controller"
+        {
+            "domain": "homekit_controller"
+        }
     ],
     "_homekit._tcp.local.": [
         "homekit"
     ],
     "_http._tcp.local.": [
-        "shelly"
+        {
+            "domain": "shelly",
+            "name": "shelly"
+        }
     ],
     "_ipp._tcp.local.": [
-        "ipp"
+        {
+            "domain": "ipp"
+        }
     ],
     "_ipps._tcp.local.": [
-        "ipp"
+        {
+            "domain": "ipp"
+        }
     ],
     "_miio._udp.local.": [
-        "xiaomi_aqara",
-        "xiaomi_miio"
+        {
+            "domain": "xiaomi_aqara"
+        },
+        {
+            "domain": "xiaomi_miio"
+        }
     ],
     "_nut._tcp.local.": [
-        "nut"
+        {
+            "domain": "nut"
+        }
     ],
     "_plugwise._tcp.local.": [
-        "plugwise"
+        {
+            "domain": "plugwise"
+        }
     ],
     "_printer._tcp.local.": [
-        "brother"
+        {
+            "domain": "brother",
+            "name": "brother"
+        }
     ],
     "_spotify-connect._tcp.local.": [
-        "spotify"
+        {
+            "domain": "spotify"
+        }
     ],
     "_ssh._tcp.local.": [
-        "smappee"
+        {
+            "domain": "smappee",
+            "name": "smappee1"
+        },
+        {
+            "domain": "smappee",
+            "name": "smappee2"
+        }
     ],
     "_viziocast._tcp.local.": [
-        "vizio"
+        {
+            "domain": "vizio"
+        }
     ],
     "_wled._tcp.local.": [
-        "wled"
+        {
+            "domain": "wled"
+        }
     ],
     "_xbmc-jsonrpc-h._tcp.local.": [
-        "kodi"
+        {
+            "domain": "kodi"
+        }
     ]
 }
 

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -70,7 +70,9 @@ ZEROCONF = {
         }
     ],
     "_homekit._tcp.local.": [
-        "homekit"
+        {
+            "domain": "homekit"
+        }
     ],
     "_http._tcp.local.": [
         {

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -158,7 +158,7 @@ async def async_get_zeroconf(hass: "HomeAssistant") -> Dict[str, List[Dict[str, 
             if isinstance(entry, dict):
                 typ = entry["type"]
                 entry_without_type = entry.copy()
-                entry_without_type.pop("type")
+                del entry_without_type["type"]
                 data.update(entry_without_type)
             else:
                 typ = entry

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -145,18 +145,25 @@ async def async_get_config_flows(hass: "HomeAssistant") -> Set[str]:
     return flows
 
 
-async def async_get_zeroconf(hass: "HomeAssistant") -> Dict[str, List]:
+async def async_get_zeroconf(hass: "HomeAssistant") -> Dict[str, List[Dict[str, str]]]:
     """Return cached list of zeroconf types."""
-    zeroconf: Dict[str, List] = ZEROCONF.copy()
+    zeroconf: Dict[str, List[Dict[str, str]]] = ZEROCONF.copy()
 
     integrations = await async_get_custom_components(hass)
     for integration in integrations.values():
         if not integration.zeroconf:
             continue
-        for typ in integration.zeroconf:
-            zeroconf.setdefault(typ, [])
-            if integration.domain not in zeroconf[typ]:
-                zeroconf[typ].append(integration.domain)
+        for entry in integration.zeroconf:
+            data = {"domain": integration.domain}
+            if isinstance(entry, dict):
+                typ = entry["type"]
+                entry_without_type = entry.copy()
+                entry_without_type.pop("type")
+                data.update(entry_without_type)
+            else:
+                typ = entry
+
+            zeroconf.setdefault(typ, []).append(data)
 
     return zeroconf
 

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -38,7 +38,18 @@ MANIFEST_SCHEMA = vol.Schema(
         vol.Required("domain"): str,
         vol.Required("name"): str,
         vol.Optional("config_flow"): bool,
-        vol.Optional("zeroconf"): [str],
+        vol.Optional("zeroconf"): [
+            vol.Any(
+                str,
+                vol.Schema(
+                    {
+                        vol.Required("type"): str,
+                        vol.Optional("macaddress"): str,
+                        vol.Optional("name"): str,
+                    }
+                ),
+            )
+        ],
         vol.Optional("ssdp"): vol.Schema(
             vol.All([vol.All(vol.Schema({}, extra=vol.ALLOW_EXTRA), vol.Length(min=1))])
         ),

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -37,8 +37,17 @@ def generate_and_validate(integrations: Dict[str, Integration]):
         if not (service_types or homekit_models):
             continue
 
-        for service_type in service_types:
-            service_type_dict[service_type].append(domain)
+        for entry in service_types:
+            data = {"domain": domain}
+            if isinstance(entry, dict):
+                typ = entry["type"]
+                entry_without_type = entry.copy()
+                entry_without_type.pop("type")
+                data.update(entry_without_type)
+            else:
+                typ = entry
+
+            service_type_dict[typ].append(data)
 
         for model in homekit_models:
             if model in homekit_dict:

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -42,7 +42,7 @@ def generate_and_validate(integrations: Dict[str, Integration]):
             if isinstance(entry, dict):
                 typ = entry["type"]
                 entry_without_type = entry.copy()
-                entry_without_type.pop("type")
+                del entry_without_type["type"]
                 data.update(entry_without_type)
             else:
                 typ = entry

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -79,6 +79,24 @@ def get_homekit_info_mock(model, pairing_status):
     return mock_homekit_info
 
 
+def get_zeroconf_info_mock(macaddress):
+    """Return info for get_service_info for an zeroconf device."""
+
+    def mock_zc_info(service_type, name):
+        return ServiceInfo(
+            service_type,
+            name,
+            addresses=[b"\n\x00\x00\x14"],
+            port=80,
+            weight=0,
+            priority=0,
+            server="name.local.",
+            properties={b"macaddress": macaddress.encode()},
+        )
+
+    return mock_zc_info
+
+
 async def test_setup(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.object(
@@ -94,7 +112,11 @@ async def test_setup(hass, mock_zeroconf):
     assert len(mock_service_browser.mock_calls) == 1
     expected_flow_calls = 0
     for matching_components in zc_gen.ZEROCONF.values():
-        expected_flow_calls += len(matching_components)
+        domains = set()
+        for component in matching_components:
+            if len(component) == 1:
+                domains.add(component["domain"])
+        expected_flow_calls += len(domains)
     assert len(mock_config_flow.mock_calls) == expected_flow_calls
 
     # Test instance is set.
@@ -209,10 +231,77 @@ async def test_service_with_invalid_name(hass, mock_zeroconf, caplog):
     assert "Failed to get info for device name" in caplog.text
 
 
+async def test_zeroconf_match(hass, mock_zeroconf):
+    """Test configured options for a device are loaded via config entry."""
+
+    def http_only_service_update_mock(zeroconf, services, handlers):
+        """Call service update handler."""
+        handlers[0](
+            zeroconf,
+            "_http._tcp.local.",
+            "shelly108._http._tcp.local.",
+            ServiceStateChange.Added,
+        )
+
+    with patch.dict(
+        zc_gen.ZEROCONF,
+        {"_http._tcp.local.": [{"domain": "shelly", "name": "shelly*"}]},
+        clear=True,
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
+    ) as mock_service_browser:
+        mock_zeroconf.get_service_info.side_effect = get_zeroconf_info_mock(
+            "FFAADDCC11DD"
+        )
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert len(mock_service_browser.mock_calls) == 1
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "shelly"
+
+
+async def test_zeroconf_no_match(hass, mock_zeroconf):
+    """Test configured options for a device are loaded via config entry."""
+
+    def http_only_service_update_mock(zeroconf, services, handlers):
+        """Call service update handler."""
+        handlers[0](
+            zeroconf,
+            "_http._tcp.local.",
+            "somethingelse._http._tcp.local.",
+            ServiceStateChange.Added,
+        )
+
+    with patch.dict(
+        zc_gen.ZEROCONF,
+        {"_http._tcp.local.": [{"domain": "shelly", "name": "shelly*"}]},
+        clear=True,
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow, patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
+    ) as mock_service_browser:
+        mock_zeroconf.get_service_info.side_effect = get_zeroconf_info_mock(
+            "FFAADDCC11DD"
+        )
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert len(mock_service_browser.mock_calls) == 1
+    assert len(mock_config_flow.mock_calls) == 0
+
+
 async def test_homekit_match_partial_space(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
-        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+        zc_gen.ZEROCONF,
+        {zeroconf.HOMEKIT_TYPE: [{"domain": "homekit_controller"}]},
+        clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
@@ -233,7 +322,9 @@ async def test_homekit_match_partial_space(hass, mock_zeroconf):
 async def test_homekit_match_partial_dash(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
-        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+        zc_gen.ZEROCONF,
+        {zeroconf.HOMEKIT_TYPE: [{"domain": "homekit_controller"}]},
+        clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
@@ -254,7 +345,9 @@ async def test_homekit_match_partial_dash(hass, mock_zeroconf):
 async def test_homekit_match_full(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
-        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+        zc_gen.ZEROCONF,
+        {zeroconf.HOMEKIT_TYPE: [{"domain": "homekit_controller"}]},
+        clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
@@ -267,11 +360,6 @@ async def test_homekit_match_full(hass, mock_zeroconf):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    homekit_mock = get_homekit_info_mock("BSB002", HOMEKIT_STATUS_UNPAIRED)
-    info = homekit_mock("_hap._tcp.local.", "BSB002._hap._tcp.local.")
-    import pprint
-
-    pprint.pprint(["homekit", info])
     assert len(mock_service_browser.mock_calls) == 1
     assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
@@ -280,7 +368,9 @@ async def test_homekit_match_full(hass, mock_zeroconf):
 async def test_homekit_already_paired(hass, mock_zeroconf):
     """Test that an already paired device is sent to homekit_controller."""
     with patch.dict(
-        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+        zc_gen.ZEROCONF,
+        {zeroconf.HOMEKIT_TYPE: [{"domain": "homekit_controller"}]},
+        clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
@@ -302,7 +392,9 @@ async def test_homekit_already_paired(hass, mock_zeroconf):
 async def test_homekit_invalid_paring_status(hass, mock_zeroconf):
     """Test that missing paring data is not sent to homekit_controller."""
     with patch.dict(
-        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+        zc_gen.ZEROCONF,
+        {zeroconf.HOMEKIT_TYPE: [{"domain": "homekit_controller"}]},
+        clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
@@ -323,7 +415,9 @@ async def test_homekit_invalid_paring_status(hass, mock_zeroconf):
 async def test_homekit_not_paired(hass, mock_zeroconf):
     """Test that an not paired device is sent to homekit_controller."""
     with patch.dict(
-        zc_gen.ZEROCONF, {zeroconf.HOMEKIT_TYPE: ["homekit_controller"]}, clear=True
+        zc_gen.ZEROCONF,
+        {zeroconf.HOMEKIT_TYPE: [{"domain": "homekit_controller"}]},
+        clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -218,6 +218,23 @@ def test_integration_properties(hass):
     assert integration.zeroconf is None
     assert integration.ssdp is None
 
+    integration = loader.Integration(
+        hass,
+        "custom_components.hue",
+        None,
+        {
+            "name": "Philips Hue",
+            "domain": "hue",
+            "dependencies": ["test-dep"],
+            "zeroconf": [{"type": "_hue._tcp.local.", "name": "hue*"}],
+            "requirements": ["test-req==1.0.0"],
+        },
+    )
+    assert integration.is_built_in is False
+    assert integration.homekit is None
+    assert integration.zeroconf == [{"type": "_hue._tcp.local.", "name": "hue*"}]
+    assert integration.ssdp is None
+
 
 async def test_integrations_only_once(hass):
     """Test that we load integrations only once."""
@@ -247,6 +264,25 @@ def _get_test_integration(hass, name, config_flow):
             "dependencies": [],
             "requirements": [],
             "zeroconf": [f"_{name}._tcp.local."],
+            "homekit": {"models": [name]},
+            "ssdp": [{"manufacturer": name, "modelName": name}],
+        },
+    )
+
+
+def _get_test_integration_with_zeroconf_matcher(hass, name, config_flow):
+    """Return a generated test integration with a zeroconf matcher."""
+    return loader.Integration(
+        hass,
+        f"homeassistant.components.{name}",
+        None,
+        {
+            "name": name,
+            "domain": name,
+            "config_flow": config_flow,
+            "dependencies": [],
+            "requirements": [],
+            "zeroconf": [{"type": f"_{name}._tcp.local.", "name": f"{name}*"}],
             "homekit": {"models": [name]},
             "ssdp": [{"manufacturer": name, "modelName": name}],
         },
@@ -289,7 +325,9 @@ async def test_get_config_flows(hass):
 async def test_get_zeroconf(hass):
     """Verify that custom components with zeroconf are found."""
     test_1_integration = _get_test_integration(hass, "test_1", True)
-    test_2_integration = _get_test_integration(hass, "test_2", True)
+    test_2_integration = _get_test_integration_with_zeroconf_matcher(
+        hass, "test_2", True
+    )
 
     with patch("homeassistant.loader.async_get_custom_components") as mock_get:
         mock_get.return_value = {
@@ -297,8 +335,10 @@ async def test_get_zeroconf(hass):
             "test_2": test_2_integration,
         }
         zeroconf = await loader.async_get_zeroconf(hass)
-        assert zeroconf["_test_1._tcp.local."] == ["test_1"]
-        assert zeroconf["_test_2._tcp.local."] == ["test_2"]
+        assert zeroconf["_test_1._tcp.local."] == [{"domain": "test_1"}]
+        assert zeroconf["_test_2._tcp.local."] == [
+            {"domain": "test_2", "name": "test_2*"}
+        ]
 
 
 async def test_get_homekit(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Limit zeroconf discovery to name/macaddress when provided.

In testing I found that `axis`, `smappee`, `shelly`, and `brother`
were being loaded unexpectedly on every install on my Houston
home network.

Avoid loading integrations that do not match. This is going
to be more of a problem over time as we have more and more
integrations looking at the same type.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39876
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
