### PR TITLE
Clean dyson climate tests

### DIFF
--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -273,12 +273,6 @@ class DysonTest(unittest.TestCase):
         assert entity.supported_features == dyson.SUPPORT_FLAGS
         assert entity.temperature_unit == TEMP_CELSIUS
 
-    def test_property_current_humidity(self):
-        """Test properties of current humidity."""
-        device = _get_device_heat_on()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert entity.current_humidity == 53
-
     def test_property_current_humidity_with_invalid_env_state(self):
         """Test properties of current humidity with invalid env state."""
         device = _get_device_off()
@@ -306,6 +300,7 @@ async def test_dyson_heat_on(mocked_login, mocked_devices, hass):
     state = hass.states.get("climate.temp_name")
     assert state.attributes["temperature"] == 23
     assert state.attributes["current_temperature"] == 289 - 273
+    assert state.attributes["current_humidity"] == 53
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -238,12 +238,6 @@ class DysonTest(unittest.TestCase):
         set_config = device.set_configuration
         set_config.assert_called_with(heat_mode=HeatMode.HEAT_ON)
 
-    def test_dyson_heat_value_on(self):
-        """Test get heat value on."""
-        device = _get_device_heat_on()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert entity.hvac_mode == dyson.HVAC_MODE_HEAT
-
     def test_dyson_heat_value_off(self):
         """Test get heat value off."""
         device = _get_device_cool()
@@ -301,6 +295,7 @@ async def test_dyson_heat_on(mocked_login, mocked_devices, hass):
     assert state.attributes["temperature"] == 23
     assert state.attributes["current_temperature"] == 289 - 273
     assert state.attributes["current_humidity"] == 53
+    assert state.state == HVAC_MODE_HEAT
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -43,8 +43,13 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
 )
 from homeassistant.components.dyson import climate as dyson
-from homeassistant.components.dyson.climate import FAN_DIFFUSE, FAN_FOCUS
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.components.dyson.climate import FAN_DIFFUSE, FAN_FOCUS, SUPPORT_FLAGS
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_TEMPERATURE,
+    TEMP_CELSIUS,
+)
 from homeassistant.setup import async_setup_component
 
 from .common import load_mock_device
@@ -212,14 +217,6 @@ class DysonTest(unittest.TestCase):
         assert entity.hvac_mode == dyson.HVAC_MODE_HEAT
         assert entity.hvac_action == dyson.CURRENT_HVAC_IDLE
 
-    def test_general_properties(self):
-        """Test properties of entity."""
-        device = _get_device_with_no_state()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert entity.should_poll is False
-        assert entity.supported_features == dyson.SUPPORT_FLAGS
-        assert entity.temperature_unit == TEMP_CELSIUS
-
     def test_property_current_humidity_with_invalid_env_state(self):
         """Test properties of current humidity with invalid env state."""
         device = _get_device_off()
@@ -279,6 +276,7 @@ async def test_pure_hot_cool_link_state(mocked_login, mocked_devices, hass):
     await hass.async_block_till_done()
 
     state = hass.states.get("climate.temp_name")
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_FLAGS
     assert state.attributes["temperature"] == 23
     assert state.attributes["current_temperature"] == 289 - 273
     assert state.attributes["current_humidity"] == 53

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -210,7 +210,7 @@ class DysonTest(unittest.TestCase):
     return_value=[_get_device_heat_on()],
 )
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
-async def test_dyson_heat_on_set_fan(mocked_login, mocked_devices, hass):
+async def test_pure_hot_cool_link_set_fan(mocked_login, mocked_devices, hass):
     """Test set climate temperature."""
     await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
     await hass.async_block_till_done()

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -26,6 +26,7 @@ from homeassistant.components.climate import (
 from homeassistant.components.climate.const import (
     ATTR_CURRENT_HUMIDITY,
     ATTR_FAN_MODE,
+    ATTR_FAN_MODES,
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
     ATTR_HVAC_MODES,
@@ -42,6 +43,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
 )
 from homeassistant.components.dyson import climate as dyson
+from homeassistant.components.dyson.climate import FAN_DIFFUSE, FAN_FOCUS
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.setup import async_setup_component
 
@@ -181,14 +183,6 @@ class DysonTest(unittest.TestCase):
         set_config = device.set_configuration
         set_config.assert_called_with(focus_mode=FocusMode.FOCUS_OFF)
 
-    def test_dyson_fan_modes(self):
-        """Test get fan list."""
-        device = _get_device_heat_on()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert len(entity.fan_modes) == 2
-        assert dyson.FAN_FOCUS in entity.fan_modes
-        assert dyson.FAN_DIFFUSE in entity.fan_modes
-
     def test_dyson_fan_mode_focus(self):
         """Test fan focus mode."""
         device = _get_device_focus()
@@ -292,6 +286,9 @@ async def test_dyson_heat_on(mocked_login, mocked_devices, hass):
     assert len(state.attributes[ATTR_HVAC_MODES]) == 2
     assert HVAC_MODE_HEAT in state.attributes[ATTR_HVAC_MODES]
     assert HVAC_MODE_COOL in state.attributes[ATTR_HVAC_MODES]
+    assert len(state.attributes[ATTR_FAN_MODES]) == 2
+    assert FAN_FOCUS in state.attributes[ATTR_FAN_MODES]
+    assert FAN_DIFFUSE in state.attributes[ATTR_FAN_MODES]
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -210,12 +210,6 @@ class DysonTest(unittest.TestCase):
         entity = dyson.DysonPureHotCoolLinkEntity(device)
         assert entity.hvac_mode == dyson.HVAC_MODE_COOL
 
-    def test_property_current_humidity_without_env_state(self):
-        """Test properties of current humidity without env state."""
-        device = _get_device_with_no_state()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert entity.current_humidity is None
-
 
 @patch(
     "homeassistant.components.dyson.DysonAccount.devices",
@@ -301,6 +295,13 @@ async def test_pure_hot_cool_link_state(mocked_login, mocked_devices, hass):
     assert state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
 
     device.environmental_state.humidity = 0
+    await hass.async_add_executor_job(update_callback, MockDysonState())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.temp_name")
+    assert state.attributes.get(ATTR_CURRENT_HUMIDITY) is None
+
+    device.environmental_state = None
     await hass.async_add_executor_job(update_callback, MockDysonState())
     await hass.async_block_till_done()
 

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -210,13 +210,6 @@ class DysonTest(unittest.TestCase):
         entity = dyson.DysonPureHotCoolLinkEntity(device)
         assert entity.hvac_mode == dyson.HVAC_MODE_COOL
 
-    def test_dyson_heat_value_idle(self):
-        """Test get heat value idle."""
-        device = _get_device_heat_off()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert entity.hvac_mode == dyson.HVAC_MODE_HEAT
-        assert entity.hvac_action == dyson.CURRENT_HVAC_IDLE
-
     def test_property_current_humidity_with_invalid_env_state(self):
         """Test properties of current humidity with invalid env state."""
         device = _get_device_off()
@@ -302,6 +295,14 @@ async def test_pure_hot_cool_link_state(mocked_login, mocked_devices, hass):
 
     state = hass.states.get("climate.temp_name")
     assert state.attributes[ATTR_FAN_MODE] == FAN_DIFFUSE
+
+    device.state.heat_mode = HeatMode.HEAT_ON.value
+    device.state.heat_state = HeatState.HEAT_STATE_OFF.value
+    await hass.async_add_executor_job(update_callback, MockDysonState())
+
+    state = hass.states.get("climate.temp_name")
+    assert state.state == HVAC_MODE_HEAT
+    assert state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -46,7 +46,7 @@ from homeassistant.setup import async_setup_component
 
 from .common import load_mock_device
 
-from tests.async_mock import MagicMock, Mock, patch
+from tests.async_mock import Mock, patch
 from tests.common import get_test_home_assistant
 
 
@@ -165,30 +165,6 @@ class DysonTest(unittest.TestCase):
     def tear_down_cleanup(self):
         """Stop everything that was started."""
         self.hass.stop()
-
-    def test_setup_component_with_devices(self):
-        """Test setup component with valid devices."""
-        devices = [
-            _get_device_with_no_state(),
-            _get_device_off(),
-            _get_device_heat_on(),
-        ]
-        self.hass.data[dyson.DYSON_DEVICES] = devices
-        add_devices = MagicMock()
-        dyson.setup_platform(self.hass, None, add_devices, discovery_info={})
-        assert add_devices.called
-
-    def test_setup_component(self):
-        """Test setup component with devices."""
-        device_fan = _get_device_heat_on()
-        device_non_fan = _get_device_off()
-
-        def _add_device(devices):
-            assert len(devices) == 1
-            assert devices[0].name == "Device_name"
-
-        self.hass.data[dyson.DYSON_DEVICES] = [device_fan, device_non_fan]
-        dyson.setup_platform(self.hass, None, _add_device)
 
     def test_dyson_set_temperature(self):
         """Test set climate temperature."""

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -15,7 +15,6 @@ from libpurecool.dyson_pure_hotcool_link import DysonPureHotCoolLink
 from libpurecool.dyson_pure_state import DysonPureHotCoolState
 from libpurecool.dyson_pure_state_v2 import DysonPureHotCoolV2State
 
-from homeassistant.components import dyson as dyson_parent
 from homeassistant.components.climate import (
     DOMAIN,
     SERVICE_SET_FAN_MODE,
@@ -41,12 +40,20 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
 )
-from homeassistant.components.dyson import climate as dyson
-from homeassistant.components.dyson.climate import FAN_DIFFUSE, FAN_FOCUS, SUPPORT_FLAGS
+from homeassistant.components.dyson import CONF_LANGUAGE, DOMAIN as DYSON_DOMAIN
+from homeassistant.components.dyson.climate import (
+    FAN_DIFFUSE,
+    FAN_FOCUS,
+    SUPPORT_FLAGS,
+    DysonPureHotCoolEntity,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
+    CONF_DEVICES,
+    CONF_PASSWORD,
+    CONF_USERNAME,
     TEMP_CELSIUS,
 )
 from homeassistant.setup import async_setup_component
@@ -70,11 +77,11 @@ class MockDysonState(DysonPureHotCoolState):
 def _get_config():
     """Return a config dictionary."""
     return {
-        dyson_parent.DOMAIN: {
-            dyson_parent.CONF_USERNAME: "email",
-            dyson_parent.CONF_PASSWORD: "password",
-            dyson_parent.CONF_LANGUAGE: "GB",
-            dyson_parent.CONF_DEVICES: [
+        DYSON_DOMAIN: {
+            CONF_USERNAME: "email",
+            CONF_PASSWORD: "password",
+            CONF_LANGUAGE: "GB",
+            CONF_DEVICES: [
                 {"device_id": "XX-XXXXX-XX", "device_ip": "192.168.0.1"},
                 {"device_id": "YY-YYYYY-YY", "device_ip": "192.168.0.2"},
             ],
@@ -133,7 +140,7 @@ def _get_device_heat_on():
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
 async def test_pure_hot_cool_link_set_mode(mocked_login, mocked_devices, hass):
     """Test set climate mode."""
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     device = mocked_devices.return_value[0]
@@ -166,7 +173,7 @@ async def test_pure_hot_cool_link_set_mode(mocked_login, mocked_devices, hass):
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
 async def test_pure_hot_cool_link_set_fan(mocked_login, mocked_devices, hass):
     """Test set climate fan."""
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     device = mocked_devices.return_value[0]
@@ -200,7 +207,7 @@ async def test_pure_hot_cool_link_set_fan(mocked_login, mocked_devices, hass):
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
 async def test_pure_hot_cool_link_state(mocked_login, mocked_devices, hass):
     """Test set climate temperature."""
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     state = hass.states.get("climate.temp_name")
@@ -273,7 +280,7 @@ async def test_pure_hot_cool_link_state(mocked_login, mocked_devices, hass):
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
 async def test_setup_component_without_devices(mocked_login, mocked_devices, hass):
     """Test setup component with no devices."""
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     entity_ids = hass.states.async_entity_ids("climate")
@@ -287,7 +294,7 @@ async def test_setup_component_without_devices(mocked_login, mocked_devices, has
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
 async def test_dyson_set_temperature(mocked_login, mocked_devices, hass):
     """Test set climate temperature."""
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     device = mocked_devices.return_value[0]
@@ -355,7 +362,7 @@ async def test_dyson_set_temperature_when_cooling_mode(
     mocked_login, mocked_devices, hass
 ):
     """Test set climate temperature when heating is off."""
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     device = mocked_devices.return_value[0]
@@ -383,7 +390,7 @@ async def test_setup_component_with_parent_discovery(
     mocked_login, mocked_devices, hass
 ):
     """Test setup_component using discovery."""
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     entity_ids = hass.states.async_entity_ids("climate")
@@ -398,7 +405,7 @@ async def test_setup_component_with_parent_discovery(
 async def test_purehotcool_component_setup_only_once(devices, login, hass):
     """Test if entities are created only once."""
     config = _get_config()
-    await async_setup_component(hass, dyson_parent.DOMAIN, config)
+    await async_setup_component(hass, DYSON_DOMAIN, config)
     await hass.async_block_till_done()
 
     entity_ids = hass.states.async_entity_ids("climate")
@@ -415,7 +422,7 @@ async def test_purehotcool_component_setup_only_once(devices, login, hass):
 async def test_purehotcoollink_component_setup_only_once(devices, login, hass):
     """Test if entities are created only once."""
     config = _get_config()
-    await async_setup_component(hass, dyson_parent.DOMAIN, config)
+    await async_setup_component(hass, DYSON_DOMAIN, config)
     await hass.async_block_till_done()
 
     entity_ids = hass.states.async_entity_ids("climate")
@@ -432,7 +439,7 @@ async def test_purehotcoollink_component_setup_only_once(devices, login, hass):
 async def test_purehotcool_update_state(devices, login, hass):
     """Test state update."""
     device = devices.return_value[0]
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
     event = {
         "msg": "CURRENT-STATE",
@@ -467,7 +474,7 @@ async def test_purehotcool_update_state(devices, login, hass):
 
     for add_call in device.add_message_listener.call_args_list:
         callback = add_call[0][0]
-        if type(callback.__self__) == dyson.DysonPureHotCoolEntity:
+        if type(callback.__self__) == DysonPureHotCoolEntity:
             callback(device.state)
 
     await hass.async_block_till_done()
@@ -488,7 +495,7 @@ async def test_purehotcool_empty_env_attributes(devices, login, hass):
     device = devices.return_value[0]
     device.environmental_state.temperature = 0
     device.environmental_state.humidity = None
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     state = hass.states.get("climate.living_room")
@@ -506,7 +513,7 @@ async def test_purehotcool_fan_state_off(devices, login, hass):
     """Test device fan state off."""
     device = devices.return_value[0]
     device.state.fan_state = FanState.FAN_OFF.value
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     state = hass.states.get("climate.living_room")
@@ -524,7 +531,7 @@ async def test_purehotcool_hvac_action_cool(devices, login, hass):
     """Test device HVAC action cool."""
     device = devices.return_value[0]
     device.state.fan_power = FanPower.POWER_ON.value
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     state = hass.states.get("climate.living_room")
@@ -543,7 +550,7 @@ async def test_purehotcool_hvac_action_idle(devices, login, hass):
     device = devices.return_value[0]
     device.state.fan_power = FanPower.POWER_ON.value
     device.state.heat_mode = HeatMode.HEAT_ON.value
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     state = hass.states.get("climate.living_room")
@@ -560,7 +567,7 @@ async def test_purehotcool_hvac_action_idle(devices, login, hass):
 async def test_purehotcool_set_temperature(devices, login, hass):
     """Test set temperature."""
     device = devices.return_value[0]
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
     state = hass.states.get("climate.living_room")
     attributes = state.attributes
@@ -611,7 +618,7 @@ async def test_purehotcool_set_temperature(devices, login, hass):
 async def test_purehotcool_set_fan_mode(devices, login, hass):
     """Test set fan mode."""
     device = devices.return_value[0]
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -675,7 +682,7 @@ async def test_purehotcool_set_fan_mode(devices, login, hass):
 async def test_purehotcool_set_hvac_mode(devices, login, hass):
     """Test set HVAC mode."""
     device = devices.return_value[0]
-    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -299,11 +299,19 @@ class DysonTest(unittest.TestCase):
         # Result should be in celsius, hence then subtraction of 273.
         assert entity.current_temperature == 289 - 273
 
-    def test_property_target_temperature(self):
-        """Test properties of target temperature."""
-        device = _get_device_heat_on()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert entity.target_temperature == 23
+
+@patch(
+    "homeassistant.components.dyson.DysonAccount.devices",
+    return_value=[_get_device_heat_on()],
+)
+@patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
+async def test_dyson_heat_on(mocked_login, mocked_devices, hass):
+    """Test set climate temperature."""
+    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.temp_name")
+    assert state.attributes["temperature"] == 23
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -23,11 +23,16 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.climate.const import (
     ATTR_CURRENT_HUMIDITY,
+    ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
     ATTR_FAN_MODES,
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
     ATTR_HVAC_MODES,
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
@@ -212,9 +217,9 @@ async def test_pure_hot_cool_link_state(mocked_login, mocked_devices, hass):
 
     state = hass.states.get("climate.temp_name")
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_FLAGS
-    assert state.attributes["temperature"] == 23
-    assert state.attributes["current_temperature"] == 289 - 273
-    assert state.attributes["current_humidity"] == 53
+    assert state.attributes[ATTR_TEMPERATURE] == 23
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 289 - 273
+    assert state.attributes[ATTR_CURRENT_HUMIDITY] == 53
     assert state.state == HVAC_MODE_HEAT
     assert len(state.attributes[ATTR_HVAC_MODES]) == 2
     assert HVAC_MODE_HEAT in state.attributes[ATTR_HVAC_MODES]
@@ -283,7 +288,7 @@ async def test_setup_component_without_devices(mocked_login, mocked_devices, has
     await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
-    entity_ids = hass.states.async_entity_ids("climate")
+    entity_ids = hass.states.async_entity_ids(DOMAIN)
     assert not entity_ids
 
 
@@ -306,8 +311,8 @@ async def test_dyson_set_temperature(mocked_login, mocked_devices, hass):
         SERVICE_SET_TEMPERATURE,
         {
             ATTR_ENTITY_ID: "climate.temp_name",
-            "target_temp_high": 25.0,
-            "target_temp_low": 15.0,
+            ATTR_TARGET_TEMP_HIGH: 25.0,
+            ATTR_TARGET_TEMP_LOW: 15.0,
         },
         True,
     )
@@ -393,7 +398,7 @@ async def test_setup_component_with_parent_discovery(
     await async_setup_component(hass, DYSON_DOMAIN, _get_config())
     await hass.async_block_till_done()
 
-    entity_ids = hass.states.async_entity_ids("climate")
+    entity_ids = hass.states.async_entity_ids(DOMAIN)
     assert len(entity_ids) == 2
 
 
@@ -408,7 +413,7 @@ async def test_purehotcool_component_setup_only_once(devices, login, hass):
     await async_setup_component(hass, DYSON_DOMAIN, config)
     await hass.async_block_till_done()
 
-    entity_ids = hass.states.async_entity_ids("climate")
+    entity_ids = hass.states.async_entity_ids(DOMAIN)
     assert len(entity_ids) == 1
     state = hass.states.get(entity_ids[0])
     assert state.name == "Living room"
@@ -425,7 +430,7 @@ async def test_purehotcoollink_component_setup_only_once(devices, login, hass):
     await async_setup_component(hass, DYSON_DOMAIN, config)
     await hass.async_block_till_done()
 
-    entity_ids = hass.states.async_entity_ids("climate")
+    entity_ids = hass.states.async_entity_ids(DOMAIN)
     assert len(entity_ids) == 1
     state = hass.states.get(entity_ids[0])
     assert state.name == "Temp Name"
@@ -571,8 +576,8 @@ async def test_purehotcool_set_temperature(devices, login, hass):
     await hass.async_block_till_done()
     state = hass.states.get("climate.living_room")
     attributes = state.attributes
-    min_temp = attributes["min_temp"]
-    max_temp = attributes["max_temp"]
+    min_temp = attributes[ATTR_MIN_TEMP]
+    max_temp = attributes[ATTR_MAX_TEMP]
 
     await hass.services.async_call(
         DOMAIN,

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -204,12 +204,6 @@ class DysonTest(unittest.TestCase):
         set_config = device.set_configuration
         set_config.assert_called_with(heat_mode=HeatMode.HEAT_ON)
 
-    def test_dyson_heat_value_off(self):
-        """Test get heat value off."""
-        device = _get_device_cool()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert entity.hvac_mode == dyson.HVAC_MODE_COOL
-
 
 @patch(
     "homeassistant.components.dyson.DysonAccount.devices",
@@ -307,6 +301,15 @@ async def test_pure_hot_cool_link_state(mocked_login, mocked_devices, hass):
 
     state = hass.states.get("climate.temp_name")
     assert state.attributes.get(ATTR_CURRENT_HUMIDITY) is None
+
+    device.state.heat_mode = HeatMode.HEAT_OFF.value
+    device.state.heat_state = HeatState.HEAT_STATE_OFF.value
+    await hass.async_add_executor_job(update_callback, MockDysonState())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.temp_name")
+    assert state.state == HVAC_MODE_COOL
+    assert state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_COOL
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -307,7 +307,8 @@ class DysonTest(unittest.TestCase):
 
 
 @patch(
-    "homeassistant.components.dyson.DysonAccount.devices", return_value=[],
+    "homeassistant.components.dyson.DysonAccount.devices",
+    return_value=[],
 )
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
 async def test_setup_component_without_devices(mocked_login, mocked_devices, hass):

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -292,13 +292,6 @@ class DysonTest(unittest.TestCase):
         entity = dyson.DysonPureHotCoolLinkEntity(device)
         assert entity.current_humidity is None
 
-    def test_property_current_temperature(self):
-        """Test properties of current temperature."""
-        device = _get_device_heat_on()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        # Result should be in celsius, hence then subtraction of 273.
-        assert entity.current_temperature == 289 - 273
-
 
 @patch(
     "homeassistant.components.dyson.DysonAccount.devices",
@@ -312,6 +305,7 @@ async def test_dyson_heat_on(mocked_login, mocked_devices, hass):
 
     state = hass.states.get("climate.temp_name")
     assert state.attributes["temperature"] == 23
+    assert state.attributes["current_temperature"] == 289 - 273
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -28,6 +28,7 @@ from homeassistant.components.climate.const import (
     ATTR_FAN_MODE,
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
+    ATTR_HVAC_MODES,
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
@@ -214,14 +215,6 @@ class DysonTest(unittest.TestCase):
         set_config = device.set_configuration
         set_config.assert_called_with(heat_mode=HeatMode.HEAT_OFF)
 
-    def test_dyson_operation_list(self):
-        """Test get operation list."""
-        device = _get_device_heat_on()
-        entity = dyson.DysonPureHotCoolLinkEntity(device)
-        assert len(entity.hvac_modes) == 2
-        assert dyson.HVAC_MODE_HEAT in entity.hvac_modes
-        assert dyson.HVAC_MODE_COOL in entity.hvac_modes
-
     def test_dyson_heat_off(self):
         """Test turn off heat."""
         device = _get_device_heat_off()
@@ -296,6 +289,9 @@ async def test_dyson_heat_on(mocked_login, mocked_devices, hass):
     assert state.attributes["current_temperature"] == 289 - 273
     assert state.attributes["current_humidity"] == 53
     assert state.state == HVAC_MODE_HEAT
+    assert len(state.attributes[ATTR_HVAC_MODES]) == 2
+    assert HVAC_MODE_HEAT in state.attributes[ATTR_HVAC_MODES]
+    assert HVAC_MODE_COOL in state.attributes[ATTR_HVAC_MODES]
 
 
 @patch(

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -166,13 +166,6 @@ class DysonTest(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_setup_component_without_devices(self):
-        """Test setup component with no devices."""
-        self.hass.data[dyson.DYSON_DEVICES] = []
-        add_devices = MagicMock()
-        dyson.setup_platform(self.hass, None, add_devices)
-        add_devices.assert_not_called()
-
     def test_setup_component_with_devices(self):
         """Test setup component with valid devices."""
         devices = [
@@ -384,6 +377,19 @@ class DysonTest(unittest.TestCase):
         device = _get_device_heat_on()
         entity = dyson.DysonPureHotCoolLinkEntity(device)
         assert entity.target_temperature == 23
+
+
+@patch(
+    "homeassistant.components.dyson.DysonAccount.devices", return_value=[],
+)
+@patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
+async def test_setup_component_without_devices(mocked_login, mocked_devices, hass):
+    """Test setup component with no devices."""
+    await async_setup_component(hass, dyson_parent.DOMAIN, _get_config())
+    await hass.async_block_till_done()
+
+    entity_ids = hass.states.async_entity_ids("climate")
+    assert not entity_ids
 
 
 @patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Move to async pytest standalone tests.
- Clean up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
