### PR TITLE
Add Carbon Monoxide binary sensor to Homekit Controller

### DIFF
--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -73,7 +73,7 @@ class HomeKitSmokeSensor(HomeKitEntity, BinarySensorEntity):
         return self.service.value(CharacteristicsTypes.SMOKE_DETECTED) == 1
 
 
-class HomeKitCOSensor(HomeKitEntity, BinarySensorEntity):
+class HomeKitCarbonMonoxideSensor(HomeKitEntity, BinarySensorEntity):
     """Representation of a Homekit BO sensor."""
 
     @property
@@ -89,6 +89,7 @@ class HomeKitCOSensor(HomeKitEntity, BinarySensorEntity):
     def is_on(self):
         """Return true if CO is currently detected."""
         return self.service.value(CharacteristicsTypes.CARBON_MONOXIDE_DETECTED) == 1
+
 
 class HomeKitOccupancySensor(HomeKitEntity, BinarySensorEntity):
     """Representation of a Homekit occupancy sensor."""
@@ -130,7 +131,7 @@ ENTITY_TYPES = {
     "motion": HomeKitMotionSensor,
     "contact": HomeKitContactSensor,
     "smoke": HomeKitSmokeSensor,
-    "carbon-monoxide": HomeKitCOSensor,
+    "carbon-monoxide": HomeKitCarbonMonoxideSensor,
     "occupancy": HomeKitOccupancySensor,
     "leak": HomeKitLeakSensor,
 }

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -4,6 +4,7 @@ import logging
 from aiohomekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_GAS,
     DEVICE_CLASS_MOISTURE,
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
@@ -72,6 +73,23 @@ class HomeKitSmokeSensor(HomeKitEntity, BinarySensorEntity):
         return self.service.value(CharacteristicsTypes.SMOKE_DETECTED) == 1
 
 
+class HomeKitCOSensor(HomeKitEntity, BinarySensorEntity):
+    """Representation of a Homekit BO sensor."""
+
+    @property
+    def device_class(self) -> str:
+        """Return the class of this sensor."""
+        return DEVICE_CLASS_GAS
+
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity is tracking."""
+        return [CharacteristicsTypes.CARBON_MONOXIDE_DETECTED]
+
+    @property
+    def is_on(self):
+        """Return true if CO is currently detected."""
+        return self.service.value(CharacteristicsTypes.CARBON_MONOXIDE_DETECTED) == 1
+
 class HomeKitOccupancySensor(HomeKitEntity, BinarySensorEntity):
     """Representation of a Homekit occupancy sensor."""
 
@@ -112,6 +130,7 @@ ENTITY_TYPES = {
     "motion": HomeKitMotionSensor,
     "contact": HomeKitContactSensor,
     "smoke": HomeKitSmokeSensor,
+    "carbon-monoxide": HomeKitCOSensor,
     "occupancy": HomeKitOccupancySensor,
     "leak": HomeKitLeakSensor,
 }

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -28,6 +28,7 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     "temperature": "sensor",
     "battery": "sensor",
     "smoke": "binary_sensor",
+    "carbon-monoxide": "binary_sensor",
     "leak": "binary_sensor",
     "fan": "fan",
     "fanv2": "fan",

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -3,6 +3,7 @@ from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_GAS,
     DEVICE_CLASS_MOISTURE,
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
@@ -15,6 +16,7 @@ from tests.components.homekit_controller.common import setup_test_component
 MOTION_DETECTED = ("motion", "motion-detected")
 CONTACT_STATE = ("contact", "contact-state")
 SMOKE_DETECTED = ("smoke", "smoke-detected")
+CARBON_MONOXIDE_DETECTED = ("carbon-monoxide", "carbon-monoxide-detected")
 OCCUPANCY_DETECTED = ("occupancy", "occupancy-detected")
 LEAK_DETECTED = ("leak", "leak-detected")
 
@@ -86,6 +88,29 @@ async def test_smoke_sensor_read_state(hass, utcnow):
     assert state.state == "on"
 
     assert state.attributes["device_class"] == DEVICE_CLASS_SMOKE
+
+
+def create_co_sensor_service(accessory):
+    """Define carbon monoxide sensor characteristics."""
+    service = accessory.add_service(ServicesTypes.CARBON_MONOXIDE_SENSOR)
+
+    cur_state = service.add_char(CharacteristicsTypes.CARBON_MONOXIDE_DETECTED)
+    cur_state.value = 0
+
+
+async def test_co_sensor_read_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit contact accessory."""
+    helper = await setup_test_component(hass, create_co_sensor_service)
+
+    helper.characteristics[CARBON_MONOXIDE_DETECTED].value = 0
+    state = await helper.poll_and_get_state()
+    assert state.state == "off"
+
+    helper.characteristics[CARBON_MONOXIDE_DETECTED].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.state == "on"
+
+    assert state.attributes["device_class"] == DEVICE_CLASS_GAS
 
 
 def create_occupancy_sensor_service(accessory):

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -90,7 +90,7 @@ async def test_smoke_sensor_read_state(hass, utcnow):
     assert state.attributes["device_class"] == DEVICE_CLASS_SMOKE
 
 
-def create_co_sensor_service(accessory):
+def create_carbon_monoxide_sensor_service(accessory):
     """Define carbon monoxide sensor characteristics."""
     service = accessory.add_service(ServicesTypes.CARBON_MONOXIDE_SENSOR)
 
@@ -98,9 +98,9 @@ def create_co_sensor_service(accessory):
     cur_state.value = 0
 
 
-async def test_co_sensor_read_state(hass, utcnow):
+async def test_carbon_monoxide_sensor_read_state(hass, utcnow):
     """Test that we can read the state of a HomeKit contact accessory."""
-    helper = await setup_test_component(hass, create_co_sensor_service)
+    helper = await setup_test_component(hass, create_carbon_monoxide_sensor_service)
 
     helper.characteristics[CARBON_MONOXIDE_DETECTED].value = 0
     state = await helper.poll_and_get_state()

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -16,7 +16,7 @@ from tests.components.homekit_controller.common import setup_test_component
 MOTION_DETECTED = ("motion", "motion-detected")
 CONTACT_STATE = ("contact", "contact-state")
 SMOKE_DETECTED = ("smoke", "smoke-detected")
-CARBON_MONOXIDE_DETECTED = ("carbon-monoxide", "carbon-monoxide-detected")
+CARBON_MONOXIDE_DETECTED = ("carbon-monoxide", "carbon-monoxide.detected")
 OCCUPANCY_DETECTED = ("occupancy", "occupancy-detected")
 LEAK_DETECTED = ("leak", "leak-detected")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the Homekit Controller when integrating the Nest Protect accessory from Homebridge only adds Smoke and Motion entities, whilst the Protect support CO as well. The CO characteristic is available in the information received from Homebridge, but the integration doesn’t consume it.

This PR is based on duplicating the Smoke entity, which utilises the HA binary sensor DEVICE_CLASS_SMOKE, however there is no DEVICE_CLASS_CO in binary sensor. I’ve seen conversation about using DEVICE_CLASS_GAS so this has been utilised.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Installed via UI only.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
