### PR TITLE
0.115.3

### DIFF
--- a/homeassistant/components/accuweather/manifest.json
+++ b/homeassistant/components/accuweather/manifest.json
@@ -2,7 +2,7 @@
   "domain": "accuweather",
   "name": "AccuWeather",
   "documentation": "https://www.home-assistant.io/integrations/accuweather/",
-  "requirements": ["accuweather==0.0.10"],
+  "requirements": ["accuweather==0.0.11"],
   "codeowners": ["@bieniu"],
   "config_flow": true,
   "quality_scale": "platinum"

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,11 +3,11 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
-  "requirements": ["axis==35"],
+  "requirements": ["axis==37"],
   "zeroconf": [
-    {"type":"_axis-video._tcp.local.","macaddress":"00408C*"},
-    {"type":"_axis-video._tcp.local.","macaddress":"ACCC8E*"},
-    {"type":"_axis-video._tcp.local.","macaddress":"B8A44F*"}
+    { "type": "_axis-video._tcp.local.", "macaddress": "00408C*" },
+    { "type": "_axis-video._tcp.local.", "macaddress": "ACCC8E*" },
+    { "type": "_axis-video._tcp.local.", "macaddress": "B8A44F*" }
   ],
   "after_dependencies": ["mqtt"],
   "codeowners": ["@Kane610"]

--- a/homeassistant/components/bom/weather.py
+++ b/homeassistant/components/bom/weather.py
@@ -54,7 +54,9 @@ class BOMWeather(WeatherEntity):
     @property
     def condition(self):
         """Return the current condition."""
-        return self.bom_data.get_reading("weather")
+        return self.bom_data.get_reading("weather") or self.bom_data.get_reading(
+            "cloud"
+        )
 
     # Now implement the WeatherEntity interface
 

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -48,9 +48,9 @@ class DSMRConnection:
         """Test if we can validate connection with the device."""
 
         def update_telegram(telegram):
-            self._telegram = telegram
-
-            transport.close()
+            if obis_ref.EQUIPMENT_IDENTIFIER in telegram:
+                self._telegram = telegram
+                transport.close()
 
         if self._host is None:
             reader_factory = partial(

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -2,7 +2,7 @@
   "domain": "frontend",
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
-  "requirements": ["home-assistant-frontend==20200918.0"],
+  "requirements": ["home-assistant-frontend==20200918.2"],
   "dependencies": [
     "api",
     "auth",

--- a/homeassistant/components/gogogate2/manifest.json
+++ b/homeassistant/components/gogogate2/manifest.json
@@ -3,7 +3,7 @@
   "name": "Gogogate2 and iSmartGate",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gogogate2",
-  "requirements": ["gogogate2-api==2.0.2"],
+  "requirements": ["gogogate2-api==2.0.3"],
   "codeowners": ["@vangorra"],
   "homekit": {
     "models": [

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.core import State
+from homeassistant.core import CoreState, State
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -162,6 +162,10 @@ class CoverGroup(GroupEntity, CoverEntity):
                 self.hass, self._entities, self._update_supported_features_event
             )
         )
+
+        if self.hass.state == CoreState.running:
+            await self.async_update()
+            return
         await super().async_added_to_hass()
 
     @property

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import State
+from homeassistant.core import CoreState, State
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
@@ -111,6 +111,11 @@ class LightGroup(GroupEntity, light.LightEntity):
                 self.hass, self._entity_ids, async_state_changed_listener
             )
         )
+
+        if self.hass.state == CoreState.running:
+            await self.async_update()
+            return
+
         await super().async_added_to_hass()
 
     @property

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -145,7 +145,7 @@ async def async_attach_trigger(
             else:
                 cur_value = new_st.attributes.get(attribute)
 
-            if CONF_TO not in config:
+            if CONF_FROM in config and CONF_TO not in config:
                 return cur_value != old_value
 
             return cur_value == new_value

--- a/homeassistant/components/homeassistant/triggers/time_pattern.py
+++ b/homeassistant/components/homeassistant/triggers/time_pattern.py
@@ -36,7 +36,7 @@ class TimePattern:
             if isinstance(value, str) and value.startswith("/"):
                 number = int(value[1:])
             else:
-                number = int(value)
+                value = number = int(value)
 
             if not (0 <= number <= self.maximum):
                 raise vol.Invalid(f"must be a value between 0 and {self.maximum}")

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -2,7 +2,7 @@
   "domain": "insteon",
   "name": "Insteon",
   "documentation": "https://www.home-assistant.io/integrations/insteon",
-  "requirements": ["pyinsteon==1.0.7"],
+  "requirements": ["pyinsteon==1.0.8"],
   "codeowners": ["@teharris1"],
   "config_flow": true
 }

--- a/homeassistant/components/kodi/config_flow.py
+++ b/homeassistant/components/kodi/config_flow.py
@@ -202,6 +202,10 @@ class KodiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._ws_port = user_input.get(CONF_WS_PORT)
 
+            # optional ints return 0 rather than None when empty
+            if self._ws_port == 0:
+                self._ws_port = None
+
             try:
                 await validate_ws(self.hass, self._get_data())
             except WSCannotConnect:

--- a/homeassistant/components/luci/device_tracker.py
+++ b/homeassistant/components/luci/device_tracker.py
@@ -94,7 +94,11 @@ class LuciDeviceScanner(DeviceScanner):
 
         last_results = []
         for device in result:
-            if device.reachable:
+            if (
+                not hasattr(self.router.router.owrt_version, "release")
+                or self.router.router.owrt_version.release[0] < 19
+                or device.reachable
+            ):
                 last_results.append(device)
 
         self.last_results = last_results

--- a/homeassistant/components/luci/device_tracker.py
+++ b/homeassistant/components/luci/device_tracker.py
@@ -96,6 +96,7 @@ class LuciDeviceScanner(DeviceScanner):
         for device in result:
             if (
                 not hasattr(self.router.router.owrt_version, "release")
+                or not self.router.router.owrt_version.release
                 or self.router.router.owrt_version.release[0] < 19
                 or device.reachable
             ):

--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -5,6 +5,8 @@ import voluptuous as vol
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_TEMP,
+    ATTR_FORECAST_TIME,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
@@ -209,8 +211,11 @@ class MetWeather(CoordinatorEntity, WeatherEntity):
             met_forecast = self.coordinator.data.hourly_forecast
         else:
             met_forecast = self.coordinator.data.daily_forecast
+        required_keys = {ATTR_FORECAST_TEMP, ATTR_FORECAST_TIME}
         ha_forecast = []
         for met_item in met_forecast:
+            if not set(met_item).issuperset(required_keys):
+                continue
             ha_item = {
                 k: met_item[v] for k, v in FORECAST_MAP.items() if met_item.get(v)
             }

--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -214,8 +214,9 @@ class MetWeather(CoordinatorEntity, WeatherEntity):
             ha_item = {
                 k: met_item[v] for k, v in FORECAST_MAP.items() if met_item.get(v)
             }
-            ha_item[ATTR_FORECAST_CONDITION] = format_condition(
-                ha_item[ATTR_FORECAST_CONDITION]
-            )
+            if ha_item.get(ATTR_FORECAST_CONDITION):
+                ha_item[ATTR_FORECAST_CONDITION] = format_condition(
+                    ha_item[ATTR_FORECAST_CONDITION]
+                )
             ha_forecast.append(ha_item)
         return ha_forecast

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -158,20 +158,23 @@ class ModbusCoilSwitch(ToggleEntity, RestoreEntity):
         """Update the state of the switch."""
         self._is_on = self._read_coil(self._coil)
 
-    def _read_coil(self, coil) -> Optional[bool]:
+    def _read_coil(self, coil) -> bool:
         """Read coil using the Modbus hub slave."""
         try:
             result = self._hub.read_coils(self._slave, coil, 1)
         except ConnectionException:
             self._available = False
-            return
+            return False
 
         if isinstance(result, (ModbusException, ExceptionResponse)):
             self._available = False
-            return
+            return False
 
         self._available = True
-        return bool(result.bits[coil])
+        # bits[0] select the lowest bit in result,
+        # is_on for a binary_sensor is true if the bit are 1
+        # The other bits are not considered.
+        return bool(result.bits[0])
 
     def _write_coil(self, coil, value):
         """Write coil using the Modbus hub slave."""

--- a/homeassistant/components/nextcloud/__init__.py
+++ b/homeassistant/components/nextcloud/__init__.py
@@ -100,6 +100,7 @@ def setup(hass, config):
         _LOGGER.error("Nextcloud setup failed - Check configuration")
 
     hass.data[DOMAIN] = get_data_points(ncm.data)
+    hass.data[DOMAIN]["instance"] = conf[CONF_URL]
 
     def nextcloud_update(event_time):
         """Update data from nextcloud api."""

--- a/homeassistant/components/proxy/camera.py
+++ b/homeassistant/components/proxy/camera.py
@@ -77,6 +77,8 @@ def _precheck_image(image, opts):
     if imgfmt not in ("PNG", "JPEG"):
         _LOGGER.warning("Image is of unsupported type: %s", imgfmt)
         raise ValueError()
+    if not img.mode == "RGB":
+        img = img.convert("RGB")
     return img
 
 

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -86,7 +86,7 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         try:
             async with async_timeout.timeout(5):
                 return await self.device.update()
-        except aiocoap_error.Error as err:
+        except (aiocoap_error.Error, OSError) as err:
             raise update_coordinator.UpdateFailed("Error fetching data") from err
 
     @property

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -267,7 +267,8 @@ class SolarEdgeStorageLevelSensor(SolarEdgeSensor):
         """Get the latest inventory data and update state and attributes."""
         self.data_service.update()
         attr = self.data_service.attributes.get(self._json_key)
-        self._state = attr["soc"]
+        if attr and "soc" in attr:
+            self._state = attr["soc"]
 
 
 class SolarEdgeDataService:

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -113,7 +113,11 @@ def _stream_worker_internal(hass, stream, quit_event):
             # Get to first video keyframe
             while first_packet[video_stream] is None:
                 packet = next(container.demux())
-                if packet.stream == video_stream and packet.is_keyframe:
+                if (
+                    packet.stream == video_stream
+                    and packet.is_keyframe
+                    and packet.dts is not None
+                ):
                     first_packet[video_stream] = packet
                     initial_packets.append(packet)
             # Get first_pts from subsequent frame to first keyframe
@@ -121,6 +125,8 @@ def _stream_worker_internal(hass, stream, quit_event):
                 [pts is None for pts in {**first_packet, **first_pts}.values()]
             ) and (len(initial_packets) < PACKETS_TO_WAIT_FOR_AUDIO):
                 packet = next(container.demux((video_stream, audio_stream)))
+                if packet.dts is None:
+                    continue  # Discard packets with no dts
                 if (
                     first_packet[packet.stream] is None
                 ):  # actually video already found above so only for audio

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -77,6 +77,9 @@ def _stream_worker_internal(hass, stream, quit_event):
     # compatible with empty_moov and manual bitstream filters not in PyAV
     if container.format.name in {"hls", "mpegts"}:
         audio_stream = None
+    # Some audio streams do not have a profile and throw errors when remuxing
+    if audio_stream and audio_stream.profile is None:
+        audio_stream = None
 
     # The presentation timestamps of the first packet in each stream we receive
     # Use to adjust before muxing or outputting, but we don't adjust internally

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -67,7 +67,7 @@ class Device:
         """Create UPnP/IGD device."""
         # build async_upnp_client requester
         session = async_get_clientsession(hass)
-        requester = AiohttpSessionRequester(session, True)
+        requester = AiohttpSessionRequester(session, True, 10)
 
         # create async_upnp_client device
         factory = UpnpFactory(requester, disable_state_variable_validation=True)

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -305,7 +305,9 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         """Flag media player features that are supported."""
         supported = SUPPORT_WEBOSTV
 
-        if self._client.sound_output == "external_arc":
+        if (self._client.sound_output == "external_arc") or (
+            self._client.sound_output == "external_speaker"
+        ):
             supported = supported | SUPPORT_WEBOSTV_VOLUME
         elif self._client.sound_output != "lineout":
             supported = supported | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 115
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ defusedxml==0.6.0
 distro==1.5.0
 emoji==0.5.4
 hass-nabucasa==0.37.0
-home-assistant-frontend==20200918.0
+home-assistant-frontend==20200918.2
 importlib-metadata==1.6.0;python_version<'3.8'
 jinja2>=2.11.2
 netdisco==2.8.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -669,7 +669,7 @@ glances_api==0.2.0
 gntp==1.0.3
 
 # homeassistant.components.gogogate2
-gogogate2-api==2.0.2
+gogogate2-api==2.0.3
 
 # homeassistant.components.google
 google-api-python-client==1.6.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -102,7 +102,7 @@ YesssSMS==0.4.1
 abodepy==1.1.0
 
 # homeassistant.components.accuweather
-accuweather==0.0.10
+accuweather==0.0.11
 
 # homeassistant.components.mcp23017
 adafruit-blinka==3.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==35
+axis==37
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -747,7 +747,7 @@ hole==0.5.1
 holidays==0.10.3
 
 # homeassistant.components.frontend
-home-assistant-frontend==20200918.0
+home-assistant-frontend==20200918.2
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1401,7 +1401,7 @@ pyialarm==0.3
 pyicloud==0.9.7
 
 # homeassistant.components.insteon
-pyinsteon==1.0.7
+pyinsteon==1.0.8
 
 # homeassistant.components.intesishome
 pyintesishome==1.7.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -174,7 +174,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==35
+axis==37
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -674,7 +674,7 @@ pyhomematic==0.1.68
 pyicloud==0.9.7
 
 # homeassistant.components.insteon
-pyinsteon==1.0.7
+pyinsteon==1.0.8
 
 # homeassistant.components.ipma
 pyipma==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -370,7 +370,7 @@ hole==0.5.1
 holidays==0.10.3
 
 # homeassistant.components.frontend
-home-assistant-frontend==20200918.0
+home-assistant-frontend==20200918.2
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -45,7 +45,7 @@ YesssSMS==0.4.1
 abodepy==1.1.0
 
 # homeassistant.components.accuweather
-accuweather==0.0.10
+accuweather==0.0.11
 
 # homeassistant.components.androidtv
 adb-shell[async]==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -334,7 +334,7 @@ gios==0.1.4
 glances_api==0.2.0
 
 # homeassistant.components.gogogate2
-gogogate2-api==2.0.2
+gogogate2-api==2.0.3
 
 # homeassistant.components.google
 google-api-python-client==1.6.4

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -737,6 +737,11 @@ async def test_reload_with_base_integration_platform_not_setup(hass):
         },
     )
     await hass.async_block_till_done()
+    hass.states.async_set("light.master_hall_lights", STATE_ON)
+    hass.states.async_set("light.master_hall_lights_2", STATE_OFF)
+
+    hass.states.async_set("light.outside_patio_lights", STATE_OFF)
+    hass.states.async_set("light.outside_patio_lights_2", STATE_OFF)
 
     yaml_path = path.join(
         _get_fixtures_base_path(),
@@ -755,6 +760,8 @@ async def test_reload_with_base_integration_platform_not_setup(hass):
     assert hass.states.get("light.light_group") is None
     assert hass.states.get("light.master_hall_lights_g") is not None
     assert hass.states.get("light.outside_patio_lights_g") is not None
+    assert hass.states.get("light.master_hall_lights_g").state == STATE_ON
+    assert hass.states.get("light.outside_patio_lights_g").state == STATE_OFF
 
 
 def _get_fixtures_base_path():

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -1,4 +1,6 @@
 """The tests for the time_pattern automation."""
+from datetime import timedelta
+
 import pytest
 import voluptuous as vol
 
@@ -118,6 +120,39 @@ async def test_if_fires_when_second_matches(hass, calls):
         )
 
     async_fire_time_changed(hass, now.replace(year=now.year + 2, second=0))
+
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_if_fires_when_second_as_string_matches(hass, calls):
+    """Test for firing if seconds are matching."""
+    now = dt_util.utcnow()
+    time_that_will_not_match_right_away = dt_util.utcnow().replace(
+        year=now.year + 1, second=15
+    )
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time_pattern",
+                        "hours": "*",
+                        "minutes": "*",
+                        "seconds": "30",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
+
+    async_fire_time_changed(
+        hass, time_that_will_not_match_right_away + timedelta(seconds=15)
+    )
 
     await hass.async_block_till_done()
     assert len(calls) == 1


### PR DESCRIPTION
- Use Cloud State as alternative state if condition unknown ([@thehaxxa] - [#37121]) ([bom docs])
- Guard SolarEdge for inverters without batteries ([@mhaack] - [#40295]) ([solaredge docs])
- Ignore packets with missing dts in peek_first_pts ([@uvjustin] - [#40299]) ([stream docs])
- Axis - Fix list applications breaks if empty response ([@Kane610] - [#40360]) ([axis docs])
- Fix Met.no missing conditions in API forecasts ([@thimic] - [#40373]) ([met docs])
- Bump pyinsteon to 1.0.8 ([@teharris1] - [#40383]) ([insteon docs])
- Fix OSError ([@bieniu] - [#40393]) ([shelly docs])
- Fix handling of empty ws port ([@OnFreund] - [#40399]) ([kodi docs])
- Validate Met.no forecast entries before passing them on to HA ([@thimic] - [#40400]) ([met docs])
- Fix luci device_tracker incorrectly reporting devices status ([@cagnulein] - [#40409]) ([luci docs])
- Make modbus switch read_coil failure resistent ([@janiversen] - [#40417]) ([modbus docs])
- Fix webostv supported features for "external_speaker" sound output ([@PedroLamas] - [#40435]) ([webostv docs])
- Fix regression in Nextcloud component ([@meichthys] - [#40438]) ([nextcloud docs])
- Fix proxy camera conversion with PNG Alpha(RGBA) ([@square99] - [#40446]) ([proxy docs])
- Bump accuweather library to version 0.0.11 ([@bieniu] - [#40458])
- Increase gogogate2 request timeout ([@vangorra] - [#40461]) ([gogogate2 docs])
- Fix handling of quoted time_pattern values ([@amelchio] - [#40470]) ([homeassistant docs])
- Ensure group state is recalculated when re-adding on reload ([@bdraco] - [#40497]) ([group docs])
- Disable audio in stream when audio stream profile is None ([@uvjustin] - [#40521]) ([stream docs])
- Fix luci device_tracker when release is none ([@cagnulein] - [#40524]) ([luci docs])
- Increase upnp timeout from 5 seconds to 10 seconds ([@StevenLooman] - [#40540]) ([upnp docs])
- Fix connection validation during import for dsmr integration ([@RobBie1221] - [#40548]) ([dsmr docs])
- Updated frontend to 20200918.2 ([@bramkragten] - [#40549]) ([frontend docs])
- Fix bug in state trigger when using for: without to: ([@KevinCathcart] - [#40556]) ([homeassistant docs])

[#37121]: https://github.com/home-assistant/core/pull/37121
[#40295]: https://github.com/home-assistant/core/pull/40295
[#40299]: https://github.com/home-assistant/core/pull/40299
[#40360]: https://github.com/home-assistant/core/pull/40360
[#40373]: https://github.com/home-assistant/core/pull/40373
[#40383]: https://github.com/home-assistant/core/pull/40383
[#40393]: https://github.com/home-assistant/core/pull/40393
[#40399]: https://github.com/home-assistant/core/pull/40399
[#40400]: https://github.com/home-assistant/core/pull/40400
[#40409]: https://github.com/home-assistant/core/pull/40409
[#40417]: https://github.com/home-assistant/core/pull/40417
[#40435]: https://github.com/home-assistant/core/pull/40435
[#40438]: https://github.com/home-assistant/core/pull/40438
[#40446]: https://github.com/home-assistant/core/pull/40446
[#40458]: https://github.com/home-assistant/core/pull/40458
[#40461]: https://github.com/home-assistant/core/pull/40461
[#40470]: https://github.com/home-assistant/core/pull/40470
[#40497]: https://github.com/home-assistant/core/pull/40497
[#40521]: https://github.com/home-assistant/core/pull/40521
[#40524]: https://github.com/home-assistant/core/pull/40524
[#40540]: https://github.com/home-assistant/core/pull/40540
[#40548]: https://github.com/home-assistant/core/pull/40548
[#40549]: https://github.com/home-assistant/core/pull/40549
[#40556]: https://github.com/home-assistant/core/pull/40556
[@Kane610]: https://github.com/Kane610
[@KevinCathcart]: https://github.com/KevinCathcart
[@OnFreund]: https://github.com/OnFreund
[@PedroLamas]: https://github.com/PedroLamas
[@RobBie1221]: https://github.com/RobBie1221
[@StevenLooman]: https://github.com/StevenLooman
[@amelchio]: https://github.com/amelchio
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@bramkragten]: https://github.com/bramkragten
[@cagnulein]: https://github.com/cagnulein
[@janiversen]: https://github.com/janiversen
[@meichthys]: https://github.com/meichthys
[@mhaack]: https://github.com/mhaack
[@square99]: https://github.com/square99
[@teharris1]: https://github.com/teharris1
[@thehaxxa]: https://github.com/thehaxxa
[@thimic]: https://github.com/thimic
[@uvjustin]: https://github.com/uvjustin
[@vangorra]: https://github.com/vangorra
[axis docs]: https://www.home-assistant.io/integrations/axis/
[bom docs]: https://www.home-assistant.io/integrations/bom/
[dsmr docs]: https://www.home-assistant.io/integrations/dsmr/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[gogogate2 docs]: https://www.home-assistant.io/integrations/gogogate2/
[group docs]: https://www.home-assistant.io/integrations/group/
[homeassistant docs]: https://www.home-assistant.io/integrations/homeassistant/
[insteon docs]: https://www.home-assistant.io/integrations/insteon/
[kodi docs]: https://www.home-assistant.io/integrations/kodi/
[luci docs]: https://www.home-assistant.io/integrations/luci/
[met docs]: https://www.home-assistant.io/integrations/met/
[modbus docs]: https://www.home-assistant.io/integrations/modbus/
[nextcloud docs]: https://www.home-assistant.io/integrations/nextcloud/
[proxy docs]: https://www.home-assistant.io/integrations/proxy/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[solaredge docs]: https://www.home-assistant.io/integrations/solaredge/
[stream docs]: https://www.home-assistant.io/integrations/stream/
[upnp docs]: https://www.home-assistant.io/integrations/upnp/
[webostv docs]: https://www.home-assistant.io/integrations/webostv/