### PR TITLE
Allow non-authenticated calls to snapshots during onboarding

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -151,6 +151,6 @@ def _need_auth(hass, path: str) -> bool:
     """Return if a path need authentication."""
     if not async_is_onboarded(hass) and path.startswith("snapshots"):
         return False
-    elif NO_AUTH.match(path):
+    if NO_AUTH.match(path):
         return False
     return True

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -12,6 +12,7 @@ from aiohttp.web_exceptions import HTTPBadGateway
 import async_timeout
 
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
+from homeassistant.components.onboarding import async_is_onboarded
 from homeassistant.const import HTTP_UNAUTHORIZED
 
 from .const import X_HASS_IS_ADMIN, X_HASS_USER_ID, X_HASSIO
@@ -54,7 +55,8 @@ class HassIOView(HomeAssistantView):
         self, request: web.Request, path: str
     ) -> Union[web.Response, web.StreamResponse]:
         """Route data to Hass.io."""
-        if _need_auth(path) and not request[KEY_AUTHENTICATED]:
+        hass = request.app["hass"]
+        if _need_auth(hass, path) and not request[KEY_AUTHENTICATED]:
             return web.Response(status=HTTP_UNAUTHORIZED)
 
         return await self._command_proxy(path, request)
@@ -145,8 +147,10 @@ def _get_timeout(path: str) -> int:
     return 300
 
 
-def _need_auth(path: str) -> bool:
+def _need_auth(hass, path: str) -> bool:
     """Return if a path need authentication."""
-    if NO_AUTH.match(path):
+    if not async_is_onboarded(hass) and path.startswith("snapshots"):
+        return False
+    elif NO_AUTH.match(path):
         return False
     return True

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -3,6 +3,7 @@ import asyncio
 
 import pytest
 
+from homeassistant.components.hassio.http import _need_auth
 from tests.async_mock import patch
 
 
@@ -147,3 +148,12 @@ async def test_snapshot_upload_headers(hassio_client, aioclient_mock):
 
     req_headers = aioclient_mock.mock_calls[0][-1]
     req_headers["Content-Type"] == content_type
+
+
+def test_need_auth(hass):
+    """Test if the requested path needs authentication."""
+    assert not _need_auth(hass, "addons/test/logo")
+    assert _need_auth(hass, "snapshots/new/upload")
+
+    hass.data["onboarding"] = False
+    assert not _need_auth(hass, "snapshots/new/upload")

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -4,6 +4,7 @@ import asyncio
 import pytest
 
 from homeassistant.components.hassio.http import _need_auth
+
 from tests.async_mock import patch
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This will allow the user to interface with the snapshot API of the supervisor during onboarding.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/3910
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
