### PR TITLE
Don't trigger on attribute when the attribute doesn't change

### DIFF
--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -80,11 +80,17 @@ async def async_attach_trigger(
         else:
             new_value = to_s.attributes.get(attribute)
 
+        # When we listen for state changes with `match_all`, we
+        # will trigger even if just an attribute changes. When
+        # we listen to just an attribute, we should ignore all
+        # other attribute changes.
+        if attribute is not None and old_value == new_value:
+            return
+
         if (
             not match_from_state(old_value)
             or not match_to_state(new_value)
             or (not match_all and old_value == new_value)
-            or (attribute is not None and match_all and old_value == new_value)
         ):
             return
 

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -84,6 +84,7 @@ async def async_attach_trigger(
             not match_from_state(old_value)
             or not match_to_state(new_value)
             or (not match_all and old_value == new_value)
+            or (attribute is not None and match_all and old_value == new_value)
         ):
             return
 

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -1157,6 +1157,12 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     await hass.async_block_till_done()
     assert len(calls) == 1
 
+    # Make sure that there is no trigger when the attribute stays the same
+    hass.states.async_set("test.entity", "bla", {"name": "hello"})
+    hass.states.async_set("test.entity", "bla", {"name": "hello"})
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
     hass.states.async_remove("test.entity")
     await hass.async_block_till_done()
 

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -1112,6 +1112,42 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters(hass, calls
     assert len(calls) == 1
 
 
+async def test_attribute_if_fires_on_entity_where_attr_stays_constant(hass, calls):
+    """Test for firing if attribute stays the same."""
+    hass.states.async_set("test.entity", "bla", {"name": "hello", "other": "old_value"})
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "attribute": "name",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Leave all attributes the same
+    hass.states.async_set("test.entity", "bla", {"name": "hello", "other": "old_value"})
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    # Change the untracked attribute
+    hass.states.async_set("test.entity", "bla", {"name": "hello", "other": "new_value"})
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    # Change the tracked attribute
+    hass.states.async_set("test.entity", "bla", {"name": "world", "other": "old_value"})
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
 async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     hass, calls
 ):
@@ -1154,12 +1190,6 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     # Now remove state while inside "for"
     hass.states.async_set("test.entity", "bla", {"name": "hello"})
     hass.states.async_set("test.entity", "bla", {"name": "world"})
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    # Make sure that there is no trigger when the attribute stays the same
-    hass.states.async_set("test.entity", "bla", {"name": "hello"})
-    hass.states.async_set("test.entity", "bla", {"name": "hello"})
     await hass.async_block_till_done()
     assert len(calls) == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes https://github.com/home-assistant/core/issues/39904 and adds a test that previously failed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39904
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
