### PR TITLE
Update xknx to 0.14.2

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -6,7 +6,12 @@ from xknx import XKNX
 from xknx.devices import DateTime, ExposeSensor
 from xknx.dpt import DPTArray, DPTBase, DPTBinary
 from xknx.exceptions import XKNXException
-from xknx.io import DEFAULT_MCAST_PORT, ConnectionConfig, ConnectionType
+from xknx.io import (
+    DEFAULT_MCAST_GRP,
+    DEFAULT_MCAST_PORT,
+    ConnectionConfig,
+    ConnectionType,
+)
 from xknx.telegram import AddressFilter, GroupAddress, Telegram
 
 from homeassistant.const import (
@@ -48,6 +53,9 @@ CONF_KNX_ROUTING = "routing"
 CONF_KNX_TUNNELING = "tunneling"
 CONF_KNX_FIRE_EVENT = "fire_event"
 CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
+CONF_KNX_INDIVIDUAL_ADDRESS = "individual_address"
+CONF_KNX_MCAST_GRP = "multicast_group"
+CONF_KNX_MCAST_PORT = "multicast_port"
 CONF_KNX_STATE_UPDATER = "state_updater"
 CONF_KNX_RATE_LIMIT = "rate_limit"
 CONF_KNX_EXPOSE = "expose"
@@ -72,6 +80,11 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Inclusive(CONF_KNX_FIRE_EVENT_FILTER, "fire_ev"): vol.All(
                     cv.ensure_list, [cv.string]
                 ),
+                vol.Optional(
+                    CONF_KNX_INDIVIDUAL_ADDRESS, default=XKNX.DEFAULT_ADDRESS
+                ): cv.string,
+                vol.Optional(CONF_KNX_MCAST_GRP, default=DEFAULT_MCAST_GRP): cv.string,
+                vol.Optional(CONF_KNX_MCAST_PORT, default=DEFAULT_MCAST_PORT): cv.port,
                 vol.Optional(CONF_KNX_STATE_UPDATER, default=True): cv.boolean,
                 vol.Optional(CONF_KNX_RATE_LIMIT, default=20): vol.All(
                     vol.Coerce(int), vol.Range(min=1, max=100)
@@ -130,17 +143,15 @@ async def async_setup(hass, config):
         hass.data[DATA_KNX].async_create_exposures()
         await hass.data[DATA_KNX].start()
     except XKNXException as ex:
-        _LOGGER.warning("Can't connect to KNX interface: %s", ex)
+        _LOGGER.warning("Could not connect to KNX interface: %s", ex)
         hass.components.persistent_notification.async_create(
-            f"Can't connect to KNX interface: <br><b>{ex}</b>", title="KNX"
+            f"Could not connect to KNX interface: <br><b>{ex}</b>", title="KNX"
         )
 
     for platform in SupportedPlatforms:
         if platform.value in config[DOMAIN]:
             for device_config in config[DOMAIN][platform.value]:
-                create_knx_device(
-                    hass, platform, hass.data[DATA_KNX].xknx, device_config
-                )
+                create_knx_device(platform, hass.data[DATA_KNX].xknx, device_config)
 
     # We need to wait until all entities are loaded into the device list since they could also be created from other platforms
     for platform in SupportedPlatforms:
@@ -181,7 +192,10 @@ class KNXModule:
         self.xknx = XKNX(
             config=self.config_file(),
             loop=self.hass.loop,
+            own_address=self.config[DOMAIN][CONF_KNX_INDIVIDUAL_ADDRESS],
             rate_limit=self.config[DOMAIN][CONF_KNX_RATE_LIMIT],
+            multicast_group=self.config[DOMAIN][CONF_KNX_MCAST_GRP],
+            multicast_port=self.config[DOMAIN][CONF_KNX_MCAST_PORT],
         )
 
     async def start(self):
@@ -229,12 +243,10 @@ class KNXModule:
     def connection_config_tunneling(self):
         """Return the connection_config if tunneling is configured."""
         gateway_ip = self.config[DOMAIN][CONF_KNX_TUNNELING][CONF_HOST]
-        gateway_port = self.config[DOMAIN][CONF_KNX_TUNNELING].get(CONF_PORT)
+        gateway_port = self.config[DOMAIN][CONF_KNX_TUNNELING][CONF_PORT]
         local_ip = self.config[DOMAIN][CONF_KNX_TUNNELING].get(
             ConnectionSchema.CONF_KNX_LOCAL_IP
         )
-        if gateway_port is None:
-            gateway_port = DEFAULT_MCAST_PORT
         return ConnectionConfig(
             connection_type=ConnectionType.TUNNELING,
             gateway_ip=gateway_ip,
@@ -267,7 +279,7 @@ class KNXModule:
             attribute = to_expose.get(ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE)
             default = to_expose.get(ExposeSchema.CONF_KNX_EXPOSE_DEFAULT)
             address = to_expose.get(ExposeSchema.CONF_KNX_EXPOSE_ADDRESS)
-            if expose_type in ["time", "date", "datetime"]:
+            if expose_type.lower() in ["time", "date", "datetime"]:
                 exposure = KNXExposeTime(self.xknx, expose_type, address)
                 exposure.async_register()
                 self.exposures.append(exposure)
@@ -313,29 +325,29 @@ class KNXModule:
         payload = calculate_payload(attr_payload)
         address = GroupAddress(attr_address)
 
-        telegram = Telegram()
-        telegram.payload = payload
-        telegram.group_address = address
+        telegram = Telegram(group_address=address, payload=payload)
         await self.xknx.telegrams.put(telegram)
 
 
 class KNXExposeTime:
     """Object to Expose Time/Date object to KNX bus."""
 
-    def __init__(self, xknx, expose_type, address):
+    def __init__(self, xknx: XKNX, expose_type: str, address: str):
         """Initialize of Expose class."""
         self.xknx = xknx
-        self.type = expose_type
+        self.expose_type = expose_type
         self.address = address
         self.device = None
 
     @callback
     def async_register(self):
         """Register listener."""
-        broadcast_type_string = self.type.upper()
-        broadcast_type = broadcast_type_string
         self.device = DateTime(
-            self.xknx, "Time", broadcast_type=broadcast_type, group_address=self.address
+            self.xknx,
+            name=self.expose_type.capitalize(),
+            broadcast_type=self.expose_type.upper(),
+            localtime=True,
+            group_address=self.address,
         )
 
 

--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -2,9 +2,10 @@
 from xknx.devices import BinarySensor as XknxBinarySensor
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 
-from . import DATA_KNX
+from .const import DATA_KNX, DOMAIN
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -27,9 +28,18 @@ class KNXBinarySensor(BinarySensorEntity):
     def async_register_callbacks(self):
         """Register callbacks to update hass after device was changed."""
 
-        async def after_update_callback(device):
+        async def after_update_callback(device: XknxBinarySensor):
             """Call after device was updated."""
             self.async_write_ha_state()
+
+            self.hass.bus.fire(
+                f"{DOMAIN}_{self.entity_id}",
+                {
+                    # how often has the input sensor been pressed
+                    "counter": device.counter,
+                    "state": STATE_ON if device.state else STATE_OFF,
+                },
+            )
 
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -1,11 +1,12 @@
 """Support for KNX/IP binary sensors."""
+from typing import Any, Dict, Optional
+
 from xknx.devices import BinarySensor as XknxBinarySensor
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 
-from .const import DATA_KNX, DOMAIN
+from .const import ATTR_COUNTER, DATA_KNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -31,15 +32,6 @@ class KNXBinarySensor(BinarySensorEntity):
         async def after_update_callback(device: XknxBinarySensor):
             """Call after device was updated."""
             self.async_write_ha_state()
-
-            self.hass.bus.fire(
-                f"{DOMAIN}_{self.entity_id}",
-                {
-                    # how often has the input sensor been pressed
-                    "counter": device.counter,
-                    "state": STATE_ON if device.state else STATE_OFF,
-                },
-            )
 
         self.device.register_device_updated_cb(after_update_callback)
 
@@ -75,3 +67,8 @@ class KNXBinarySensor(BinarySensorEntity):
     def is_on(self):
         """Return true if the binary sensor is on."""
         return self.device.is_on()
+
+    @property
+    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return device specific state attributes."""
+        return {ATTR_COUNTER: self.device.counter}

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -60,3 +60,5 @@ PRESET_MODES = {
     "Standby": PRESET_AWAY,
     "Comfort": PRESET_COMFORT,
 }
+
+ATTR_COUNTER = "counter"

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -60,3 +60,11 @@ PRESET_MODES = {
     "Standby": PRESET_AWAY,
     "Comfort": PRESET_COMFORT,
 }
+
+ATTR_BRIGHTNESS_SOUTH = "brightness_south"
+ATTR_BRIGHTNESS_NORTH = "brightness_north"
+ATTR_BRIGHTNESS_EAST = "brightness_east"
+ATTR_BRIGHTNESS_WEST = "brightness_west"
+ATTR_WIND_ALARM = "wind_alarm"
+ATTR_FROST_ALARM = "frost_alarm"
+ATTR_RAIN_ALARM = "rain_alarm"

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -60,11 +60,3 @@ PRESET_MODES = {
     "Standby": PRESET_AWAY,
     "Comfort": PRESET_COMFORT,
 }
-
-ATTR_BRIGHTNESS_SOUTH = "brightness_south"
-ATTR_BRIGHTNESS_NORTH = "brightness_north"
-ATTR_BRIGHTNESS_EAST = "brightness_east"
-ATTR_BRIGHTNESS_WEST = "brightness_west"
-ATTR_WIND_ALARM = "wind_alarm"
-ATTR_FROST_ALARM = "frost_alarm"
-ATTR_RAIN_ALARM = "rain_alarm"

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,6 +2,6 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.13.0"],
+  "requirements": ["xknx==0.14.0"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"]
 }

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,6 +2,6 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.14.0"],
+  "requirements": ["xknx==0.14.2"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"]
 }

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -1,6 +1,7 @@
 """Voluptuous schemas for the KNX integration."""
 import voluptuous as vol
 from xknx.devices.climate import SetpointShiftMode
+from xknx.io import DEFAULT_MCAST_PORT
 
 from homeassistant.const import (
     CONF_ADDRESS,
@@ -29,9 +30,9 @@ class ConnectionSchema:
 
     TUNNELING_SCHEMA = vol.Schema(
         {
+            vol.Optional(CONF_PORT, default=DEFAULT_MCAST_PORT): cv.port,
             vol.Required(CONF_HOST): cv.string,
             vol.Optional(CONF_KNX_LOCAL_IP): cv.string,
-            vol.Optional(CONF_PORT): cv.port,
         }
     )
 
@@ -84,27 +85,14 @@ class BinarySensorSchema:
     CONF_STATE_ADDRESS = CONF_STATE_ADDRESS
     CONF_SYNC_STATE = CONF_SYNC_STATE
     CONF_IGNORE_INTERNAL_STATE = "ignore_internal_state"
-    CONF_AUTOMATION = "automation"
-    CONF_HOOK = "hook"
-    CONF_DEFAULT_HOOK = "on"
-    CONF_COUNTER = "counter"
-    CONF_DEFAULT_COUNTER = 1
-    CONF_ACTION = "action"
+    CONF_CONTEXT_TIMEOUT = "context_timeout"
     CONF_RESET_AFTER = "reset_after"
 
     DEFAULT_NAME = "KNX Binary Sensor"
-    AUTOMATION_SCHEMA = vol.Schema(
-        {
-            vol.Optional(CONF_HOOK, default=CONF_DEFAULT_HOOK): cv.string,
-            vol.Optional(CONF_COUNTER, default=CONF_DEFAULT_COUNTER): cv.port,
-            vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
-        }
-    )
-
-    AUTOMATIONS_SCHEMA = vol.All(cv.ensure_list, [AUTOMATION_SCHEMA])
 
     SCHEMA = vol.All(
         cv.deprecated("significant_bit"),
+        cv.deprecated("automation"),
         vol.Schema(
             {
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -113,11 +101,13 @@ class BinarySensorSchema:
                     cv.boolean,
                     cv.string,
                 ),
-                vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=False): cv.boolean,
+                vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=True): cv.boolean,
+                vol.Optional(CONF_CONTEXT_TIMEOUT, default=1.0): vol.All(
+                    vol.Coerce(float), vol.Range(min=0, max=10)
+                ),
                 vol.Required(CONF_STATE_ADDRESS): cv.string,
                 vol.Optional(CONF_DEVICE_CLASS): cv.string,
                 vol.Optional(CONF_RESET_AFTER): cv.positive_int,
-                vol.Optional(CONF_AUTOMATION): AUTOMATIONS_SCHEMA,
             }
         ),
     )
@@ -350,6 +340,7 @@ class WeatherSchema:
     CONF_KNX_BRIGHTNESS_SOUTH_ADDRESS = "address_brightness_south"
     CONF_KNX_BRIGHTNESS_EAST_ADDRESS = "address_brightness_east"
     CONF_KNX_BRIGHTNESS_WEST_ADDRESS = "address_brightness_west"
+    CONF_KNX_BRIGHTNESS_NORTH_ADDRESS = "address_brightness_north"
     CONF_KNX_WIND_SPEED_ADDRESS = "address_wind_speed"
     CONF_KNX_RAIN_ALARM_ADDRESS = "address_rain_alarm"
     CONF_KNX_FROST_ALARM_ADDRESS = "address_frost_alarm"
@@ -374,6 +365,7 @@ class WeatherSchema:
             vol.Optional(CONF_KNX_BRIGHTNESS_SOUTH_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_BRIGHTNESS_EAST_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_BRIGHTNESS_WEST_ADDRESS): cv.string,
+            vol.Optional(CONF_KNX_BRIGHTNESS_NORTH_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_WIND_SPEED_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_RAIN_ALARM_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_FROST_ALARM_ADDRESS): cv.string,

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -1,21 +1,11 @@
 """Support for KNX/IP weather station."""
-from typing import Any, Dict, Optional
 
 from xknx.devices import Weather as XknxWeather
 
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.const import TEMP_CELSIUS
 
-from .const import (
-    ATTR_BRIGHTNESS_EAST,
-    ATTR_BRIGHTNESS_NORTH,
-    ATTR_BRIGHTNESS_SOUTH,
-    ATTR_BRIGHTNESS_WEST,
-    ATTR_FROST_ALARM,
-    ATTR_RAIN_ALARM,
-    ATTR_WIND_ALARM,
-    DATA_KNX,
-)
+from .const import DATA_KNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -76,31 +66,3 @@ class KNXWeather(WeatherEntity):
         return (
             self.device.wind_speed * 3.6 if self.device.wind_speed is not None else None
         )
-
-    @property
-    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
-        """Return the device specific state attributes."""
-        attr = {}
-
-        if self.device.brightness_south:
-            attr[ATTR_BRIGHTNESS_SOUTH] = self.device.brightness_south
-
-        if self.device.brightness_north:
-            attr[ATTR_BRIGHTNESS_NORTH] = self.device.brightness_north
-
-        if self.device.brightness_east:
-            attr[ATTR_BRIGHTNESS_EAST] = self.device.brightness_east
-
-        if self.device.brightness_west:
-            attr[ATTR_BRIGHTNESS_WEST] = self.device.brightness_west
-
-        if self.device.rain_alarm:
-            attr[ATTR_RAIN_ALARM] = self.device.rain_alarm
-
-        if self.device.wind_alarm:
-            attr[ATTR_WIND_ALARM] = self.device.wind_alarm
-
-        if self.device.frost_alarm:
-            attr[ATTR_FROST_ALARM] = self.device.frost_alarm
-
-        return attr

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -6,7 +6,16 @@ from xknx.devices import Weather as XknxWeather
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.const import TEMP_CELSIUS
 
-from .const import DATA_KNX
+from .const import (
+    ATTR_BRIGHTNESS_EAST,
+    ATTR_BRIGHTNESS_NORTH,
+    ATTR_BRIGHTNESS_SOUTH,
+    ATTR_BRIGHTNESS_WEST,
+    ATTR_FROST_ALARM,
+    ATTR_RAIN_ALARM,
+    ATTR_WIND_ALARM,
+    DATA_KNX,
+)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -71,4 +80,27 @@ class KNXWeather(WeatherEntity):
     @property
     def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return the device specific state attributes."""
-        return self.device.ha_state_attributes
+        attr = {}
+
+        if self.device.brightness_south:
+            attr[ATTR_BRIGHTNESS_SOUTH] = self.device.brightness_south
+
+        if self.device.brightness_north:
+            attr[ATTR_BRIGHTNESS_NORTH] = self.device.brightness_north
+
+        if self.device.brightness_east:
+            attr[ATTR_BRIGHTNESS_EAST] = self.device.brightness_east
+
+        if self.device.brightness_west:
+            attr[ATTR_BRIGHTNESS_WEST] = self.device.brightness_west
+
+        if self.device.rain_alarm:
+            attr[ATTR_RAIN_ALARM] = self.device.rain_alarm
+
+        if self.device.wind_alarm:
+            attr[ATTR_WIND_ALARM] = self.device.wind_alarm
+
+        if self.device.frost_alarm:
+            attr[ATTR_FROST_ALARM] = self.device.frost_alarm
+
+        return attr

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -1,4 +1,6 @@
 """Support for KNX/IP weather station."""
+from typing import Any, Dict, Optional
+
 from xknx.devices import Weather as XknxWeather
 
 from homeassistant.components.weather import WeatherEntity
@@ -65,3 +67,8 @@ class KNXWeather(WeatherEntity):
         return (
             self.device.wind_speed * 3.6 if self.device.wind_speed is not None else None
         )
+
+    @property
+    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return the device specific state attributes."""
+        return self.device.ha_state_attributes

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2262,7 +2262,7 @@ xboxapi==2.0.1
 xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
-xknx==0.14.0
+xknx==0.14.2
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2262,7 +2262,7 @@ xboxapi==2.0.1
 xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
-xknx==0.13.0
+xknx==0.14.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

We changed the way how we handle binary sensors in the underlying library. It is no longer possible to support automations based on the binary_sensor schema. Instead, you can use the new `counter` state attribute for any given KNX binary sensor.

Before this change:

```
-  name: cover_abstell
   state_address: "2/0/33"
   automation:
     - counter: 1
       hook: 'on'
       action:
         - entity_id: cover.sonne_abstellkammer
           service: cover.open_cover
     - counter: 1
       hook: 'off'
       action:
         - entity_id: cover.sonne_abstellkammer
           service: cover.close_cover
```

After this change:

binary_sensor.yaml:

```
- name: cover_abstell
  state_address: "2/0/33"
```

automation.yaml:

```
automation:
  - alias: 'Binary sensor test counter=1 on'
    trigger:
      platform: numeric_state
      entity_id: binary_sensor.cover_abstell
      attribute: counter
      above: 0
      below: 2
    condition: 
      - condition: state
        entity_id: binary_sensor.cover_abstell
        state: 'on'
    action:
      - service: cover.open_cover
        entity_id: cover.sonne_abstellkammer

  - alias: 'Binary sensor test counter=1 off'
    trigger:
      platform: numeric_state
      entity_id: binary_sensor.cover_abstell
      attribute: counter
      above: 0
      below: 2
    condition:
      - condition: state
        entity_id: binary_sensor.cover_abstell
        state: 'off'
    action:
      - service: cover.close_cover
        entity_id: cover.sonne_abstellkammer
```

If you intend to use the counter feature (counter > 1) make sure you also enable `ignore_internal_state` (default: True) for your binary_sensor and set the new `context_timeout` attribute to the time in between you want it to react to your sensor clicks (defaults to 1 - which should be fine). Otherwise the counter will not work correctly.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the underlying library for KNX to version 0.14.2. Have a look at the changelog here: https://github.com/XKNX/xknx/releases/tag/0.14.0
https://github.com/XKNX/xknx/releases/tag/0.14.1
https://github.com/XKNX/xknx/releases/tag/0.14.2


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14567

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
