### PR TITLE
Add support to reauthorize expired Plex tokens

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -225,7 +225,10 @@ async def async_unload_entry(hass, entry):
 async def async_options_updated(hass, entry):
     """Triggered by config entry options updates."""
     server_id = entry.data[CONF_SERVER_IDENTIFIER]
-    hass.data[PLEX_DOMAIN][SERVERS][server_id].options = entry.options
+
+    # Guard incomplete setup during reauth flows
+    if server_id in hass.data[PLEX_DOMAIN][SERVERS]:
+        hass.data[PLEX_DOMAIN][SERVERS][server_id].options = entry.options
 
 
 def play_on_sonos(hass, service_call):

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -14,8 +14,10 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
 )
+from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    CONF_SOURCE,
     CONF_URL,
     CONF_VERIFY_SSL,
     EVENT_HOMEASSISTANT_STOP,
@@ -75,7 +77,11 @@ async def async_setup_entry(hass, entry):
         hass.config_entries.async_update_entry(entry, options=options)
 
     plex_server = PlexServer(
-        hass, server_config, entry.data[CONF_SERVER_IDENTIFIER], entry.options
+        hass,
+        server_config,
+        entry.data[CONF_SERVER_IDENTIFIER],
+        entry.options,
+        entry.entry_id,
     )
     try:
         await hass.async_add_executor_job(plex_server.connect)
@@ -95,9 +101,21 @@ async def async_setup_entry(hass, entry):
             error,
         )
         raise ConfigEntryNotReady from error
+    except plexapi.exceptions.Unauthorized:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                PLEX_DOMAIN,
+                context={CONF_SOURCE: SOURCE_REAUTH},
+                data={**entry.data, "config_entry_id": entry.entry_id},
+            )
+        )
+        _LOGGER.error(
+            "Token not accepted, please reauthenticate Plex server '%s'",
+            entry.data[CONF_SERVER],
+        )
+        return False
     except (
         plexapi.exceptions.BadRequest,
-        plexapi.exceptions.Unauthorized,
         plexapi.exceptions.NotFound,
     ) as error:
         _LOGGER.error(

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_CLIENT_ID,
     CONF_HOST,
     CONF_PORT,
+    CONF_SOURCE,
     CONF_SSL,
     CONF_TOKEN,
     CONF_URL,
@@ -70,7 +71,7 @@ async def async_discover(hass):
     for server_data in gdm.entries:
         await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+            context={CONF_SOURCE: config_entries.SOURCE_INTEGRATION_DISCOVERY},
             data=server_data,
         )
 
@@ -95,6 +96,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.token = None
         self.client_id = None
         self._manual = False
+        self._entry_id = None
 
     async def async_step_user(
         self, user_input=None, errors=None
@@ -209,10 +211,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_user(errors=errors)
 
         server_id = plex_server.machine_identifier
-
-        await self.async_set_unique_id(server_id)
-        self._abort_if_unique_id_configured()
-
         url = plex_server.url_in_use
         token = server_config.get(CONF_TOKEN)
 
@@ -226,16 +224,29 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL
             )
 
+        data = {
+            CONF_SERVER: plex_server.friendly_name,
+            CONF_SERVER_IDENTIFIER: server_id,
+            PLEX_SERVER_CONFIG: entry_config,
+        }
+
+        await self.async_set_unique_id(server_id)
+        if self.context[CONF_SOURCE] == config_entries.SOURCE_REAUTH:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+
+            if entry is None:
+                return self.async_abort(reason="unknown_entry")
+
+            self.hass.config_entries.async_update_entry(entry, data=data)
+            _LOGGER.debug("Updated config entry for %s", plex_server.friendly_name)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        self._abort_if_unique_id_configured()
+
         _LOGGER.debug("Valid config created for %s", plex_server.friendly_name)
 
-        return self.async_create_entry(
-            title=plex_server.friendly_name,
-            data={
-                CONF_SERVER: plex_server.friendly_name,
-                CONF_SERVER_IDENTIFIER: server_id,
-                PLEX_SERVER_CONFIG: entry_config,
-            },
-        )
+        return self.async_create_entry(title=plex_server.friendly_name, data=data)
 
     async def async_step_select_server(self, user_input=None):
         """Use selected Plex server."""
@@ -315,6 +326,18 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Continue server validation with external token."""
         server_config = {CONF_TOKEN: self.token}
         return await self.async_step_server_validate(server_config)
+
+    async def async_step_reauth(self, data=None):
+        """Handle a reauthorization flow request."""
+        entry_data = dict(data)
+        self.current_login = entry_data
+        self._entry_id = self.current_login.get("config_entry_id")
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            return self.async_abort(reason="unknown_entry")
+
+        return await self.async_step_user()
 
 
 class PlexOptionsFlowHandler(config_entries.OptionsFlow):

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -236,10 +236,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             == config_entries.SOURCE_REAUTH
         ):
             entry = self.hass.config_entries.async_get_entry(self._entry_id)
-
-            if entry is None:
-                return self.async_abort(reason="unknown_entry")
-
             self.hass.config_entries.async_update_entry(entry, data=data)
             _LOGGER.debug("Updated config entry for %s", plex_server.friendly_name)
             await self.hass.config_entries.async_reload(entry.entry_id)
@@ -330,16 +326,10 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         server_config = {CONF_TOKEN: self.token}
         return await self.async_step_server_validate(server_config)
 
-    async def async_step_reauth(self, data=None):
+    async def async_step_reauth(self, data):
         """Handle a reauthorization flow request."""
-        entry_data = dict(data)
-        self.current_login = entry_data
-        self._entry_id = self.current_login.get("config_entry_id")
-
-        entry = self.hass.config_entries.async_get_entry(self._entry_id)
-        if entry is None:
-            return self.async_abort(reason="unknown_entry")
-
+        self.current_login = dict(data)
+        self._entry_id = self.current_login.pop("config_entry_id")
         return await self.async_step_user()
 
 

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -231,7 +231,10 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         }
 
         await self.async_set_unique_id(server_id)
-        if self.context[CONF_SOURCE] == config_entries.SOURCE_REAUTH:
+        if (
+            self.context[CONF_SOURCE]  # pylint: disable=no-member
+            == config_entries.SOURCE_REAUTH
+        ):
             entry = self.hass.config_entries.async_get_entry(self._entry_id)
 
             if entry is None:

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -43,8 +43,7 @@
       "already_in_progress": "Plex is being configured",
       "reauth_successful": "Successfully reauthenticated",
       "token_request_timeout": "Timed out obtaining token",
-      "unknown": "[%key:common::config_flow::error::unknown%]",
-      "unknown_entry": "Unknown config entry referenced"
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "options": {

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -41,8 +41,10 @@
       "all_configured": "All linked servers already configured",
       "already_configured": "This Plex server is already configured",
       "already_in_progress": "Plex is being configured",
+      "reauth_successful": "Successfully reauthenticated",
       "token_request_timeout": "Timed out obtaining token",
-      "unknown": "Failed for unknown reason"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unknown_entry": "Unknown config entry referenced"
     }
   },
   "options": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The integration currently needs to be removed and recreated if an authentication token expires. This detects an expired token and begins a config flow to reauthorize while preserving entities/options/etc.

If an expired token is detected during runtime, the integration will reload itself to avoid continuous logging errors and trigger the reauth step.

Currently does not handle reauthorizing in advanced mode as the reauth flow is created by the backend while that flag is set by the frontend.

Example reconfiguration alert from Integrations page:
![image](https://user-images.githubusercontent.com/1203111/93940285-cfb0a680-fcf1-11ea-8f58-63c93d9b9a7e.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
