### PR TITLE
Fix logbook with empty filter and remove unused code

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -127,8 +127,14 @@ def _get_significant_states(
     else:
         baked_query += lambda q: q.filter(States.last_updated > bindparam("start_time"))
 
-    if filters:
-        filters.bake(baked_query, entity_ids)
+    if entity_ids is not None:
+        baked_query += lambda q: q.filter(
+            States.entity_id.in_(bindparam("entity_ids", expanding=True))
+        )
+    else:
+        baked_query += lambda q: q.filter(~States.domain.in_(IGNORE_DOMAINS))
+        if filters:
+            filters.bake(baked_query)
 
     if end_time is not None:
         baked_query += lambda q: q.filter(States.last_updated < bindparam("end_time"))
@@ -296,10 +302,14 @@ def _get_states_with_session(
     query = query.join(
         most_recent_state_ids,
         States.state_id == most_recent_state_ids.c.max_state_id,
-    ).filter(~States.domain.in_(IGNORE_DOMAINS))
+    )
 
-    if filters:
-        query = filters.apply(query, entity_ids)
+    if entity_ids is not None:
+        query = query.filter(States.entity_id.in_(entity_ids))
+    else:
+        query = query.filter(~States.domain.in_(IGNORE_DOMAINS))
+        if filters:
+            query = filters.apply(query)
 
     return [LazyState(row) for row in execute(query)]
 
@@ -583,28 +593,12 @@ class Filters:
         self.included_domains = []
         self.included_entity_globs = []
 
-    def apply(self, query, entity_ids=None):
-        """Apply the include/exclude filter on domains and entities on query.
+    def apply(self, query):
+        """Apply the entity filter."""
+        if not self.has_config:
+            return query
 
-        Following rules apply:
-        * only the include section is configured - just query the specified
-          entities or domains.
-        * only the exclude section is configured - filter the specified
-          entities and domains from all the entities in the system.
-        * if include and exclude is defined - select the entities specified in
-          the include and filter out the ones from the exclude list.
-        """
-        # specific entities requested - do not in/exclude anything
-        if entity_ids is not None:
-            return query.filter(States.entity_id.in_(entity_ids))
-
-        query = query.filter(~States.domain.in_(IGNORE_DOMAINS))
-
-        entity_filter = self.entity_filter()
-        if entity_filter is not None:
-            query = query.filter(entity_filter)
-
-        return query
+        return query.filter(self.entity_filter())
 
     @property
     def has_config(self):
@@ -621,21 +615,15 @@ class Filters:
 
         return False
 
-    def bake(self, baked_query, entity_ids=None):
+    def bake(self, baked_query):
         """Update a baked query.
 
         Works the same as apply on a baked_query.
         """
-        if entity_ids is not None:
-            baked_query += lambda q: q.filter(
-                States.entity_id.in_(bindparam("entity_ids", expanding=True))
-            )
+        if not self.has_config:
             return
 
-        baked_query += lambda q: q.filter(~States.domain.in_(IGNORE_DOMAINS))
-
-        if self.has_config:
-            baked_query += lambda q: q.filter(self.entity_filter())
+        baked_query += lambda q: q.filter(self.entity_filter())
 
     def entity_filter(self):
         """Generate the entity filter query."""

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.recorder.models import (
     Events,
     States,
-    process_timestamp,
     process_timestamp_to_utc_isoformat,
 )
 from homeassistant.components.recorder.util import session_scope
@@ -764,7 +763,6 @@ class LazyEventPartialState:
     __slots__ = [
         "_row",
         "_event_data",
-        "_time_fired",
         "_time_fired_isoformat",
         "_attributes",
         "event_type",
@@ -780,7 +778,6 @@ class LazyEventPartialState:
         """Init the lazy event."""
         self._row = row
         self._event_data = None
-        self._time_fired = None
         self._time_fired_isoformat = None
         self._attributes = None
         self.event_type = self._row.event_type
@@ -842,24 +839,13 @@ class LazyEventPartialState:
         return self._event_data
 
     @property
-    def time_fired(self):
-        """Time event was fired in utc."""
-        if not self._time_fired:
-            self._time_fired = (
-                process_timestamp(self._row.time_fired) or dt_util.utcnow()
-            )
-        return self._time_fired
-
-    @property
     def time_fired_isoformat(self):
         """Time event was fired in utc isoformat."""
         if not self._time_fired_isoformat:
-            if self._time_fired:
-                self._time_fired_isoformat = self._time_fired.isoformat()
-            else:
-                self._time_fired_isoformat = process_timestamp_to_utc_isoformat(
-                    self._row.time_fired or dt_util.utcnow()
-                )
+            self._time_fired_isoformat = process_timestamp_to_utc_isoformat(
+                self._row.time_fired or dt_util.utcnow()
+            )
+
         return self._time_fired_isoformat
 
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -218,7 +218,8 @@ def process_timestamp_to_utc_isoformat(ts):
     """Process a timestamp into UTC isotime."""
     if ts is None:
         return None
+    if ts.tzinfo == dt_util.UTC:
+        return ts.isoformat()
     if ts.tzinfo is None:
         return f"{ts.isoformat()}{DB_TIMEZONE}"
-
-    return dt_util.as_utc(ts).isoformat()
+    return ts.astimezone(dt_util.UTC).isoformat()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove unused code in logbook.  This code is no longer used after the last round of refactoring and cleanups.

Tweak timestamp conversion and reorder code (elif was missing)

Fixes the empty config case @bramkragten pointed out here https://github.com/home-assistant/frontend/pull/6978#issuecomment-699946231

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
