### PR TITLE
Fix local media browser source conflicting with local www folder

### DIFF
--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -190,10 +190,10 @@ class LocalMediaView(HomeAssistantView):
     ) -> web.FileResponse:
         """Start a GET request."""
         if location != sanitize_path(location):
-            return web.HTTPNotFound()
+            raise web.HTTPNotFound()
 
         if source_dir_id not in self.hass.config.media_dirs:
-            return web.HTTPNotFound()
+            raise web.HTTPNotFound()
 
         media_path = self.source.async_full_path(source_dir_id, location)
 

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -64,7 +64,7 @@ class LocalSource(MediaSource):
         mime_type, _ = mimetypes.guess_type(
             str(self.async_full_path(source_dir_id, location))
         )
-        return PlayMedia(f"/local_source/{item.identifier}", mime_type)
+        return PlayMedia(f"/media/{item.identifier}", mime_type)
 
     async def async_browse_media(
         self, item: MediaSourceItem, media_types: Tuple[str] = MEDIA_MIME_TYPES
@@ -177,7 +177,7 @@ class LocalMediaView(HomeAssistantView):
     Returns media files in config/media.
     """
 
-    url = "/local_source/{source_dir_id}/{location:.*}"
+    url = "/media/{source_dir_id}/{location:.*}"
     name = "media"
 
     def __init__(self, hass: HomeAssistant, source: LocalSource):

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -510,9 +510,9 @@ async def async_process_ha_core_config(hass: HomeAssistant, config: Dict) -> Non
 
     if CONF_MEDIA_DIRS not in config:
         if is_docker_env():
-            hac.media_dirs = {"media": "/media"}
+            hac.media_dirs = {"local": "/media"}
         else:
-            hac.media_dirs = {"media": hass.config.path("media")}
+            hac.media_dirs = {"local": hass.config.path("media")}
 
     # Init whitelist external dir
     hac.allowlist_external_dirs = {hass.config.path("www"), *hac.media_dirs.values()}

--- a/tests/common.py
+++ b/tests/common.py
@@ -205,7 +205,7 @@ async def async_test_home_assistant(loop):
     hass.config.elevation = 0
     hass.config.time_zone = date_util.get_time_zone("US/Pacific")
     hass.config.units = METRIC_SYSTEM
-    hass.config.media_dirs = {"media": get_test_config_dir("media")}
+    hass.config.media_dirs = {"local": get_test_config_dir("media")}
     hass.config.skip_pip = True
 
     hass.config_entries = config_entries.ConfigEntries(hass, {})

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -65,7 +65,7 @@ async def test_async_resolve_media(hass):
 
     media = await media_source.async_resolve_media(
         hass,
-        media_source.generate_media_source_id(const.DOMAIN, "media/test.mp3"),
+        media_source.generate_media_source_id(const.DOMAIN, "local/test.mp3"),
     )
     assert isinstance(media, media_source.models.PlayMedia)
 
@@ -140,7 +140,7 @@ async def test_websocket_resolve_media(hass, hass_ws_client):
 
     client = await hass_ws_client(hass)
 
-    media = media_source.models.PlayMedia("/local_source/media/test.mp3", "audio/mpeg")
+    media = media_source.models.PlayMedia("/media/local/test.mp3", "audio/mpeg")
 
     with patch(
         "homeassistant.components.media_source.async_resolve_media",
@@ -150,7 +150,7 @@ async def test_websocket_resolve_media(hass, hass_ws_client):
             {
                 "id": 1,
                 "type": "media_source/resolve_media",
-                "media_content_id": f"{const.URI_SCHEME}{const.DOMAIN}/media/test.mp3",
+                "media_content_id": f"{const.URI_SCHEME}{const.DOMAIN}/local/test.mp3",
             }
         )
 

--- a/tests/components/media_source/test_local_source.py
+++ b/tests/components/media_source/test_local_source.py
@@ -11,7 +11,7 @@ async def test_async_browse_media(hass):
     """Test browse media."""
     local_media = hass.config.path("media")
     await async_process_ha_core_config(
-        hass, {"media_dirs": {"media": local_media, "recordings": local_media}}
+        hass, {"media_dirs": {"local": local_media, "recordings": local_media}}
     )
     await hass.async_block_till_done()
 
@@ -21,14 +21,14 @@ async def test_async_browse_media(hass):
     # Test path not exists
     with pytest.raises(media_source.BrowseError) as excinfo:
         await media_source.async_browse_media(
-            hass, f"{const.URI_SCHEME}{const.DOMAIN}/media/test/not/exist"
+            hass, f"{const.URI_SCHEME}{const.DOMAIN}/local/test/not/exist"
         )
     assert str(excinfo.value) == "Path does not exist."
 
     # Test browse file
     with pytest.raises(media_source.BrowseError) as excinfo:
         await media_source.async_browse_media(
-            hass, f"{const.URI_SCHEME}{const.DOMAIN}/media/test.mp3"
+            hass, f"{const.URI_SCHEME}{const.DOMAIN}/local/test.mp3"
         )
     assert str(excinfo.value) == "Path is not a directory."
 
@@ -42,7 +42,7 @@ async def test_async_browse_media(hass):
     # Test directory traversal
     with pytest.raises(media_source.BrowseError) as excinfo:
         await media_source.async_browse_media(
-            hass, f"{const.URI_SCHEME}{const.DOMAIN}/media/../configuration.yaml"
+            hass, f"{const.URI_SCHEME}{const.DOMAIN}/local/../configuration.yaml"
         )
     assert str(excinfo.value) == "Invalid path."
 
@@ -53,7 +53,7 @@ async def test_async_browse_media(hass):
     assert media
 
     media = await media_source.async_browse_media(
-        hass, f"{const.URI_SCHEME}{const.DOMAIN}/media/."
+        hass, f"{const.URI_SCHEME}{const.DOMAIN}/local/."
     )
     assert media
 
@@ -67,7 +67,7 @@ async def test_media_view(hass, hass_client):
     """Test media view."""
     local_media = hass.config.path("media")
     await async_process_ha_core_config(
-        hass, {"media_dirs": {"media": local_media, "recordings": local_media}}
+        hass, {"media_dirs": {"local": local_media, "recordings": local_media}}
     )
     await hass.async_block_till_done()
 
@@ -77,23 +77,23 @@ async def test_media_view(hass, hass_client):
     client = await hass_client()
 
     # Protects against non-existent files
-    resp = await client.get("/local_source/media/invalid.txt")
+    resp = await client.get("/media/local/invalid.txt")
     assert resp.status == 404
 
-    resp = await client.get("/local_source/recordings/invalid.txt")
+    resp = await client.get("/media/recordings/invalid.txt")
     assert resp.status == 404
 
     # Protects against non-media files
-    resp = await client.get("/local_source/media/not_media.txt")
+    resp = await client.get("/media/local/not_media.txt")
     assert resp.status == 404
 
     # Protects against unknown local media sources
-    resp = await client.get("/local_source/unknown_source/not_media.txt")
+    resp = await client.get("/media/unknown_source/not_media.txt")
     assert resp.status == 404
 
     # Fetch available media
-    resp = await client.get("/local_source/media/test.mp3")
+    resp = await client.get("/media/local/test.mp3")
     assert resp.status == 200
 
-    resp = await client.get("/local_source/recordings/test.mp3")
+    resp = await client.get("/media/recordings/test.mp3")
     assert resp.status == 200

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -499,7 +499,7 @@ async def test_loading_configuration_default_media_dirs_docker(hass):
     assert hass.config.location_name == "Huis"
     assert len(hass.config.allowlist_external_dirs) == 2
     assert "/media" in hass.config.allowlist_external_dirs
-    assert hass.config.media_dirs == {"media": "/media"}
+    assert hass.config.media_dirs == {"local": "/media"}
 
 
 async def test_loading_configuration_from_packages(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`aiohttp`:

A static resources, e.g., `/local` that maps to folder `www`, needs to me matched: `/local*`.

So our new `/local_source/` folder didn't work on those installations. This PR moves it back to the original `/media` path, but makes the default resource `local`. 

Which makes the default local media path on the webserver: `/media/local/*`.


Also came across 2 cases of returning an error instead of raising it. Adjusted that as well.

P.S.: @hunterjm, don't 😂 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
