### PR TITLE
Remove auto from the fan speed modes for VeSync

### DIFF
--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -21,8 +21,8 @@ DEV_TYPE_TO_HA = {
     "LV-PUR131S": "fan",
 }
 
-SPEED_AUTO = "auto"
 FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+FAN_MODE_AUTO = "auto"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -70,8 +70,8 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
     @property
     def speed(self):
         """Return the current speed."""
-        if self.smartfan.mode == SPEED_AUTO:
-            return SPEED_AUTO
+        if self.smartfan.mode == FAN_MODE_AUTO:
+            return None
         if self.smartfan.mode == "manual":
             current_level = self.smartfan.fan_level
             if current_level is not None:
@@ -101,6 +101,9 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
 
     def set_speed(self, speed):
         """Set the speed of the device."""
+        if not self.smartfan.is_on:
+            self.smartfan.turn_on()
+
         self.smartfan.manual_mode()
         self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))
 

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -36,7 +36,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DOMAIN][VS_DISPATCHERS].append(disp)
 
     _async_setup_entities(hass.data[DOMAIN][VS_FANS], async_add_entities)
-    return True
 
 
 @callback

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -101,14 +101,8 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
 
     def set_speed(self, speed):
         """Set the speed of the device."""
-        if not self.smartfan.is_on:
-            self.smartfan.turn_on()
-
-        if speed is None or speed == SPEED_AUTO:
-            self.smartfan.auto_mode()
-        else:
-            self.smartfan.manual_mode()
-            self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))
+        self.smartfan.manual_mode()
+        self.smartfan.change_fan_speed(FAN_SPEEDS.index(speed))
 
     def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn the device on."""

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -22,7 +22,7 @@ DEV_TYPE_TO_HA = {
 }
 
 SPEED_AUTO = "auto"
-FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SPEED_AUTO]
+FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -22,7 +22,7 @@ DEV_TYPE_TO_HA = {
 }
 
 SPEED_AUTO = "auto"
-FAN_SPEEDS = [SPEED_AUTO, SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SPEED_AUTO]
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Remove the auto fan mode for the fan platform. The auto mode isn't supported by the entity model in Home Assistant and was initially added overlooking our entity model. Users that have automations or scripts targeting the vesync fan entity should review these and update as needed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40552
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
