### PR TITLE
Add support for toggling Daikin streamers

### DIFF
--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -3,7 +3,7 @@
   "name": "Daikin AC",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
-  "requirements": ["pydaikin==2.3.1"],
+  "requirements": ["pydaikin==2.4.0"],
   "codeowners": ["@fredrike"],
   "zeroconf": ["_dkapi._tcp.local."],
   "quality_scale": "platinum"

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -1,4 +1,5 @@
 """Support for Daikin AirBase zones."""
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity import ToggleEntity
 
 from . import DOMAIN as DAIKIN_DOMAIN
@@ -85,7 +86,7 @@ class DaikinZoneSwitch(ToggleEntity):
         await self._api.device.set_zone(self._zone_id, "0")
 
 
-class DaikinStreamerSwitch(ToggleEntity):
+class DaikinStreamerSwitch(SwitchEntity):
     """Streamer state."""
 
     def __init__(self, daikin_api):

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -4,6 +4,9 @@ from homeassistant.helpers.entity import ToggleEntity
 from . import DOMAIN as DAIKIN_DOMAIN
 
 ZONE_ICON = "mdi:home-circle"
+STREAMER_ICON = "mdi:air-filter"
+DAIKIN_ATTR_ADVANCED = "adv"
+DAIKIN_ATTR_STREAMER = "streamer"
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -17,15 +20,23 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
     daikin_api = hass.data[DAIKIN_DOMAIN][entry.entry_id]
+    switches = []
     zones = daikin_api.device.zones
     if zones:
-        async_add_entities(
+        switches.extend(
             [
                 DaikinZoneSwitch(daikin_api, zone_id)
                 for zone_id, zone in enumerate(zones)
                 if zone != ("-", "0")
             ]
         )
+    if daikin_api.device.support_advanced_modes:
+        # It isn't possible to find out from the API responses if a specific
+        # device supports the streamer, so assume so if it does support
+        # advanced modes.
+        switches.append(DaikinStreamerSwitch(daikin_api))
+    if switches:
+        async_add_entities(switches)
 
 
 class DaikinZoneSwitch(ToggleEntity):
@@ -72,3 +83,50 @@ class DaikinZoneSwitch(ToggleEntity):
     async def async_turn_off(self, **kwargs):
         """Turn the zone off."""
         await self._api.device.set_zone(self._zone_id, "0")
+
+
+class DaikinStreamerSwitch(ToggleEntity):
+    """Streamer state."""
+
+    def __init__(self, daikin_api):
+        """Initialize streamer switch."""
+        self._api = daikin_api
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._api.device.mac}-streamer"
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return STREAMER_ICON
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self._api.name} streamer"
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        return (
+            DAIKIN_ATTR_STREAMER in self._api.device.represent(DAIKIN_ATTR_ADVANCED)[1]
+        )
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return self._api.device_info
+
+    async def async_update(self):
+        """Retrieve latest state."""
+        await self._api.async_update()
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the zone on."""
+        await self._api.device.set_streamer("on")
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the zone off."""
+        await self._api.device.set_streamer("off")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1331,7 +1331,7 @@ pycsspeechtts==1.0.4
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-pydaikin==2.3.1
+pydaikin==2.4.0
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -670,7 +670,7 @@ pycoolmasternet-async==0.1.2
 pycountry==19.8.18
 
 # homeassistant.components.daikin
-pydaikin==2.3.1
+pydaikin==2.4.0
 
 # homeassistant.components.deconz
 pydeconz==76


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for toggling the streamer (air filter) on Daikin units that have one.

Upstream package changes: <https://bitbucket.org/mustang51/pydaikin/commits/tag/v2.4.0>

Documentation PR: https://github.com/home-assistant/home-assistant.io/pull/15927

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
