### PR TITLE
Update xknx to 0.14.3

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,6 +2,7 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.14.2"],
-  "codeowners": ["@Julius2342", "@farmio", "@marvin-w"]
+  "requirements": ["xknx==0.14.3"],
+  "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
+  "quality_scale": "silver"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2265,7 +2265,7 @@ xboxapi==2.0.1
 xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
-xknx==0.14.2
+xknx==0.14.3
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates the xknx library to 0.14.3 to comply with the requirements of silver integrations: https://github.com/XKNX/xknx/releases/tag/0.14.3


**Quality requirements for silver:**

- Connection/configuration is handled via a component.

The `KNXModule` is responsible for handling the connection. Configuration is handled by the device factory in `factory.py`.

- Set an appropriate SCAN_INTERVAL (if a polling integration)

KNX doesn't need polling.

- Raise PlatformNotReady if unable to connect during platform setup (if appropriate)

Connection is handled globally for all devices. Thus, raising PlatformNotReady is not possible?

If, at all, this should belong to: https://github.com/home-assistant/core/blob/dev/homeassistant/components/knx/__init__.py#L146 

But that's not a platform setup.

- Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.

KNX doesn't need expiring auth credentials.

- Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.

Reconnection mechanism is implemented in the underlying library. KNX doesn't require active internet connectivity if used within the same local network than HA.

- Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.

Reconnection mechanism is implemented in the underlying library.

```
2020-09-21 20:49:16 WARNING (MainThread) [xknx.log] Heartbeat to KNX bus failed. Reconnecting.
2020-09-21 21:30:58 INFO (MainThread) [xknx.log] Successfully reconnected to KNX bus.
```

- Set available property to False if appropriate (docs)

Done in `KnxEntity`. If the bus is disconnected the entities become unavailable.

- Entities have unique ID (if available) (docs)

Not only can multiple KNX entities belong to the same device but also we cannot read the serial number or any other uniquely identifiable information from that device. So unfortunately, this is impossible for us.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
