### PR TITLE
Add and use currency constants

### DIFF
--- a/homeassistant/components/dsmr_reader/definitions.py
+++ b/homeassistant/components/dsmr_reader/definitions.py
@@ -1,6 +1,7 @@
 """Definitions for DSMR Reader sensors added to MQTT."""
 
 from homeassistant.const import (
+    CURRENCY_EURO,
     ELECTRICAL_CURRENT_AMPERE,
     ENERGY_KILO_WATT_HOUR,
     VOLT,
@@ -166,17 +167,17 @@ DEFINITIONS = {
     "dsmr/day-consumption/electricity1_cost": {
         "name": "Low tariff cost",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/electricity2_cost": {
         "name": "High tariff cost",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/electricity_cost_merged": {
         "name": "Power total cost",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/gas": {
         "name": "Gas usage",
@@ -186,37 +187,37 @@ DEFINITIONS = {
     "dsmr/day-consumption/gas_cost": {
         "name": "Gas cost",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/total_cost": {
         "name": "Total cost",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/energy_supplier_price_electricity_delivered_1": {
         "name": "Low tariff delivered price",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/energy_supplier_price_electricity_delivered_2": {
         "name": "High tariff delivered price",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/energy_supplier_price_electricity_returned_1": {
         "name": "Low tariff returned price",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/energy_supplier_price_electricity_returned_2": {
         "name": "High tariff returned price",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/day-consumption/energy_supplier_price_gas": {
         "name": "Gas price",
         "icon": "mdi:currency-eur",
-        "unit": "€",
+        "unit": CURRENCY_EURO,
     },
     "dsmr/meter-stats/dsmr_version": {
         "name": "DSMR version",

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
+    CURRENCY_EURO,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
@@ -39,8 +40,8 @@ SCAN_INTERVAL = datetime.timedelta(minutes=5)
 # Sensor type order is: Sensor name, Unit of measurement, api data name, additional options
 
 TOTAL_SENSOR_TYPES = {
-    "total_money_today": ("Total money today", "€", "plantMoneyText", {}),
-    "total_money_total": ("Money lifetime", "€", "totalMoneyText", {}),
+    "total_money_today": ("Total money today", CURRENCY_EURO, "plantMoneyText", {}),
+    "total_money_total": ("Money lifetime", CURRENCY_EURO, "totalMoneyText", {}),
     "total_energy_today": (
         "Energy Today",
         ENERGY_KILO_WATT_HOUR,

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -45,6 +45,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
+    CURRENCY_DOLLAR,
     DEGREE,
     ENERGY_KILO_WATT_HOUR,
     FREQUENCY_HERTZ,
@@ -396,7 +397,7 @@ UOM_FRIENDLY_NAME = {
     UOM_8_BIT_RANGE: "",  # Range 0-255, no unit.
     UOM_DOUBLE_TEMP: UOM_DOUBLE_TEMP,
     "102": "kWs",
-    "103": "$",
+    "103": CURRENCY_DOLLAR,
     "104": "¢",
     "105": LENGTH_INCHES,
     "106": f"mm/{TIME_DAYS}",

--- a/homeassistant/components/pvpc_hourly_pricing/sensor.py
+++ b/homeassistant/components/pvpc_hourly_pricing/sensor.py
@@ -6,7 +6,7 @@ from typing import Optional
 from aiopvpc import PVPCData
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_NAME, ENERGY_KILO_WATT_HOUR
+from homeassistant.const import CONF_NAME, CURRENCY_EURO, ENERGY_KILO_WATT_HOUR
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later, async_track_time_change
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_PRICE = "price"
 ICON = "mdi:currency-eur"
-UNIT = f"€/{ENERGY_KILO_WATT_HOUR}"
+UNIT = f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}"
 
 _DEFAULT_TIMEOUT = 10
 

--- a/homeassistant/components/tankerkoenig/sensor.py
+++ b/homeassistant/components/tankerkoenig/sensor.py
@@ -2,7 +2,12 @@
 
 import logging
 
-from homeassistant.const import ATTR_ATTRIBUTION, ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CURRENCY_EURO,
+)
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -106,7 +111,7 @@ class FuelPriceSensor(CoordinatorEntity):
     @property
     def unit_of_measurement(self):
         """Return unit of measurement."""
-        return "€"
+        return CURRENCY_EURO
 
     @property
     def state(self):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -380,6 +380,10 @@ ELECTRICAL_VOLT_AMPERE = f"{VOLT}{ELECTRICAL_CURRENT_AMPERE}"
 # Degree units
 DEGREE = "°"
 
+# Currency units
+CURRENCY_EURO = "€"
+CURRENCY_DOLLAR = "$"
+
 # Temperature units
 TEMP_CELSIUS = f"{DEGREE}C"
 TEMP_FAHRENHEIT = f"{DEGREE}F"

--- a/tests/components/pvpc_hourly_pricing/conftest.py
+++ b/tests/components/pvpc_hourly_pricing/conftest.py
@@ -2,7 +2,11 @@
 import pytest
 
 from homeassistant.components.pvpc_hourly_pricing import ATTR_TARIFF, DOMAIN
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, ENERGY_KILO_WATT_HOUR
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    CURRENCY_EURO,
+    ENERGY_KILO_WATT_HOUR,
+)
 
 from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -15,7 +19,10 @@ FIXTURE_JSON_DATA_2019_10_29 = "PVPC_CURV_DD_2019_10_29.json"
 def check_valid_state(state, tariff: str, value=None, key_attr=None):
     """Ensure that sensor has a valid state and attributes."""
     assert state
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == f"€/{ENERGY_KILO_WATT_HOUR}"
+    assert (
+        state.attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}"
+    )
     try:
         _ = float(state.state)
         # safety margins for current electricity price (it shouldn't be out of [0, 0.2])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Adds CURRENCY_EURO and CURRENCY_DOLLAR to HA constants
- Uses the newly added constants throughout the code base


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
