### PR TITLE
Remove unsupported states from security systems in HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -125,11 +125,13 @@ class SecuritySystem(HomeAccessory):
 
         serv_alarm = self.add_preload_service(SERV_SECURITY_SYSTEM)
         self.char_current_state = serv_alarm.configure_char(
-            CHAR_CURRENT_SECURITY_STATE, value=3, valid_values=new_current_states
+            CHAR_CURRENT_SECURITY_STATE,
+            value=HASS_TO_HOMEKIT[STATE_ALARM_DISARMED],
+            valid_values=new_current_states,
         )
         self.char_target_state = serv_alarm.configure_char(
             CHAR_TARGET_SECURITY_STATE,
-            value=3,
+            value=HASS_TO_HOMEKIT_SERVICES[SERVICE_ALARM_DISARM],
             valid_values=new_target_services,
             setter_callback=self.set_security_state,
         )

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -40,6 +40,9 @@ HASS_TO_HOMEKIT = {
     STATE_ALARM_ARMED_NIGHT: 2,
     STATE_ALARM_DISARMED: 3,
     STATE_ALARM_TRIGGERED: 4,
+}
+
+HASS_TO_HOMEKIT_SERVICES = {
     SERVICE_ALARM_ARM_HOME: 0,
     SERVICE_ALARM_ARM_AWAY: 1,
     SERVICE_ALARM_ARM_NIGHT: 2,
@@ -91,19 +94,25 @@ class SecuritySystem(HomeAccessory):
             HASS_TO_HOMEKIT[STATE_ALARM_DISARMED],
             HASS_TO_HOMEKIT[STATE_ALARM_TRIGGERED],
         ]
-        target_supported_services = [HASS_TO_HOMEKIT[SERVICE_ALARM_DISARM]]
+        target_supported_services = [HASS_TO_HOMEKIT_SERVICES[SERVICE_ALARM_DISARM]]
 
         if supported_states & SUPPORT_ALARM_ARM_HOME:
             current_supported_states.append(HASS_TO_HOMEKIT[STATE_ALARM_ARMED_HOME])
-            target_supported_services.append(HASS_TO_HOMEKIT[SERVICE_ALARM_ARM_HOME])
+            target_supported_services.append(
+                HASS_TO_HOMEKIT_SERVICES[SERVICE_ALARM_ARM_HOME]
+            )
 
         if supported_states & SUPPORT_ALARM_ARM_AWAY:
             current_supported_states.append(HASS_TO_HOMEKIT[STATE_ALARM_ARMED_AWAY])
-            target_supported_services.append(HASS_TO_HOMEKIT[SERVICE_ALARM_ARM_AWAY])
+            target_supported_services.append(
+                HASS_TO_HOMEKIT_SERVICES[SERVICE_ALARM_ARM_AWAY]
+            )
 
         if supported_states & SUPPORT_ALARM_ARM_NIGHT:
             current_supported_states.append(HASS_TO_HOMEKIT[STATE_ALARM_ARMED_NIGHT])
-            target_supported_services.append(HASS_TO_HOMEKIT[SERVICE_ALARM_ARM_NIGHT])
+            target_supported_services.append(
+                HASS_TO_HOMEKIT_SERVICES[SERVICE_ALARM_ARM_NIGHT]
+            )
 
         new_current_states = {
             key: val


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Not all security systems support all HomeKit modes (`home`, `away`, `night`). SimpliSafe, for instance, only supports `home` and `away`. Today we're showing all of them to users in HomeKit.

With this PR we're hiding the unsupported ones from HomeKit, making it easier for users to set the right state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
