### PR TITLE
Add tests for modbus binary sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -536,6 +536,9 @@ omit =
     homeassistant/components/mjpeg/camera.py
     homeassistant/components/mobile_app/*
     homeassistant/components/mochad/*
+    homeassistant/components/modbus/climate.py
+    homeassistant/components/modbus/cover.py
+    homeassistant/components/modbus/switch.py
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/mpchc/media_player.py
     homeassistant/components/mpd/media_player.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -536,10 +536,6 @@ omit =
     homeassistant/components/mjpeg/camera.py
     homeassistant/components/mobile_app/*
     homeassistant/components/mochad/*
-	homeassistant/components/modbus/binary_sensor.py
-	homeassistant/components/modbus/climate.py
-	homeassistant/components/modbus/sensor.py
-	homeassistant/components/modbus/switch.py
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/mpchc/media_player.py
     homeassistant/components/mpd/media_player.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -537,6 +537,10 @@ omit =
     homeassistant/components/mobile_app/*
     homeassistant/components/mochad/*
     homeassistant/components/modbus/*
+	homeassistant/components/modbus/binary_sensor.py
+	homeassistant/components/modbus/climate.py
+	homeassistant/components/modbus/sensor.py
+	homeassistant/components/modbus/switch.py
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/mpchc/media_player.py
     homeassistant/components/mpd/media_player.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -536,7 +536,6 @@ omit =
     homeassistant/components/mjpeg/camera.py
     homeassistant/components/mobile_app/*
     homeassistant/components/mochad/*
-    homeassistant/components/modbus/*
 	homeassistant/components/modbus/binary_sensor.py
 	homeassistant/components/modbus/climate.py
 	homeassistant/components/modbus/sensor.py

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -6,14 +6,13 @@ from unittest import mock
 import pytest
 
 from homeassistant.components.modbus.const import (
+    CALL_TYPE_COIL,
+    CALL_TYPE_DISCRETE,
     CALL_TYPE_REGISTER_INPUT,
-    CONF_REGISTER,
-    CONF_REGISTER_TYPE,
-    CONF_REGISTERS,
     DEFAULT_HUB,
     MODBUS_DOMAIN as DOMAIN,
 )
-from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_PLATFORM, CONF_SCAN_INTERVAL
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -38,31 +37,41 @@ class ReadResult:
     def __init__(self, register_words):
         """Init."""
         self.registers = register_words
+        self.bits = register_words
 
 
-async def run_test(
-    hass, use_mock_hub, register_config, entity_domain, register_words, expected
+async def run_base_test(
+    sensor_name,
+    hass,
+    use_mock_hub,
+    data_name,
+    data_array,
+    register_type,
+    entity_domain,
+    register_words,
+    expected,
 ):
-    """Run test for given config and check that sensor outputs expected result."""
+    """Run test for given config."""
 
     # Full sensor configuration
-    sensor_name = "modbus_test_sensor"
     scan_interval = 5
     config = {
         entity_domain: {
             CONF_PLATFORM: "modbus",
             CONF_SCAN_INTERVAL: scan_interval,
-            CONF_REGISTERS: [
-                dict(**{CONF_NAME: sensor_name, CONF_REGISTER: 1234}, **register_config)
-            ],
+            data_name: data_array,
         }
     }
 
     # Setup inputs for the sensor
     read_result = ReadResult(register_words)
-    if register_config.get(CONF_REGISTER_TYPE) == CALL_TYPE_REGISTER_INPUT:
+    if register_type == CALL_TYPE_COIL:
+        use_mock_hub.read_coils.return_value = read_result
+    elif register_type == CALL_TYPE_DISCRETE:
+        use_mock_hub.read_discrete_inputs.return_value = read_result
+    elif register_type == CALL_TYPE_REGISTER_INPUT:
         use_mock_hub.read_input_registers.return_value = read_result
-    else:
+    else:  # CALL_TYPE_REGISTER_HOLDING
         use_mock_hub.read_holding_registers.return_value = read_result
 
     # Initialize sensor
@@ -76,8 +85,3 @@ async def run_test(
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
-
-    # Check state
-    entity_id = f"{entity_domain}.{sensor_name}"
-    state = hass.states.get(entity_id).state
-    assert state == expected

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -44,7 +44,6 @@ async def run_base_test(
     sensor_name,
     hass,
     use_mock_hub,
-    data_name,
     data_array,
     register_type,
     entity_domain,
@@ -59,7 +58,7 @@ async def run_base_test(
         entity_domain: {
             CONF_PLATFORM: "modbus",
             CONF_SCAN_INTERVAL: scan_interval,
-            data_name: data_array,
+            **data_array,
         }
     }
 

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.modbus.const import (
     CONF_INPUT_TYPE,
     CONF_INPUTS,
 )
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
 
 from .conftest import run_base_test
 
@@ -52,7 +52,7 @@ async def test_coil_true(hass, mock_hub):
         mock_hub,
         register_config,
         [0xFF],
-        expected="on",
+        STATE_ON,
     )
 
 
@@ -66,7 +66,7 @@ async def test_coil_false(hass, mock_hub):
         mock_hub,
         register_config,
         [0x00],
-        expected="off",
+        STATE_OFF,
     )
 
 

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -1,0 +1,97 @@
+"""The tests for the Modbus sensor component."""
+import logging
+
+from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.modbus.const import (
+    CALL_TYPE_COIL,
+    CALL_TYPE_DISCRETE,
+    CONF_ADDRESS,
+    CONF_INPUT_TYPE,
+    CONF_INPUTS,
+)
+from homeassistant.const import CONF_NAME
+
+from .conftest import run_base_test
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def run_sensor_test(hass, use_mock_hub, register_config, value, expected):
+    """Run test for given config."""
+    sensor_name = "modbus_test_binary_sensor"
+    entity_domain = SENSOR_DOMAIN
+    data_array = [
+        dict(**{CONF_NAME: sensor_name, CONF_ADDRESS: 1234}, **register_config)
+    ]
+    await run_base_test(
+        sensor_name,
+        hass,
+        use_mock_hub,
+        CONF_INPUTS,
+        data_array,
+        register_config.get(CONF_INPUT_TYPE),
+        entity_domain,
+        value,
+        expected,
+    )
+
+    # Check state
+    entity_id = f"{entity_domain}.{sensor_name}"
+    state = hass.states.get(entity_id).state
+    assert state == expected
+
+
+async def test_coil_true(hass, mock_hub):
+    """Test conversion of single word register."""
+    register_config = {
+        CONF_INPUT_TYPE: CALL_TYPE_COIL,
+    }
+    await run_sensor_test(
+        hass,
+        mock_hub,
+        register_config,
+        [0xFF],
+        expected="on",
+    )
+
+
+async def test_coil_false(hass, mock_hub):
+    """Test conversion of single word register."""
+    register_config = {
+        CONF_INPUT_TYPE: CALL_TYPE_COIL,
+    }
+    await run_sensor_test(
+        hass,
+        mock_hub,
+        register_config,
+        [0x00],
+        expected="off",
+    )
+
+
+async def test_discrete_true(hass, mock_hub):
+    """Test conversion of single word register."""
+    register_config = {
+        CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
+    }
+    await run_sensor_test(
+        hass,
+        mock_hub,
+        register_config,
+        [0xFF],
+        expected="on",
+    )
+
+
+async def test_discrete_false(hass, mock_hub):
+    """Test conversion of single word register."""
+    register_config = {
+        CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
+    }
+    await run_sensor_test(
+        hass,
+        mock_hub,
+        register_config,
+        [0x00],
+        expected="off",
+    )

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -20,14 +20,15 @@ async def run_sensor_test(hass, use_mock_hub, register_config, value, expected):
     """Run test for given config."""
     sensor_name = "modbus_test_binary_sensor"
     entity_domain = SENSOR_DOMAIN
-    data_array = [
-        dict(**{CONF_NAME: sensor_name, CONF_ADDRESS: 1234}, **register_config)
-    ]
+    data_array = {
+        CONF_INPUTS: [
+            dict(**{CONF_NAME: sensor_name, CONF_ADDRESS: 1234}, **register_config)
+        ]
+    }
     await run_base_test(
         sensor_name,
         hass,
         use_mock_hub,
-        CONF_INPUTS,
         data_array,
         register_config.get(CONF_INPUT_TYPE),
         entity_domain,

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -8,7 +8,9 @@ from homeassistant.components.modbus.const import (
     CONF_DATA_TYPE,
     CONF_OFFSET,
     CONF_PRECISION,
+    CONF_REGISTER,
     CONF_REGISTER_TYPE,
+    CONF_REGISTERS,
     CONF_REVERSE_ORDER,
     CONF_SCALE,
     DATA_TYPE_FLOAT,
@@ -17,10 +19,39 @@ from homeassistant.components.modbus.const import (
     DATA_TYPE_UINT,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_NAME
 
-from .conftest import run_test
+from .conftest import run_base_test
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def run_sensor_test(
+    hass, use_mock_hub, register_config, register_words, expected
+):
+    """Run test for sensor."""
+    sensor_name = "modbus_test_sensor"
+    entity_domain = SENSOR_DOMAIN
+    data_array = [
+        dict(**{CONF_NAME: sensor_name, CONF_REGISTER: 1234}, **register_config)
+    ]
+
+    await run_base_test(
+        sensor_name,
+        hass,
+        use_mock_hub,
+        CONF_REGISTERS,
+        data_array,
+        register_config.get(CONF_REGISTER_TYPE),
+        entity_domain,
+        register_words,
+        expected,
+    )
+
+    # Check state
+    entity_id = f"{entity_domain}.{sensor_name}"
+    state = hass.states.get(entity_id).state
+    assert state == expected
 
 
 async def test_simple_word_register(hass, mock_hub):
@@ -32,11 +63,10 @@ async def test_simple_word_register(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0],
         expected="0",
     )
@@ -45,11 +75,10 @@ async def test_simple_word_register(hass, mock_hub):
 async def test_optional_conf_keys(hass, mock_hub):
     """Test handling of optional configuration keys."""
     register_config = {}
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x8000],
         expected="-32768",
     )
@@ -64,11 +93,10 @@ async def test_offset(hass, mock_hub):
         CONF_OFFSET: 13,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[7],
         expected="20",
     )
@@ -83,11 +111,10 @@ async def test_scale_and_offset(hass, mock_hub):
         CONF_OFFSET: 13,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[7],
         expected="34",
     )
@@ -102,11 +129,10 @@ async def test_ints_can_have_precision(hass, mock_hub):
         CONF_OFFSET: 13,
         CONF_PRECISION: 4,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[7],
         expected="34.0000",
     )
@@ -121,11 +147,10 @@ async def test_floats_get_rounded_correctly(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[1],
         expected="2",
     )
@@ -140,11 +165,10 @@ async def test_parameters_as_strings(hass, mock_hub):
         CONF_OFFSET: "5",
         CONF_PRECISION: "1",
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[9],
         expected="18.5",
     )
@@ -159,11 +183,10 @@ async def test_floating_point_scale(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 2,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[1],
         expected="2.40",
     )
@@ -178,11 +201,10 @@ async def test_floating_point_offset(hass, mock_hub):
         CONF_OFFSET: -10.3,
         CONF_PRECISION: 1,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[2],
         expected="-8.3",
     )
@@ -197,11 +219,10 @@ async def test_signed_two_word_register(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x89AB, 0xCDEF],
         expected="-1985229329",
     )
@@ -216,11 +237,10 @@ async def test_unsigned_two_word_register(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x89AB, 0xCDEF],
         expected=str(0x89ABCDEF),
     )
@@ -233,11 +253,10 @@ async def test_reversed(hass, mock_hub):
         CONF_DATA_TYPE: DATA_TYPE_UINT,
         CONF_REVERSE_ORDER: True,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x89AB, 0xCDEF],
         expected=str(0xCDEF89AB),
     )
@@ -252,11 +271,10 @@ async def test_four_word_register(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x89AB, 0xCDEF, 0x0123, 0x4567],
         expected="9920249030613615975",
     )
@@ -271,11 +289,10 @@ async def test_four_word_register_precision_is_intact_with_int_params(hass, mock
         CONF_OFFSET: 3,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x0123, 0x4567, 0x89AB, 0xCDEF],
         expected="163971058432973793",
     )
@@ -290,11 +307,10 @@ async def test_four_word_register_precision_is_lost_with_float_params(hass, mock
         CONF_OFFSET: 3.0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x0123, 0x4567, 0x89AB, 0xCDEF],
         expected="163971058432973792",
     )
@@ -310,11 +326,10 @@ async def test_two_word_input_register(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x89AB, 0xCDEF],
         expected=str(0x89ABCDEF),
     )
@@ -330,11 +345,10 @@ async def test_two_word_holding_register(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x89AB, 0xCDEF],
         expected=str(0x89ABCDEF),
     )
@@ -350,11 +364,10 @@ async def test_float_data_type(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 5,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[16286, 1617],
         expected="1.23457",
     )
@@ -370,11 +383,10 @@ async def test_string_data_type(hass, mock_hub):
         CONF_OFFSET: 0,
         CONF_PRECISION: 0,
     }
-    await run_test(
+    await run_sensor_test(
         hass,
         mock_hub,
         register_config,
-        SENSOR_DOMAIN,
         register_words=[0x3037, 0x2D30, 0x352D, 0x3230, 0x3230, 0x2031, 0x343A, 0x3335],
         expected="07-05-2020 14:35",
     )

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -32,15 +32,16 @@ async def run_sensor_test(
     """Run test for sensor."""
     sensor_name = "modbus_test_sensor"
     entity_domain = SENSOR_DOMAIN
-    data_array = [
-        dict(**{CONF_NAME: sensor_name, CONF_REGISTER: 1234}, **register_config)
-    ]
+    data_array = {
+        CONF_REGISTERS: [
+            dict(**{CONF_NAME: sensor_name, CONF_REGISTER: 1234}, **register_config)
+        ]
+    }
 
     await run_base_test(
         sensor_name,
         hass,
         use_mock_hub,
-        CONF_REGISTERS,
         data_array,
         register_config.get(CONF_REGISTER_TYPE),
         entity_domain,


### PR DESCRIPTION
Add test coverage of binary sensor.

update conftest.py to be generic (handle both sensor and binary_sensor).
update test_modbus_sensor.py due to the updates in conftest.py.

Add new file test_modbus_binary_sensor.py

This is part of an ongoing process to add tests for all parts of modbus.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x ] I have reviewed two other [open pull requests][prs] in this repository.


[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
