### PR TITLE
Add entity glob matching support to history

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -591,9 +591,6 @@ def _keep_event(hass, event, entities_filter):
     if event.event_type in HOMEASSISTANT_EVENTS:
         return entities_filter is None or entities_filter(HA_DOMAIN_ENTITY_ID)
 
-    if event.event_type == EVENT_STATE_CHANGED:
-        return entities_filter is None or entities_filter(event.entity_id)
-
     entity_id = event.data_entity_id
     if entity_id:
         return entities_filter is None or entities_filter(entity_id)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -15,7 +15,6 @@ from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.recorder.models import process_timestamp_to_utc_isoformat
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_STARTED,
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -27,6 +26,7 @@ from homeassistant.const import (
     CONF_INCLUDE,
     EVENT_CALL_SERVICE,
     EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
     EVENT_STATE_CHANGED,
     STATE_NOT_HOME,
@@ -34,10 +34,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 import homeassistant.core as ha
-from homeassistant.helpers.entityfilter import (
-    CONF_ENTITY_GLOBS,
-    convert_include_exclude_filter,
-)
+from homeassistant.helpers.entityfilter import CONF_ENTITY_GLOBS
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component, setup_component
 import homeassistant.util.dt as dt_util
@@ -167,7 +164,6 @@ class TestComponentLogbook(unittest.TestCase):
         self.assert_entry(
             entries[1], pointC, "bla", domain="sensor", entity_id=entity_id
         )
-
 
     def test_home_assistant_start_stop_grouped(self):
         """Test if HA start and stop events are grouped.
@@ -870,9 +866,9 @@ class TestComponentLogbook(unittest.TestCase):
     # pylint: disable=no-self-use
     def assert_entry(
         self, entry, when=None, name=None, message=None, domain=None, entity_id=None
-    ):    
+    ):
+        """Assert an entry is what is expected."""
         return _assert_entry(entry, when, name, message, domain, entity_id)
-
 
     def create_state_changed_event(
         self,
@@ -1886,12 +1882,10 @@ async def test_icon_and_state(hass, hass_client):
     assert response_json[2]["state"] == STATE_OFF
 
 
-
 async def test_exclude_events_domain(hass, hass_client):
     """Test if events are filtered if domain is excluded in config."""
     entity_id = "switch.bla"
     entity_id2 = "sensor.blu"
-
 
     config = logbook.CONFIG_SCHEMA(
         {
@@ -1912,18 +1906,15 @@ async def test_exclude_events_domain(hass, hass_client):
 
     await _async_commit_and_wait(hass)
 
-
     client = await hass_client()
     entries = await _async_fetch_logbook(client)
-    
 
     assert len(entries) == 2
     _assert_entry(
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
-    _assert_entry(
-        entries[1], name="blu", domain="sensor", entity_id=entity_id2
-    )
+    _assert_entry(entries[1], name="blu", domain="sensor", entity_id=entity_id2)
+
 
 async def test_exclude_events_domain_glob(hass, hass_client):
     """Test if events are filtered if domain or glob is excluded in config."""
@@ -1959,15 +1950,12 @@ async def test_exclude_events_domain_glob(hass, hass_client):
     client = await hass_client()
     entries = await _async_fetch_logbook(client)
 
-    import pprint
-    pprint.pprint(entries)
     assert len(entries) == 2
     _assert_entry(
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
-    _assert_entry(
-        entries[1], name="blu", domain="sensor", entity_id=entity_id2
-    )
+    _assert_entry(entries[1], name="blu", domain="sensor", entity_id=entity_id2)
+
 
 async def test_include_events_entity(hass, hass_client):
     """Test if events are filtered if entity is included in config."""
@@ -2004,10 +1992,7 @@ async def test_include_events_entity(hass, hass_client):
     _assert_entry(
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
-    _assert_entry(
-        entries[1], name="blu", domain="sensor", entity_id=entity_id2
-    )
-
+    _assert_entry(entries[1], name="blu", domain="sensor", entity_id=entity_id2)
 
 
 async def test_exclude_events_entity(hass, hass_client):
@@ -2037,11 +2022,9 @@ async def test_exclude_events_entity(hass, hass_client):
     entries = await _async_fetch_logbook(client)
     assert len(entries) == 2
     _assert_entry(
-        entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
-    _assert_entry(
-        entries[1], name="blu", domain="sensor", entity_id=entity_id2
-    )
+    _assert_entry(entries[1], name="blu", domain="sensor", entity_id=entity_id2)
 
 
 async def test_include_events_domain(hass, hass_client):
@@ -2081,9 +2064,8 @@ async def test_include_events_domain(hass, hass_client):
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
     _assert_entry(entries[1], name="Amazon Alexa", domain="alexa")
-    _assert_entry(
-        entries[2], name="blu", domain="sensor", entity_id=entity_id2
-    )
+    _assert_entry(entries[2], name="blu", domain="sensor", entity_id=entity_id2)
+
 
 async def test_include_events_domain_glob(hass, hass_client):
     """Test if events are filtered if domain or glob is included in config."""
@@ -2128,27 +2110,16 @@ async def test_include_events_domain_glob(hass, hass_client):
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
     _assert_entry(entries[1], name="Amazon Alexa", domain="alexa")
-    _assert_entry(
-        entries[2], name="blu", domain="sensor", entity_id=entity_id2
-    )
-    _assert_entry(
-        entries[3], name="included", domain="switch", entity_id=entity_id3
-    )
+    _assert_entry(entries[2], name="blu", domain="sensor", entity_id=entity_id2)
+    _assert_entry(entries[3], name="included", domain="switch", entity_id=entity_id3)
+
 
 async def test_include_exclude_events(hass, hass_client):
     """Test if events are filtered if include and exclude is configured."""
     entity_id = "switch.bla"
     entity_id2 = "sensor.blu"
     entity_id3 = "sensor.bli"
-    pointA = dt_util.utcnow()
-    pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-    entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-    eventA1 = self.create_state_changed_event(pointA, entity_id, 10)
-    eventA2 = self.create_state_changed_event(pointA, entity_id2, 10)
-    eventA3 = self.create_state_changed_event(pointA, entity_id3, 10)
-    eventB1 = self.create_state_changed_event(pointB, entity_id, 20)
-    eventB2 = self.create_state_changed_event(pointB, entity_id2, 20)
+    entity_id4 = "sensor.keep"
 
     config = logbook.CONFIG_SCHEMA(
         {
@@ -2165,37 +2136,34 @@ async def test_include_exclude_events(hass, hass_client):
             },
         }
     )
-    entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-    events = [
-        e
-        for e in (
-            MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-            eventA1,
-            eventA2,
-            eventA3,
-            eventB1,
-            eventB2,
-        )
-        if logbook._keep_event(self.hass, e, entities_filter)
-    ]
-    entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
 
-    assert len(entries) == 5
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 10)
+    hass.states.async_set(entity_id3, None)
+    hass.states.async_set(entity_id3, 10)
+    hass.states.async_set(entity_id, 20)
+    hass.states.async_set(entity_id2, 20)
+    hass.states.async_set(entity_id4, None)
+    hass.states.async_set(entity_id4, 10)
+
+    await _async_commit_and_wait(hass)
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+
+    assert len(entries) == 3
     _assert_entry(
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
-    _assert_entry(
-        entries[1], name="bla", domain="switch", entity_id=entity_id
-    )
-    _assert_entry(
-        entries[2], name="blu", domain="sensor", entity_id=entity_id2
-    )
-    _assert_entry(
-        entries[3], name="bla", domain="switch", entity_id=entity_id
-    )
-    _assert_entry(
-        entries[4], name="blu", domain="sensor", entity_id=entity_id2
-    )
+    _assert_entry(entries[1], name="blu", domain="sensor", entity_id=entity_id2)
+    _assert_entry(entries[2], name="keep", domain="sensor", entity_id=entity_id4)
+
 
 async def test_include_exclude_events_with_glob_filters(hass, hass_client):
     """Test if events are filtered if include and exclude is configured."""
@@ -2205,20 +2173,6 @@ async def test_include_exclude_events_with_glob_filters(hass, hass_client):
     entity_id4 = "light.included"
     entity_id5 = "switch.included"
     entity_id6 = "sensor.excluded"
-    pointA = dt_util.utcnow()
-    pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-    pointC = pointB + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-    entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-    eventA1 = self.create_state_changed_event(pointA, entity_id, 10)
-    eventA2 = self.create_state_changed_event(pointA, entity_id2, 10)
-    eventA3 = self.create_state_changed_event(pointA, entity_id3, 10)
-    eventB1 = self.create_state_changed_event(pointB, entity_id, 20)
-    eventB2 = self.create_state_changed_event(pointB, entity_id2, 20)
-    eventC1 = self.create_state_changed_event(pointC, entity_id4, 30)
-    eventC2 = self.create_state_changed_event(pointC, entity_id5, 30)
-    eventC3 = self.create_state_changed_event(pointC, entity_id6, 30)
-
     config = logbook.CONFIG_SCHEMA(
         {
             ha.DOMAIN: {},
@@ -2236,43 +2190,38 @@ async def test_include_exclude_events_with_glob_filters(hass, hass_client):
             },
         }
     )
-    entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-    events = [
-        e
-        for e in (
-            MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-            eventA1,
-            eventA2,
-            eventA3,
-            eventB1,
-            eventB2,
-            eventC1,
-            eventC2,
-            eventC3,
-        )
-        if logbook._keep_event(self.hass, e, entities_filter)
-    ]
-    entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
 
-    assert len(entries) == 6
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 10)
+    hass.states.async_set(entity_id3, None)
+    hass.states.async_set(entity_id3, 10)
+    hass.states.async_set(entity_id, 20)
+    hass.states.async_set(entity_id2, 20)
+    hass.states.async_set(entity_id4, None)
+    hass.states.async_set(entity_id4, 30)
+    hass.states.async_set(entity_id5, None)
+    hass.states.async_set(entity_id5, 30)
+    hass.states.async_set(entity_id6, None)
+    hass.states.async_set(entity_id6, 30)
+
+    await _async_commit_and_wait(hass)
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+
+    assert len(entries) == 3
     _assert_entry(
         entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
     )
-    _assert_entry(
-        entries[1], name="bla", domain="switch", entity_id=entity_id
-    )
-    _assert_entry(
-        entries[2], name="blu", domain="sensor", entity_id=entity_id2
-    )
-    _assert_entry(
-        entries[3], name="bla", domain="switch", entity_id=entity_id
-    )
-    _assert_entry(
-        entries[4], name="blu", domain="sensor", entity_id=entity_id2
-    )
-    _assert_entry(
-        entries[5], name="included", domain="light", entity_id=entity_id4
-    )
+    _assert_entry(entries[1], name="blu", domain="sensor", entity_id=entity_id2)
+    _assert_entry(entries[2], name="included", domain="light", entity_id=entity_id4)
+
 
 async def _async_fetch_logbook(client):
 
@@ -2282,9 +2231,12 @@ async def _async_fetch_logbook(client):
 
     # Test today entries without filters
     end_time = start + timedelta(hours=48)
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?end_time={end_time}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?end_time={end_time}"
+    )
     assert response.status == 200
     return await response.json()
+
 
 async def _async_commit_and_wait(hass):
     await hass.async_block_till_done()
@@ -2292,6 +2244,7 @@ async def _async_commit_and_wait(hass):
     await hass.async_block_till_done()
     await hass.async_add_executor_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
     await hass.async_block_till_done()
+
 
 def _assert_entry(
     entry, when=None, name=None, message=None, domain=None, entity_id=None
@@ -2311,6 +2264,7 @@ def _assert_entry(
 
     if entity_id:
         assert entity_id == entry["entity_id"]
+
 
 class MockLazyEventPartialState(ha.Event):
     """Minimal mock of a Lazy event."""

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.recorder.models import process_timestamp_to_utc_isoformat
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -167,412 +168,6 @@ class TestComponentLogbook(unittest.TestCase):
             entries[1], pointC, "bla", domain="sensor", entity_id=entity_id
         )
 
-    def test_exclude_events_entity(self):
-        """Test if events are filtered if entity is excluded in config."""
-        entity_id = "sensor.bla"
-        entity_id2 = "sensor.blu"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        eventA = self.create_state_changed_event(pointA, entity_id, 10)
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {CONF_EXCLUDE: {CONF_ENTITIES: [entity_id]}},
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_STOP),
-                eventA,
-                eventB,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 2
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_exclude_events_domain(self):
-        """Test if events are filtered if domain is excluded in config."""
-        entity_id = "switch.bla"
-        entity_id2 = "sensor.blu"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        eventA = self.create_state_changed_event(pointA, entity_id, 10)
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {CONF_EXCLUDE: {CONF_DOMAINS: ["switch", "alexa"]}},
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-                MockLazyEventPartialState(EVENT_ALEXA_SMART_HOME),
-                eventA,
-                eventB,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 2
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_exclude_events_domain_glob(self):
-        """Test if events are filtered if domain or glob is excluded in config."""
-        entity_id = "switch.bla"
-        entity_id2 = "sensor.blu"
-        entity_id3 = "sensor.excluded"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        pointC = pointB + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        eventA = self.create_state_changed_event(pointA, entity_id, 10)
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-        eventC = self.create_state_changed_event(pointC, entity_id3, 30)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {
-                    CONF_EXCLUDE: {
-                        CONF_DOMAINS: ["switch", "alexa"],
-                        CONF_ENTITY_GLOBS: "*.excluded",
-                    }
-                },
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-                MockLazyEventPartialState(EVENT_ALEXA_SMART_HOME),
-                eventA,
-                eventB,
-                eventC,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 2
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_include_events_entity(self):
-        """Test if events are filtered if entity is included in config."""
-        entity_id = "sensor.bla"
-        entity_id2 = "sensor.blu"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        eventA = self.create_state_changed_event(pointA, entity_id, 10)
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {
-                    CONF_INCLUDE: {
-                        CONF_DOMAINS: ["homeassistant"],
-                        CONF_ENTITIES: [entity_id2],
-                    }
-                },
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_STOP),
-                eventA,
-                eventB,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 2
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_include_events_domain(self):
-        """Test if events are filtered if domain is included in config."""
-        assert setup_component(self.hass, "alexa", {})
-        entity_id = "switch.bla"
-        entity_id2 = "sensor.blu"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        event_alexa = MockLazyEventPartialState(
-            EVENT_ALEXA_SMART_HOME,
-            {"request": {"namespace": "Alexa.Discovery", "name": "Discover"}},
-        )
-
-        eventA = self.create_state_changed_event(pointA, entity_id, 10)
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {
-                    CONF_INCLUDE: {CONF_DOMAINS: ["homeassistant", "sensor", "alexa"]}
-                },
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-                event_alexa,
-                eventA,
-                eventB,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 3
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
-        )
-        self.assert_entry(entries[1], name="Amazon Alexa", domain="alexa")
-        self.assert_entry(
-            entries[2], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_include_events_domain_glob(self):
-        """Test if events are filtered if domain or glob is included in config."""
-        assert setup_component(self.hass, "alexa", {})
-        entity_id = "switch.bla"
-        entity_id2 = "sensor.blu"
-        entity_id3 = "switch.included"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        pointC = pointB + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        event_alexa = MockLazyEventPartialState(
-            EVENT_ALEXA_SMART_HOME,
-            {"request": {"namespace": "Alexa.Discovery", "name": "Discover"}},
-        )
-
-        eventA = self.create_state_changed_event(pointA, entity_id, 10)
-        eventB = self.create_state_changed_event(pointB, entity_id2, 20)
-        eventC = self.create_state_changed_event(pointC, entity_id3, 30)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {
-                    CONF_INCLUDE: {
-                        CONF_DOMAINS: ["homeassistant", "sensor", "alexa"],
-                        CONF_ENTITY_GLOBS: ["*.included"],
-                    }
-                },
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-                event_alexa,
-                eventA,
-                eventB,
-                eventC,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 4
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
-        )
-        self.assert_entry(entries[1], name="Amazon Alexa", domain="alexa")
-        self.assert_entry(
-            entries[2], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-        self.assert_entry(
-            entries[3], pointC, "included", domain="switch", entity_id=entity_id3
-        )
-
-    def test_include_exclude_events(self):
-        """Test if events are filtered if include and exclude is configured."""
-        entity_id = "switch.bla"
-        entity_id2 = "sensor.blu"
-        entity_id3 = "sensor.bli"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        eventA1 = self.create_state_changed_event(pointA, entity_id, 10)
-        eventA2 = self.create_state_changed_event(pointA, entity_id2, 10)
-        eventA3 = self.create_state_changed_event(pointA, entity_id3, 10)
-        eventB1 = self.create_state_changed_event(pointB, entity_id, 20)
-        eventB2 = self.create_state_changed_event(pointB, entity_id2, 20)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {
-                    CONF_INCLUDE: {
-                        CONF_DOMAINS: ["sensor", "homeassistant"],
-                        CONF_ENTITIES: ["switch.bla"],
-                    },
-                    CONF_EXCLUDE: {
-                        CONF_DOMAINS: ["switch"],
-                        CONF_ENTITIES: ["sensor.bli"],
-                    },
-                },
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-                eventA1,
-                eventA2,
-                eventA3,
-                eventB1,
-                eventB2,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 5
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointA, "bla", domain="switch", entity_id=entity_id
-        )
-        self.assert_entry(
-            entries[2], pointA, "blu", domain="sensor", entity_id=entity_id2
-        )
-        self.assert_entry(
-            entries[3], pointB, "bla", domain="switch", entity_id=entity_id
-        )
-        self.assert_entry(
-            entries[4], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-
-    def test_include_exclude_events_with_glob_filters(self):
-        """Test if events are filtered if include and exclude is configured."""
-        entity_id = "switch.bla"
-        entity_id2 = "sensor.blu"
-        entity_id3 = "sensor.bli"
-        entity_id4 = "light.included"
-        entity_id5 = "switch.included"
-        entity_id6 = "sensor.excluded"
-        pointA = dt_util.utcnow()
-        pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        pointC = pointB + timedelta(minutes=logbook.GROUP_BY_MINUTES)
-        entity_attr_cache = logbook.EntityAttributeCache(self.hass)
-
-        eventA1 = self.create_state_changed_event(pointA, entity_id, 10)
-        eventA2 = self.create_state_changed_event(pointA, entity_id2, 10)
-        eventA3 = self.create_state_changed_event(pointA, entity_id3, 10)
-        eventB1 = self.create_state_changed_event(pointB, entity_id, 20)
-        eventB2 = self.create_state_changed_event(pointB, entity_id2, 20)
-        eventC1 = self.create_state_changed_event(pointC, entity_id4, 30)
-        eventC2 = self.create_state_changed_event(pointC, entity_id5, 30)
-        eventC3 = self.create_state_changed_event(pointC, entity_id6, 30)
-
-        config = logbook.CONFIG_SCHEMA(
-            {
-                ha.DOMAIN: {},
-                logbook.DOMAIN: {
-                    CONF_INCLUDE: {
-                        CONF_DOMAINS: ["sensor", "homeassistant"],
-                        CONF_ENTITIES: ["switch.bla"],
-                        CONF_ENTITY_GLOBS: ["*.included"],
-                    },
-                    CONF_EXCLUDE: {
-                        CONF_DOMAINS: ["switch"],
-                        CONF_ENTITY_GLOBS: ["*.excluded"],
-                        CONF_ENTITIES: ["sensor.bli"],
-                    },
-                },
-            }
-        )
-        entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
-        events = [
-            e
-            for e in (
-                MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
-                eventA1,
-                eventA2,
-                eventA3,
-                eventB1,
-                eventB2,
-                eventC1,
-                eventC2,
-                eventC3,
-            )
-            if logbook._keep_event(self.hass, e, entities_filter)
-        ]
-        entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
-
-        assert len(entries) == 6
-        self.assert_entry(
-            entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
-        )
-        self.assert_entry(
-            entries[1], pointA, "bla", domain="switch", entity_id=entity_id
-        )
-        self.assert_entry(
-            entries[2], pointA, "blu", domain="sensor", entity_id=entity_id2
-        )
-        self.assert_entry(
-            entries[3], pointB, "bla", domain="switch", entity_id=entity_id
-        )
-        self.assert_entry(
-            entries[4], pointB, "blu", domain="sensor", entity_id=entity_id2
-        )
-        self.assert_entry(
-            entries[5], pointC, "included", domain="light", entity_id=entity_id4
-        )
 
     def test_home_assistant_start_stop_grouped(self):
         """Test if HA start and stop events are grouped.
@@ -1275,22 +870,9 @@ class TestComponentLogbook(unittest.TestCase):
     # pylint: disable=no-self-use
     def assert_entry(
         self, entry, when=None, name=None, message=None, domain=None, entity_id=None
-    ):
-        """Assert an entry is what is expected."""
-        if when:
-            assert when.isoformat() == entry["when"]
+    ):    
+        return _assert_entry(entry, when, name, message, domain, entity_id)
 
-        if name:
-            assert name == entry["name"]
-
-        if message:
-            assert message == entry["message"]
-
-        if domain:
-            assert domain == entry["domain"]
-
-        if entity_id:
-            assert entity_id == entry["entity_id"]
 
     def create_state_changed_event(
         self,
@@ -2287,22 +1869,10 @@ async def test_icon_and_state(hass, hass_client):
     )
     hass.states.async_set("light.kitchen", STATE_OFF, {"icon": "mdi:chemical-weapon"})
 
-    await hass.async_block_till_done()
-
-    await hass.async_add_job(trigger_db_commit, hass)
-    await hass.async_block_till_done()
-    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+    await _async_commit_and_wait(hass)
 
     client = await hass_client()
-
-    # Today time 00:00:00
-    start = dt_util.utcnow().date()
-    start_date = datetime(start.year, start.month, start.day)
-
-    # Test today entries without filters
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}")
-    assert response.status == 200
-    response_json = await response.json()
+    response_json = await _async_fetch_logbook(client)
 
     assert len(response_json) == 3
     assert response_json[0]["domain"] == "homeassistant"
@@ -2315,6 +1885,432 @@ async def test_icon_and_state(hass, hass_client):
     assert response_json[2]["icon"] == "mdi:chemical-weapon"
     assert response_json[2]["state"] == STATE_OFF
 
+
+
+async def test_exclude_events_domain(hass, hass_client):
+    """Test if events are filtered if domain is excluded in config."""
+    entity_id = "switch.bla"
+    entity_id2 = "sensor.blu"
+
+
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {CONF_EXCLUDE: {CONF_DOMAINS: ["switch", "alexa"]}},
+        }
+    )
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 20)
+
+    await _async_commit_and_wait(hass)
+
+
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+    
+
+    assert len(entries) == 2
+    _assert_entry(
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
+    )
+    _assert_entry(
+        entries[1], name="blu", domain="sensor", entity_id=entity_id2
+    )
+
+async def test_exclude_events_domain_glob(hass, hass_client):
+    """Test if events are filtered if domain or glob is excluded in config."""
+    entity_id = "switch.bla"
+    entity_id2 = "sensor.blu"
+    entity_id3 = "sensor.excluded"
+
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {
+                CONF_EXCLUDE: {
+                    CONF_DOMAINS: ["switch", "alexa"],
+                    CONF_ENTITY_GLOBS: "*.excluded",
+                }
+            },
+        }
+    )
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 20)
+    hass.states.async_set(entity_id3, None)
+    hass.states.async_set(entity_id3, 30)
+
+    await _async_commit_and_wait(hass)
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+
+    import pprint
+    pprint.pprint(entries)
+    assert len(entries) == 2
+    _assert_entry(
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
+    )
+    _assert_entry(
+        entries[1], name="blu", domain="sensor", entity_id=entity_id2
+    )
+
+async def test_include_events_entity(hass, hass_client):
+    """Test if events are filtered if entity is included in config."""
+    entity_id = "sensor.bla"
+    entity_id2 = "sensor.blu"
+
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {
+                CONF_INCLUDE: {
+                    CONF_DOMAINS: ["homeassistant"],
+                    CONF_ENTITIES: [entity_id2],
+                }
+            },
+        }
+    )
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 20)
+
+    await _async_commit_and_wait(hass)
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+
+    assert len(entries) == 2
+    _assert_entry(
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
+    )
+    _assert_entry(
+        entries[1], name="blu", domain="sensor", entity_id=entity_id2
+    )
+
+
+
+async def test_exclude_events_entity(hass, hass_client):
+    """Test if events are filtered if entity is excluded in config."""
+    entity_id = "sensor.bla"
+    entity_id2 = "sensor.blu"
+
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {CONF_EXCLUDE: {CONF_ENTITIES: [entity_id]}},
+        }
+    )
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 20)
+
+    await _async_commit_and_wait(hass)
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+    assert len(entries) == 2
+    _assert_entry(
+        entries[0], name="Home Assistant", message="stopped", domain=ha.DOMAIN
+    )
+    _assert_entry(
+        entries[1], name="blu", domain="sensor", entity_id=entity_id2
+    )
+
+
+async def test_include_events_domain(hass, hass_client):
+    """Test if events are filtered if domain is included in config."""
+    assert await async_setup_component(hass, "alexa", {})
+    entity_id = "switch.bla"
+    entity_id2 = "sensor.blu"
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {
+                CONF_INCLUDE: {CONF_DOMAINS: ["homeassistant", "sensor", "alexa"]}
+            },
+        }
+    )
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.bus.async_fire(
+        EVENT_ALEXA_SMART_HOME,
+        {"request": {"namespace": "Alexa.Discovery", "name": "Discover"}},
+    )
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 20)
+
+    await _async_commit_and_wait(hass)
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+
+    assert len(entries) == 3
+    _assert_entry(
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
+    )
+    _assert_entry(entries[1], name="Amazon Alexa", domain="alexa")
+    _assert_entry(
+        entries[2], name="blu", domain="sensor", entity_id=entity_id2
+    )
+
+async def test_include_events_domain_glob(hass, hass_client):
+    """Test if events are filtered if domain or glob is included in config."""
+    assert await async_setup_component(hass, "alexa", {})
+    entity_id = "switch.bla"
+    entity_id2 = "sensor.blu"
+    entity_id3 = "switch.included"
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {
+                CONF_INCLUDE: {
+                    CONF_DOMAINS: ["homeassistant", "sensor", "alexa"],
+                    CONF_ENTITY_GLOBS: ["*.included"],
+                }
+            },
+        }
+    )
+    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_setup_component(hass, "logbook", config)
+    await hass.async_add_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.bus.async_fire(
+        EVENT_ALEXA_SMART_HOME,
+        {"request": {"namespace": "Alexa.Discovery", "name": "Discover"}},
+    )
+    hass.states.async_set(entity_id, None)
+    hass.states.async_set(entity_id, 10)
+    hass.states.async_set(entity_id2, None)
+    hass.states.async_set(entity_id2, 20)
+    hass.states.async_set(entity_id3, None)
+    hass.states.async_set(entity_id3, 30)
+
+    await _async_commit_and_wait(hass)
+    client = await hass_client()
+    entries = await _async_fetch_logbook(client)
+
+    assert len(entries) == 4
+    _assert_entry(
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
+    )
+    _assert_entry(entries[1], name="Amazon Alexa", domain="alexa")
+    _assert_entry(
+        entries[2], name="blu", domain="sensor", entity_id=entity_id2
+    )
+    _assert_entry(
+        entries[3], name="included", domain="switch", entity_id=entity_id3
+    )
+
+async def test_include_exclude_events(hass, hass_client):
+    """Test if events are filtered if include and exclude is configured."""
+    entity_id = "switch.bla"
+    entity_id2 = "sensor.blu"
+    entity_id3 = "sensor.bli"
+    pointA = dt_util.utcnow()
+    pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
+    entity_attr_cache = logbook.EntityAttributeCache(self.hass)
+
+    eventA1 = self.create_state_changed_event(pointA, entity_id, 10)
+    eventA2 = self.create_state_changed_event(pointA, entity_id2, 10)
+    eventA3 = self.create_state_changed_event(pointA, entity_id3, 10)
+    eventB1 = self.create_state_changed_event(pointB, entity_id, 20)
+    eventB2 = self.create_state_changed_event(pointB, entity_id2, 20)
+
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {
+                CONF_INCLUDE: {
+                    CONF_DOMAINS: ["sensor", "homeassistant"],
+                    CONF_ENTITIES: ["switch.bla"],
+                },
+                CONF_EXCLUDE: {
+                    CONF_DOMAINS: ["switch"],
+                    CONF_ENTITIES: ["sensor.bli"],
+                },
+            },
+        }
+    )
+    entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
+    events = [
+        e
+        for e in (
+            MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
+            eventA1,
+            eventA2,
+            eventA3,
+            eventB1,
+            eventB2,
+        )
+        if logbook._keep_event(self.hass, e, entities_filter)
+    ]
+    entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
+
+    assert len(entries) == 5
+    _assert_entry(
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
+    )
+    _assert_entry(
+        entries[1], name="bla", domain="switch", entity_id=entity_id
+    )
+    _assert_entry(
+        entries[2], name="blu", domain="sensor", entity_id=entity_id2
+    )
+    _assert_entry(
+        entries[3], name="bla", domain="switch", entity_id=entity_id
+    )
+    _assert_entry(
+        entries[4], name="blu", domain="sensor", entity_id=entity_id2
+    )
+
+async def test_include_exclude_events_with_glob_filters(hass, hass_client):
+    """Test if events are filtered if include and exclude is configured."""
+    entity_id = "switch.bla"
+    entity_id2 = "sensor.blu"
+    entity_id3 = "sensor.bli"
+    entity_id4 = "light.included"
+    entity_id5 = "switch.included"
+    entity_id6 = "sensor.excluded"
+    pointA = dt_util.utcnow()
+    pointB = pointA + timedelta(minutes=logbook.GROUP_BY_MINUTES)
+    pointC = pointB + timedelta(minutes=logbook.GROUP_BY_MINUTES)
+    entity_attr_cache = logbook.EntityAttributeCache(self.hass)
+
+    eventA1 = self.create_state_changed_event(pointA, entity_id, 10)
+    eventA2 = self.create_state_changed_event(pointA, entity_id2, 10)
+    eventA3 = self.create_state_changed_event(pointA, entity_id3, 10)
+    eventB1 = self.create_state_changed_event(pointB, entity_id, 20)
+    eventB2 = self.create_state_changed_event(pointB, entity_id2, 20)
+    eventC1 = self.create_state_changed_event(pointC, entity_id4, 30)
+    eventC2 = self.create_state_changed_event(pointC, entity_id5, 30)
+    eventC3 = self.create_state_changed_event(pointC, entity_id6, 30)
+
+    config = logbook.CONFIG_SCHEMA(
+        {
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {
+                CONF_INCLUDE: {
+                    CONF_DOMAINS: ["sensor", "homeassistant"],
+                    CONF_ENTITIES: ["switch.bla"],
+                    CONF_ENTITY_GLOBS: ["*.included"],
+                },
+                CONF_EXCLUDE: {
+                    CONF_DOMAINS: ["switch"],
+                    CONF_ENTITY_GLOBS: ["*.excluded"],
+                    CONF_ENTITIES: ["sensor.bli"],
+                },
+            },
+        }
+    )
+    entities_filter = convert_include_exclude_filter(config[logbook.DOMAIN])
+    events = [
+        e
+        for e in (
+            MockLazyEventPartialState(EVENT_HOMEASSISTANT_START),
+            eventA1,
+            eventA2,
+            eventA3,
+            eventB1,
+            eventB2,
+            eventC1,
+            eventC2,
+            eventC3,
+        )
+        if logbook._keep_event(self.hass, e, entities_filter)
+    ]
+    entries = list(logbook.humanify(self.hass, events, entity_attr_cache, {}))
+
+    assert len(entries) == 6
+    _assert_entry(
+        entries[0], name="Home Assistant", message="started", domain=ha.DOMAIN
+    )
+    _assert_entry(
+        entries[1], name="bla", domain="switch", entity_id=entity_id
+    )
+    _assert_entry(
+        entries[2], name="blu", domain="sensor", entity_id=entity_id2
+    )
+    _assert_entry(
+        entries[3], name="bla", domain="switch", entity_id=entity_id
+    )
+    _assert_entry(
+        entries[4], name="blu", domain="sensor", entity_id=entity_id2
+    )
+    _assert_entry(
+        entries[5], name="included", domain="light", entity_id=entity_id4
+    )
+
+async def _async_fetch_logbook(client):
+
+    # Today time 00:00:00
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day) - timedelta(hours=24)
+
+    # Test today entries without filters
+    end_time = start + timedelta(hours=48)
+    response = await client.get(f"/api/logbook/{start_date.isoformat()}?end_time={end_time}")
+    assert response.status == 200
+    return await response.json()
+
+async def _async_commit_and_wait(hass):
+    await hass.async_block_till_done()
+    await hass.async_add_executor_job(trigger_db_commit, hass)
+    await hass.async_block_till_done()
+    await hass.async_add_executor_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+    await hass.async_block_till_done()
+
+def _assert_entry(
+    entry, when=None, name=None, message=None, domain=None, entity_id=None
+):
+    """Assert an entry is what is expected."""
+    if when:
+        assert when.isoformat() == entry["when"]
+
+    if name:
+        assert name == entry["name"]
+
+    if message:
+        assert message == entry["message"]
+
+    if domain:
+        assert domain == entry["domain"]
+
+    if entity_id:
+        assert entity_id == entry["entity_id"]
 
 class MockLazyEventPartialState(ha.Event):
     """Minimal mock of a Lazy event."""


### PR DESCRIPTION
I'm adding this because this is the implementation used in logbook as well, and it
doesn't actual work as documented (details below).  history happens to get this
for free when we fix logbook.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add entity glob matching support to history

The logbook and history docs are currently wrong about the include/exclude matching as its done in sql and uses a different algorithm.  The tests were not end-to-end tests and only testing `_keep_event` which didn't include the sql part. 

It actually works like this:

No includes or excludes - pass all entities
Includes, no excludes - only include specified entities
Excludes, no includes - only exclude specified entities
Both includes and excludes - include specified entities and exclude specified entities from the remaining.

Logbook is actually using both algorithms so the behavior is undefined when mixing excludes and includes so it has a broken entity globs implementation where only excludes work (in some cases) even though its documented as supporting both. https://github.com/home-assistant/core/pull/40075 fixes that, and after this PR history and logbook will both use the same method.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14589

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
