### PR TITLE
Extract variable rendering

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -77,7 +77,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 SCRIPT_SERVICE_SCHEMA = vol.Schema(dict)
 SCRIPT_TURN_ONOFF_SCHEMA = make_entity_service_schema(
-    {vol.Optional(ATTR_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA}
+    {vol.Optional(ATTR_VARIABLES): {str: cv.match_all}}
 )
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -81,7 +81,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import split_entity_id, valid_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper
+from homeassistant.helpers import (
+    script_variables as script_variables_helper,
+    template as template_helper,
+)
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 import homeassistant.util.dt as dt_util
@@ -863,7 +866,11 @@ def make_entity_service_schema(
     )
 
 
-SCRIPT_VARIABLES_SCHEMA = vol.Schema({str: template_complex})
+SCRIPT_VARIABLES_SCHEMA = vol.All(
+    vol.Schema({str: template_complex}),
+    # pylint: disable=unecessary-lambda
+    lambda val: script_variables_helper.ScriptVariables(val),
+)
 
 
 def script_action(value: Any) -> dict:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -868,7 +868,7 @@ def make_entity_service_schema(
 
 SCRIPT_VARIABLES_SCHEMA = vol.All(
     vol.Schema({str: template_complex}),
-    # pylint: disable=unecessary-lambda
+    # pylint: disable=unnecessary-lambda
     lambda val: script_variables_helper.ScriptVariables(val),
 )
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -55,6 +55,7 @@ from homeassistant.const import (
 from homeassistant.core import SERVICE_CALL_LIMIT, Context, HomeAssistant, callback
 from homeassistant.helpers import condition, config_validation as cv, template
 from homeassistant.helpers.event import async_call_later, async_track_template
+from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.service import (
     CONF_SERVICE_DATA,
     async_prepare_call_from_config,
@@ -717,7 +718,7 @@ class Script:
         logger: Optional[logging.Logger] = None,
         log_exceptions: bool = True,
         top_level: bool = True,
-        variables: Optional[Dict[str, Any]] = None,
+        variables: Optional[ScriptVariables] = None,
     ) -> None:
         """Initialize the script."""
         all_scripts = hass.data.get(DATA_SCRIPTS)
@@ -900,15 +901,19 @@ class Script:
         # during the run back to the caller.
         if self._top_level:
             if self.variables:
-                if self._variables_dynamic:
-                    variables = template.render_complex(self.variables, run_variables)
-                else:
-                    variables = dict(self.variables)
+                try:
+                    variables = self.variables.async_render(
+                        self._hass,
+                        run_variables,
+                    )
+                except template.TemplateError as err:
+                    self._log("Error rendering variables: %s", err, level=logging.ERROR)
+                    raise
+            elif run_variables:
+                variables = dict(run_variables)
             else:
                 variables = {}
 
-            if run_variables:
-                variables.update(run_variables)
             variables["context"] = context
         else:
             variables = cast(dict, run_variables)

--- a/homeassistant/helpers/script_variables.py
+++ b/homeassistant/helpers/script_variables.py
@@ -1,0 +1,57 @@
+"""Script variables."""
+from typing import Any, Dict, Mapping, Optional
+
+from homeassistant.core import HomeAssistant, callback
+
+from . import template
+
+
+class ScriptVariables:
+    """Class to hold and render script variables."""
+
+    def __init__(self, variables: Dict[str, Any]):
+        """Initialize script variables."""
+        self.variables = variables
+        self._has_template: Optional[bool] = None
+
+    @callback
+    def async_render(
+        self,
+        hass: HomeAssistant,
+        run_variables: Optional[Mapping[str, Any]],
+    ) -> Dict[str, Any]:
+        """Render script variables.
+
+        The run variables are used to compute the static variables, but afterwards will also
+        be merged on top of the static variables.
+        """
+        if self._has_template is None:
+            self._has_template = template.is_complex(self.variables)
+            template.attach(hass, self.variables)
+
+        if not self._has_template:
+            rendered_variables = dict(self.variables)
+
+            if run_variables is not None:
+                rendered_variables.update(run_variables)
+
+            return rendered_variables
+
+        rendered_variables = {} if run_variables is None else dict(run_variables)
+
+        for key, value in self.variables.items():
+            # We can skip if we're going to override this key with
+            # run variables anyway
+            if key in rendered_variables:
+                continue
+
+            rendered_variables[key] = template.render_complex(value, rendered_variables)
+
+        if run_variables:
+            rendered_variables.update(run_variables)
+
+        return rendered_variables
+
+    def as_dict(self) -> dict:
+        """Return dict version of this class."""
+        return self.variables

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, callback, split_entity_id
 from homeassistant.exceptions import ServiceNotFound
+from homeassistant.helpers import template
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.loader import bind_hass
@@ -617,7 +618,7 @@ async def test_concurrent_script(hass, concurrently):
     assert not script.is_on(hass, "script.script2")
 
 
-async def test_script_variables(hass):
+async def test_script_variables(hass, caplog):
     """Test defining scripts."""
     assert await async_setup_component(
         hass,
@@ -642,6 +643,19 @@ async def test_script_variables(hass):
                 "script2": {
                     "variables": {
                         "test_var": "from_config",
+                    },
+                    "sequence": [
+                        {
+                            "service": "test.script",
+                            "data": {
+                                "value": "{{ test_var }}",
+                            },
+                        },
+                    ],
+                },
+                "script3": {
+                    "variables": {
+                        "test_var": "{{ break + 1 }}",
                     },
                     "sequence": [
                         {
@@ -681,3 +695,14 @@ async def test_script_variables(hass):
 
     assert len(mock_calls) == 3
     assert mock_calls[2].data["value"] == "from_service"
+
+    assert "Error rendering variables" not in caplog.text
+    with pytest.raises(template.TemplateError):
+        await hass.services.async_call("script", "script3", blocking=True)
+    assert "Error rendering variables" in caplog.text
+    assert len(mock_calls) == 3
+
+    await hass.services.async_call("script", "script3", {"break": 0}, blocking=True)
+
+    assert len(mock_calls) == 4
+    assert mock_calls[3].data["value"] == "1"

--- a/tests/helpers/test_script_variables.py
+++ b/tests/helpers/test_script_variables.py
@@ -1,0 +1,60 @@
+"""Test script variables."""
+import pytest
+
+from homeassistant.helpers import config_validation as cv, template
+
+
+async def test_static_vars():
+    """Test static vars."""
+    orig = {"hello": "world"}
+    var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
+    rendered = var.async_render(None, None)
+    assert rendered is not orig
+    assert rendered == orig
+
+
+async def test_static_vars_run_args():
+    """Test static vars."""
+    orig = {"hello": "world"}
+    orig_copy = dict(orig)
+    var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
+    rendered = var.async_render(None, {"hello": "override", "run": "var"})
+    assert rendered == {"hello": "override", "run": "var"}
+    # Make sure we don't change original vars
+    assert orig == orig_copy
+
+
+async def test_template_vars(hass):
+    """Test template vars."""
+    var = cv.SCRIPT_VARIABLES_SCHEMA({"hello": "{{ 1 + 1 }}"})
+    rendered = var.async_render(hass, None)
+    assert rendered == {"hello": "2"}
+
+
+async def test_template_vars_run_args(hass):
+    """Test template vars."""
+    var = cv.SCRIPT_VARIABLES_SCHEMA(
+        {
+            "something": "{{ run_var_ex + 1 }}",
+            "something_2": "{{ run_var_ex + 1 }}",
+        }
+    )
+    rendered = var.async_render(
+        hass,
+        {
+            "run_var_ex": 5,
+            "something_2": 1,
+        },
+    )
+    assert rendered == {
+        "run_var_ex": 5,
+        "something": "6",
+        "something_2": 1,
+    }
+
+
+async def test_template_vars_error(hass):
+    """Test template vars."""
+    var = cv.SCRIPT_VARIABLES_SCHEMA({"hello": "{{ canont.work }}"})
+    with pytest.raises(template.TemplateError):
+        var.async_render(hass, None)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extract variable rendering from automation/script so they can be reused in #39915.

Also picks up @thomasloven idea to render 1 var at a time so we can reference previous vars as we go.

How vars are rendered:
 - static vars are rendered with run vars passed in
 - then run vars will override the static vars


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
