### PR TITLE
Add rpi_power during onboarding on RPi

### DIFF
--- a/homeassistant/components/onboarding/manifest.json
+++ b/homeassistant/components/onboarding/manifest.json
@@ -2,7 +2,16 @@
   "domain": "onboarding",
   "name": "Home Assistant Onboarding",
   "documentation": "https://www.home-assistant.io/integrations/onboarding",
-  "dependencies": ["auth", "http", "person"],
-  "codeowners": ["@home-assistant/core"],
+  "after_dependencies": [
+    "hassio"
+  ],
+  "dependencies": [
+    "auth",
+    "http",
+    "person"
+  ],
+  "codeowners": [
+    "@home-assistant/core"
+  ],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -159,6 +159,14 @@ class CoreConfigOnboardingView(_BaseOnboardingView):
                 "met", context={"source": "onboarding"}
             )
 
+            if (
+                hass.components.hassio.is_hassio()
+                and "raspberrypi" in hass.components.hassio.get_core_info()["machine"]
+            ):
+                await hass.config_entries.flow.async_init(
+                    "rpi_power", context={"source": "onboarding"}
+                )
+
             return self.json({})
 
 

--- a/homeassistant/components/rpi_power/config_flow.py
+++ b/homeassistant/components/rpi_power/config_flow.py
@@ -1,9 +1,11 @@
 """Config flow for Raspberry Pi Power Supply Checker."""
+from typing import Any, Dict, Optional
+
 from rpi_bad_power import new_under_voltage
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_flow
+from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
 
 from .const import DOMAIN
 
@@ -14,9 +16,29 @@ async def _async_supported(hass: HomeAssistant) -> bool:
     return under_voltage is not None
 
 
-config_entry_flow.register_discovery_flow(
-    DOMAIN,
-    "Raspberry Pi Power Supply Checker",
-    _async_supported,
-    config_entries.CONN_CLASS_LOCAL_POLL,
-)
+class RPiPowerFlow(DiscoveryFlowHandler, domain=DOMAIN):
+    """Discovery flow handler."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Set up config flow."""
+        super().__init__(
+            DOMAIN,
+            "Raspberry Pi Power Supply Checker",
+            _async_supported,
+            config_entries.CONN_CLASS_LOCAL_POLL,
+        )
+
+    async def async_step_onboarding(
+        self, data: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Handle a flow initialized by onboarding."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        has_devices = await self._discovery_function(self.hass)
+
+        if not has_devices:
+            return self.async_abort(reason="no_devices_found")
+        return self.async_create_entry(title=self._title, data={})

--- a/homeassistant/components/rpi_power/config_flow.py
+++ b/homeassistant/components/rpi_power/config_flow.py
@@ -34,9 +34,6 @@ class RPiPowerFlow(DiscoveryFlowHandler, domain=DOMAIN):
         self, data: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Handle a flow initialized by onboarding."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         has_devices = await self._discovery_function(self.hass)
 
         if not has_devices:

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -1,5 +1,6 @@
 """Test the onboarding views."""
 import asyncio
+import os
 
 import pytest
 
@@ -27,6 +28,57 @@ def auth_active(hass):
     hass.loop.run_until_complete(
         register_auth_provider(hass, {"type": "homeassistant"})
     )
+
+
+@pytest.fixture(name="rpi")
+async def rpi_fixture(hass, aioclient_mock, mock_supervisor):
+    """Mock core info with rpi."""
+    aioclient_mock.get(
+        "http://127.0.0.1/core/info",
+        json={
+            "result": "ok",
+            "data": {"version_latest": "1.0.0", "machine": "raspberrypi3"},
+        },
+    )
+    assert await async_setup_component(hass, "hassio", {})
+    await hass.async_block_till_done()
+
+
+@pytest.fixture(name="no_rpi")
+async def no_rpi_fixture(hass, aioclient_mock, mock_supervisor):
+    """Mock core info with rpi."""
+    aioclient_mock.get(
+        "http://127.0.0.1/core/info",
+        json={
+            "result": "ok",
+            "data": {"version_latest": "1.0.0", "machine": "odroid-n2"},
+        },
+    )
+    assert await async_setup_component(hass, "hassio", {})
+    await hass.async_block_till_done()
+
+
+@pytest.fixture(name="mock_supervisor")
+async def mock_supervisor_fixture(hass, aioclient_mock):
+    """Mock supervisor."""
+    aioclient_mock.post("http://127.0.0.1/homeassistant/options", json={"result": "ok"})
+    aioclient_mock.post("http://127.0.0.1/supervisor/options", json={"result": "ok"})
+    with patch.dict(os.environ, {"HASSIO": "127.0.0.1"}), patch(
+        "homeassistant.components.hassio.HassIO.is_connected",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.hassio.HassIO.get_info",
+        return_value={},
+    ), patch(
+        "homeassistant.components.hassio.HassIO.get_host_info",
+        return_value={},
+    ), patch(
+        "homeassistant.components.hassio.HassIO.get_ingress_panels",
+        return_value={"panels": {}},
+    ), patch.dict(
+        os.environ, {"HASSIO_TOKEN": "123456"}
+    ):
+        yield
 
 
 async def test_onboarding_progress(hass, hass_storage, aiohttp_client):
@@ -277,3 +329,51 @@ async def test_onboarding_core_sets_up_met(hass, hass_storage, hass_client):
 
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids("weather")) == 1
+
+
+async def test_onboarding_core_sets_up_rpi_power(
+    hass, hass_storage, hass_client, aioclient_mock, rpi
+):
+    """Test that the core step sets up rpi_power on RPi."""
+    mock_storage(hass_storage, {"done": [const.STEP_USER]})
+    await async_setup_component(hass, "persistent_notification", {})
+
+    assert await async_setup_component(hass, "onboarding", {})
+
+    client = await hass_client()
+
+    with patch(
+        "homeassistant.components.rpi_power.config_flow.new_under_voltage"
+    ), patch("homeassistant.components.rpi_power.binary_sensor.new_under_voltage"):
+        resp = await client.post("/api/onboarding/core_config")
+
+        assert resp.status == 200
+
+        await hass.async_block_till_done()
+
+    rpi_power_state = hass.states.get("binary_sensor.rpi_power_status")
+    assert rpi_power_state
+
+
+async def test_onboarding_core_no_rpi_power(
+    hass, hass_storage, hass_client, aioclient_mock, no_rpi
+):
+    """Test that the core step do not set up rpi_power on non RPi."""
+    mock_storage(hass_storage, {"done": [const.STEP_USER]})
+    await async_setup_component(hass, "persistent_notification", {})
+
+    assert await async_setup_component(hass, "onboarding", {})
+
+    client = await hass_client()
+
+    with patch(
+        "homeassistant.components.rpi_power.config_flow.new_under_voltage"
+    ), patch("homeassistant.components.rpi_power.binary_sensor.new_under_voltage"):
+        resp = await client.post("/api/onboarding/core_config")
+
+        assert resp.status == 200
+
+        await hass.async_block_till_done()
+
+    rpi_power_state = hass.states.get("binary_sensor.rpi_power_status")
+    assert not rpi_power_state

--- a/tests/components/rpi_power/test_config_flow.py
+++ b/tests/components/rpi_power/test_config_flow.py
@@ -14,7 +14,7 @@ from tests.common import patch
 MODULE = "homeassistant.components.rpi_power.config_flow.new_under_voltage"
 
 
-async def test_setup(hass: HomeAssistant):
+async def test_setup(hass: HomeAssistant) -> None:
     """Test setting up manually."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -29,7 +29,7 @@ async def test_setup(hass: HomeAssistant):
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
 
 
-async def test_not_supported(hass: HomeAssistant):
+async def test_not_supported(hass: HomeAssistant) -> None:
     """Test setting up on not supported system."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -38,5 +38,26 @@ async def test_not_supported(hass: HomeAssistant):
 
     with patch(MODULE, return_value=None):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+async def test_onboarding(hass: HomeAssistant) -> None:
+    """Test setting up via onboarding."""
+    with patch(MODULE, return_value=MagicMock()):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "onboarding"},
+        )
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_onboarding_not_supported(hass: HomeAssistant) -> None:
+    """Test setting up via onboarding with unsupported system."""
+    with patch(MODULE, return_value=None):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "onboarding"},
+        )
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "no_devices_found"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add rpi_power during onboarding if Supervisor is set up and machine is RaspberryPi.

## Todo

- [x] Adjust frontend to not show integration selected during onboarding: https://github.com/home-assistant/frontend/pull/7001

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
