### PR TITLE
Enable co-existence of two IPMA weather entities for the same location

### DIFF
--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     @callback
     def _async_migrator(entity_entry: entity_registry.RegistryEntry):
         # Reject if new unique_id
-        if any([mode in entity_entry.unique_id for mode in FORECAST_MODE]):
+        if entity_entry.unique_id.count(',') == 2:
             return None
 
         new_unique_id = (

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     @callback
     def _async_migrator(entity_entry: entity_registry.RegistryEntry):
         # Reject if new unique_id
-        if entity_entry.unique_id.count(',') == 2:
+        if entity_entry.unique_id.count(",") == 2:
             return None
 
         new_unique_id = (

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -90,6 +90,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add a weather entity from a config_entry."""
     latitude = config_entry.data[CONF_LATITUDE]
     longitude = config_entry.data[CONF_LONGITUDE]
+    mode = config_entry.data[CONF_MODE]
 
     api = await async_get_api(hass)
     location = await async_get_location(hass, api, latitude, longitude)
@@ -100,8 +101,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         # Reject if new unique_id
         if any([mode in entity_entry.unique_id for mode in FORECAST_MODE]):
             return None
-
-        mode = entity_entry.data[CONF_MODE]
 
         new_unique_id = (
             f"{location.station_latitude}, {location.station_longitude}, {mode}"

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -157,7 +157,7 @@ class IPMAWeather(WeatherEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique id."""
-        return f"{self._location.station_latitude}, {self._location.station_longitude}"
+        return f"{self._location.station_latitude}, {self._location.station_longitude}, {self._mode}"
 
     @property
     def attribution(self):

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -132,12 +132,25 @@ async def test_config_entry_migration(hass):
     )
     ipma_entry.add_to_hass(hass)
 
+    ipma_entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        data={CONF_LATITUDE: 0, CONF_LONGITUDE: 0, CONF_MODE: "hourly"},
+    )
+    ipma_entry2.add_to_hass(hass)
+
     mock_registry(
         hass,
         {
             "weather.hometown": entity_registry.RegistryEntry(
                 entity_id="weather.hometown",
                 unique_id="0, 0",
+                platform="ipma",
+                config_entry_id=ipma_entry.entry_id,
+            ),
+            "weather.hometown_2": entity_registry.RegistryEntry(
+                entity_id="weather.hometown_2",
+                unique_id="0, 0, hourly",
                 platform="ipma",
                 config_entry_id=ipma_entry.entry_id,
             ),
@@ -155,3 +168,6 @@ async def test_config_entry_migration(hass):
 
         weather_home = ent_reg.async_get("weather.hometown")
         assert weather_home.unique_id == "0, 0, daily"
+
+        weather_home2 = ent_reg.async_get("weather.hometown_2")
+        assert weather_home2.unique_id == "0, 0, hourly"

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -1,9 +1,14 @@
 """Tests for IPMA config flow."""
 
-from homeassistant.components.ipma import config_flow
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.components.ipma import DOMAIN, config_flow
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE
+from homeassistant.helpers import entity_registry
+from homeassistant.setup import async_setup_component
+
+from .test_weather import MockLocation
 
 from tests.async_mock import Mock, patch
+from tests.common import MockConfigEntry, mock_registry
 
 
 async def test_show_config_form():
@@ -116,3 +121,37 @@ async def test_flow_entry_config_entry_already_exists():
         assert len(config_form.mock_calls) == 1
         assert len(config_entries.mock_calls) == 1
         assert len(flow._errors) == 1
+
+
+async def test_config_entry_migration(hass):
+    """Tests config entry without mode in unique_id can be migrated."""
+    ipma_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        data={CONF_LATITUDE: 0, CONF_LONGITUDE: 0, CONF_MODE: "daily"},
+    )
+    ipma_entry.add_to_hass(hass)
+
+    mock_registry(
+        hass,
+        {
+            "weather.hometown": entity_registry.RegistryEntry(
+                entity_id="weather.hometown",
+                unique_id="0, 0",
+                platform="ipma",
+                config_entry_id=ipma_entry.entry_id,
+            ),
+        },
+    )
+
+    with patch(
+        "homeassistant.components.ipma.weather.async_get_location",
+        return_value=MockLocation(),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        ent_reg = await entity_registry.async_get_registry(hass)
+
+        weather_home = ent_reg.async_get("weather.hometown")
+        assert weather_home.unique_id == "0, 0, daily"

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -24,7 +24,12 @@ from homeassistant.util.dt import now
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
-TEST_CONFIG = {"name": "HomeTown", "latitude": "40.00", "longitude": "-8.00"}
+TEST_CONFIG = {
+    "name": "HomeTown",
+    "latitude": "40.00",
+    "longitude": "-8.00",
+    "mode": "daily",
+}
 
 
 class MockLocation:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
~~We have changed how we create unique_id of a weather entity. We now include the forecast mode(hourly, daily) enabling the co-existence of two weather entities for the same location with complementary information.~~
We now migrate the config entry

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Includes the "mode" in the unique_id property

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
ipma:

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37242
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
