### PR TITLE
Add bare hostname as valid known hostname in get_url helper

### DIFF
--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -88,10 +88,12 @@ def get_url(
             scheme=scheme, host=request_host, port=hass.config.api.port
         )
 
-        known_hostname = None
+        known_hostnames = ["localhost"]
         if hass.components.hassio.is_hassio():
             host_info = hass.components.hassio.get_host_info()
-            known_hostname = f"{host_info['hostname']}.local"
+            known_hostnames.extend(
+                [host_info["hostname"], f"{host_info['hostname']}.local"]
+            )
 
         if (
             (
@@ -100,7 +102,7 @@ def get_url(
                     and is_ip_address(request_host)
                     and is_loopback(ip_address(request_host))
                 )
-                or request_host in ["localhost", known_hostname]
+                or request_host in known_hostnames
             )
             and (not require_ssl or current_url.scheme == "https")
             and (not require_standard_port or current_url.is_default_port())

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -849,6 +849,14 @@ async def test_get_current_request_url_with_known_host(
         )
 
     with patch(
+        "homeassistant.helpers.network._get_request_host",
+        return_value="homeassistant",
+    ):
+        assert (
+            get_url(hass, require_current_request=True) == "http://homeassistant:8123"
+        )
+
+    with patch(
         "homeassistant.helpers.network._get_request_host", return_value="unknown.local"
     ), pytest.raises(NoURLAvailableError):
         get_url(hass, require_current_request=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

For Home Assistant 0.115 I've added more logic to the get_url helper and our OAuth handling to handle `localhost` and the known hostname (e.g., `homeassistant.local`) automatically and gracefully.


On Discord @Sholofly ran into issues, as he was not using `http://homeassistant.local` but the `http://homeassistant` variant. Which can be valid in many cases as well.

This PR add support for the base hostname variant in the known hostnames, which should ease another situation with OAuth2 redirecting.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
