### PR TITLE
Refactor Plex tests using fixtures

### DIFF
--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -37,7 +37,7 @@ def mock_websocket():
 
 
 @pytest.fixture
-async def setup_plex_server(hass, entry, mock_plex_account, mock_websocket):
+def setup_plex_server(hass, entry, mock_plex_account, mock_websocket):
     """Set up and return a mocked Plex server instance."""
 
     async def _wrapper(**kwargs):

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -1,0 +1,59 @@
+"""Fixtures for Plex tests."""
+import pytest
+
+from homeassistant.components.plex.const import DOMAIN
+
+from .const import DEFAULT_DATA, DEFAULT_OPTIONS
+from .mock_classes import MockPlexAccount, MockPlexServer
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="entry")
+def mock_config_entry():
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=DEFAULT_DATA,
+        options=DEFAULT_OPTIONS,
+        unique_id=DEFAULT_DATA["server_id"],
+    )
+
+
+@pytest.fixture
+def mock_plex_account():
+    """Mock the PlexAccount class and return the used instance."""
+    plex_account = MockPlexAccount()
+    with patch("plexapi.myplex.MyPlexAccount", return_value=plex_account):
+        yield plex_account
+
+
+@pytest.fixture
+def mock_websocket():
+    """Mock the PlexWebsocket class."""
+    with patch("homeassistant.components.plex.PlexWebsocket", autospec=True) as ws:
+        yield ws
+
+
+@pytest.fixture
+async def setup_plex_server(hass, entry, mock_plex_account, mock_websocket):
+    """Set up and return a mocked Plex server instance."""
+
+    async def _wrapper(**kwargs):
+        """Wrap the fixture to allow passing arguments to the MockPlexServer instance."""
+        config_entry = kwargs.get("config_entry", entry)
+        plex_server = MockPlexServer(**kwargs)
+        with patch("plexapi.server.PlexServer", return_value=plex_server):
+            config_entry.add_to_hass(hass)
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+        return plex_server
+
+    return _wrapper
+
+
+@pytest.fixture
+async def mock_plex_server(entry, setup_plex_server):
+    """Init from a config entry and return a mocked PlexServer instance."""
+    return await setup_plex_server(config_entry=entry)

--- a/tests/components/plex/test_browse_media.py
+++ b/tests/components/plex/test_browse_media.py
@@ -3,39 +3,16 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
 )
-from homeassistant.components.plex.const import CONF_SERVER_IDENTIFIER, DOMAIN
+from homeassistant.components.plex.const import CONF_SERVER_IDENTIFIER
 from homeassistant.components.plex.media_browser import SPECIAL_METHODS
 from homeassistant.components.websocket_api.const import ERR_UNKNOWN_ERROR, TYPE_RESULT
 
-from .const import DEFAULT_DATA, DEFAULT_OPTIONS
+from .const import DEFAULT_DATA
 from .helpers import trigger_plex_update
-from .mock_classes import MockPlexAccount, MockPlexServer
-
-from tests.async_mock import patch
-from tests.common import MockConfigEntry
 
 
-async def test_browse_media(hass, hass_ws_client):
+async def test_browse_media(hass, hass_ws_client, mock_plex_server, mock_websocket):
     """Test getting Plex clients from plex.tv."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=DEFAULT_DATA,
-        options=DEFAULT_OPTIONS,
-        unique_id=DEFAULT_DATA["server_id"],
-    )
-
-    mock_plex_server = MockPlexServer(config_entry=entry)
-    mock_plex_account = MockPlexAccount()
-
-    with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "plexapi.myplex.MyPlexAccount", return_value=mock_plex_account
-    ), patch(
-        "homeassistant.components.plex.PlexWebsocket", autospec=True
-    ) as mock_websocket:
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
     websocket_client = await hass_ws_client(hass)
 
     trigger_plex_update(mock_websocket)

--- a/tests/components/plex/test_playback.py
+++ b/tests/components/plex/test_playback.py
@@ -10,32 +10,11 @@ from homeassistant.components.plex.const import DOMAIN, SERVERS, SERVICE_PLAY_ON
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DEFAULT_DATA, DEFAULT_OPTIONS
-from .mock_classes import MockPlexAccount, MockPlexServer
-
 from tests.async_mock import patch
-from tests.common import MockConfigEntry
 
 
-async def test_sonos_playback(hass):
+async def test_sonos_playback(hass, mock_plex_server):
     """Test playing media on a Sonos speaker."""
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=DEFAULT_DATA,
-        options=DEFAULT_OPTIONS,
-        unique_id=DEFAULT_DATA["server_id"],
-    )
-
-    mock_plex_server = MockPlexServer(config_entry=entry)
-
-    with patch("plexapi.server.PlexServer", return_value=mock_plex_server), patch(
-        "plexapi.myplex.MyPlexAccount", return_value=MockPlexAccount()
-    ), patch("homeassistant.components.plex.PlexWebsocket.listen"):
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
     server_id = mock_plex_server.machineIdentifier
     loaded_server = hass.data[DOMAIN][SERVERS][server_id]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Plex tests had a lot of reused code. This moves most of the common test dependencies into a fixtures.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
