### PR TITLE
Add bimonthly period feature for utility_meter component

### DIFF
--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -5,10 +5,11 @@ HOURLY = "hourly"
 DAILY = "daily"
 WEEKLY = "weekly"
 MONTHLY = "monthly"
+BIMONTHLY = "bimonthly"
 QUARTERLY = "quarterly"
 YEARLY = "yearly"
 
-METER_TYPES = [HOURLY, DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY]
+METER_TYPES = [HOURLY, DAILY, WEEKLY, MONTHLY, BIMONTHLY, QUARTERLY, YEARLY]
 
 DATA_UTILITY = "utility_meter_data"
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -35,6 +35,7 @@ from .const import (
     DATA_UTILITY,
     HOURLY,
     MONTHLY,
+    BIMONTHLY,
     QUARTERLY,
     SERVICE_CALIBRATE_METER,
     SIGNAL_RESET_METER,
@@ -205,6 +206,11 @@ class UtilityMeterSensor(RestoreEntity):
         ):
             return
         if (
+            self._period == BIMONTHLY
+            and now != date(now.year, (((now.month - 1) // 2) * 2 + 1), 1) + self._period_offset
+        ):
+            return
+        if (
             self._period == QUARTERLY
             and now
             != date(now.year, (((now.month - 1) // 3) * 3 + 1), 1) + self._period_offset
@@ -241,7 +247,7 @@ class UtilityMeterSensor(RestoreEntity):
                 minute=self._period_offset.seconds // 60,
                 second=self._period_offset.seconds % 60,
             )
-        elif self._period in [DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY]:
+        elif self._period in [DAILY, WEEKLY, MONTHLY, BIMONTHLY, QUARTERLY, YEARLY]:
             async_track_time_change(
                 self.hass,
                 self._async_reset_meter,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -24,6 +24,7 @@ import homeassistant.util.dt as dt_util
 
 from .const import (
     ATTR_VALUE,
+    BIMONTHLY,
     CONF_METER,
     CONF_METER_NET_CONSUMPTION,
     CONF_METER_OFFSET,
@@ -35,7 +36,6 @@ from .const import (
     DATA_UTILITY,
     HOURLY,
     MONTHLY,
-    BIMONTHLY,
     QUARTERLY,
     SERVICE_CALIBRATE_METER,
     SIGNAL_RESET_METER,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -207,7 +207,8 @@ class UtilityMeterSensor(RestoreEntity):
             return
         if (
             self._period == BIMONTHLY
-            and now != date(now.year, (((now.month - 1) // 2) * 2 + 1), 1) + self._period_offset
+            and now
+            != date(now.year, (((now.month - 1) // 2) * 2 + 1), 1) + self._period_offset
         ):
             return
         if (

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -288,6 +288,13 @@ async def test_self_reset_monthly(hass, legacy_patchable_time):
     )
 
 
+async def test_self_reset_bimonthly(hass, legacy_patchable_time):
+    """Test bimonthly reset of meter."""
+    await _test_self_reset(
+        hass, gen_config("bimonthly"), "2017-12-31T23:59:00.000000+00:00"
+    )
+
+
 async def test_self_reset_quarterly(hass, legacy_patchable_time):
     """Test quarterly reset of meter."""
     await _test_self_reset(

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -289,9 +289,16 @@ async def test_self_reset_monthly(hass, legacy_patchable_time):
 
 
 async def test_self_reset_bimonthly(hass, legacy_patchable_time):
-    """Test bimonthly reset of meter."""
+    """Test bimonthly reset of meter occurs on even months."""
     await _test_self_reset(
         hass, gen_config("bimonthly"), "2017-12-31T23:59:00.000000+00:00"
+    )
+
+
+async def test_self_no_reset_bimonthly(hass, legacy_patchable_time):
+    """Test bimonthly reset of meter does not occur on odd months."""
+    await _test_self_reset(
+        hass, gen_config("bimonthly"), "2018-01-01T23:59:00.000000+00:00"
     )
 
 

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -298,7 +298,10 @@ async def test_self_reset_bimonthly(hass, legacy_patchable_time):
 async def test_self_no_reset_bimonthly(hass, legacy_patchable_time):
     """Test bimonthly reset of meter does not occur on odd months."""
     await _test_self_reset(
-        hass, gen_config("bimonthly"), "2018-01-01T23:59:00.000000+00:00"
+        hass,
+        gen_config("bimonthly"),
+        "2018-01-01T23:59:00.000000+00:00",
+        expect_reset=False,
     )
 
 


### PR DESCRIPTION
## Proposed change
In the `utility_meter` component, added `bimonthly` period for the cycle.

**`cycle`**
How often to reset the counter. Valid values are `hourly`,` daily`, `weekly`, `monthly`, **`bimonthly`**, `quarterly` and `yearly`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml entry
utility_meter:
  energy:
    source: sensor.energy_in_kwh
    cycle: bimonthly
```
<!--
## Additional information

  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14469
-->
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
