### PR TITLE
Bump aioshelly library to version 0.3.3

### DIFF
--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -62,6 +62,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await self._async_get_info(host)
             except HTTP_CONNECT_ERRORS:
                 errors["base"] = "cannot_connect"
+            except aioshelly.FirmwareUnsupported:
+                return self.async_abort(reason="unsupported_firmware")
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -76,8 +78,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     device_info = await validate_input(self.hass, self.host, {})
                 except HTTP_CONNECT_ERRORS:
                     errors["base"] = "cannot_connect"
-                except aioshelly.FirmwareUnsupported:
-                    return self.async_abort(reason="unsupported_firmware")
                 except Exception:  # pylint: disable=broad-except
                     _LOGGER.exception("Unexpected exception")
                     errors["base"] = "unknown"
@@ -104,8 +104,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors["base"] = "cannot_connect"
             except HTTP_CONNECT_ERRORS:
                 errors["base"] = "cannot_connect"
-            except aioshelly.FirmwareUnsupported:
-                return self.async_abort(reason="unsupported_firmware")
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -137,6 +135,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.info = info = await self._async_get_info(zeroconf_info["host"])
         except HTTP_CONNECT_ERRORS:
             return self.async_abort(reason="cannot_connect")
+        except aioshelly.FirmwareUnsupported:
+            return self.async_abort(reason="unsupported_firmware")
 
         await self.async_set_unique_id(info["mac"])
         self._abort_if_unique_id_configured({CONF_HOST: zeroconf_info["host"]})
@@ -156,8 +156,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 device_info = await validate_input(self.hass, self.host, {})
             except HTTP_CONNECT_ERRORS:
                 errors["base"] = "cannot_connect"
-            except aioshelly.FirmwareUnsupported:
-                return self.async_abort(reason="unsupported_firmware")
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -6,7 +6,6 @@ import re
 import aiohttp
 import aioshelly
 import async_timeout
-import semantic_version
 import voluptuous as vol
 
 from homeassistant import config_entries, core
@@ -26,7 +25,7 @@ HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 
 HTTP_CONNECT_ERRORS = (asyncio.TimeoutError, aiohttp.ClientError)
 
-MIN_FIRMWARE_VERSION = "1.8.0"
+MIN_FIRMWARE_DATE = 20200812
 
 
 async def validate_input(hass: core.HomeAssistant, host, data):
@@ -51,14 +50,12 @@ async def validate_input(hass: core.HomeAssistant, host, data):
 
 def supported_firmware(ver_str):
     """Return True if firmware version is supported."""
-    ver_pattern = re.compile(r"(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.\d+)")
+    data_pattern = re.compile(r"^(\d{8})")
     try:
-        ver = ver_pattern.search(ver_str)[0]
+        data = int(data_pattern.search(ver_str)[0])
     except TypeError:
         return False
-    return semantic_version.Version.coerce(ver) > semantic_version.Version.coerce(
-        MIN_FIRMWARE_VERSION
-    )
+    return data > MIN_FIRMWARE_DATE
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==0.3.2"],
+  "requirements": ["aioshelly==0.3.3"],
   "zeroconf": [{"type": "_http._tcp.local.", "name":"shelly*"}],
   "codeowners": ["@balloob", "@bieniu"]
 }

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==0.3.2", "semantic_version==2.8.5"],
+  "requirements": ["aioshelly==0.3.2"],
   "zeroconf": [{"type": "_http._tcp.local.", "name":"shelly*"}],
   "codeowners": ["@balloob", "@bieniu"]
 }

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==0.3.2"],
+  "requirements": ["aioshelly==0.3.2", "semantic_version==2.8.5"],
   "zeroconf": [{"type": "_http._tcp.local.", "name":"shelly*"}],
   "codeowners": ["@balloob", "@bieniu"]
 }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -24,7 +24,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "unsupported_firmware": "The device is using an unsupported firmware version."
     }
   }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -221,7 +221,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.3.2
+aioshelly==0.3.3
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1959,6 +1959,9 @@ schiene==0.23
 # homeassistant.components.scsgate
 scsgate==0.1.0
 
+# homeassistant.components.shelly
+semantic_version==2.8.5
+
 # homeassistant.components.sendgrid
 sendgrid==6.4.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1959,9 +1959,6 @@ schiene==0.23
 # homeassistant.components.scsgate
 scsgate==0.1.0
 
-# homeassistant.components.shelly
-semantic_version==2.8.5
-
 # homeassistant.components.sendgrid
 sendgrid==6.4.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.3.2
+aioshelly==0.3.3
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -913,9 +913,6 @@ samsungctl[websocket]==0.7.1
 # homeassistant.components.samsungtv
 samsungtvws==1.4.0
 
-# homeassistant.components.shelly
-semantic_version==2.8.5
-
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
 sense_energy==0.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -913,6 +913,9 @@ samsungctl[websocket]==0.7.1
 # homeassistant.components.samsungtv
 samsungtvws==1.4.0
 
+# homeassistant.components.shelly
+semantic_version==2.8.5
+
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
 sense_energy==0.8.0

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -217,7 +217,7 @@ async def test_form_firmware_unsupported(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "fw": "20200827-070306/test-build@4a8bc427",
+            "fw": "070306/test-build@4a8bc427",
         },
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -401,7 +401,7 @@ async def test_zeroconf_firmware_unsupported(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "fw": "20200827-070306/v1.7.0@4a8bc427",
+            "fw": "20200421-070306/v1.7.0@4a8bc427",
         },
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -27,7 +27,6 @@ async def test_form(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ), patch(
         "aioshelly.Device.create",
@@ -72,7 +71,6 @@ async def test_form_auth(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": True,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -152,7 +150,6 @@ async def test_form_errors_test_connection(hass, error):
         return_value={
             "mac": "test-mac",
             "auth": False,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ), patch(
         "aioshelly.Device.create",
@@ -185,7 +182,6 @@ async def test_form_already_configured(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -240,7 +236,6 @@ async def test_form_auth_errors_test_connection(hass, error):
         return_value={
             "mac": "test-mac",
             "auth": True,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -270,7 +265,6 @@ async def test_zeroconf(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ):
         result = await hass.config_entries.flow.async_init(
@@ -324,7 +318,6 @@ async def test_zeroconf_confirm_error(hass, error):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ):
         result = await hass.config_entries.flow.async_init(
@@ -362,7 +355,6 @@ async def test_zeroconf_already_configured(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ):
         result = await hass.config_entries.flow.async_init(
@@ -418,7 +410,6 @@ async def test_zeroconf_require_auth(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": True,
-            "fw": "20200827-070306/v1.8.4@4a8bc427",
         },
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -23,11 +23,7 @@ async def test_form(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ), patch(
         "aioshelly.Device.create",
         new=AsyncMock(
@@ -67,11 +63,7 @@ async def test_form_auth(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": True,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": True},
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -122,10 +114,7 @@ async def test_form_errors_get_info(hass, error):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "aioshelly.get_info",
-        side_effect=exc,
-    ):
+    with patch("aioshelly.get_info", side_effect=exc):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1"},
@@ -146,15 +135,8 @@ async def test_form_errors_test_connection(hass, error):
     )
 
     with patch(
-        "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "auth": False,
-        },
-    ), patch(
-        "aioshelly.Device.create",
-        new=AsyncMock(side_effect=exc),
-    ):
+        "aioshelly.get_info", return_value={"mac": "test-mac", "auth": False}
+    ), patch("aioshelly.Device.create", new=AsyncMock(side_effect=exc)):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1"},
@@ -178,11 +160,7 @@ async def test_form_already_configured(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -202,10 +180,7 @@ async def test_form_firmware_unsupported(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "aioshelly.get_info",
-        side_effect=aioshelly.FirmwareUnsupported,
-    ):
+    with patch("aioshelly.get_info", side_effect=aioshelly.FirmwareUnsupported):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1"},
@@ -231,13 +206,7 @@ async def test_form_auth_errors_test_connection(hass, error):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "auth": True,
-        },
-    ):
+    with patch("aioshelly.get_info", return_value={"mac": "test-mac", "auth": True}):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1"},
@@ -261,11 +230,7 @@ async def test_zeroconf(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -314,11 +279,7 @@ async def test_zeroconf_confirm_error(hass, error):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -351,11 +312,7 @@ async def test_zeroconf_already_configured(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -371,10 +328,7 @@ async def test_zeroconf_already_configured(hass):
 
 async def test_zeroconf_firmware_unsupported(hass):
     """Test we abort if device firmware is unsupported."""
-    with patch(
-        "aioshelly.get_info",
-        side_effect=aioshelly.FirmwareUnsupported,
-    ):
+    with patch("aioshelly.get_info", side_effect=aioshelly.FirmwareUnsupported):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
@@ -387,10 +341,7 @@ async def test_zeroconf_firmware_unsupported(hass):
 
 async def test_zeroconf_cannot_connect(hass):
     """Test we get the form."""
-    with patch(
-        "aioshelly.get_info",
-        side_effect=asyncio.TimeoutError,
-    ):
+    with patch("aioshelly.get_info", side_effect=asyncio.TimeoutError):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
@@ -406,11 +357,7 @@ async def test_zeroconf_require_auth(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": True,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": True},
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -2,6 +2,7 @@
 import asyncio
 
 import aiohttp
+import aioshelly
 import pytest
 
 from homeassistant import config_entries, setup
@@ -207,12 +208,7 @@ async def test_form_firmware_unsupported(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-            "fw": "070306/test-build@4a8bc427",
-        },
+        side_effect=aioshelly.FirmwareUnsupported,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -385,12 +381,7 @@ async def test_zeroconf_firmware_unsupported(hass):
     """Test we abort if device firmware is unsupported."""
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-            "fw": "070306/test-build@4a8bc427",
-        },
+        side_effect=aioshelly.FirmwareUnsupported,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -398,16 +389,8 @@ async def test_zeroconf_firmware_unsupported(hass):
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
 
-        assert result["type"] == "form"
-        assert result["errors"] == {}
-
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"host": "1.1.1.1"},
-        )
-
-        assert result2["type"] == "abort"
-        assert result2["reason"] == "unsupported_firmware"
+        assert result["type"] == "abort"
+        assert result["reason"] == "unsupported_firmware"
 
 
 async def test_zeroconf_cannot_connect(hass):
@@ -482,43 +465,6 @@ async def test_zeroconf_require_auth(hass):
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_zeroconf_require_auth_firmware_unsupported(hass):
-    """Test we abort if device firmware is unsupported."""
-    with patch(
-        "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": True,
-            "fw": "070306/test-build@4a8bc427",
-        },
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
-            context={"source": config_entries.SOURCE_ZEROCONF},
-        )
-
-        assert result["type"] == "form"
-        assert result["errors"] == {}
-
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"host": "1.1.1.1"},
-        )
-
-        assert result2["type"] == "form"
-        assert result2["errors"] == {}
-
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            {"username": "test username", "password": "test password"},
-        )
-
-        assert result3["type"] == "abort"
-        assert result3["reason"] == "unsupported_firmware"
 
 
 async def test_zeroconf_not_shelly(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `aioshelly` library to version 0.3.3 to:
- abort Shelly integration config flow if device firmware version is unupported

Changelog: https://github.com/home-assistant-libs/aioshelly/compare/0.3.2...0.3.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40564
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
