### PR TITLE
Fix textual error in dutch Unifi translation

### DIFF
--- a/homeassistant/components/unifi/.translations/nl.json
+++ b/homeassistant/components/unifi/.translations/nl.json
@@ -16,7 +16,7 @@
                     "port": "Poort",
                     "site": "Site ID",
                     "username": "Gebruikersnaam",
-                    "verify_ssl": "Controller gebruik van het juiste certificaat"
+                    "verify_ssl": "Controleer gebruik van het juiste certificaat"
                 },
                 "title": "Stel de UniFi-controller in"
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minor textual error. In the given textual context the word "Controleer" (==verify/check)  should be used and not "Controller".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

Textual fix in translation

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
