### PR TITLE
Fix Vizio async_unload_entry bug

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -94,7 +94,7 @@ async def async_unload_entry(
         and entry.data[CONF_DEVICE_CLASS] == DEVICE_CLASS_TV
         for entry in hass.config_entries.async_entries(DOMAIN)
     ):
-        hass.data[DOMAIN].pop(CONF_APPS)
+        hass.data[DOMAIN].pop(CONF_APPS, None)
 
     if not hass.data[DOMAIN]:
         hass.data.pop(DOMAIN)

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -6,7 +6,7 @@ from homeassistant.components.vizio.const import DOMAIN
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
 
-from .const import MOCK_USER_VALID_TV_CONFIG, UNIQUE_ID
+from .const import MOCK_SPEAKER_CONFIG, MOCK_USER_VALID_TV_CONFIG, UNIQUE_ID
 
 from tests.common import MockConfigEntry
 
@@ -24,14 +24,35 @@ async def test_setup_component(
     assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
 
 
-async def test_load_and_unload(
+async def test_tv_load_and_unload(
     hass: HomeAssistantType,
     vizio_connect: pytest.fixture,
     vizio_update: pytest.fixture,
 ) -> None:
-    """Test loading and unloading entry."""
+    """Test loading and unloading TV entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
+    assert DOMAIN in hass.data
+
+    assert await config_entry.async_unload(hass)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 0
+    assert DOMAIN not in hass.data
+
+
+async def test_speaker_load_and_unload(
+    hass: HomeAssistantType,
+    vizio_connect: pytest.fixture,
+    vizio_update: pytest.fixture,
+) -> None:
+    """Test loading and unloading speaker entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
When unloading an entry and there are no other remaining `vizio` entries with a device class of `tv`, `async_unload_entry` fails because it tries to pop a key that doesn't exist. This will prevent that call from failing (the test I added would fail before the change).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
