### PR TITLE
Return the listeners with the template result for the websocket api

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -253,9 +253,11 @@ def handle_render_template(hass, connection, msg):
     template.hass = hass
 
     variables = msg.get("variables")
+    info = None
 
     @callback
     def _template_listener(event, updates):
+        nonlocal info
         track_template_result = updates.pop()
         result = track_template_result.result
         if isinstance(result, TemplateError):
@@ -267,7 +269,11 @@ def handle_render_template(hass, connection, msg):
 
             result = None
 
-        connection.send_message(messages.event_message(msg["id"], {"result": result}))
+        connection.send_message(
+            messages.event_message(
+                msg["id"], {"result": result, "listeners": info.listeners}  # type: ignore
+            )
+        )
 
     info = async_track_template_result(
         hass, [TrackTemplate(template, variables)], _template_listener

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -529,6 +529,7 @@ class _TrackTemplateResultInfo:
 
     @property
     def listeners(self) -> Dict:
+        """State changes that will cause a re-render."""
         return {
             "all": self._all_listener is not None,
             "entities": self._last_entities,

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -528,6 +528,14 @@ class _TrackTemplateResultInfo:
         self._create_listeners()
 
     @property
+    def listeners(self) -> Dict:
+        return {
+            "all": self._all_listener is not None,
+            "entities": self._last_entities,
+            "domains": self._last_domains,
+        }
+
+    @property
     def _needs_all_listener(self) -> bool:
         for track_template_ in self._track_templates:
             template = track_template_.template

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -420,14 +420,20 @@ async def test_render_template_renders_template(
     assert msg["id"] == 5
     assert msg["type"] == "event"
     event = msg["event"]
-    assert event == {"result": "State is: on"}
+    assert event == {
+        "result": "State is: on",
+        "listeners": {"all": False, "domains": [], "entities": ["light.test"]},
+    }
 
     hass.states.async_set("light.test", "off")
     msg = await websocket_client.receive_json()
     assert msg["id"] == 5
     assert msg["type"] == "event"
     event = msg["event"]
-    assert event == {"result": "State is: off"}
+    assert event == {
+        "result": "State is: off",
+        "listeners": {"all": False, "domains": [], "entities": ["light.test"]},
+    }
 
 
 async def test_render_template_manual_entity_ids_no_longer_needed(
@@ -453,14 +459,20 @@ async def test_render_template_manual_entity_ids_no_longer_needed(
     assert msg["id"] == 5
     assert msg["type"] == "event"
     event = msg["event"]
-    assert event == {"result": "State is: on"}
+    assert event == {
+        "result": "State is: on",
+        "listeners": {"all": False, "domains": [], "entities": ["light.test"]},
+    }
 
     hass.states.async_set("light.test", "off")
     msg = await websocket_client.receive_json()
     assert msg["id"] == 5
     assert msg["type"] == "event"
     event = msg["event"]
-    assert event == {"result": "State is: off"}
+    assert event == {
+        "result": "State is: off",
+        "listeners": {"all": False, "domains": [], "entities": ["light.test"]},
+    }
 
 
 async def test_render_template_with_error(
@@ -480,7 +492,10 @@ async def test_render_template_with_error(
     assert msg["id"] == 5
     assert msg["type"] == "event"
     event = msg["event"]
-    assert event == {"result": None}
+    assert event == {
+        "result": None,
+        "listeners": {"all": True, "domains": [], "entities": []},
+    }
 
     assert "my_unknown_var" in caplog.text
     assert "TemplateError" in caplog.text


### PR DESCRIPTION
## Backstory

@SeanPM5 had some templates that were listening for all states which needed to be cut down to just the needed states.  Its hard to tell what the template will listen for currently.  To solve this we can return what the template is listening for in the websocket api response.  cc @bramkragten    

I'm not sure if there are enough users with lots of 'all states' templates that
we should try to get this into 0.115

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Return the listeners with the template result for the websocket api

This should make it much easier to find inefficient templates

The thinking is we could update `/developer-tools/template` to show
what the template is listening for to help make more efficient 
templates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

# Example api responses

```
{
	"id": 24,
	"type": "event",
	"event": {
		"result": "The temperature is 25 \u00b0C.\n\nThe sun will rise at 2020-09-11 07:04:11.\n\nFor loop example getting 3 entity values:\n\nThe security is disarmed, the david office unknown 2 is off and the main fridge usage is 0 W.",
		"listeners": {
			"all": true,
			"entities": [],
			"domains": []
		}
	}
}
```

```
{
	"id": 32,
	"type": "event",
	"event": {
		"result": "The temperature is 25 \u00b0C.\n\nThe sun will rise at 2020-09-11 07:04:11.\n\nFor loop example getting 3 entity values:\n\nThe dark sky is partlycloudy.",
		"listeners": {
			"all": false,
			"entities": ["weather.dark_sky", "sun.sun"],
			"domains": ["weather"]
		}
	}
}
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
