### PR TITLE
Suppress homekit bridge discovery by homekit controller

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -8,12 +8,19 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    async_get_registry as async_get_device_registry,
+)
 
 from .connection import get_accessory_name, get_bridge_information
 from .const import DOMAIN, KNOWN_DEVICES
 
-HOMEKIT_IGNORE = ["Home Assistant Bridge"]
 HOMEKIT_DIR = ".homekit"
+HOMEKIT_BRIDGE_DOMAIN = "homekit"
+HOMEKIT_BRIDGE_SERIAL_NUMBER = "homekit.bridge"
+HOMEKIT_BRIDGE_MODEL = "Home Assistant HomeKit Bridge"
+
 PAIRING_FILE = "pairing.json"
 
 PIN_FORMAT = re.compile(r"^(\d{3})-{0,1}(\d{2})-{0,1}(\d{3})$")
@@ -141,6 +148,19 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         return self.async_abort(reason="no_devices")
 
+    async def _hkid_is_homekit_bridge(self, hkid):
+        """Determine if the device is a homekit bridge."""
+        dev_reg = await async_get_device_registry(self.hass)
+        device = dev_reg.async_get_device(
+            identifiers=set(), connections={(CONNECTION_NETWORK_MAC, hkid)}
+        )
+
+        if device is None:
+            return False
+        if device.model == HOMEKIT_BRIDGE_MODEL:
+            return True
+        return False
+
     async def async_step_zeroconf(self, discovery_info):
         """Handle a discovered HomeKit accessory.
 
@@ -152,6 +172,12 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         properties = {
             key.lower(): value for (key, value) in discovery_info["properties"].items()
         }
+
+        if "id" not in properties:
+            _LOGGER.warning(
+                "HomeKit device %s: id not exposed, in violation of spec", properties
+            )
+            return self.async_abort(reason="invalid_properties")
 
         # The hkid is a unique random number that looks like a pairing code.
         # It changes if a device is factory reset.
@@ -208,7 +234,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         # Devices in HOMEKIT_IGNORE have native local integrations - users
         # should be encouraged to use native integration and not confused
         # by alternative HK API.
-        if model in HOMEKIT_IGNORE:
+        if await self._hkid_is_homekit_bridge(hkid):
             return self.async_abort(reason="ignored_model")
 
         self.model = model

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -157,9 +157,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         if device is None:
             return False
-        if device.model == HOMEKIT_BRIDGE_MODEL:
-            return True
-        return False
+        return device.model == HOMEKIT_BRIDGE_MODEL
 
     async def async_step_zeroconf(self, discovery_info):
         """Handle a discovered HomeKit accessory.

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -44,6 +44,7 @@
       "already_configured": "Accessory is already configured with this controller.",
       "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting configuration entry for it in Home Assistant that must first be removed.",
       "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
+      "invalid_properties": "Invalid properties announced by device.",
       "already_in_progress": "Config flow for device is already in progress."
     }
   },

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -8,10 +8,11 @@ from aiohomekit.model.services import ServicesTypes
 import pytest
 
 from homeassistant.components.homekit_controller import config_flow
+from homeassistant.helpers import device_registry
 
 import tests.async_mock
 from tests.async_mock import patch
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, mock_device_registry
 
 PAIRING_START_FORM_ERRORS = [
     (KeyError, "pairing_failed"),
@@ -233,11 +234,45 @@ async def test_pair_already_paired_1(hass, controller):
     assert result["reason"] == "already_paired"
 
 
+async def test_id_missing(hass, controller):
+    """Test id is missing."""
+    device = setup_mock_accessory(controller)
+    discovery_info = get_device_discovery_info(device)
+
+    # Remove id from device
+    del discovery_info["properties"]["id"]
+
+    # Device is discovered
+    result = await hass.config_entries.flow.async_init(
+        "homekit_controller", context={"source": "zeroconf"}, data=discovery_info
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "invalid_properties"
+
+
 async def test_discovery_ignored_model(hass, controller):
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
-    discovery_info["properties"]["md"] = config_flow.HOMEKIT_IGNORE[0]
+
+    config_entry = MockConfigEntry(domain=config_flow.HOMEKIT_BRIDGE_DOMAIN, data={})
+    formatted_mac = device_registry.format_mac("AA:BB:CC:DD:EE:FF")
+
+    dev_reg = mock_device_registry(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={
+            (
+                config_flow.HOMEKIT_BRIDGE_DOMAIN,
+                config_entry.entry_id,
+                config_flow.HOMEKIT_BRIDGE_SERIAL_NUMBER,
+            )
+        },
+        connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
+        model=config_flow.HOMEKIT_BRIDGE_MODEL,
+    )
+
+    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Suppress homekit bridge discovery by homekit controller
Suppression stopped working when we added support for multiple bridges.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39976
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
