### PR TITLE
Serialize websocket event message once

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -77,7 +77,7 @@ def handle_subscribe_events(hass, connection, msg):
             ):
                 return
 
-            connection.send_message(messages.event_message(msg["id"], event))
+            connection.send_message(messages.cached_event_message(msg["id"], event))
 
     else:
 
@@ -87,7 +87,7 @@ def handle_subscribe_events(hass, connection, msg):
             if event.event_type == EVENT_TIME_CHANGED:
                 return
 
-            connection.send_message(messages.event_message(msg["id"], event.as_dict()))
+            connection.send_message(messages.cached_event_message(msg["id"], event))
 
     connection.subscriptions[msg["id"]] = hass.bus.async_listen(
         event_type, forward_events

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -11,17 +11,11 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.util.json import (
-    find_paths_unserializable_data,
-    format_unserializable_data,
-)
 
 from .auth import AuthPhase, auth_required_message
 from .const import (
     CANCELLATION_ERRORS,
     DATA_CONNECTIONS,
-    ERR_UNKNOWN_ERROR,
-    JSON_DUMP,
     MAX_PENDING_MSG,
     PENDING_MSG_PEAK,
     PENDING_MSG_PEAK_TIME,
@@ -30,7 +24,7 @@ from .const import (
     URL,
 )
 from .error import Disconnect
-from .messages import error_message
+from .messages import message_to_json
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 
@@ -72,27 +66,10 @@ class WebSocketHandler:
 
                 self._logger.debug("Sending %s", message)
 
-                if isinstance(message, str):
-                    await self.wsock.send_str(message)
-                    continue
+                if not isinstance(message, str):
+                    message = message_to_json(message)
 
-                try:
-                    dumped = JSON_DUMP(message)
-                except (ValueError, TypeError):
-                    await self.wsock.send_json(
-                        error_message(
-                            message["id"], ERR_UNKNOWN_ERROR, "Invalid JSON in response"
-                        )
-                    )
-                    self._logger.error(
-                        "Unable to serialize to JSON. Bad data found at %s",
-                        format_unserializable_data(
-                            find_paths_unserializable_data(message, dump=JSON_DUMP)
-                        ),
-                    )
-                    continue
-
-                await self.wsock.send_str(dumped)
+                await self.wsock.send_str(message)
 
         # Clean up the peaker checker when we shut down the writer
         if self._peak_checker_unsub:

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -1,11 +1,21 @@
 """Message templates for websocket commands."""
 
+from functools import lru_cache
+import logging
+from typing import Any, Dict
+
 import voluptuous as vol
 
+from homeassistant.core import Event
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util.json import (
+    find_paths_unserializable_data,
+    format_unserializable_data,
+)
 
 from . import const
 
+_LOGGER = logging.getLogger(__name__)
 # mypy: allow-untyped-defs
 
 # Minimal requirements of a message
@@ -18,12 +28,12 @@ MINIMAL_MESSAGE_SCHEMA = vol.Schema(
 BASE_COMMAND_MESSAGE_SCHEMA = vol.Schema({vol.Required("id"): cv.positive_int})
 
 
-def result_message(iden, result=None):
+def result_message(iden: int, result: Any = None) -> Dict:
     """Return a success result message."""
     return {"id": iden, "type": const.TYPE_RESULT, "success": True, "result": result}
 
 
-def error_message(iden, code, message):
+def error_message(iden: int, code: str, message: str) -> Dict:
     """Return an error result message."""
     return {
         "id": iden,
@@ -33,6 +43,37 @@ def error_message(iden, code, message):
     }
 
 
-def event_message(iden, event):
+def event_message(iden: int, event: Any) -> Dict:
     """Return an event message."""
     return {"id": iden, "type": "event", "event": event}
+
+
+@lru_cache(maxsize=128)
+def cached_event_message(iden: int, event: Event) -> str:
+    """Return an event message.
+
+    Serialize to json once per message.
+
+    Since we can have many clients connected that are
+    all getting many of the same events (mostly state changed)
+    we can avoid serializing the same data for each connection.
+    """
+    return message_to_json(event_message(iden, event))
+
+
+def message_to_json(message: Any) -> str:
+    """Serialize a websocket message to json."""
+    try:
+        return const.JSON_DUMP(message)
+    except (ValueError, TypeError):
+        _LOGGER.error(
+            "Unable to serialize to JSON. Bad data found at %s",
+            format_unserializable_data(
+                find_paths_unserializable_data(message, dump=const.JSON_DUMP)
+            ),
+        )
+        return const.JSON_DUMP(
+            error_message(
+                message["id"], const.ERR_UNKNOWN_ERROR, "Invalid JSON in response"
+            )
+        )

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -548,6 +548,11 @@ class Event:
         self.time_fired = time_fired or dt_util.utcnow()
         self.context: Context = context or Context()
 
+    def __hash__(self) -> int:
+        """Make hashable."""
+        # The only event type that shares context are the TIME_CHANGED
+        return hash((self.event_type, self.context.id, self.time_fired))
+
     def as_dict(self) -> Dict:
         """Create a dict representation of this Event.
 

--- a/tests/components/websocket_api/test_messages.py
+++ b/tests/components/websocket_api/test_messages.py
@@ -1,0 +1,65 @@
+"""Test Websocket API messages module."""
+
+from homeassistant.components.websocket_api.messages import (
+    cached_event_message,
+    message_to_json,
+)
+from homeassistant.const import EVENT_STATE_CHANGED
+from homeassistant.core import callback
+
+
+async def test_cached_event_message(hass):
+    """Test that we cache event messages."""
+
+    events = []
+
+    @callback
+    def _event_listener(event):
+        events.append(event)
+
+    hass.bus.async_listen(EVENT_STATE_CHANGED, _event_listener)
+
+    hass.states.async_set("light.window", "on")
+    hass.states.async_set("light.window", "off")
+    await hass.async_block_till_done()
+
+    assert len(events) == 2
+
+    msg0 = cached_event_message(2, events[0])
+    assert msg0 == cached_event_message(2, events[0])
+
+    msg1 = cached_event_message(2, events[1])
+    assert msg1 == cached_event_message(2, events[1])
+
+    assert msg0 != msg1
+
+    cache_info = cached_event_message.cache_info()
+    assert cache_info.hits == 2
+    assert cache_info.misses == 2
+    assert cache_info.currsize == 2
+
+    cached_event_message(2, events[1])
+    cache_info = cached_event_message.cache_info()
+    assert cache_info.hits == 3
+    assert cache_info.misses == 2
+    assert cache_info.currsize == 2
+
+
+async def test_message_to_json(caplog):
+    """Test we can serialize websocket messages."""
+
+    json_str = message_to_json({"id": 1, "message": "xyz"})
+
+    assert json_str == '{"id": 1, "message": "xyz"}'
+
+    json_str2 = message_to_json({"id": 1, "message": _Unserializeable()})
+
+    assert (
+        json_str2
+        == '{"id": 1, "type": "result", "success": false, "error": {"code": "unknown_error", "message": "Invalid JSON in response"}}'
+    )
+    assert "Unable to serialize to JSON" in caplog.text
+
+
+class _Unserializeable:
+    """A class that cannot be serialized."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Serialize websocket event messages once.

Since most of the json serialize work for the websocket was done
multiple times for the same message, we can avoid the overhead
of serializing the same message many times (once per websocket
client) with a cache.

Before (serialize taking roughly half of the websocket time):
<img width="1427" alt="Screen Shot 2020-09-22 at 7 55 15 AM" src="https://user-images.githubusercontent.com/663432/93884912-1ded8780-fca9-11ea-9e10-983b16df231f.png">

After (serialize not showing up on the profile):
<img width="1434" alt="Screen Shot 2020-09-22 at 7 55 25 AM" src="https://user-images.githubusercontent.com/663432/93884921-21810e80-fca9-11ea-8471-cd0c273777a0.png">

This also solves a problem where websocket messages would
get backed up waiting for cpu time to serialize the messages.


With many clients (10 in testing) connected, there was a noticeable slowdown
in updates.
After the change, the UI update lag is no longer apparent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40292
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
