### PR TITLE
Revert "Support learning different command types with remote"

### DIFF
--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -30,7 +30,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_ACTIVITY = "activity"
 ATTR_COMMAND = "command"
-ATTR_COMMAND_TYPE = "command_type"
 ATTR_DEVICE = "device"
 ATTR_NUM_REPEATS = "num_repeats"
 ATTR_DELAY_SECS = "delay_secs"
@@ -104,7 +103,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         {
             vol.Optional(ATTR_DEVICE): cv.string,
             vol.Optional(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
-            vol.Optional(ATTR_COMMAND_TYPE): cv.string,
             vol.Optional(ATTR_ALTERNATIVE): cv.boolean,
             vol.Optional(ATTR_TIMEOUT): cv.positive_int,
         },

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -58,9 +58,6 @@ learn_command:
     command:
       description: A single command or a list of commands to learn.
       example: "Turn on"
-    command_type:
-      description: The type of command to be learned.
-      example: "rf"
     alternative:
       description: If code must be stored as alternative (useful for discrete remotes).
       example: "True"

--- a/tests/components/remote/common.py
+++ b/tests/components/remote/common.py
@@ -7,7 +7,6 @@ from homeassistant.components.remote import (
     ATTR_ACTIVITY,
     ATTR_ALTERNATIVE,
     ATTR_COMMAND,
-    ATTR_COMMAND_TYPE,
     ATTR_DELAY_SECS,
     ATTR_DEVICE,
     ATTR_NUM_REPEATS,
@@ -82,7 +81,6 @@ def learn_command(
     device=None,
     command=None,
     alternative=None,
-    command_type=None,
     timeout=None,
 ):
     """Learn a command from a device."""
@@ -95,9 +93,6 @@ def learn_command(
 
     if command:
         data[ATTR_COMMAND] = command
-
-    if command_type:
-        data[ATTR_COMMAND_TYPE] = command_type
 
     if alternative:
         data[ATTR_ALTERNATIVE] = alternative

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -101,7 +101,6 @@ class TestRemote(unittest.TestCase):
             entity_id="entity_id_val",
             device="test_device",
             command=["test_command"],
-            command_type="rf",
             alternative=True,
             timeout=20,
         )


### PR DESCRIPTION
Reverts home-assistant/core#39670

That PR changed our entity models without prior architectural discussion, which is required as per:

https://developers.home-assistant.io/docs/core/entity#changing-the-entity-model

This PR reverts #39670 until an architectural decision has been made.

CC: @ctalkington @felipediel @MartinHjelmare 