### PR TITLE
Improve tracking of existing entities in deconz

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -40,7 +40,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ binary sensor."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[DOMAIN] = {DOMAIN: set()}
+    gateway.entities[DOMAIN] = set()
 
     @callback
     def async_add_sensor(sensors):
@@ -51,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 sensor.BINARY
-                and sensor.uniqueid not in gateway.entities[DOMAIN][DOMAIN]
+                and sensor.uniqueid not in gateway.entities[DOMAIN]
                 and (
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")
@@ -75,7 +75,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     """Representation of a deCONZ binary sensor."""
 
-    DOMAIN = DOMAIN
     TYPE = DOMAIN
 
     @callback

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -43,15 +43,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway.entities[DOMAIN] = {DOMAIN: set()}
 
     @callback
-    def async_add_sensor(sensors, new=True):
+    def async_add_sensor(sensors):
         """Add binary sensor from deCONZ."""
         entities = []
 
         for sensor in sensors:
 
             if (
-                new
-                and sensor.BINARY
+                sensor.BINARY
+                and sensor.uniqueid not in gateway.entities[DOMAIN][DOMAIN]
                 and (
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OPENING,
     DEVICE_CLASS_SMOKE,
     DEVICE_CLASS_VIBRATION,
+    DOMAIN,
     BinarySensorEntity,
 )
 from homeassistant.const import ATTR_TEMPERATURE
@@ -39,6 +40,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ binary sensor."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = {DOMAIN: set()}
 
     @callback
     def async_add_sensor(sensors, new=True):
@@ -72,6 +74,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     """Representation of a deCONZ binary sensor."""
+
+    DOMAIN = DOMAIN
+    TYPE = DOMAIN
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -32,15 +32,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway.entities[DOMAIN] = {DOMAIN: set()}
 
     @callback
-    def async_add_climate(sensors, new=True):
+    def async_add_climate(sensors):
         """Add climate devices from deCONZ."""
         entities = []
 
         for sensor in sensors:
 
             if (
-                new
-                and sensor.type in Thermostat.ZHATYPE
+                sensor.type in Thermostat.ZHATYPE
+                and sensor.uniqueid not in gateway.entities[DOMAIN][DOMAIN]
                 and (
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Thermostats are based on the same device class as sensors in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[DOMAIN] = {DOMAIN: set()}
+    gateway.entities[DOMAIN] = set()
 
     @callback
     def async_add_climate(sensors):
@@ -40,7 +40,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 sensor.type in Thermostat.ZHATYPE
-                and sensor.uniqueid not in gateway.entities[DOMAIN][DOMAIN]
+                and sensor.uniqueid not in gateway.entities[DOMAIN]
                 and (
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")
@@ -62,7 +62,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DeconzThermostat(DeconzDevice, ClimateEntity):
     """Representation of a deCONZ thermostat."""
 
-    DOMAIN = DOMAIN
     TYPE = DOMAIN
 
     @property

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -1,7 +1,7 @@
 """Support for deCONZ climate devices."""
 from pydeconz.sensor import Thermostat
 
-from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate import DOMAIN, ClimateEntity
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
@@ -29,6 +29,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Thermostats are based on the same device class as sensors in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = {DOMAIN: set()}
 
     @callback
     def async_add_climate(sensors, new=True):
@@ -60,6 +61,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class DeconzThermostat(DeconzDevice, ClimateEntity):
     """Representation of a deCONZ thermostat."""
+
+    DOMAIN = DOMAIN
+    TYPE = DOMAIN
 
     @property
     def supported_features(self):

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -24,7 +24,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up covers for deCONZ component.
 
-    Covers are based on same device class as lights in deCONZ.
+    Covers are based on the same device class as lights in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = {DOMAIN: set()}
@@ -35,7 +35,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
 
         for light in lights:
-            if light.type in COVER_TYPES:
+            if (
+                light.type in COVER_TYPES
+                and light.uniqueid not in gateway.entities[DOMAIN][DOMAIN]
+            ):
                 entities.append(DeconzCover(light, gateway))
 
         async_add_entities(entities, True)

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -2,6 +2,7 @@
 from homeassistant.components.cover import (
     ATTR_POSITION,
     DEVICE_CLASS_WINDOW,
+    DOMAIN,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
@@ -26,6 +27,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Covers are based on same device class as lights in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = {DOMAIN: set()}
 
     @callback
     def async_add_cover(lights):
@@ -49,6 +51,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class DeconzCover(DeconzDevice, CoverEntity):
     """Representation of a deCONZ cover."""
+
+    DOMAIN = DOMAIN
+    TYPE = DOMAIN
 
     def __init__(self, device, gateway):
         """Set up cover device."""

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Covers are based on the same device class as lights in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[DOMAIN] = {DOMAIN: set()}
+    gateway.entities[DOMAIN] = set()
 
     @callback
     def async_add_cover(lights):
@@ -37,7 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for light in lights:
             if (
                 light.type in COVER_TYPES
-                and light.uniqueid not in gateway.entities[DOMAIN][DOMAIN]
+                and light.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzCover(light, gateway))
 

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -55,7 +55,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DeconzCover(DeconzDevice, CoverEntity):
     """Representation of a deCONZ cover."""
 
-    DOMAIN = DOMAIN
     TYPE = DOMAIN
 
     def __init__(self, device, gateway):

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -17,9 +17,6 @@ class DeconzBase:
         """Set up device and add update callback to get data from websocket."""
         self._device = device
         self.gateway = gateway
-
-    async def async_added_to_hass(self) -> None:
-        """Register unique id."""
         self.gateway.entities[self.DOMAIN][self.TYPE].add(self.unique_id)
 
     async def async_will_remove_from_hass(self) -> None:
@@ -74,7 +71,6 @@ class DeconzDevice(DeconzBase, Entity):
 
     async def async_added_to_hass(self):
         """Subscribe to device events."""
-        await super().async_added_to_hass()
         self._device.register_callback(self.async_update_callback)
         self.gateway.deconz_ids[self.entity_id] = self._device.deconz_id
         self.async_on_remove(

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -61,10 +61,6 @@ class DeconzBase:
 class DeconzDevice(DeconzBase, Entity):
     """Representation of a deCONZ device."""
 
-    def __init__(self, device, gateway):
-        """Set up device and add update callback to get data from websocket."""
-        super().__init__(device, gateway)
-
     @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry.

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -17,10 +17,13 @@ class DeconzBase:
         """Set up device and add update callback to get data from websocket."""
         self._device = device
         self.gateway = gateway
+
+    async def async_added_to_hass(self) -> None:
+        """Register unique id."""
         self.gateway.entities[self.DOMAIN][self.TYPE].add(self.unique_id)
 
     async def async_will_remove_from_hass(self) -> None:
-        """Disconnect device object when removed."""
+        """Remove unique id."""
         self.gateway.entities[self.DOMAIN][self.TYPE].remove(self.unique_id)
 
     @property
@@ -75,6 +78,7 @@ class DeconzDevice(DeconzBase, Entity):
 
     async def async_added_to_hass(self):
         """Subscribe to device events."""
+        await super().async_added_to_hass()
         self._device.register_callback(self.async_update_callback)
         self.gateway.deconz_ids[self.entity_id] = self._device.deconz_id
         self.async_on_remove(

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -10,11 +10,18 @@ from .const import DOMAIN as DECONZ_DOMAIN
 class DeconzBase:
     """Common base for deconz entities and events."""
 
+    DOMAIN = ""
+    TYPE = ""
+
     def __init__(self, device, gateway):
         """Set up device and add update callback to get data from websocket."""
         self._device = device
         self.gateway = gateway
-        self.listeners = []
+        self.gateway.entities[self.DOMAIN][self.TYPE].add(self.unique_id)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect device object when removed."""
+        self.gateway.entities[self.DOMAIN][self.TYPE].remove(self.unique_id)
 
     @property
     def unique_id(self):
@@ -55,8 +62,6 @@ class DeconzDevice(DeconzBase, Entity):
         """Set up device and add update callback to get data from websocket."""
         super().__init__(device, gateway)
 
-        self.unsub_dispatcher = None
-
     @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry.
@@ -72,7 +77,7 @@ class DeconzDevice(DeconzBase, Entity):
         """Subscribe to device events."""
         self._device.register_callback(self.async_update_callback)
         self.gateway.deconz_ids[self.entity_id] = self._device.deconz_id
-        self.listeners.append(
+        self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, self.gateway.signal_reachable, self.async_update_callback
             )
@@ -83,8 +88,7 @@ class DeconzDevice(DeconzBase, Entity):
         self._device.remove_callback(self.async_update_callback)
         if self.entity_id in self.gateway.deconz_ids:
             del self.gateway.deconz_ids[self.entity_id]
-            for unsub_dispatcher in self.listeners:
-                unsub_dispatcher()
+        await super().async_will_remove_from_hass()
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -10,18 +10,17 @@ from .const import DOMAIN as DECONZ_DOMAIN
 class DeconzBase:
     """Common base for deconz entities and events."""
 
-    DOMAIN = ""
     TYPE = ""
 
     def __init__(self, device, gateway):
         """Set up device and add update callback to get data from websocket."""
         self._device = device
         self.gateway = gateway
-        self.gateway.entities[self.DOMAIN][self.TYPE].add(self.unique_id)
+        self.gateway.entities[self.TYPE].add(self.unique_id)
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove unique id."""
-        self.gateway.entities[self.DOMAIN][self.TYPE].remove(self.unique_id)
+        self.gateway.entities[self.TYPE].remove(self.unique_id)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -16,16 +16,20 @@ EVENT = "Event"
 
 async def async_setup_events(gateway) -> None:
     """Set up the deCONZ events."""
+    gateway.entities[EVENT] = set()
 
     @callback
-    def async_add_sensor(sensors, new=True):
+    def async_add_sensor(sensors):
         """Create DeconzEvent."""
         for sensor in sensors:
 
             if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
                 continue
 
-            if not new or sensor.type not in Switch.ZHATYPE:
+            if (
+                sensor.type not in Switch.ZHATYPE
+                or sensor.uniqueid in gateway.entities[EVENT]
+            ):
                 continue
 
             new_event = DeconzEvent(sensor, gateway)
@@ -46,7 +50,7 @@ async def async_setup_events(gateway) -> None:
 async def async_unload_events(gateway) -> None:
     """Unload all deCONZ events."""
     for event in gateway.events:
-        event.async_will_remove_from_hass()
+        await event.async_will_remove_from_hass()
 
     gateway.events.clear()
 

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -1,7 +1,6 @@
 """Representation of a deCONZ remote."""
 from pydeconz.sensor import Switch
 
-from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -59,7 +58,6 @@ class DeconzEvent(DeconzBase):
     instead of a sensor entity in hass.
     """
 
-    DOMAIN = DOMAIN
     TYPE = EVENT
 
     def __init__(self, device, gateway):

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -1,6 +1,7 @@
 """Representation of a deCONZ remote."""
 from pydeconz.sensor import Switch
 
+from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -56,6 +57,9 @@ class DeconzEvent(DeconzBase):
     instead of a sensor entity in hass.
     """
 
+    DOMAIN = DOMAIN
+    TYPE = "Event"
+
     def __init__(self, device, gateway):
         """Register callback that will be used for signals."""
         super().__init__(device, gateway)
@@ -76,6 +80,7 @@ class DeconzEvent(DeconzBase):
         """Disconnect event object when removed."""
         self._device.remove_callback(self.async_update_callback)
         self._device = None
+        self.gateway.hass.async_create_task(super().async_will_remove_from_hass())
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -77,11 +77,10 @@ class DeconzEvent(DeconzBase):
         """Return Event device."""
         return self._device
 
-    @callback
-    def async_will_remove_from_hass(self) -> None:
+    async def async_will_remove_from_hass(self) -> None:
         """Disconnect event object when removed."""
         self._device.remove_callback(self.async_update_callback)
-        self.gateway.hass.async_create_task(super().async_will_remove_from_hass())
+        await super().async_will_remove_from_hass()
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -12,6 +12,8 @@ from .deconz_device import DeconzBase
 
 CONF_DECONZ_EVENT = "deconz_event"
 
+EVENT = "Event"
+
 
 async def async_setup_events(gateway) -> None:
     """Set up the deCONZ events."""
@@ -58,7 +60,7 @@ class DeconzEvent(DeconzBase):
     """
 
     DOMAIN = DOMAIN
-    TYPE = "Event"
+    TYPE = EVENT
 
     def __init__(self, device, gateway):
         """Register callback that will be used for signals."""

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -81,7 +81,6 @@ class DeconzEvent(DeconzBase):
     def async_will_remove_from_hass(self) -> None:
         """Disconnect event object when removed."""
         self._device.remove_callback(self.async_update_callback)
-        self._device = None
         self.gateway.hass.async_create_task(super().async_will_remove_from_hass())
 
     @callback

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -49,6 +49,8 @@ class DeconzGateway:
         self.events = []
         self.listeners = []
 
+        self.entities = {}
+
         self._current_option_allow_clip_sensor = self.option_allow_clip_sensor
         self._current_option_allow_deconz_groups = self.option_allow_deconz_groups
 

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -33,7 +33,6 @@ from .const import (
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
-LIGHT = "light"
 GROUP = "group"
 
 
@@ -44,7 +43,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ lights and groups from a config entry."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[DOMAIN] = {LIGHT: set(), GROUP: set()}
+    gateway.entities[DOMAIN] = set()
+    gateway.entities[GROUP] = set()
 
     @callback
     def async_add_light(lights):
@@ -54,7 +54,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for light in lights:
             if (
                 light.type not in COVER_TYPES + SWITCH_TYPES
-                and light.uniqueid not in gateway.entities[DOMAIN][LIGHT]
+                and light.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLight(light, gateway))
 
@@ -78,7 +78,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if not group.lights:
                 continue
 
-            known_groups = list(gateway.entities[DOMAIN][GROUP])
+            known_groups = list(gateway.entities[GROUP])
             new_group = DeconzGroup(group, gateway)
             if new_group.unique_id not in known_groups:
                 entities.append(new_group)
@@ -97,8 +97,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class DeconzBaseLight(DeconzDevice, LightEntity):
     """Representation of a deCONZ light."""
-
-    DOMAIN = DOMAIN
 
     def __init__(self, device, gateway):
         """Set up light."""
@@ -222,7 +220,7 @@ class DeconzBaseLight(DeconzDevice, LightEntity):
 class DeconzLight(DeconzBaseLight):
     """Representation of a deCONZ light."""
 
-    TYPE = LIGHT
+    TYPE = DOMAIN
 
     @property
     def max_mireds(self):

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -33,8 +33,6 @@ from .const import (
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
-GROUP = "group"
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up deCONZ platforms."""
@@ -44,7 +42,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ lights and groups from a config entry."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
-    gateway.entities[GROUP] = set()
 
     @callback
     def async_add_light(lights):
@@ -78,7 +75,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if not group.lights:
                 continue
 
-            known_groups = list(gateway.entities[GROUP])
+            known_groups = list(gateway.entities[DOMAIN])
             new_group = DeconzGroup(group, gateway)
             if new_group.unique_id not in known_groups:
                 entities.append(new_group)
@@ -97,6 +94,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class DeconzBaseLight(DeconzDevice, LightEntity):
     """Representation of a deCONZ light."""
+
+    TYPE = DOMAIN
 
     def __init__(self, device, gateway):
         """Set up light."""
@@ -220,8 +219,6 @@ class DeconzBaseLight(DeconzDevice, LightEntity):
 class DeconzLight(DeconzBaseLight):
     """Representation of a deCONZ light."""
 
-    TYPE = DOMAIN
-
     @property
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
@@ -235,8 +232,6 @@ class DeconzLight(DeconzBaseLight):
 
 class DeconzGroup(DeconzBaseLight):
     """Representation of a deCONZ group."""
-
-    TYPE = GROUP
 
     def __init__(self, device, gateway):
         """Set up group and create an unique id."""

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -78,8 +78,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if not group.lights:
                 continue
 
+            known_groups = list(gateway.entities[DOMAIN][GROUP])
             new_group = DeconzGroup(group, gateway)
-            if new_group.unique_id not in gateway.entities[DOMAIN][GROUP]:
+            if new_group.unique_id not in known_groups:
                 entities.append(new_group)
 
         async_add_entities(entities, True)

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -12,6 +12,7 @@ from pydeconz.sensor import (
     Thermostat,
 )
 
+from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     ATTR_VOLTAGE,
@@ -74,6 +75,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ sensors."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = {DOMAIN: set(), "Battery": set(), "Event": set()}
 
     batteries = set()
     battery_handler = DeconzBatteryHandler(gateway)
@@ -126,6 +128,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class DeconzSensor(DeconzDevice):
     """Representation of a deCONZ sensor."""
+
+    DOMAIN = DOMAIN
+    TYPE = DOMAIN
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):
@@ -191,6 +196,9 @@ class DeconzSensor(DeconzDevice):
 
 class DeconzBattery(DeconzDevice):
     """Battery class for when a device is only represented as an event."""
+
+    DOMAIN = DOMAIN
+    TYPE = "Battery"
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -99,8 +99,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if sensor.battery is not None:
                 battery_handler.remove_tracker(sensor)
 
+                known_batteries = list(gateway.entities[DOMAIN][BATTERY])
                 new_battery = DeconzBattery(sensor, gateway)
-                if new_battery.unique_id not in gateway.entities[DOMAIN][BATTERY]:
+                if new_battery.unique_id not in known_batteries:
                     entities.append(new_battery)
 
             else:

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -87,7 +87,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         """Add sensors from deCONZ.
 
         Create DeconzBattery if sensor has a battery attribute.
-        Create DeconzEvent if part of ZHAType list.
         Create DeconzSensor if not a battery, switch or thermostat and not a binary sensor.
         """
         entities = []
@@ -109,7 +108,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 battery_handler.create_tracker(sensor)
 
             if (
-                sensor.BINARY is False
+                not sensor.BINARY
                 and sensor.type
                 not in Battery.ZHATYPE + Switch.ZHATYPE + Thermostat.ZHATYPE
                 and sensor.uniqueid not in gateway.entities[DOMAIN]

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -77,7 +77,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ sensors."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[DOMAIN] = {DOMAIN: set(), BATTERY: set(), EVENT: set()}
+    gateway.entities[BATTERY] = set()
+    gateway.entities[DOMAIN] = set()
+    gateway.entities[EVENT] = set()
 
     battery_handler = DeconzBatteryHandler(gateway)
 
@@ -99,7 +101,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if sensor.battery is not None:
                 battery_handler.remove_tracker(sensor)
 
-                known_batteries = list(gateway.entities[DOMAIN][BATTERY])
+                known_batteries = list(gateway.entities[BATTERY])
                 new_battery = DeconzBattery(sensor, gateway)
                 if new_battery.unique_id not in known_batteries:
                     entities.append(new_battery)
@@ -111,7 +113,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 sensor.BINARY is False
                 and sensor.type
                 not in Battery.ZHATYPE + Switch.ZHATYPE + Thermostat.ZHATYPE
-                and sensor.uniqueid not in gateway.entities[DOMAIN][DOMAIN]
+                and sensor.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzSensor(sensor, gateway))
 
@@ -131,7 +133,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DeconzSensor(DeconzDevice):
     """Representation of a deCONZ sensor."""
 
-    DOMAIN = DOMAIN
     TYPE = DOMAIN
 
     @callback
@@ -199,7 +200,6 @@ class DeconzSensor(DeconzDevice):
 class DeconzBattery(DeconzDevice):
     """Battery class for when a device is only represented as an event."""
 
-    DOMAIN = DOMAIN
     TYPE = BATTERY
 
     @callback

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -79,7 +79,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[BATTERY] = set()
     gateway.entities[DOMAIN] = set()
-    gateway.entities[EVENT] = set()
 
     battery_handler = DeconzBatteryHandler(gateway)
 

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -67,8 +67,6 @@ UNIT_OF_MEASUREMENT = {
     Temperature: TEMP_CELSIUS,
 }
 
-BATTERY = "battery"
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up deCONZ platforms."""
@@ -77,7 +75,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ sensors."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[BATTERY] = set()
     gateway.entities[DOMAIN] = set()
 
     battery_handler = DeconzBatteryHandler(gateway)
@@ -99,7 +96,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if sensor.battery is not None:
                 battery_handler.remove_tracker(sensor)
 
-                known_batteries = list(gateway.entities[BATTERY])
+                known_batteries = list(gateway.entities[DOMAIN])
                 new_battery = DeconzBattery(sensor, gateway)
                 if new_battery.unique_id not in known_batteries:
                     entities.append(new_battery)
@@ -198,7 +195,7 @@ class DeconzSensor(DeconzDevice):
 class DeconzBattery(DeconzDevice):
     """Battery class for when a device is only represented as an event."""
 
-    TYPE = BATTERY
+    TYPE = DOMAIN
 
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -1,14 +1,11 @@
 """Support for deCONZ switches."""
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import NEW_LIGHT, POWER_PLUGS, SIRENS
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
-
-POWER_PLUG = "power_plug"
-SIREN = "siren"
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -21,8 +18,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Switches are based on the same device class as lights in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[POWER_PLUG] = set()
-    gateway.entities[SIREN] = set()
+    gateway.entities[DOMAIN] = set()
 
     @callback
     def async_add_switch(lights):
@@ -33,11 +29,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 light.type in POWER_PLUGS
-                and light.uniqueid not in gateway.entities[POWER_PLUG]
+                and light.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzPowerPlug(light, gateway))
 
-            elif light.type in SIRENS and light.uniqueid not in gateway.entities[SIREN]:
+            elif (
+                light.type in SIRENS and light.uniqueid not in gateway.entities[DOMAIN]
+            ):
                 entities.append(DeconzSiren(light, gateway))
 
         async_add_entities(entities, True)
@@ -54,7 +52,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DeconzPowerPlug(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ power plug."""
 
-    TYPE = POWER_PLUG
+    TYPE = DOMAIN
 
     @property
     def is_on(self):
@@ -75,7 +73,7 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
 class DeconzSiren(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ siren."""
 
-    TYPE = SIREN
+    TYPE = DOMAIN
 
     @property
     def is_on(self):

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -1,5 +1,5 @@
 """Support for deCONZ switches."""
-from homeassistant.components.switch import DOMAIN, SwitchEntity
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -21,7 +21,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Switches are based on the same device class as lights in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[DOMAIN] = {POWER_PLUG: set(), SIREN: set()}
+    gateway.entities[POWER_PLUG] = set()
+    gateway.entities[SIREN] = set()
 
     @callback
     def async_add_switch(lights):
@@ -32,14 +33,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 light.type in POWER_PLUGS
-                and light.uniqueid not in gateway.entities[DOMAIN][POWER_PLUG]
+                and light.uniqueid not in gateway.entities[POWER_PLUG]
             ):
                 entities.append(DeconzPowerPlug(light, gateway))
 
-            elif (
-                light.type in SIRENS
-                and light.uniqueid not in gateway.entities[DOMAIN][SIREN]
-            ):
+            elif light.type in SIRENS and light.uniqueid not in gateway.entities[SIREN]:
                 entities.append(DeconzSiren(light, gateway))
 
         async_add_entities(entities, True)
@@ -56,7 +54,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DeconzPowerPlug(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ power plug."""
 
-    DOMAIN = DOMAIN
     TYPE = POWER_PLUG
 
     @property
@@ -78,7 +75,6 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
 class DeconzSiren(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ siren."""
 
-    DOMAIN = DOMAIN
     TYPE = SIREN
 
     @property

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -1,5 +1,5 @@
 """Support for deCONZ switches."""
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -18,6 +18,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Switches are based same device class as lights in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = {"PowerPlug": set(), "Siren": set()}
 
     @callback
     def async_add_switch(lights):
@@ -46,6 +47,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DeconzPowerPlug(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ power plug."""
 
+    DOMAIN = DOMAIN
+    TYPE = "PowerPlug"
+
     @property
     def is_on(self):
         """Return true if switch is on."""
@@ -64,6 +68,9 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
 
 class DeconzSiren(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ siren."""
+
+    DOMAIN = DOMAIN
+    TYPE = "Siren"
 
     @property
     def is_on(self):

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -7,6 +7,9 @@ from .const import NEW_LIGHT, POWER_PLUGS, SIRENS
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
+POWER_PLUG = "power_plug"
+SIREN = "siren"
+
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up deCONZ platforms."""
@@ -15,10 +18,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switches for deCONZ component.
 
-    Switches are based same device class as lights in deCONZ.
+    Switches are based on the same device class as lights in deCONZ.
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
-    gateway.entities[DOMAIN] = {"PowerPlug": set(), "Siren": set()}
+    gateway.entities[DOMAIN] = {POWER_PLUG: set(), SIREN: set()}
 
     @callback
     def async_add_switch(lights):
@@ -27,10 +30,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for light in lights:
 
-            if light.type in POWER_PLUGS:
+            if (
+                light.type in POWER_PLUGS
+                and light.uniqueid not in gateway.entities[DOMAIN][POWER_PLUG]
+            ):
                 entities.append(DeconzPowerPlug(light, gateway))
 
-            elif light.type in SIRENS:
+            elif (
+                light.type in SIRENS
+                and light.uniqueid not in gateway.entities[DOMAIN][SIREN]
+            ):
                 entities.append(DeconzSiren(light, gateway))
 
         async_add_entities(entities, True)
@@ -48,7 +57,7 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ power plug."""
 
     DOMAIN = DOMAIN
-    TYPE = "PowerPlug"
+    TYPE = POWER_PLUG
 
     @property
     def is_on(self):
@@ -70,7 +79,7 @@ class DeconzSiren(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ siren."""
 
     DOMAIN = DOMAIN
-    TYPE = "Siren"
+    TYPE = SIREN
 
     @property
     def is_on(self):

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -67,6 +67,7 @@ async def test_no_binary_sensors(hass):
     """Test that no sensors in deconz results in no sensor entities."""
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 0
     assert len(hass.states.async_all()) == 0
 
 
@@ -80,6 +81,7 @@ async def test_binary_sensors(hass):
     assert "binary_sensor.clip_presence_sensor" not in gateway.deconz_ids
     assert "binary_sensor.vibration_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 3
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 2
 
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
     assert presence_sensor.state == "off"
@@ -111,6 +113,7 @@ async def test_binary_sensors(hass):
     await gateway.async_reset()
 
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 0
 
 
 async def test_allow_clip_sensor(hass):
@@ -127,6 +130,7 @@ async def test_allow_clip_sensor(hass):
     assert "binary_sensor.clip_presence_sensor" in gateway.deconz_ids
     assert "binary_sensor.vibration_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 4
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 3
 
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
     assert presence_sensor.state == "off"
@@ -150,6 +154,7 @@ async def test_allow_clip_sensor(hass):
     assert "binary_sensor.clip_presence_sensor" not in gateway.deconz_ids
     assert "binary_sensor.vibration_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 3
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 2
 
     hass.config_entries.async_update_entry(
         gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: True}
@@ -161,12 +166,14 @@ async def test_allow_clip_sensor(hass):
     assert "binary_sensor.clip_presence_sensor" in gateway.deconz_ids
     assert "binary_sensor.vibration_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 4
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 3
 
 
 async def test_add_new_binary_sensor(hass):
     """Test that adding a new binary sensor works."""
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 0
 
     state_added_event = {
         "t": "event",
@@ -182,3 +189,4 @@ async def test_add_new_binary_sensor(hass):
 
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
     assert presence_sensor.state == "off"
+    assert len(gateway.entities[binary_sensor.DOMAIN]) == 1

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -59,6 +59,7 @@ async def test_no_sensors(hass):
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[climate.DOMAIN]) == 0
 
 
 async def test_climate_devices(hass):
@@ -72,6 +73,7 @@ async def test_climate_devices(hass):
     assert "climate.presence_sensor" not in gateway.deconz_ids
     assert "climate.clip_thermostat" not in gateway.deconz_ids
     assert len(hass.states.async_all()) == 3
+    assert len(gateway.entities[climate.DOMAIN]) == 1
 
     thermostat = hass.states.get("climate.thermostat")
     assert thermostat.state == "auto"
@@ -181,6 +183,7 @@ async def test_climate_devices(hass):
     await gateway.async_reset()
 
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[climate.DOMAIN]) == 0
 
 
 async def test_clip_climate_device(hass):
@@ -198,6 +201,7 @@ async def test_clip_climate_device(hass):
     assert "climate.presence_sensor" not in gateway.deconz_ids
     assert "climate.clip_thermostat" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 4
+    assert len(gateway.entities[climate.DOMAIN]) == 2
 
     thermostat = hass.states.get("climate.thermostat")
     assert thermostat.state == "auto"
@@ -225,6 +229,7 @@ async def test_clip_climate_device(hass):
     assert "climate.presence_sensor" not in gateway.deconz_ids
     assert "climate.clip_thermostat" not in gateway.deconz_ids
     assert len(hass.states.async_all()) == 3
+    assert len(gateway.entities[climate.DOMAIN]) == 1
 
     hass.config_entries.async_update_entry(
         gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: True}
@@ -237,6 +242,7 @@ async def test_clip_climate_device(hass):
     assert "climate.presence_sensor" not in gateway.deconz_ids
     assert "climate.clip_thermostat" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 4
+    assert len(gateway.entities[climate.DOMAIN]) == 2
 
 
 async def test_verify_state_update(hass):
@@ -268,6 +274,7 @@ async def test_add_new_climate_device(hass):
     """Test that adding a new climate device works."""
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
+    assert len(gateway.entities[climate.DOMAIN]) == 0
 
     state_added_event = {
         "t": "event",
@@ -283,3 +290,4 @@ async def test_add_new_climate_device(hass):
 
     thermostat = hass.states.get("climate.thermostat")
     assert thermostat.state == "auto"
+    assert len(gateway.entities[climate.DOMAIN]) == 1

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -67,6 +67,7 @@ async def test_no_covers(hass):
     """Test that no cover entities are created."""
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
+    assert len(gateway.entities[cover.DOMAIN]) == 0
     assert len(hass.states.async_all()) == 0
 
 
@@ -81,6 +82,7 @@ async def test_cover(hass):
     assert "cover.deconz_old_brightness_cover" in gateway.deconz_ids
     assert "cover.window_covering_controller" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 5
+    assert len(gateway.entities[cover.DOMAIN]) == 4
 
     level_controllable_cover = hass.states.get("cover.level_controllable_cover")
     assert level_controllable_cover.state == "open"
@@ -158,3 +160,4 @@ async def test_cover(hass):
     await gateway.async_reset()
 
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[cover.DOMAIN]) == 0

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -1,7 +1,7 @@
 """Test deCONZ remote events."""
 from copy import deepcopy
 
-from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
+from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT, EVENT
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
@@ -62,6 +62,7 @@ async def test_deconz_events(hass):
     assert "sensor.switch_2_battery_level" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 3
     assert len(gateway.events) == 5
+    assert len(gateway.entities[EVENT]) == 5
 
     switch_1 = hass.states.get("sensor.switch_1")
     assert switch_1 is None
@@ -127,3 +128,4 @@ async def test_deconz_events(hass):
 
     assert len(hass.states.async_all()) == 0
     assert len(gateway.events) == 0
+    assert len(gateway.entities[EVENT]) == 0

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -2,6 +2,7 @@
 from copy import deepcopy
 
 from homeassistant.components import deconz
+from homeassistant.components.deconz.light import GROUP
 import homeassistant.components.light as light
 from homeassistant.setup import async_setup_component
 
@@ -95,6 +96,8 @@ async def test_no_lights_or_groups(hass):
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[light.DOMAIN]) == 0
+    assert len(gateway.entities[GROUP]) == 0
 
 
 async def test_lights_and_groups(hass):
@@ -111,6 +114,8 @@ async def test_lights_and_groups(hass):
     assert "light.on_off_light" in gateway.deconz_ids
 
     assert len(hass.states.async_all()) == 6
+    assert len(gateway.entities[light.DOMAIN]) == 4
+    assert len(gateway.entities[GROUP]) == 1
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light.state == "on"
@@ -256,6 +261,8 @@ async def test_lights_and_groups(hass):
     await gateway.async_reset()
 
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[light.DOMAIN]) == 0
+    assert len(gateway.entities[GROUP]) == 0
 
 
 async def test_disable_light_groups(hass):
@@ -275,6 +282,8 @@ async def test_disable_light_groups(hass):
     assert "light.on_off_switch" not in gateway.deconz_ids
     # 3 entities
     assert len(hass.states.async_all()) == 5
+    assert len(gateway.entities[light.DOMAIN]) == 4
+    assert len(gateway.entities[GROUP]) == 0
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light is not None
@@ -300,6 +309,8 @@ async def test_disable_light_groups(hass):
     assert "light.on_off_switch" not in gateway.deconz_ids
     # 3 entities
     assert len(hass.states.async_all()) == 6
+    assert len(gateway.entities[light.DOMAIN]) == 4
+    assert len(gateway.entities[GROUP]) == 1
 
     hass.config_entries.async_update_entry(
         gateway.config_entry, options={deconz.gateway.CONF_ALLOW_DECONZ_GROUPS: False}
@@ -313,3 +324,5 @@ async def test_disable_light_groups(hass):
     assert "light.on_off_switch" not in gateway.deconz_ids
     # 3 entities
     assert len(hass.states.async_all()) == 5
+    assert len(gateway.entities[light.DOMAIN]) == 4
+    assert len(gateway.entities[GROUP]) == 0

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -2,7 +2,6 @@
 from copy import deepcopy
 
 from homeassistant.components import deconz
-from homeassistant.components.deconz.light import GROUP
 import homeassistant.components.light as light
 from homeassistant.setup import async_setup_component
 
@@ -97,7 +96,6 @@ async def test_no_lights_or_groups(hass):
     assert len(gateway.deconz_ids) == 0
     assert len(hass.states.async_all()) == 0
     assert len(gateway.entities[light.DOMAIN]) == 0
-    assert len(gateway.entities[GROUP]) == 0
 
 
 async def test_lights_and_groups(hass):
@@ -114,8 +112,7 @@ async def test_lights_and_groups(hass):
     assert "light.on_off_light" in gateway.deconz_ids
 
     assert len(hass.states.async_all()) == 6
-    assert len(gateway.entities[light.DOMAIN]) == 4
-    assert len(gateway.entities[GROUP]) == 1
+    assert len(gateway.entities[light.DOMAIN]) == 5
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light.state == "on"
@@ -262,7 +259,6 @@ async def test_lights_and_groups(hass):
 
     assert len(hass.states.async_all()) == 0
     assert len(gateway.entities[light.DOMAIN]) == 0
-    assert len(gateway.entities[GROUP]) == 0
 
 
 async def test_disable_light_groups(hass):
@@ -283,7 +279,6 @@ async def test_disable_light_groups(hass):
     # 3 entities
     assert len(hass.states.async_all()) == 5
     assert len(gateway.entities[light.DOMAIN]) == 4
-    assert len(gateway.entities[GROUP]) == 0
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light is not None
@@ -309,8 +304,7 @@ async def test_disable_light_groups(hass):
     assert "light.on_off_switch" not in gateway.deconz_ids
     # 3 entities
     assert len(hass.states.async_all()) == 6
-    assert len(gateway.entities[light.DOMAIN]) == 4
-    assert len(gateway.entities[GROUP]) == 1
+    assert len(gateway.entities[light.DOMAIN]) == 5
 
     hass.config_entries.async_update_entry(
         gateway.config_entry, options={deconz.gateway.CONF_ALLOW_DECONZ_GROUPS: False}
@@ -325,4 +319,3 @@ async def test_disable_light_groups(hass):
     # 3 entities
     assert len(hass.states.async_all()) == 5
     assert len(gateway.entities[light.DOMAIN]) == 4
-    assert len(gateway.entities[GROUP]) == 0

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -2,6 +2,8 @@
 from copy import deepcopy
 
 from homeassistant.components import deconz
+from homeassistant.components.deconz.deconz_event import EVENT
+from homeassistant.components.deconz.sensor import BATTERY
 import homeassistant.components.sensor as sensor
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
@@ -96,6 +98,8 @@ async def test_no_sensors(hass):
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[sensor.DOMAIN]) == 0
+    assert len(gateway.entities[BATTERY]) == 0
 
 
 async def test_sensors(hass):
@@ -114,6 +118,8 @@ async def test_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" not in gateway.deconz_ids
     assert len(hass.states.async_all()) == 5
+    assert len(gateway.entities[sensor.DOMAIN]) == 4
+    assert len(gateway.entities[BATTERY]) == 1
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
     assert light_level_sensor.state == "999.8"
@@ -174,6 +180,9 @@ async def test_sensors(hass):
     await gateway.async_reset()
 
     assert len(hass.states.async_all()) == 0
+    # Daylight sensor from deCONZ is added to set but is disabled by default
+    assert len(gateway.entities[sensor.DOMAIN]) == 1
+    assert len(gateway.entities[BATTERY]) == 0
 
 
 async def test_allow_clip_sensors(hass):
@@ -196,6 +205,8 @@ async def test_allow_clip_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 6
+    assert len(gateway.entities[sensor.DOMAIN]) == 5
+    assert len(gateway.entities[BATTERY]) == 1
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
     assert light_level_sensor.state == "999.8"
@@ -243,6 +254,8 @@ async def test_allow_clip_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" not in gateway.deconz_ids
     assert len(hass.states.async_all()) == 5
+    assert len(gateway.entities[sensor.DOMAIN]) == 4
+    assert len(gateway.entities[BATTERY]) == 1
 
     hass.config_entries.async_update_entry(
         gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: True}
@@ -260,6 +273,8 @@ async def test_allow_clip_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 6
+    assert len(gateway.entities[sensor.DOMAIN]) == 5
+    assert len(gateway.entities[BATTERY]) == 1
 
 
 async def test_add_new_sensor(hass):
@@ -292,6 +307,9 @@ async def test_add_battery_later(hass):
     assert len(gateway.deconz_ids) == 0
     assert len(gateway.events) == 1
     assert len(remote._callbacks) == 2
+    assert len(gateway.entities[sensor.DOMAIN]) == 0
+    assert len(gateway.entities[BATTERY]) == 0
+    assert len(gateway.entities[EVENT]) == 1
 
     remote.update({"config": {"battery": 50}})
     await hass.async_block_till_done()
@@ -302,3 +320,6 @@ async def test_add_battery_later(hass):
 
     battery_sensor = hass.states.get("sensor.switch_1_battery_level")
     assert battery_sensor is not None
+    assert len(gateway.entities[sensor.DOMAIN]) == 0
+    assert len(gateway.entities[BATTERY]) == 1
+    assert len(gateway.entities[EVENT]) == 1

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 
 from homeassistant.components import deconz
 from homeassistant.components.deconz.deconz_event import EVENT
-from homeassistant.components.deconz.sensor import BATTERY
 import homeassistant.components.sensor as sensor
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
@@ -99,7 +98,6 @@ async def test_no_sensors(hass):
     assert len(gateway.deconz_ids) == 0
     assert len(hass.states.async_all()) == 0
     assert len(gateway.entities[sensor.DOMAIN]) == 0
-    assert len(gateway.entities[BATTERY]) == 0
 
 
 async def test_sensors(hass):
@@ -118,8 +116,7 @@ async def test_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" not in gateway.deconz_ids
     assert len(hass.states.async_all()) == 5
-    assert len(gateway.entities[sensor.DOMAIN]) == 4
-    assert len(gateway.entities[BATTERY]) == 1
+    assert len(gateway.entities[sensor.DOMAIN]) == 5
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
     assert light_level_sensor.state == "999.8"
@@ -182,7 +179,6 @@ async def test_sensors(hass):
     assert len(hass.states.async_all()) == 0
     # Daylight sensor from deCONZ is added to set but is disabled by default
     assert len(gateway.entities[sensor.DOMAIN]) == 1
-    assert len(gateway.entities[BATTERY]) == 0
 
 
 async def test_allow_clip_sensors(hass):
@@ -205,8 +201,7 @@ async def test_allow_clip_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 6
-    assert len(gateway.entities[sensor.DOMAIN]) == 5
-    assert len(gateway.entities[BATTERY]) == 1
+    assert len(gateway.entities[sensor.DOMAIN]) == 6
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
     assert light_level_sensor.state == "999.8"
@@ -254,8 +249,7 @@ async def test_allow_clip_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" not in gateway.deconz_ids
     assert len(hass.states.async_all()) == 5
-    assert len(gateway.entities[sensor.DOMAIN]) == 4
-    assert len(gateway.entities[BATTERY]) == 1
+    assert len(gateway.entities[sensor.DOMAIN]) == 5
 
     hass.config_entries.async_update_entry(
         gateway.config_entry, options={deconz.gateway.CONF_ALLOW_CLIP_SENSOR: True}
@@ -273,8 +267,7 @@ async def test_allow_clip_sensors(hass):
     assert "sensor.consumption_sensor" in gateway.deconz_ids
     assert "sensor.clip_light_level_sensor" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 6
-    assert len(gateway.entities[sensor.DOMAIN]) == 5
-    assert len(gateway.entities[BATTERY]) == 1
+    assert len(gateway.entities[sensor.DOMAIN]) == 6
 
 
 async def test_add_new_sensor(hass):
@@ -308,7 +301,6 @@ async def test_add_battery_later(hass):
     assert len(gateway.events) == 1
     assert len(remote._callbacks) == 2
     assert len(gateway.entities[sensor.DOMAIN]) == 0
-    assert len(gateway.entities[BATTERY]) == 0
     assert len(gateway.entities[EVENT]) == 1
 
     remote.update({"config": {"battery": 50}})
@@ -320,6 +312,5 @@ async def test_add_battery_later(hass):
 
     battery_sensor = hass.states.get("sensor.switch_1_battery_level")
     assert battery_sensor is not None
-    assert len(gateway.entities[sensor.DOMAIN]) == 0
-    assert len(gateway.entities[BATTERY]) == 1
+    assert len(gateway.entities[sensor.DOMAIN]) == 1
     assert len(gateway.entities[EVENT]) == 1

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -2,6 +2,7 @@
 from copy import deepcopy
 
 from homeassistant.components import deconz
+from homeassistant.components.deconz.switch import POWER_PLUG, SIREN
 import homeassistant.components.switch as switch
 from homeassistant.setup import async_setup_component
 
@@ -64,6 +65,8 @@ async def test_no_switches(hass):
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[POWER_PLUG]) == 0
+    assert len(gateway.entities[SIREN]) == 0
 
 
 async def test_switches(hass):
@@ -77,6 +80,8 @@ async def test_switches(hass):
     assert "switch.unsupported_switch" not in gateway.deconz_ids
     assert "switch.on_off_relay" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 5
+    assert len(gateway.entities[POWER_PLUG]) == 3
+    assert len(gateway.entities[SIREN]) == 1
 
     on_off_switch = hass.states.get("switch.on_off_switch")
     assert on_off_switch.state == "on"
@@ -173,3 +178,5 @@ async def test_switches(hass):
     await gateway.async_reset()
 
     assert len(hass.states.async_all()) == 0
+    assert len(gateway.entities[POWER_PLUG]) == 0
+    assert len(gateway.entities[SIREN]) == 0

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -2,7 +2,6 @@
 from copy import deepcopy
 
 from homeassistant.components import deconz
-from homeassistant.components.deconz.switch import POWER_PLUG, SIREN
 import homeassistant.components.switch as switch
 from homeassistant.setup import async_setup_component
 
@@ -65,8 +64,7 @@ async def test_no_switches(hass):
     gateway = await setup_deconz_integration(hass)
     assert len(gateway.deconz_ids) == 0
     assert len(hass.states.async_all()) == 0
-    assert len(gateway.entities[POWER_PLUG]) == 0
-    assert len(gateway.entities[SIREN]) == 0
+    assert len(gateway.entities[switch.DOMAIN]) == 0
 
 
 async def test_switches(hass):
@@ -80,8 +78,7 @@ async def test_switches(hass):
     assert "switch.unsupported_switch" not in gateway.deconz_ids
     assert "switch.on_off_relay" in gateway.deconz_ids
     assert len(hass.states.async_all()) == 5
-    assert len(gateway.entities[POWER_PLUG]) == 3
-    assert len(gateway.entities[SIREN]) == 1
+    assert len(gateway.entities[switch.DOMAIN]) == 4
 
     on_off_switch = hass.states.get("switch.on_off_switch")
     assert on_off_switch.state == "on"
@@ -178,5 +175,4 @@ async def test_switches(hass):
     await gateway.async_reset()
 
     assert len(hass.states.async_all()) == 0
-    assert len(gateway.entities[POWER_PLUG]) == 0
-    assert len(gateway.entities[SIREN]) == 0
+    assert len(gateway.entities[switch.DOMAIN]) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve handling of how to track what entities are known to the integration. This will help in future PRs improving config entry options and signalling of adding / removing entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
