### PR TITLE
Reduce listener cancelation code in template tracker

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -630,25 +630,12 @@ class _TrackTemplateResultInfo:
         self._setup_entities_listener(self._last_domains, self._last_entities)
 
     @callback
-    def _cancel_domains_listener(self) -> None:
-        if self._domains_listener is None:
+    def _cancel_listener(self, attr_name: str) -> None:
+        attr_ = getattr(self, attr_name)
+        if attr_ is None:
             return
-        self._domains_listener()
-        self._domains_listener = None
-
-    @callback
-    def _cancel_entities_listener(self) -> None:
-        if self._entities_listener is None:
-            return
-        self._entities_listener()
-        self._entities_listener = None
-
-    @callback
-    def _cancel_all_listener(self) -> None:
-        if self._all_listener is None:
-            return
-        self._all_listener()
-        self._all_listener = None
+        attr_()
+        setattr(self, attr_name, None)
 
     @callback
     def _update_listeners(self) -> None:
@@ -657,25 +644,25 @@ class _TrackTemplateResultInfo:
                 return
             self._last_domains = set()
             self._last_entities = set()
-            self._cancel_domains_listener()
-            self._cancel_entities_listener()
+            self._cancel_listener("_domains_listener")
+            self._cancel_listener("_entities_listener")
             self._setup_all_listener()
             return
 
         had_all_listener = self._all_listener is not None
         if had_all_listener:
-            self._cancel_all_listener()
+            self._cancel_listener("_all_listener")
 
         entities, domains = _entities_domains_from_info(self._info.values())
         domains_changed = domains != self._last_domains
 
         if had_all_listener or domains_changed:
             domains_changed = True
-            self._cancel_domains_listener()
+            self._cancel_listener("_domains_listener")
             self._setup_domains_listener(domains)
 
         if had_all_listener or domains_changed or entities != self._last_entities:
-            self._cancel_entities_listener()
+            self._cancel_listener("_entities_listener")
             self._setup_entities_listener(domains, entities)
 
         self._last_domains = domains
@@ -713,9 +700,9 @@ class _TrackTemplateResultInfo:
     @callback
     def async_remove(self) -> None:
         """Cancel the listener."""
-        self._cancel_all_listener()
-        self._cancel_domains_listener()
-        self._cancel_entities_listener()
+        self._cancel_listener("_all_listener")
+        self._cancel_listener("_domains_listener")
+        self._cancel_listener("_entities_listener")
 
     @callback
     def async_refresh(self) -> None:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -61,6 +61,10 @@ TRACK_STATE_REMOVED_DOMAIN_LISTENER = "track_state_removed_domain_listener"
 TRACK_ENTITY_REGISTRY_UPDATED_CALLBACKS = "track_entity_registry_updated_callbacks"
 TRACK_ENTITY_REGISTRY_UPDATED_LISTENER = "track_entity_registry_updated_listener"
 
+_TEMPLATE_ALL_LISTENER = "all"
+_TEMPLATE_DOMAINS_LISTENER = "domains"
+_TEMPLATE_ENTITIES_LISTENER = "entities"
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -553,9 +557,7 @@ class _TrackTemplateResultInfo:
             track_template_.template.hass = hass
         self._track_templates = track_templates
 
-        self._all_listener: Optional[Callable] = None
-        self._domains_listener: Optional[Callable] = None
-        self._entities_listener: Optional[Callable] = None
+        self._listeners: Dict[str, Callable] = {}
 
         self._last_result: Dict[Template, Union[str, TemplateError]] = {}
         self._last_info: Dict[Template, RenderInfo] = {}
@@ -584,7 +586,7 @@ class _TrackTemplateResultInfo:
     def listeners(self) -> Dict:
         """State changes that will cause a re-render."""
         return {
-            "all": self._all_listener is not None,
+            "all": _TEMPLATE_ALL_LISTENER in self._listeners,
             "entities": self._last_entities,
             "domains": self._last_domains,
         }
@@ -630,39 +632,40 @@ class _TrackTemplateResultInfo:
         self._setup_entities_listener(self._last_domains, self._last_entities)
 
     @callback
-    def _cancel_listener(self, attr_name: str) -> None:
-        attr_ = getattr(self, attr_name)
-        if attr_ is None:
+    def _cancel_listener(self, listener_name: str) -> None:
+        if listener_name not in self._listeners:
             return
-        attr_()
-        setattr(self, attr_name, None)
+
+        self._listeners[listener_name]()
+        del self._listeners[listener_name]
 
     @callback
     def _update_listeners(self) -> None:
+        had_all_listener = _TEMPLATE_ALL_LISTENER in self._listeners
+
         if self._needs_all_listener:
-            if self._all_listener:
+            if had_all_listener:
                 return
             self._last_domains = set()
             self._last_entities = set()
-            self._cancel_listener("_domains_listener")
-            self._cancel_listener("_entities_listener")
+            self._cancel_listener(_TEMPLATE_DOMAINS_LISTENER)
+            self._cancel_listener(_TEMPLATE_ENTITIES_LISTENER)
             self._setup_all_listener()
             return
 
-        had_all_listener = self._all_listener is not None
         if had_all_listener:
-            self._cancel_listener("_all_listener")
+            self._cancel_listener(_TEMPLATE_ALL_LISTENER)
 
         entities, domains = _entities_domains_from_info(self._info.values())
         domains_changed = domains != self._last_domains
 
         if had_all_listener or domains_changed:
             domains_changed = True
-            self._cancel_listener("_domains_listener")
+            self._cancel_listener(_TEMPLATE_DOMAINS_LISTENER)
             self._setup_domains_listener(domains)
 
         if had_all_listener or domains_changed or entities != self._last_entities:
-            self._cancel_listener("_entities_listener")
+            self._cancel_listener(_TEMPLATE_ENTITIES_LISTENER)
             self._setup_entities_listener(domains, entities)
 
         self._last_domains = domains
@@ -678,7 +681,7 @@ class _TrackTemplateResultInfo:
         if not entities:
             return
 
-        self._entities_listener = async_track_state_change_event(
+        self._listeners[_TEMPLATE_ENTITIES_LISTENER] = async_track_state_change_event(
             self.hass, entities, self._refresh
         )
 
@@ -687,22 +690,22 @@ class _TrackTemplateResultInfo:
         if not domains:
             return
 
-        self._domains_listener = async_track_state_added_domain(
+        self._listeners[_TEMPLATE_DOMAINS_LISTENER] = async_track_state_added_domain(
             self.hass, domains, self._refresh
         )
 
     @callback
     def _setup_all_listener(self) -> None:
-        self._all_listener = self.hass.bus.async_listen(
+        self._listeners[_TEMPLATE_ALL_LISTENER] = self.hass.bus.async_listen(
             EVENT_STATE_CHANGED, self._refresh
         )
 
     @callback
     def async_remove(self) -> None:
         """Cancel the listener."""
-        self._cancel_listener("_all_listener")
-        self._cancel_listener("_domains_listener")
-        self._cancel_listener("_entities_listener")
+        self._cancel_listener(_TEMPLATE_ALL_LISTENER)
+        self._cancel_listener(_TEMPLATE_DOMAINS_LISTENER)
+        self._cancel_listener(_TEMPLATE_ENTITIES_LISTENER)
 
     @callback
     def async_refresh(self) -> None:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -636,8 +636,7 @@ class _TrackTemplateResultInfo:
         if listener_name not in self._listeners:
             return
 
-        self._listeners[listener_name]()
-        del self._listeners[listener_name]
+        self._listeners.pop(listener_name)()
 
     @callback
     def _update_listeners(self) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reduce listener cancelation code in template tracker
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
