### PR TITLE
add support for sungrow solar inverters with encrypted tcp modbus

### DIFF
--- a/homeassistant/components/modbus/SungrowModbusTcpClient.py
+++ b/homeassistant/components/modbus/SungrowModbusTcpClient.py
@@ -1,0 +1,67 @@
+from pymodbus.client.sync import ModbusTcpClient
+from Crypto.Cipher import AES
+
+priv_key = b'Grow#0*2Sun68CbE'
+NO_CRYPTO1 = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+NO_CRYPTO2 = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+GET_KEY = b'\x68\x68\x00\x00\x00\x06\xf7\x04\x0a\xe7\x00\x08'
+HEADER = bytes([0x68, 0x68])
+
+class SungrowModbusTcpClient(ModbusTcpClient):
+    def __init__(self, **kwargs):
+        ModbusTcpClient.__init__(self, **kwargs)
+        self._fifo = bytes()
+        self._key = None
+
+    def _getkey(self):
+        self._send(GET_KEY)
+        self._key_packet = self._recv(25)
+        self._pub_key = self._key_packet[9:]
+        if (self._pub_key != NO_CRYPTO1) and (self._pub_key != NO_CRYPTO2):
+           self._key = bytes(a ^ b for (a, b) in zip(self._pub_key, priv_key))
+           self._aes_ecb = AES.new(self._key, AES.MODE_ECB)
+           self._send = self._send_cipher
+           self._recv = self._recv_decipher
+        else:
+           self._key = b'no encryption'
+
+    def connect(self):
+        self.close()
+        result = ModbusTcpClient.connect(self)
+        if result and not self._key:
+           self._getkey()
+        self._fifo = bytes()
+        return result
+
+    def _send_cipher(self, request):
+        self._fifo = bytes()
+        length = len(request)
+        padding = 16 - (length % 16)
+        self._transactionID = request[:2]
+        request = HEADER + bytes(request[2:]) + bytes([0xff for i in range(0, padding)])
+        crypto_header = bytes([1, 0, length, padding])
+        encrypted_request = crypto_header + self._aes_ecb.encrypt(request)
+        return ModbusTcpClient._send(self, encrypted_request) - len(crypto_header) - padding
+
+    def _recv_decipher(self, size):
+        if len(self._fifo) == 0:
+            header = ModbusTcpClient._recv(self, 4)
+            if header and len(header) == 4:
+               packet_len = int(header[2])
+               padding = int(header[3])
+               length = packet_len + padding
+               encrypted_packet = ModbusTcpClient._recv(self, length)
+               if encrypted_packet and len(encrypted_packet) == length:
+                  packet = self._aes_ecb.decrypt(encrypted_packet)
+                  packet = self._transactionID + packet[2:]
+                  self._fifo = self._fifo + packet[:packet_len]
+
+        if size is None:
+           recv_size = 1
+        else:
+           recv_size = size
+
+        recv_size = min(recv_size, len(self._fifo))
+        result = self._fifo[:recv_size]
+        self._fifo = self._fifo[recv_size:]
+        return result

--- a/homeassistant/components/modbus/SungrowModbusTcpClient.py
+++ b/homeassistant/components/modbus/SungrowModbusTcpClient.py
@@ -1,11 +1,12 @@
 from pymodbus.client.sync import ModbusTcpClient
 from Crypto.Cipher import AES
 
-priv_key = b'Grow#0*2Sun68CbE'
-NO_CRYPTO1 = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-NO_CRYPTO2 = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
-GET_KEY = b'\x68\x68\x00\x00\x00\x06\xf7\x04\x0a\xe7\x00\x08'
+priv_key = b"Grow#0*2Sun68CbE"
+NO_CRYPTO1 = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+NO_CRYPTO2 = b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+GET_KEY = b"\x68\x68\x00\x00\x00\x06\xf7\x04\x0a\xe7\x00\x08"
 HEADER = bytes([0x68, 0x68])
+
 
 class SungrowModbusTcpClient(ModbusTcpClient):
     def __init__(self, **kwargs):
@@ -18,18 +19,18 @@ class SungrowModbusTcpClient(ModbusTcpClient):
         self._key_packet = self._recv(25)
         self._pub_key = self._key_packet[9:]
         if (self._pub_key != NO_CRYPTO1) and (self._pub_key != NO_CRYPTO2):
-           self._key = bytes(a ^ b for (a, b) in zip(self._pub_key, priv_key))
-           self._aes_ecb = AES.new(self._key, AES.MODE_ECB)
-           self._send = self._send_cipher
-           self._recv = self._recv_decipher
+            self._key = bytes(a ^ b for (a, b) in zip(self._pub_key, priv_key))
+            self._aes_ecb = AES.new(self._key, AES.MODE_ECB)
+            self._send = self._send_cipher
+            self._recv = self._recv_decipher
         else:
-           self._key = b'no encryption'
+            self._key = b"no encryption"
 
     def connect(self):
         self.close()
         result = ModbusTcpClient.connect(self)
         if result and not self._key:
-           self._getkey()
+            self._getkey()
         self._fifo = bytes()
         return result
 
@@ -38,28 +39,32 @@ class SungrowModbusTcpClient(ModbusTcpClient):
         length = len(request)
         padding = 16 - (length % 16)
         self._transactionID = request[:2]
-        request = HEADER + bytes(request[2:]) + bytes([0xff for i in range(0, padding)])
+        request = HEADER + bytes(request[2:]) + bytes([0xFF for i in range(0, padding)])
         crypto_header = bytes([1, 0, length, padding])
         encrypted_request = crypto_header + self._aes_ecb.encrypt(request)
-        return ModbusTcpClient._send(self, encrypted_request) - len(crypto_header) - padding
+        return (
+            ModbusTcpClient._send(self, encrypted_request)
+            - len(crypto_header)
+            - padding
+        )
 
     def _recv_decipher(self, size):
         if len(self._fifo) == 0:
             header = ModbusTcpClient._recv(self, 4)
             if header and len(header) == 4:
-               packet_len = int(header[2])
-               padding = int(header[3])
-               length = packet_len + padding
-               encrypted_packet = ModbusTcpClient._recv(self, length)
-               if encrypted_packet and len(encrypted_packet) == length:
-                  packet = self._aes_ecb.decrypt(encrypted_packet)
-                  packet = self._transactionID + packet[2:]
-                  self._fifo = self._fifo + packet[:packet_len]
+                packet_len = int(header[2])
+                padding = int(header[3])
+                length = packet_len + padding
+                encrypted_packet = ModbusTcpClient._recv(self, length)
+                if encrypted_packet and len(encrypted_packet) == length:
+                    packet = self._aes_ecb.decrypt(encrypted_packet)
+                    packet = self._transactionID + packet[2:]
+                    self._fifo = self._fifo + packet[:packet_len]
 
         if size is None:
-           recv_size = 1
+            recv_size = 1
         else:
-           recv_size = size
+            recv_size = size
 
         recv_size = min(recv_size, len(self._fifo))
         result = self._fifo[:recv_size]

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -4,6 +4,7 @@ import threading
 
 from pymodbus.client.sync import ModbusSerialClient, ModbusTcpClient, ModbusUdpClient
 from pymodbus.transaction import ModbusRtuFramer
+from SungrowModbusTcpClient import SungrowModbusTcpClient
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -56,7 +57,7 @@ ETHERNET_SCHEMA = BASE_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_PORT): cv.port,
-        vol.Required(CONF_TYPE): vol.Any("tcp", "udp", "rtuovertcp"),
+        vol.Required(CONF_TYPE): vol.Any("tcp", "udp", "rtuovertcp", "sungrow"),
         vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
         vol.Optional(CONF_DELAY, default=0): cv.positive_int,
     }
@@ -205,6 +206,12 @@ class ModbusHub:
             )
         elif self._config_type == "udp":
             self._client = ModbusUdpClient(
+                host=self._config_host,
+                port=self._config_port,
+                timeout=self._config_timeout,
+            )
+        elif self._config_type == "sungrow":
+            self._client = SungrowModbusTcpClient(
                 host=self._config_host,
                 port=self._config_port,
                 timeout=self._config_timeout,


### PR DESCRIPTION
## Proposed change

Add support for Sungrow solar inverters with encrypted TCP modbus communication.
To enable support use "type: sungrow" under modbus integration.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml
modbus:
  name: sungrow_sg4k
  type: sungrow
  host: 192.168.0.100
  port: 502

sensor:
  - platform: modbus
    registers:
      - name: total_dc_power
        hub: sungrow_sg4k
        slave: 1
        register: 5016
        count: 2
        register_type: input
        reverse_order: true
        unit_of_measurement: W

```
## Additional information
Minimal changes to existing code (```__init__.py```). All added functionality is in a separate file (```SungrowModbusTcpClient.py```)
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
