### PR TITLE
Ensure group state is recalculated when re-adding on reload

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.core import State
+from homeassistant.core import CoreState, State
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -162,6 +162,10 @@ class CoverGroup(GroupEntity, CoverEntity):
                 self.hass, self._entities, self._update_supported_features_event
             )
         )
+
+        if self.hass.state == CoreState.running:
+            await self.async_update()
+            return
         await super().async_added_to_hass()
 
     @property

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import CoreState, State
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
@@ -111,6 +111,11 @@ class LightGroup(GroupEntity, light.LightEntity):
                 self.hass, self._entity_ids, async_state_changed_listener
             )
         )
+
+        if self.hass.state == CoreState.running:
+            await self.async_update()
+            return
+
         await super().async_added_to_hass()
 
     @property

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -737,6 +737,11 @@ async def test_reload_with_base_integration_platform_not_setup(hass):
         },
     )
     await hass.async_block_till_done()
+    hass.states.async_set("light.master_hall_lights", STATE_ON)
+    hass.states.async_set("light.master_hall_lights_2", STATE_OFF)
+
+    hass.states.async_set("light.outside_patio_lights", STATE_OFF)
+    hass.states.async_set("light.outside_patio_lights_2", STATE_OFF)
 
     yaml_path = path.join(
         _get_fixtures_base_path(),
@@ -755,6 +760,8 @@ async def test_reload_with_base_integration_platform_not_setup(hass):
     assert hass.states.get("light.light_group") is None
     assert hass.states.get("light.master_hall_lights_g") is not None
     assert hass.states.get("light.outside_patio_lights_g") is not None
+    assert hass.states.get("light.master_hall_lights_g").state == STATE_ON
+    assert hass.states.get("light.outside_patio_lights_g").state == STATE_OFF
 
 
 def _get_fixtures_base_path():


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure group state is recalculated when re-adding on reload

The group would not be available until a state change event
that was being watched fired.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40200
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
