### PR TITLE
Log template listeners when debug logging is on

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -581,6 +581,11 @@ class _TrackTemplateResultInfo:
 
         self._last_info = self._info.copy()
         self._create_listeners()
+        _LOGGER.debug(
+            "Template group %s listens for %s",
+            [template.template for template in self._track_templates],
+            self.listeners,
+        )
 
     @property
     def listeners(self) -> Dict:
@@ -719,6 +724,9 @@ class _TrackTemplateResultInfo:
 
         for track_template_ in self._track_templates:
             template = track_template_.template
+            _LOGGER.debug(
+                "Template[%s] update triggered by event: %s", template.template, event
+            )
             if (
                 entity_id
                 and len(self._last_info) > 1
@@ -751,6 +759,11 @@ class _TrackTemplateResultInfo:
 
         if info_changed:
             self._update_listeners()
+            _LOGGER.debug(
+                "Template group %s listens for %s",
+                [template.template for template in self._track_templates],
+                self.listeners,
+            )
             self._last_info = self._info.copy()
 
         if not updates:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -583,7 +583,7 @@ class _TrackTemplateResultInfo:
         self._create_listeners()
         _LOGGER.debug(
             "Template group %s listens for %s",
-            [template.template for template in self._track_templates],
+            self._track_templates,
             self.listeners,
         )
 
@@ -761,7 +761,7 @@ class _TrackTemplateResultInfo:
             self._update_listeners()
             _LOGGER.debug(
                 "Template group %s listens for %s",
-                [template.template for template in self._track_templates],
+                self._track_templates,
                 self.listeners,
             )
             self._last_info = self._info.copy()

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -732,7 +732,7 @@ class _TrackTemplateResultInfo:
                 continue
 
             _LOGGER.debug(
-                "Template[%s] update triggered by event: %s", template.template, event
+                "Template update %s triggered by event: %s", template.template, event
             )
 
             self._info[template] = template.async_render_to_info(

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -724,15 +724,16 @@ class _TrackTemplateResultInfo:
 
         for track_template_ in self._track_templates:
             template = track_template_.template
-            _LOGGER.debug(
-                "Template[%s] update triggered by event: %s", template.template, event
-            )
             if (
                 entity_id
                 and len(self._last_info) > 1
                 and not self._last_info[template].filter_lifecycle(entity_id)
             ):
                 continue
+
+            _LOGGER.debug(
+                "Template[%s] update triggered by event: %s", template.template, event
+            )
 
             self._info[template] = template.async_render_to_info(
                 track_template_.variables

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -668,7 +668,7 @@ async def test_track_template_error(hass, caplog):
         hass.states.async_set("switch.not_exist", "off")
         await hass.async_block_till_done()
 
-    assert "lunch" not in caplog.text
+    assert "no filter named 'lunch'" not in caplog.text
     assert "TemplateAssertionError" not in caplog.text
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Log template listeners when debug logging is on



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39890
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
