### PR TITLE
Improve handling of mireds being far out of spec

### DIFF
--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==72"],
+  "requirements": ["pydeconz==73"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1295,7 +1295,7 @@ pydaikin==2.3.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==72
+pydeconz==73
 
 # homeassistant.components.delijn
 pydelijn==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -625,7 +625,7 @@ pycountry==19.8.18
 pydaikin==2.3.1
 
 # homeassistant.components.deconz
-pydeconz==72
+pydeconz==73
 
 # homeassistant.components.dexcom
 pydexcom==0.2.0

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -67,6 +67,15 @@ LIGHTS = {
         "type": "On and Off light",
         "uniqueid": "00:00:00:00:00:00:00:03-00",
     },
+    "5": {
+        "ctmax": 1000,
+        "ctmin": 0,
+        "id": "Tunable white light with bad maxmin values id",
+        "name": "Tunable white light with bad maxmin values",
+        "state": {"on": True, "colormode": "ct", "ct": 2500, "reachable": True},
+        "type": "Tunable white light",
+        "uniqueid": "00:00:00:00:00:00:00:04-00",
+    },
 }
 
 
@@ -101,7 +110,7 @@ async def test_lights_and_groups(hass):
     assert "light.on_off_switch" not in gateway.deconz_ids
     assert "light.on_off_light" in gateway.deconz_ids
 
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light.state == "on"
@@ -116,6 +125,15 @@ async def test_lights_and_groups(hass):
     assert tunable_white_light.attributes["max_mireds"] == 454
     assert tunable_white_light.attributes["min_mireds"] == 155
     assert tunable_white_light.attributes["supported_features"] == 2
+
+    tunable_white_light_bad_maxmin = hass.states.get(
+        "light.tunable_white_light_with_bad_maxmin_values"
+    )
+    assert tunable_white_light_bad_maxmin.state == "on"
+    assert tunable_white_light_bad_maxmin.attributes["color_temp"] == 2500
+    assert tunable_white_light_bad_maxmin.attributes["max_mireds"] == 650
+    assert tunable_white_light_bad_maxmin.attributes["min_mireds"] == 140
+    assert tunable_white_light_bad_maxmin.attributes["supported_features"] == 2
 
     on_off_light = hass.states.get("light.on_off_light")
     assert on_off_light.state == "on"
@@ -256,7 +274,7 @@ async def test_disable_light_groups(hass):
     assert "light.empty_group" not in gateway.deconz_ids
     assert "light.on_off_switch" not in gateway.deconz_ids
     # 3 entities
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 5
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light is not None
@@ -281,7 +299,7 @@ async def test_disable_light_groups(hass):
     assert "light.empty_group" not in gateway.deconz_ids
     assert "light.on_off_switch" not in gateway.deconz_ids
     # 3 entities
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
 
     hass.config_entries.async_update_entry(
         gateway.config_entry, options={deconz.gateway.CONF_ALLOW_DECONZ_GROUPS: False}
@@ -294,4 +312,4 @@ async def test_disable_light_groups(hass):
     assert "light.empty_group" not in gateway.deconz_ids
     assert "light.on_off_switch" not in gateway.deconz_ids
     # 3 entities
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some devices report ctmin/max as being above 65000, the library keeps a limit of 140 to 650 now to handle this.
https://github.com/Kane610/deconz/compare/v72...v73

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39013
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
