### PR TITLE
Bump pysmappee to 0.2.13

### DIFF
--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/smappee",
   "dependencies": ["http"],
   "requirements": [
-    "pysmappee==0.2.10"
+    "pysmappee==0.2.12"
   ],
   "codeowners": [
     "@bsmappee"

--- a/homeassistant/components/smappee/manifest.json
+++ b/homeassistant/components/smappee/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/smappee",
   "dependencies": ["http"],
   "requirements": [
-    "pysmappee==0.2.12"
+    "pysmappee==0.2.13"
   ],
   "codeowners": [
     "@bsmappee"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1632,7 +1632,7 @@ pyskyqhub==0.1.3
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.2.12
+pysmappee==0.2.13
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1632,7 +1632,7 @@ pyskyqhub==0.1.3
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.2.10
+pysmappee==0.2.12
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -782,7 +782,7 @@ pysignalclirestapi==0.3.4
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.2.12
+pysmappee==0.2.13
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -782,7 +782,7 @@ pysignalclirestapi==0.3.4
 pysma==0.3.5
 
 # homeassistant.components.smappee
-pysmappee==0.2.10
+pysmappee==0.2.12
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Smappee dependency update to version 0.2.13.

Release notes: <https://github.com/smappee/pysmappee/releases/tag/0.2.13>
Commit compare: <https://github.com/smappee/pysmappee/compare/0.2.10...0.2.13>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
smappee:
  client_id: 1234
  client_secret: 5678
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/39876
- This PR is related to issue: https://github.com/home-assistant/core/issues/39876
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
