### PR TITLE
Add support for selecting multiple entity ids from logbook

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -454,7 +454,7 @@ def _get_events(
             if entity_matches_only:
                 # When entity_matches_only is provided, contexts and events that do not
                 # contain the entity_ids are not included in the logbook response.
-                query = _apply_state_matchers(query, entity_ids)
+                query = _apply_event_entity_id_matchers(query, entity_ids)
 
             query = query.union_all(
                 _generate_states_query(
@@ -579,7 +579,7 @@ def _apply_event_types_filter(hass, query, event_types):
     )
 
 
-def _apply_state_matchers(events_query, entity_ids):
+def _apply_event_entity_id_matchers(events_query, entity_ids):
     return events_query.filter(
         sqlalchemy.or_(
             *[

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -577,15 +577,14 @@ def _apply_event_types_filter(hass, query, event_types):
 
 
 def _apply_state_matchers(events_query, entity_ids):
-    states_matchers = Events.event_data.contains(
-        ENTITY_ID_JSON_TEMPLATE.format(entity_ids[0])
-    )
-    for entity_id in entity_ids[1:]:
-        states_matchers |= Events.event_data.contains(
-            ENTITY_ID_JSON_TEMPLATE.format(entity_id)
+    return events_query.filter(
+        sqlalchemy.or_(
+            *[
+                Events.event_data.contains(ENTITY_ID_JSON_TEMPLATE.format(entity_id))
+                for entity_id in entity_ids
+            ]
         )
-
-    return events_query.filter(states_matchers)
+    )
 
 
 def _keep_event(hass, event, entities_filter):

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -463,19 +463,16 @@ def _get_events(
 
             query = events_query.union_all(states_query)
         else:
-            events_query = _generate_events_query(session)
-            events_query = _apply_event_time_filter(events_query, start_day, end_day)
-            events_query = _apply_events_states_filter(
-                hass, events_query, old_state
-            ).filter(
+            query = _generate_events_query(session)
+            query = _apply_event_time_filter(query, start_day, end_day)
+            query = _apply_events_states_filter(hass, query, old_state).filter(
                 (States.last_updated == States.last_changed)
                 | (Events.event_type != EVENT_STATE_CHANGED)
             )
             if filters:
-                events_query = events_query.filter(
+                query = query.filter(
                     filters.entity_filter() | (Events.event_type != EVENT_STATE_CHANGED)
                 )
-            query = events_query
 
         query = query.order_by(Events.time_fired)
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -427,7 +427,6 @@ def _get_events(
     """Get events for a period of time."""
     entity_attr_cache = EntityAttributeCache(hass)
     context_lookup = {None: None}
-    apply_sql_entities_filter = True
 
     def yield_events(query):
         """Yield Events that are not filtered away."""
@@ -439,13 +438,9 @@ def _get_events(
 
     if entity_ids is not None:
         entities_filter = generate_filter([], entity_ids, [], [])
-        apply_sql_entities_filter = False
 
     with session_scope(hass=hass) as session:
         old_state = aliased(States, name="old_state")
-        entity_filter = None
-        if apply_sql_entities_filter and filters:
-            entity_filter = filters.entity_filter()
 
         if entity_ids is not None:
             events_query = _generate_events_query_without_states(session)
@@ -466,9 +461,6 @@ def _get_events(
                 # contain the entity_ids are not included in the logbook response.
                 events_query = _apply_state_matchers(events_query, entity_ids)
 
-            if entity_filter is not None:
-                states_query = states_query.filter(entity_filter)
-
             query = events_query.union_all(states_query)
         else:
             events_query = _generate_events_query(session)
@@ -479,9 +471,9 @@ def _get_events(
                 (States.last_updated == States.last_changed)
                 | (Events.event_type != EVENT_STATE_CHANGED)
             )
-            if entity_filter is not None:
+            if filters:
                 events_query = events_query.filter(
-                    entity_filter | (Events.event_type != EVENT_STATE_CHANGED)
+                    filters.entity_filter() | (Events.event_type != EVENT_STATE_CHANGED)
                 )
             query = events_query
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -434,6 +434,8 @@ def _get_events(
         for row in query.yield_per(1000):
             event = LazyEventPartialState(row)
             context_lookup.setdefault(event.context_id, event)
+            if event.event_type == EVENT_CALL_SERVICE:
+                continue
             if event.event_type == EVENT_STATE_CHANGED or _keep_event(
                 hass, event, entities_filter
             ):
@@ -591,9 +593,6 @@ def _apply_event_entity_id_matchers(events_query, entity_ids):
 
 
 def _keep_event(hass, event, entities_filter):
-    if event.event_type == EVENT_CALL_SERVICE:
-        return False
-
     if event.event_type in HOMEASSISTANT_EVENTS:
         return entities_filter is None or entities_filter(HA_DOMAIN_ENTITY_ID)
 


### PR DESCRIPTION
Supports https://github.com/home-assistant/frontend/pull/6976 and fixes the performance issue highlighted in https://github.com/home-assistant/core/issues/40292

I think the logbook access in the more info is the root cause of some of the reported performance issues in 0.115.  The problem should just go away after this PR.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for selecting multiple entity ids from logbook

Single/multiple entity lookups via the logbook api are at least an order of magnitude faster after this change.

Loading my garage exit door lock status before 1.32s (1324ms) after 94ms

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40292
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
