### PR TITLE
Fix static/class async mocks on Python 3.8.0 and .1

### DIFF
--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 
-from tests.async_mock import patch
+from tests.async_mock import AsyncMock, patch
 from tests.common import MockConfigEntry
 
 SAMPLE_CONFIG = {
@@ -69,7 +69,8 @@ async def test_show_form(hass):
 async def test_config_flow(hass, config_entry):
     """Test that the user step works."""
     with patch(
-        "homeassistant.components.forked_daapd.config_flow.ForkedDaapdAPI.test_connection"
+        "homeassistant.components.forked_daapd.config_flow.ForkedDaapdAPI.test_connection",
+        new=AsyncMock(),
     ) as mock_test_connection, patch(
         "homeassistant.components.forked_daapd.media_player.ForkedDaapdAPI.get_request",
         autospec=True,
@@ -119,7 +120,8 @@ async def test_zeroconf_updates_title(hass, config_entry):
 async def test_config_flow_no_websocket(hass, config_entry):
     """Test config flow setup without websocket enabled on server."""
     with patch(
-        "homeassistant.components.forked_daapd.config_flow.ForkedDaapdAPI.test_connection"
+        "homeassistant.components.forked_daapd.config_flow.ForkedDaapdAPI.test_connection",
+        new=AsyncMock(),
     ) as mock_test_connection:
         # test invalid config data
         mock_test_connection.return_value = ["websocket_not_enabled"]

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -25,9 +25,11 @@ async def test_form(hass):
         return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ), patch(
         "aioshelly.Device.create",
-        return_value=Mock(
-            shutdown=AsyncMock(),
-            settings={"name": "Test name", "device": {"mac": "test-mac"}},
+        new=AsyncMock(
+            return_value=Mock(
+                shutdown=AsyncMock(),
+                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+            )
         ),
     ), patch(
         "homeassistant.components.shelly.async_setup", return_value=True
@@ -72,9 +74,11 @@ async def test_form_auth(hass):
 
     with patch(
         "aioshelly.Device.create",
-        return_value=Mock(
-            shutdown=AsyncMock(),
-            settings={"name": "Test name", "device": {"mac": "test-mac"}},
+        new=AsyncMock(
+            return_value=Mock(
+                shutdown=AsyncMock(),
+                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+            )
         ),
     ), patch(
         "homeassistant.components.shelly.async_setup", return_value=True
@@ -136,7 +140,7 @@ async def test_form_errors_test_connection(hass, error):
         "aioshelly.get_info", return_value={"mac": "test-mac", "auth": False}
     ), patch(
         "aioshelly.Device.create",
-        side_effect=exc,
+        new=AsyncMock(side_effect=exc),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -199,7 +203,7 @@ async def test_form_auth_errors_test_connection(hass, error):
 
     with patch(
         "aioshelly.Device.create",
-        side_effect=exc,
+        new=AsyncMock(side_effect=exc),
     ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
@@ -227,9 +231,11 @@ async def test_zeroconf(hass):
 
     with patch(
         "aioshelly.Device.create",
-        return_value=Mock(
-            shutdown=AsyncMock(),
-            settings={"name": "Test name", "device": {"mac": "test-mac"}},
+        new=AsyncMock(
+            return_value=Mock(
+                shutdown=AsyncMock(),
+                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+            )
         ),
     ), patch(
         "homeassistant.components.shelly.async_setup", return_value=True
@@ -274,7 +280,7 @@ async def test_zeroconf_confirm_error(hass, error):
 
     with patch(
         "aioshelly.Device.create",
-        side_effect=exc,
+        new=AsyncMock(side_effect=exc),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -349,9 +355,11 @@ async def test_zeroconf_require_auth(hass):
 
     with patch(
         "aioshelly.Device.create",
-        return_value=Mock(
-            shutdown=AsyncMock(),
-            settings={"name": "Test name", "device": {"mac": "test-mac"}},
+        new=AsyncMock(
+            return_value=Mock(
+                shutdown=AsyncMock(),
+                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+            )
         ),
     ), patch(
         "homeassistant.components.shelly.async_setup", return_value=True


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

More fixes like the ones in #39926.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #39926
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
