### PR TITLE
Add port to plugwise

### DIFF
--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -41,8 +41,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     websession = async_get_clientsession(hass, verify_ssl=False)
 
     port = 80
-    host = (entry.data[CONF_HOST],)
-    password = (entry.data[CONF_PASSWORD],)
+    host = entry.data[CONF_HOST]
+    password = entry.data[CONF_PASSWORD]
 
     if ":" in host:
         port = int(host.split(":")[1])

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -10,7 +10,7 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -21,7 +21,13 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import COORDINATOR, DEFAULT_SCAN_INTERVAL, DOMAIN, UNDO_UPDATE_LISTENER
+from .const import (
+    COORDINATOR,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    UNDO_UPDATE_LISTENER,
+)
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -40,18 +46,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Plugwise Smiles from a config entry."""
     websession = async_get_clientsession(hass, verify_ssl=False)
 
-    port = 80
-    host = entry.data[CONF_HOST]
-    password = entry.data[CONF_PASSWORD]
-
-    if ":" in host:
-        port = int(host.split(":")[1])
-        host = host.split(":")[0]
-
     api = Smile(
-        host=host,
-        password=password,
-        port=port,
+        host=entry.data[CONF_HOST],
+        password=entry.data[CONF_PASSWORD],
+        port=entry.data.get(CONF_PORT, DEFAULT_PORT),
         timeout=30,
         websession=websession,
     )

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -39,9 +39,20 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Plugwise Smiles from a config entry."""
     websession = async_get_clientsession(hass, verify_ssl=False)
+
+    port = 80
+    host = (entry.data[CONF_HOST],)
+    password = (entry.data[CONF_PASSWORD],)
+
+    if ":" in host:
+        port = int(host.split(":")[1])
+        host = host.split(":")[0]
+
     api = Smile(
-        host=entry.data[CONF_HOST],
-        password=entry.data[CONF_PASSWORD],
+        host=host,
+        password=password,
+        port=port,
+        timeout=30,
         websession=websession,
     )
 

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -40,9 +40,19 @@ async def validate_input(hass: core.HomeAssistant, data):
     Data has the keys from _base_schema() with values provided by the user.
     """
     websession = async_get_clientsession(hass, verify_ssl=False)
+
+    port = 80
+    host = data[CONF_HOST]
+    password = data[CONF_PASSWORD]
+
+    if ":" in host:
+        port = int(host.split(":")[1])
+        host = host.split(":")[0]
+
     api = Smile(
-        host=data[CONF_HOST],
-        password=data[CONF_PASSWORD],
+        host=host,
+        password=password,
+        port=port,
         timeout=30,
         websession=websession,
     )

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -31,9 +31,9 @@ def _base_schema(discovery_info):
 
     if not discovery_info:
         base_schema[vol.Required(CONF_HOST)] = str
+        base_schema[vol.Optional(CONF_PORT, default=DEFAULT_PORT)] = int
 
     base_schema[vol.Required(CONF_PASSWORD)] = str
-    base_schema[vol.Optional(CONF_PORT, default=DEFAULT_PORT)] = int
 
     return vol.Schema(base_schema)
 

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -5,12 +5,16 @@ from Plugwise_Smile.Smile import Smile
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN  # pylint:disable=unused-import
+from .const import (  # pylint:disable=unused-import
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +33,7 @@ def _base_schema(discovery_info):
         base_schema[vol.Required(CONF_HOST)] = str
 
     base_schema[vol.Required(CONF_PASSWORD)] = str
+    base_schema[vol.Optional(CONF_PORT, default=DEFAULT_PORT)] = int
 
     return vol.Schema(base_schema)
 
@@ -41,18 +46,10 @@ async def validate_input(hass: core.HomeAssistant, data):
     """
     websession = async_get_clientsession(hass, verify_ssl=False)
 
-    port = 80
-    host = data[CONF_HOST]
-    password = data[CONF_PASSWORD]
-
-    if ":" in host:
-        port = int(host.split(":")[1])
-        host = host.split(":")[0]
-
     api = Smile(
-        host=host,
-        password=password,
-        port=port,
+        host=data[CONF_HOST],
+        password=data[CONF_PASSWORD],
+        port=data[CONF_PORT],
         timeout=30,
         websession=websession,
     )

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -90,6 +90,7 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context["title_placeholders"] = {
             CONF_HOST: discovery_info[CONF_HOST],
+            CONF_PORT: discovery_info[CONF_PORT],
             "name": _name,
         }
         return await self.async_step_user()
@@ -102,6 +103,7 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if self.discovery_info:
                 user_input[CONF_HOST] = self.discovery_info[CONF_HOST]
+                user_input[CONF_PORT] = self.discovery_info[CONF_PORT]
 
             for entry in self._async_current_entries():
                 if entry.data.get(CONF_HOST) == user_input[CONF_HOST]:

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -79,9 +79,6 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.discovery_info = discovery_info
         _properties = self.discovery_info.get("properties")
 
-        if not self.discovery_info.get(CONF_PORT):
-            self.discovery_info[CONF_PORT] = DEFAULT_PORT
-
         unique_id = self.discovery_info.get("hostname").split(".")[0]
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
@@ -93,7 +90,7 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context["title_placeholders"] = {
             CONF_HOST: discovery_info[CONF_HOST],
-            CONF_PORT: discovery_info[CONF_PORT],
+            CONF_PORT: discovery_info.get(CONF_PORT, DEFAULT_PORT),
             "name": _name,
         }
         return await self.async_step_user()

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -103,7 +103,7 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if self.discovery_info:
                 user_input[CONF_HOST] = self.discovery_info[CONF_HOST]
-                user_input[CONF_PORT] = self.discovery_info[CONF_PORT]
+                user_input[CONF_PORT] = self.discovery_info.get(CONF_PORT, DEFAULT_PORT)
 
             for entry in self._async_current_entries():
                 if entry.data.get(CONF_HOST) == user_input[CONF_HOST]:

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -79,6 +79,9 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.discovery_info = discovery_info
         _properties = self.discovery_info.get("properties")
 
+        if not self.discovery_info.get(CONF_PORT):
+            self.discovery_info[CONF_PORT] = DEFAULT_PORT
+
         unique_id = self.discovery_info.get("hostname").split(".")[0]
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -15,8 +15,9 @@
         "title": "Connect to the Smile",
         "description": "Please enter:",
         "data": {
-          "host": "Smile IP address(:port)",
-          "password": "Smile ID"
+          "password": "Smile ID",
+          "host": "Smile IP address",
+          "port": "Smile port number"
         }
       }
     },

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -13,9 +13,9 @@
     "step": {
       "user": {
         "title": "Connect to the Smile",
-        "description": "Details",
+        "description": "Please enter:",
         "data": {
-          "host": "Smile IP address",
+          "host": "Smile IP address(:port)",
           "password": "Smile ID"
         }
       }

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -3,7 +3,11 @@ from Plugwise_Smile.Smile import Smile
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.plugwise.const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from homeassistant.components.plugwise.const import (
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_SCAN_INTERVAL
 
@@ -13,8 +17,7 @@ from tests.common import MockConfigEntry
 TEST_HOST = "1.1.1.1"
 TEST_HOSTNAME = "smileabcdef"
 TEST_PASSWORD = "test_password"
-TEST_HOST_PORT = "1.1.1.1:80"
-TEST_HOST_FPORT = "1.1.1.1:81"
+TEST_PORT = 81
 
 TEST_DISCOVERY = {
     "host": TEST_HOST,
@@ -62,15 +65,16 @@ async def test_form(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"host": TEST_HOST_PORT, "password": TEST_PASSWORD},
+            {"host": TEST_HOST, "password": TEST_PASSWORD},
         )
 
     await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["data"] == {
-        "host": TEST_HOST_PORT,
+        "host": TEST_HOST,
         "password": TEST_PASSWORD,
+        "port": DEFAULT_PORT,
     }
 
     assert len(mock_setup.mock_calls) == 1
@@ -109,6 +113,7 @@ async def test_zeroconf_form(hass):
     assert result2["data"] == {
         "host": TEST_HOST,
         "password": TEST_PASSWORD,
+        "port": DEFAULT_PORT,
     }
 
     assert len(mock_setup.mock_calls) == 1
@@ -190,7 +195,7 @@ async def test_form_cannot_connect_port(hass, mock_smile):
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {"host": TEST_HOST_FPORT, "password": TEST_PASSWORD},
+        {"host": TEST_HOST, "password": TEST_PASSWORD, "port": TEST_PORT},
     )
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -21,6 +21,7 @@ TEST_PORT = 81
 
 TEST_DISCOVERY = {
     "host": TEST_HOST,
+    "port": DEFAULT_PORT,
     "hostname": f"{TEST_HOSTNAME}.local.",
     "server": f"{TEST_HOSTNAME}.local.",
     "properties": {

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -9,13 +9,7 @@ from homeassistant.components.plugwise.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_SCAN_INTERVAL,
-)
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_SCAN_INTERVAL
 
 from tests.async_mock import MagicMock, patch
 from tests.common import MockConfigEntry
@@ -153,44 +147,6 @@ async def test_zeroconf_form(hass):
 
     assert result4["type"] == "abort"
     assert result4["reason"] == "already_configured"
-
-
-async def test_zeroconf_missing_port_form(hass):
-    """Test we get the form when port is absent from discovery."""
-    missing_port = TEST_DISCOVERY
-    missing_port.pop(CONF_PORT)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=missing_port
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {}
-
-    with patch(
-        "homeassistant.components.plugwise.config_flow.Smile.connect",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.plugwise.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.plugwise.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"password": TEST_PASSWORD},
-        )
-
-    await hass.async_block_till_done()
-
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["data"] == {
-        "host": TEST_HOST,
-        "password": TEST_PASSWORD,
-        "port": DEFAULT_PORT,
-    }
-
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_form_invalid_auth(hass, mock_smile):


### PR DESCRIPTION
## Proposed change
Handle additional port number present to facilitate people with out-of-subnet local Smiles. 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue:  #38276
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [x] I have reviewed one other [open pull requests][prs] in this repository.

[prs]: 35713
