### PR TITLE
Fix ozone forecast sensors in AccuWeather integration

### DIFF
--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -104,6 +104,7 @@ class AccuWeatherSensor(CoordinatorEntity):
                 return self.coordinator.data[ATTR_FORECAST][self.forecast_day][
                     self.kind
                 ]["Value"]
+            # For some forecast days, the AccuWeather API does not provide an Ozone value.
             if self.kind == "Ozone":
                 return (
                     self.coordinator.data[ATTR_FORECAST][self.forecast_day][self.kind][
@@ -162,6 +163,7 @@ class AccuWeatherSensor(CoordinatorEntity):
                 self._attrs["level"] = self.coordinator.data[ATTR_FORECAST][
                     self.forecast_day
                 ][self.kind]["Category"]
+            # For some forecast days, the AccuWeather API does not provide an Ozone value.
             elif self.kind == "Ozone" and self.coordinator.data[ATTR_FORECAST][
                 self.forecast_day
             ].get(self.kind):

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -100,10 +100,20 @@ class AccuWeatherSensor(CoordinatorEntity):
                 return self.coordinator.data[ATTR_FORECAST][self.forecast_day][
                     self.kind
                 ]["Speed"]["Value"]
-            if self.kind in ["Grass", "Mold", "Ragweed", "Tree", "UVIndex", "Ozone"]:
+            if self.kind in ["Grass", "Mold", "Ragweed", "Tree", "UVIndex"]:
                 return self.coordinator.data[ATTR_FORECAST][self.forecast_day][
                     self.kind
                 ]["Value"]
+            if self.kind == "Ozone":
+                return (
+                    self.coordinator.data[ATTR_FORECAST][self.forecast_day][self.kind][
+                        "Value"
+                    ]
+                    if self.coordinator.data[ATTR_FORECAST][self.forecast_day].get(
+                        self.kind
+                    )
+                    else None
+                )
             return self.coordinator.data[ATTR_FORECAST][self.forecast_day][self.kind]
         if self.kind == "Ceiling":
             return round(self.coordinator.data[self.kind][self._unit_system]["Value"])
@@ -148,7 +158,13 @@ class AccuWeatherSensor(CoordinatorEntity):
                 self._attrs["direction"] = self.coordinator.data[ATTR_FORECAST][
                     self.forecast_day
                 ][self.kind]["Direction"]["English"]
-            elif self.kind in ["Grass", "Mold", "Ragweed", "Tree", "UVIndex", "Ozone"]:
+            elif self.kind in ["Grass", "Mold", "Ragweed", "Tree", "UVIndex"]:
+                self._attrs["level"] = self.coordinator.data[ATTR_FORECAST][
+                    self.forecast_day
+                ][self.kind]["Category"]
+            elif self.kind == "Ozone" and self.coordinator.data[ATTR_FORECAST][
+                self.forecast_day
+            ].get(self.kind):
                 self._attrs["level"] = self.coordinator.data[ATTR_FORECAST][
                     self.forecast_day
                 ][self.kind]["Category"]

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -60,6 +60,7 @@ class AccuWeatherSensor(CoordinatorEntity):
         self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
         self._unit_system = "Metric" if self.coordinator.is_metric else "Imperial"
         self.forecast_day = forecast_day
+        self._valid_ozone_data = False
 
     @property
     def name(self):
@@ -105,14 +106,15 @@ class AccuWeatherSensor(CoordinatorEntity):
                     self.kind
                 ]["Value"]
             # For some forecast days, the AccuWeather API does not provide an Ozone value.
+            self._valid_ozone_data = bool(
+                self.coordinator.data[ATTR_FORECAST][self.forecast_day].get(self.kind)
+            )
             if self.kind == "Ozone":
                 return (
                     self.coordinator.data[ATTR_FORECAST][self.forecast_day][self.kind][
                         "Value"
                     ]
-                    if self.coordinator.data[ATTR_FORECAST][self.forecast_day].get(
-                        self.kind
-                    )
+                    if self._valid_ozone_data
                     else None
                 )
             return self.coordinator.data[ATTR_FORECAST][self.forecast_day][self.kind]
@@ -164,9 +166,7 @@ class AccuWeatherSensor(CoordinatorEntity):
                     self.forecast_day
                 ][self.kind]["Category"]
             # For some forecast days, the AccuWeather API does not provide an Ozone value.
-            elif self.kind == "Ozone" and self.coordinator.data[ATTR_FORECAST][
-                self.forecast_day
-            ].get(self.kind):
+            elif self.kind == "Ozone" and self._valid_ozone_data:
                 self._attrs["level"] = self.coordinator.data[ATTR_FORECAST][
                     self.forecast_day
                 ][self.kind]["Category"]

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -458,6 +458,14 @@ async def test_sensor_enabled_without_forecast(hass):
     assert entry
     assert entry.unique_id == "0123456-ozone-0"
 
+    # For some forecast days, the AccuWeather API does not provide an Ozone value.
+    state = hass.states.get("sensor.home_ozone_1d")
+    assert state is None
+
+    entry = registry.async_get("sensor.home_ozone_1d")
+    assert entry
+    assert entry.unique_id == "0123456-ozone-1"
+
     state = hass.states.get("sensor.home_ragweed_pollen_0d")
     assert state
     assert state.state == "0"

--- a/tests/fixtures/accuweather/forecast_data.json
+++ b/tests/fixtures/accuweather/forecast_data.json
@@ -214,11 +214,6 @@
                 "UnitType": 17
             }
         },
-        "Ozone": {
-            "Value": 39,
-            "Category": "Good",
-            "CategoryValue": 1
-        },
         "Grass": {
             "Value": 0,
             "Category": "Low",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For some forecast days, the AccuWeather API doesn't provide an Ozone value, which causes a `KeyError` exception.
This PR fix that. If there is no Ozone value, the sensor state is `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
