### PR TITLE
Improve timeout error handling for Splunk

### DIFF
--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -1,4 +1,5 @@
 """Support to send data to a Splunk instance."""
+import asyncio
 import json
 import logging
 import time
@@ -114,7 +115,7 @@ async def async_setup(hass, config):
                 _LOGGER.error(err)
             else:
                 _LOGGER.warning(err)
-        except ClientConnectionError as err:
+        except (ClientConnectionError, asyncio.TimeoutError) as err:
             _LOGGER.warning(err)
         except ClientResponseError as err:
             _LOGGER.error(err.message)

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -115,8 +115,10 @@ async def async_setup(hass, config):
                 _LOGGER.error(err)
             else:
                 _LOGGER.warning(err)
-        except (ClientConnectionError, asyncio.TimeoutError) as err:
+        except ClientConnectionError as err:
             _LOGGER.warning(err)
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Connection to %s:%s timed out", host, port)
         except ClientResponseError as err:
             _LOGGER.error(err.message)
 

--- a/homeassistant/components/splunk/manifest.json
+++ b/homeassistant/components/splunk/manifest.json
@@ -3,7 +3,7 @@
   "name": "Splunk",
   "documentation": "https://www.home-assistant.io/integrations/splunk",
   "requirements": [
-    "hass_splunk==0.1.0"
+    "hass_splunk==0.1.1"
   ],
   "codeowners": [
     "@Bre77"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -723,7 +723,7 @@ hangups==0.4.11
 hass-nabucasa==0.37.0
 
 # homeassistant.components.splunk
-hass_splunk==0.1.0
+hass_splunk==0.1.1
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bugfix to correctly catch and handle asyncio.timeout error in the updated Splunk integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Same as documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
