### PR TITLE
Improve canary tests

### DIFF
--- a/homeassistant/components/canary/__init__.py
+++ b/homeassistant/components/canary/__init__.py
@@ -76,6 +76,10 @@ class CanaryData:
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, **kwargs):
+        """Get the latest data from py-canary with a throttle."""
+        self._update(**kwargs)
+
+    def _update(self, **kwargs):
         """Get the latest data from py-canary."""
         for location in self._api.get_locations():
             location_id = location.location_id

--- a/tests/components/canary/__init__.py
+++ b/tests/components/canary/__init__.py
@@ -1,5 +1,25 @@
 """Tests for the canary component."""
-from tests.async_mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock
+
+from canary.api import SensorType
+
+from homeassistant.components.homeassistant import (
+    DOMAIN as HA_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+
+async def update_entity(hass: HomeAssistant, entity_id: str) -> None:
+    """Run an update action for an entity."""
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
 
 def mock_device(device_id, name, is_online=True, device_type_name=None):
@@ -36,6 +56,6 @@ def mock_mode(mode_id, name):
 def mock_reading(sensor_type, sensor_value):
     """Mock Canary Reading class."""
     reading = MagicMock()
-    type(reading).sensor_type = PropertyMock(return_value=sensor_type)
+    type(reading).sensor_type = SensorType(sensor_type)
     type(reading).value = PropertyMock(return_value=sensor_value)
     return reading

--- a/tests/components/canary/__init__.py
+++ b/tests/components/canary/__init__.py
@@ -1,1 +1,41 @@
 """Tests for the canary component."""
+from tests.async_mock import MagicMock, PropertyMock
+
+
+def mock_device(device_id, name, is_online=True, device_type_name=None):
+    """Mock Canary Device class."""
+    device = MagicMock()
+    type(device).device_id = PropertyMock(return_value=device_id)
+    type(device).name = PropertyMock(return_value=name)
+    type(device).is_online = PropertyMock(return_value=is_online)
+    type(device).device_type = PropertyMock(
+        return_value={"id": 1, "name": device_type_name}
+    )
+    return device
+
+
+def mock_location(location_id, name, is_celsius=True, devices=None):
+    """Mock Canary Location class."""
+    location = MagicMock()
+    type(location).location_id = PropertyMock(return_value=location_id)
+    type(location).name = PropertyMock(return_value=name)
+    type(location).is_celsius = PropertyMock(return_value=is_celsius)
+    type(location).devices = PropertyMock(return_value=devices or [])
+    return location
+
+
+def mock_mode(mode_id, name):
+    """Mock Canary Mode class."""
+    mode = MagicMock()
+    type(mode).mode_id = PropertyMock(return_value=mode_id)
+    type(mode).name = PropertyMock(return_value=name)
+    type(mode).resource_url = PropertyMock(return_value=f"/v1/modes/{mode_id}")
+    return mode
+
+
+def mock_reading(sensor_type, sensor_value):
+    """Mock Canary Reading class."""
+    reading = MagicMock()
+    type(reading).sensor_type = PropertyMock(return_value=sensor_type)
+    type(reading).value = PropertyMock(return_value=sensor_value)
+    return reading

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -44,4 +44,4 @@ def canary(hass):
         yield mock_canary
 
 
-patch("homeassistant.util.Throttle", mock_decorator).start()
+patch("homeassistant.components.canary.Throttle", mock_decorator).start()

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -7,16 +7,7 @@ from tests.async_mock import MagicMock, patch
 
 def mock_canary_update(self, **kwargs):
     """Get the latest data from py-canary."""
-    for location in self._api.get_locations():
-        location_id = location.location_id
-
-        self._locations_by_id[location_id] = location
-
-        for device in location.devices:
-            if device.is_online:
-                self._readings_by_device_id[
-                    device.device_id
-                ] = self._api.get_latest_readings(device.device_id)
+    self._update(**kwargs)
 
 
 @fixture

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -1,8 +1,23 @@
 """Define fixtures available for all tests."""
+from functools import wraps
+
 from canary.api import Api
 from pytest import fixture
 
 from tests.async_mock import MagicMock, patch
+
+
+def mock_decorator(*args, **kwargs):
+    """Mock decorator to patch unwanted decorators."""
+
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        return decorated_function
+
+    return decorator
 
 
 @fixture
@@ -27,3 +42,6 @@ def canary(hass):
         instance.set_location_mode = MagicMock(return_value=None)
 
         yield mock_canary
+
+
+patch("homeassistant.util.Throttle", mock_decorator).start()

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -24,6 +24,8 @@ def mock_decorator(*args, **kwargs):
 def canary(hass):
     """Mock the CanaryApi for easier testing."""
     with patch.object(Api, "login", return_value=True), patch(
+        "homeassistant.util.Throttle", mock_decorator
+    ), patch(
         "homeassistant.components.canary.Api"
     ) as mock_canary:
         instance = mock_canary.return_value = Api(
@@ -42,6 +44,3 @@ def canary(hass):
         instance.set_location_mode = MagicMock(return_value=None)
 
         yield mock_canary
-
-
-patch("homeassistant.components.canary.Throttle", mock_decorator).start()

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -43,4 +43,5 @@ def canary(hass):
 
         yield mock_canary
 
+
 patch("homeassistant.util.Throttle", mock_decorator).start()

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -24,8 +24,6 @@ def mock_decorator(*args, **kwargs):
 def canary(hass):
     """Mock the CanaryApi for easier testing."""
     with patch.object(Api, "login", return_value=True), patch(
-        "homeassistant.util.Throttle", mock_decorator
-    ), patch(
         "homeassistant.components.canary.Api"
     ) as mock_canary:
         instance = mock_canary.return_value = Api(
@@ -44,3 +42,5 @@ def canary(hass):
         instance.set_location_mode = MagicMock(return_value=None)
 
         yield mock_canary
+
+patch("homeassistant.util.Throttle", mock_decorator).start()

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -7,6 +7,20 @@ from pytest import fixture
 from tests.async_mock import MagicMock, patch
 
 
+def mock_canary_update(self, **kwargs):
+    """Get the latest data from py-canary."""
+    for location in self._api.get_locations():
+        location_id = location.location_id
+
+        self._locations_by_id[location_id] = location
+
+        for device in location.devices:
+            if device.is_online:
+                self._readings_by_device_id[
+                    device.device_id
+                ] = self._api.get_latest_readings(device.device_id)
+
+
 def mock_decorator(*args, **kwargs):
     """Mock decorator to patch unwanted decorators."""
 
@@ -24,6 +38,8 @@ def mock_decorator(*args, **kwargs):
 def canary(hass):
     """Mock the CanaryApi for easier testing."""
     with patch.object(Api, "login", return_value=True), patch(
+        "homeassistant.components.canary.CanaryData.update", mock_canary_update
+    ), patch(
         "homeassistant.components.canary.Api"
     ) as mock_canary:
         instance = mock_canary.return_value = Api(
@@ -44,4 +60,4 @@ def canary(hass):
         yield mock_canary
 
 
-patch("homeassistant.util.Throttle", mock_decorator).start()
+# patch("homeassistant.util.Throttle", mock_decorator).start()

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -1,6 +1,4 @@
 """Define fixtures available for all tests."""
-from functools import wraps
-
 from canary.api import Api
 from pytest import fixture
 
@@ -21,27 +19,12 @@ def mock_canary_update(self, **kwargs):
                 ] = self._api.get_latest_readings(device.device_id)
 
 
-def mock_decorator(*args, **kwargs):
-    """Mock decorator to patch unwanted decorators."""
-
-    def decorator(f):
-        @wraps(f)
-        def decorated_function(*args, **kwargs):
-            return f(*args, **kwargs)
-
-        return decorated_function
-
-    return decorator
-
-
 @fixture
 def canary(hass):
     """Mock the CanaryApi for easier testing."""
     with patch.object(Api, "login", return_value=True), patch(
         "homeassistant.components.canary.CanaryData.update", mock_canary_update
-    ), patch(
-        "homeassistant.components.canary.Api"
-    ) as mock_canary:
+    ), patch("homeassistant.components.canary.Api") as mock_canary:
         instance = mock_canary.return_value = Api(
             "test-username",
             "test-password",
@@ -58,6 +41,3 @@ def canary(hass):
         instance.set_location_mode = MagicMock(return_value=None)
 
         yield mock_canary
-
-
-# patch("homeassistant.util.Throttle", mock_decorator).start()

--- a/tests/components/canary/conftest.py
+++ b/tests/components/canary/conftest.py
@@ -1,0 +1,29 @@
+"""Define fixtures available for all tests."""
+from canary.api import Api
+from pytest import fixture
+
+from tests.async_mock import MagicMock, patch
+
+
+@fixture
+def canary(hass):
+    """Mock the CanaryApi for easier testing."""
+    with patch.object(Api, "login", return_value=True), patch(
+        "homeassistant.components.canary.Api"
+    ) as mock_canary:
+        instance = mock_canary.return_value = Api(
+            "test-username",
+            "test-password",
+            1,
+        )
+
+        instance.login = MagicMock(return_value=True)
+        instance.get_entries = MagicMock(return_value=[])
+        instance.get_locations = MagicMock(return_value=[])
+        instance.get_location = MagicMock(return_value=None)
+        instance.get_modes = MagicMock(return_value=[])
+        instance.get_readings = MagicMock(return_value=[])
+        instance.get_latest_readings = MagicMock(return_value=[])
+        instance.set_location_mode = MagicMock(return_value=None)
+
+        yield mock_canary

--- a/tests/components/canary/test_init.py
+++ b/tests/components/canary/test_init.py
@@ -7,8 +7,8 @@ from tests.async_mock import patch
 
 async def test_setup_with_valid_config(hass, canary) -> None:
     """Test setup with valid YAML."""
-    assert await async_setup_component(hass, "persistent_notification", {})
-    config = {DOMAIN: {"username": "foo@bar.org", "password": "bar"}}
+    await async_setup_component(hass, "persistent_notification", {})
+    config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
 
     with patch(
         "homeassistant.components.canary.alarm_control_panel.setup_platform",

--- a/tests/components/canary/test_init.py
+++ b/tests/components/canary/test_init.py
@@ -1,4 +1,6 @@
 """The tests for the Canary component."""
+from requests import HTTPError
+
 from homeassistant.components.canary import DOMAIN
 from homeassistant.setup import async_setup_component
 
@@ -21,4 +23,25 @@ async def test_setup_with_valid_config(hass, canary) -> None:
         return_value=True,
     ):
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+
+async def test_setup_with_http_error(hass, canary) -> None:
+    """Test setup with HTTP error."""
+    await async_setup_component(hass, "persistent_notification", {})
+    config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
+
+    canary.side_effect = HTTPError()
+
+    with patch(
+        "homeassistant.components.canary.alarm_control_panel.setup_platform",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.canary.camera.setup_platform",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.canary.sensor.setup_platform",
+        return_value=True,
+    ):
+        assert not await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()

--- a/tests/components/canary/test_init.py
+++ b/tests/components/canary/test_init.py
@@ -33,15 +33,5 @@ async def test_setup_with_http_error(hass, canary) -> None:
 
     canary.side_effect = HTTPError()
 
-    with patch(
-        "homeassistant.components.canary.alarm_control_panel.setup_platform",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.canary.camera.setup_platform",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.canary.sensor.setup_platform",
-        return_value=True,
-    ):
-        assert not await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
+    assert not await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()

--- a/tests/components/canary/test_init.py
+++ b/tests/components/canary/test_init.py
@@ -55,7 +55,17 @@ class TestCanary(unittest.TestCase):
         """Test setup component."""
         config = {"canary": {"username": "foo@bar.org", "password": "bar"}}
 
-        assert setup.setup_component(self.hass, canary.DOMAIN, config)
+        with patch(
+            "homeassistant.components.canary.alarm_control_panel.async_setup_entry",
+            return_value=True,
+        ), patch(
+            "homeassistant.components.canary.camera.async_setup_entry",
+            return_value=True,
+        ), patch(
+            "homeassistant.components.canary.sensor.async_setup_entry",
+            return_value=True,
+        ):
+            assert setup.setup_component(self.hass, canary.DOMAIN, config)
 
         mock_update.assert_called_once_with()
         mock_login.assert_called_once_with()

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -1,6 +1,4 @@
 """The tests for the Canary sensor platform."""
-from datetime import timedelta
-
 from homeassistant.components.canary import DOMAIN
 from homeassistant.components.canary.sensor import (
     ATTR_AIR_QUALITY,

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -1,4 +1,6 @@
 """The tests for the Canary sensor platform."""
+from datetime import timedelta
+
 from homeassistant.components.canary import DOMAIN
 from homeassistant.components.canary.sensor import (
     ATTR_AIR_QUALITY,
@@ -8,6 +10,7 @@ from homeassistant.components.canary.sensor import (
 )
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, TEMP_CELSIUS
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
 
 from . import mock_device, mock_location, mock_reading
 
@@ -17,7 +20,7 @@ from tests.common import mock_registry
 
 async def test_sensors_pro(hass, canary) -> None:
     """Test the creation and values of the sensors for Canary Pro."""
-    assert await async_setup_component(hass, "persistent_notification", {})
+    await async_setup_component(hass, "persistent_notification", {})
 
     registry = mock_registry(hass)
     online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
@@ -34,17 +37,9 @@ async def test_sensors_pro(hass, canary) -> None:
     ]
 
     config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
-    with patch(
-        "homeassistant.components.canary.alarm_control_panel.setup_platform",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.canary.camera.setup_platform",
-        return_value=True,
-    ):
+    with patch("homeassistant.components.canary.CANARY_COMPONENTS", ["sensor"]):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
-
-    await hass.async_block_till_done()
 
     sensors = {
         "home_dining_room_temperature": (
@@ -75,17 +70,17 @@ async def test_sensors_pro(hass, canary) -> None:
         assert entity_entry
         assert entity_entry.device_class == data[3]
         assert entity_entry.unique_id == data[0]
+        assert entity_entry.original_icon == data[4]
 
         state = hass.states.get(f"sensor.{sensor_id}")
         assert state
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
-        assert state.icon == data[4]
 
 
 async def test_sensors_attributes_pro(hass, canary) -> None:
     """Test the creation and values of the sensors attributes for Canary Pro."""
-    assert await async_setup_component(hass, "persistent_notification", {})
+    await async_setup_component(hass, "persistent_notification", {})
 
     online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
 
@@ -101,17 +96,9 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
     ]
 
     config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
-    with patch(
-        "homeassistant.components.canary.alarm_control_panel.setup_platform",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.canary.camera.setup_platform",
-        return_value=True,
-    ):
+    with patch("homeassistant.components.canary.CANARY_COMPONENTS", ["sensor"]):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
-
-    await hass.async_block_till_done()
 
     entity_id = "sensor.home_dining_room_air_quality"
     state = hass.states.get(entity_id)
@@ -123,7 +110,11 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
         mock_reading("humidity", "50.46"),
         mock_reading("air_quality", "0.4"),
     ]
-    await hass.helpers.entity_component.async_update_entity(entity_id)
+
+    future = utcnow() + timedelta(minutes=1)
+    with patch("homeassistant.util.dt.utcnow", return_value=future):
+        await hass.helpers.entity_component.async_update_entity(entity_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state
@@ -134,7 +125,11 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
         mock_reading("humidity", "50.46"),
         mock_reading("air_quality", "1.0"),
     ]
-    await hass.helpers.entity_component.async_update_entity(entity_id)
+
+    future += timedelta(minutes=1)
+    with patch("homeassistant.util.dt.utcnow", return_value=future):
+        await hass.helpers.entity_component.async_update_entity(entity_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state
@@ -143,7 +138,7 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
 
 async def test_sensors_flex(hass, canary) -> None:
     """Test the creation and values of the sensors for Canary Flex."""
-    assert await async_setup_component(hass, "persistent_notification", {})
+    await async_setup_component(hass, "persistent_notification", {})
 
     registry = mock_registry(hass)
     online_device_at_home = mock_device(20, "Dining Room", True, "Canary Flex")
@@ -159,27 +154,19 @@ async def test_sensors_flex(hass, canary) -> None:
     ]
 
     config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
-    with patch(
-        "homeassistant.components.canary.alarm_control_panel.setup_platform",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.canary.camera.setup_platform",
-        return_value=True,
-    ):
+    with patch("homeassistant.components.canary.CANARY_COMPONENTS", ["sensor"]):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
-
-    await hass.async_block_till_done()
 
     sensors = {
         "home_dining_room_battery": (
             "20_battery",
-            "70.4567",
+            "70.46",
             PERCENTAGE,
             None,
             "mdi:battery-70",
         ),
-        "home_dining_room_wifi": ("20_wifi", "-57", "dBm", None, "mdi:wifi"),
+        "home_dining_room_wifi": ("20_wifi", "-57.0", "dBm", None, "mdi:wifi"),
     }
 
     for (sensor_id, data) in sensors.items():
@@ -187,9 +174,9 @@ async def test_sensors_flex(hass, canary) -> None:
         assert entity_entry
         assert entity_entry.device_class == data[3]
         assert entity_entry.unique_id == data[0]
+        assert entity_entry.original_icon == data[4]
 
         state = hass.states.get(f"sensor.{sensor_id}")
         assert state
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
-        assert state.icon == data[4]

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -1,203 +1,195 @@
 """The tests for the Canary sensor platform."""
-import copy
-import unittest
-
-from homeassistant.components.canary import DATA_CANARY, sensor as canary
+from homeassistant.components.canary import DOMAIN
 from homeassistant.components.canary.sensor import (
     ATTR_AIR_QUALITY,
-    SENSOR_TYPES,
     STATE_AIR_QUALITY_ABNORMAL,
     STATE_AIR_QUALITY_NORMAL,
     STATE_AIR_QUALITY_VERY_ABNORMAL,
-    CanarySensor,
 )
-from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, TEMP_CELSIUS
+from homeassistant.setup import async_setup_component
 
-from tests.async_mock import Mock
-from tests.common import get_test_home_assistant
-from tests.components.canary.test_init import mock_device, mock_location
+from . import mock_device, mock_location, mock_reading
 
-VALID_CONFIG = {"canary": {"username": "foo@bar.org", "password": "bar"}}
+from tests.async_mock import patch
+from tests.common import mock_registry
 
 
-class TestCanarySensorSetup(unittest.TestCase):
-    """Test the Canary platform."""
+async def test_sensors_pro(hass, canary) -> None:
+    """Test the creation and values of the sensors for Canary Pro."""
+    assert await async_setup_component(hass, "persistent_notification", {})
 
-    DEVICES = []
+    registry = mock_registry(hass)
+    online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
 
-    def add_entities(self, devices, action):
-        """Mock add devices."""
-        for device in devices:
-            self.DEVICES.append(device)
+    instance = canary.return_value
+    instance.get_locations.return_value = [
+        mock_location(100, "Home", True, devices=[online_device_at_home]),
+    ]
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        self.config = copy.deepcopy(VALID_CONFIG)
-        self.addCleanup(self.hass.stop)
+    instance.get_latest_readings.return_value = [
+        mock_reading("temperature", "21.12"),
+        mock_reading("humidity", "50.46"),
+        mock_reading("air_quality", "0.59"),
+    ]
 
-    def test_setup_sensors(self):
-        """Test the sensor setup."""
-        online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
-        offline_device_at_home = mock_device(21, "Front Yard", False, "Canary Pro")
-        online_device_at_work = mock_device(22, "Office", True, "Canary Pro")
+    config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
+    with patch(
+        "homeassistant.components.canary.alarm_control_panel.setup_platform",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.canary.camera.setup_platform",
+        return_value=True,
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
-        self.hass.data[DATA_CANARY] = Mock()
-        self.hass.data[DATA_CANARY].locations = [
-            mock_location(
-                "Home", True, devices=[online_device_at_home, offline_device_at_home]
-            ),
-            mock_location("Work", True, devices=[online_device_at_work]),
-        ]
+    await hass.async_block_till_done()
 
-        canary.setup_platform(self.hass, self.config, self.add_entities, None)
+    sensors = {
+        "home_dining_room_temperature": (
+            "20_temperature",
+            "21.12",
+            TEMP_CELSIUS,
+            None,
+            "mdi:thermometer",
+        ),
+        "home_dining_room_humidity": (
+            "20_humidity",
+            "50.46",
+            PERCENTAGE,
+            None,
+            "mdi:water-percent",
+        ),
+        "home_dining_room_air_quality": (
+            "20_air_quality",
+            "0.59",
+            None,
+            None,
+            "mdi:weather-windy",
+        ),
+    }
 
-        assert len(self.DEVICES) == 6
+    for (sensor_id, data) in sensors.items():
+        entity_entry = registry.async_get(f"sensor.{sensor_id}")
+        assert entity_entry
+        assert entity_entry.device_class == data[3]
+        assert entity_entry.unique_id == data[0]
 
-    def test_temperature_sensor(self):
-        """Test temperature sensor with fahrenheit."""
-        device = mock_device(10, "Family Room", "Canary Pro")
-        location = mock_location("Home", False)
+        state = hass.states.get(f"sensor.{sensor_id}")
+        assert state
+        assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
+        assert state.state == data[1]
+        assert state.icon == data[4]
 
-        data = Mock()
-        data.get_reading.return_value = 21.1234
 
-        sensor = CanarySensor(data, SENSOR_TYPES[0], location, device)
-        sensor.update()
+async def test_sensors_attributes_pro(hass, canary) -> None:
+    """Test the creation and values of the sensors attributes for Canary Pro."""
+    assert await async_setup_component(hass, "persistent_notification", {})
 
-        assert sensor.name == "Home Family Room Temperature"
-        assert sensor.unit_of_measurement == TEMP_CELSIUS
-        assert sensor.state == 21.12
-        assert sensor.icon == "mdi:thermometer"
+    online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
 
-    def test_temperature_sensor_with_none_sensor_value(self):
-        """Test temperature sensor with fahrenheit."""
-        device = mock_device(10, "Family Room", "Canary Pro")
-        location = mock_location("Home", False)
+    instance = canary.return_value
+    instance.get_locations.return_value = [
+        mock_location(100, "Home", True, devices=[online_device_at_home]),
+    ]
 
-        data = Mock()
-        data.get_reading.return_value = None
+    instance.get_latest_readings.return_value = [
+        mock_reading("temperature", "21.12"),
+        mock_reading("humidity", "50.46"),
+        mock_reading("air_quality", "0.59"),
+    ]
 
-        sensor = CanarySensor(data, SENSOR_TYPES[0], location, device)
-        sensor.update()
+    config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
+    with patch(
+        "homeassistant.components.canary.alarm_control_panel.setup_platform",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.canary.camera.setup_platform",
+        return_value=True,
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
-        assert sensor.state is None
+    await hass.async_block_till_done()
 
-    def test_humidity_sensor(self):
-        """Test humidity sensor."""
-        device = mock_device(10, "Family Room", "Canary Pro")
-        location = mock_location("Home")
+    entity_id = "sensor.home_dining_room_air_quality"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_ABNORMAL
 
-        data = Mock()
-        data.get_reading.return_value = 50.4567
+    instance.get_latest_readings.return_value = [
+        mock_reading("temperature", "21.12"),
+        mock_reading("humidity", "50.46"),
+        mock_reading("air_quality", "0.4"),
+    ]
+    await hass.helpers.entity_component.async_update_entity(entity_id)
 
-        sensor = CanarySensor(data, SENSOR_TYPES[1], location, device)
-        sensor.update()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_VERY_ABNORMAL
 
-        assert sensor.name == "Home Family Room Humidity"
-        assert sensor.unit_of_measurement == PERCENTAGE
-        assert sensor.state == 50.46
-        assert sensor.icon == "mdi:water-percent"
+    instance.get_latest_readings.return_value = [
+        mock_reading("temperature", "21.12"),
+        mock_reading("humidity", "50.46"),
+        mock_reading("air_quality", "1.0"),
+    ]
+    await hass.helpers.entity_component.async_update_entity(entity_id)
 
-    def test_air_quality_sensor_with_very_abnormal_reading(self):
-        """Test air quality sensor."""
-        device = mock_device(10, "Family Room", "Canary Pro")
-        location = mock_location("Home")
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_NORMAL
 
-        data = Mock()
-        data.get_reading.return_value = 0.4
 
-        sensor = CanarySensor(data, SENSOR_TYPES[2], location, device)
-        sensor.update()
+async def test_sensors_flex(hass, canary) -> None:
+    """Test the creation and values of the sensors for Canary Flex."""
+    assert await async_setup_component(hass, "persistent_notification", {})
 
-        assert sensor.name == "Home Family Room Air Quality"
-        assert sensor.unit_of_measurement is None
-        assert sensor.state == 0.4
-        assert sensor.icon == "mdi:weather-windy"
+    registry = mock_registry(hass)
+    online_device_at_home = mock_device(20, "Dining Room", True, "Canary Flex")
 
-        air_quality = sensor.device_state_attributes[ATTR_AIR_QUALITY]
-        assert air_quality == STATE_AIR_QUALITY_VERY_ABNORMAL
+    instance = canary.return_value
+    instance.get_locations.return_value = [
+        mock_location(100, "Home", True, devices=[online_device_at_home]),
+    ]
 
-    def test_air_quality_sensor_with_abnormal_reading(self):
-        """Test air quality sensor."""
-        device = mock_device(10, "Family Room", "Canary Pro")
-        location = mock_location("Home")
+    instance.get_latest_readings.return_value = [
+        mock_reading("battery", "70.4567"),
+        mock_reading("wifi", "-57"),
+    ]
 
-        data = Mock()
-        data.get_reading.return_value = 0.59
+    config = {DOMAIN: {"username": "test-username", "password": "test-password"}}
+    with patch(
+        "homeassistant.components.canary.alarm_control_panel.setup_platform",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.canary.camera.setup_platform",
+        return_value=True,
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
-        sensor = CanarySensor(data, SENSOR_TYPES[2], location, device)
-        sensor.update()
+    await hass.async_block_till_done()
 
-        assert sensor.name == "Home Family Room Air Quality"
-        assert sensor.unit_of_measurement is None
-        assert sensor.state == 0.59
-        assert sensor.icon == "mdi:weather-windy"
+    sensors = {
+        "home_dining_room_battery": (
+            "20_battery",
+            "70.4567",
+            PERCENTAGE,
+            None,
+            "mdi:battery-70",
+        ),
+        "home_dining_room_wifi": ("20_wifi", "-57", "dBm", None, "mdi:wifi"),
+    }
 
-        air_quality = sensor.device_state_attributes[ATTR_AIR_QUALITY]
-        assert air_quality == STATE_AIR_QUALITY_ABNORMAL
+    for (sensor_id, data) in sensors.items():
+        entity_entry = registry.async_get(f"sensor.{sensor_id}")
+        assert entity_entry
+        assert entity_entry.device_class == data[3]
+        assert entity_entry.unique_id == data[0]
 
-    def test_air_quality_sensor_with_normal_reading(self):
-        """Test air quality sensor."""
-        device = mock_device(10, "Family Room", "Canary Pro")
-        location = mock_location("Home")
-
-        data = Mock()
-        data.get_reading.return_value = 1.0
-
-        sensor = CanarySensor(data, SENSOR_TYPES[2], location, device)
-        sensor.update()
-
-        assert sensor.name == "Home Family Room Air Quality"
-        assert sensor.unit_of_measurement is None
-        assert sensor.state == 1.0
-        assert sensor.icon == "mdi:weather-windy"
-
-        air_quality = sensor.device_state_attributes[ATTR_AIR_QUALITY]
-        assert air_quality == STATE_AIR_QUALITY_NORMAL
-
-    def test_air_quality_sensor_with_none_sensor_value(self):
-        """Test air quality sensor."""
-        device = mock_device(10, "Family Room", "Canary Pro")
-        location = mock_location("Home")
-
-        data = Mock()
-        data.get_reading.return_value = None
-
-        sensor = CanarySensor(data, SENSOR_TYPES[2], location, device)
-        sensor.update()
-
-        assert sensor.state is None
-        assert sensor.device_state_attributes is None
-
-    def test_battery_sensor(self):
-        """Test battery sensor."""
-        device = mock_device(10, "Family Room", "Canary Flex")
-        location = mock_location("Home")
-
-        data = Mock()
-        data.get_reading.return_value = 70.4567
-
-        sensor = CanarySensor(data, SENSOR_TYPES[4], location, device)
-        sensor.update()
-
-        assert sensor.name == "Home Family Room Battery"
-        assert sensor.unit_of_measurement == PERCENTAGE
-        assert sensor.state == 70.46
-        assert sensor.icon == "mdi:battery-70"
-
-    def test_wifi_sensor(self):
-        """Test battery sensor."""
-        device = mock_device(10, "Family Room", "Canary Flex")
-        location = mock_location("Home")
-
-        data = Mock()
-        data.get_reading.return_value = -57
-
-        sensor = CanarySensor(data, SENSOR_TYPES[3], location, device)
-        sensor.update()
-
-        assert sensor.name == "Home Family Room Wifi"
-        assert sensor.unit_of_measurement == "dBm"
-        assert sensor.state == -57
-        assert sensor.icon == "mdi:wifi"
+        state = hass.states.get(f"sensor.{sensor_id}")
+        assert state
+        assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
+        assert state.state == data[1]
+        assert state.icon == data[4]

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.canary.sensor import (
 )
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, TEMP_CELSIUS
 from homeassistant.setup import async_setup_component
-from homeassistant.util.dt import utcnow
 
 from . import mock_device, mock_location, mock_reading
 
@@ -111,10 +110,8 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
         mock_reading("air_quality", "0.4"),
     ]
 
-    future = utcnow() + timedelta(minutes=1)
-    with patch("homeassistant.util.dt.utcnow", return_value=future):
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        await hass.async_block_till_done()
+    await hass.helpers.entity_component.async_update_entity(entity_id)
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state
@@ -126,10 +123,8 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
         mock_reading("air_quality", "1.0"),
     ]
 
-    future += timedelta(minutes=1)
-    with patch("homeassistant.util.dt.utcnow", return_value=future):
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        await hass.async_block_till_done()
+    await hass.helpers.entity_component.async_update_entity(entity_id)
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This started as i noticed canary tests ttaking upwards of 5s to complete.

The tests were old pytest format and primed for updating and simplication.

I intend to make some other PRs for updates as a community side project.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
