### PR TITLE
Fix entity extraction from Template conditions

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -649,13 +649,16 @@ async def async_validate_condition_config(
 
 
 @callback
-def async_extract_entities(config: ConfigType) -> Set[str]:
+def async_extract_entities(config: Union[ConfigType, Template]) -> Set[str]:
     """Extract entities from a condition."""
     referenced: Set[str] = set()
     to_process = deque([config])
 
     while to_process:
         config = to_process.popleft()
+        if isinstance(config, Template):
+            continue
+
         condition = config[CONF_CONDITION]
 
         if condition in ("and", "not", "or"):
@@ -674,13 +677,16 @@ def async_extract_entities(config: ConfigType) -> Set[str]:
 
 
 @callback
-def async_extract_devices(config: ConfigType) -> Set[str]:
+def async_extract_devices(config: Union[ConfigType, Template]) -> Set[str]:
     """Extract devices from a condition."""
     referenced = set()
     to_process = deque([config])
 
     while to_process:
         config = to_process.popleft()
+        if isinstance(config, Template):
+            continue
+
         condition = config[CONF_CONDITION]
 
         if condition in ("and", "not", "or"):

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition
+from homeassistant.helpers.template import Template
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
@@ -807,6 +808,7 @@ async def test_extract_entities():
                     "entity_id": ["sensor.temperature_9", "sensor.temperature_10"],
                     "below": 110,
                 },
+                Template("{{ is_state('light.example', 'on') }}"),
             ],
         }
     ) == {
@@ -867,6 +869,7 @@ async def test_extract_devices():
                             },
                         ],
                     },
+                    Template("{{ is_state('light.example', 'on') }}"),
                 ],
             }
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When testing new automation features, I noticed an error showing in my logs when I was asking for related items in the UI:

```txt
2020-09-13 21:16:07 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection.140090989576048] Error handling message: Unknown error
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 21, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/search/__init__.py", line 49, in websocket_search_related
    msg["id"], searcher.async_search(msg["item_type"], msg["item_id"])
  File "/usr/src/homeassistant/homeassistant/components/search/__init__.py", line 89, in async_search
    getattr(self, f"_resolve_{search_type}")(search_id)
  File "/usr/src/homeassistant/homeassistant/components/search/__init__.py", line 163, in _resolve_entity
    for entity in automation.automations_with_entity(self.hass, entity_id):
  File "/usr/src/homeassistant/homeassistant/components/automation/__init__.py", line 135, in automations_with_entity
    return [
  File "/usr/src/homeassistant/homeassistant/components/automation/__init__.py", line 138, in <listcomp>
    if entity_id in automation_entity.referenced_entities
  File "/usr/src/homeassistant/homeassistant/components/automation/__init__.py", line 324, in referenced_entities
    referenced |= condition.async_extract_entities(conf)
  File "/usr/src/homeassistant/homeassistant/helpers/condition.py", line 659, in async_extract_entities
    condition = config[CONF_CONDITION]
TypeError: 'Template' object is not subscriptable
```

This is caused by the short hand template conditions introduced in 0.115. This PR adjusts the entity extract, so it no longer crashes.

Ideally we should get the entities for the templates as well. For the shorthand form, this would be easy enough, as they are templates already. 

Right now, I opted to fix it and keep te behavior the same as pre-0.115, skip those.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
