### PR TITLE
Bump pyloopenergy library to 0.2.1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -236,6 +236,7 @@ homeassistant/components/linux_battery/* @fabaff
 homeassistant/components/local_ip/* @issacg
 homeassistant/components/logger/* @home-assistant/core
 homeassistant/components/logi_circle/* @evanjd
+homeassistant/components/loopenergy/* @pavoni
 homeassistant/components/lovelace/* @home-assistant/frontend
 homeassistant/components/luci/* @fbradyirl @mzdrale
 homeassistant/components/luftdaten/* @fabaff

--- a/homeassistant/components/loopenergy/manifest.json
+++ b/homeassistant/components/loopenergy/manifest.json
@@ -2,6 +2,6 @@
   "domain": "loopenergy",
   "name": "Loop Energy",
   "documentation": "https://www.home-assistant.io/integrations/loopenergy",
-  "requirements": ["pyloopenergy==0.1.3"],
+  "requirements": ["pyloopenergy==0.2.0"],
   "codeowners": []
 }

--- a/homeassistant/components/loopenergy/manifest.json
+++ b/homeassistant/components/loopenergy/manifest.json
@@ -2,7 +2,7 @@
   "domain": "loopenergy",
   "name": "Loop Energy",
   "documentation": "https://www.home-assistant.io/integrations/loopenergy",
-  "requirements": ["pyloopenergy==0.2.0"],
+  "requirements": ["pyloopenergy==0.2.1"],
   "codeowners": [
     "@pavoni"
   ]

--- a/homeassistant/components/loopenergy/manifest.json
+++ b/homeassistant/components/loopenergy/manifest.json
@@ -3,5 +3,7 @@
   "name": "Loop Energy",
   "documentation": "https://www.home-assistant.io/integrations/loopenergy",
   "requirements": ["pyloopenergy==0.2.0"],
-  "codeowners": []
+  "codeowners": [
+    "@pavoni"
+  ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1455,7 +1455,7 @@ pylibrespot-java==0.1.0
 pylitejet==0.1
 
 # homeassistant.components.loopenergy
-pyloopenergy==0.2.0
+pyloopenergy==0.2.1
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1455,7 +1455,7 @@ pylibrespot-java==0.1.0
 pylitejet==0.1
 
 # homeassistant.components.loopenergy
-pyloopenergy==0.1.3
+pyloopenergy==0.2.0
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.6.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The loop_energy component was using an old and unsupported socketio library. 

This mostly worked - but I was seeing a memory / handle leak. My home network is slightly unreliable - and I believe the leak occurs when connections are lost and then re-established.

The new version of the loop_energy library moves to a newer - and actively supported - library - which looks more robust.

Change details here: https://github.com/pavoni/pyloopenergy/compare/8a7c1cabb689e56beefda60ec3f440b320c6c42e...0.2.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
