### PR TITLE
Add config flow to fritzbox netmonitor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -301,7 +301,7 @@ omit =
     homeassistant/components/freebox/switch.py
     homeassistant/components/fritz/device_tracker.py
     homeassistant/components/fritzbox_callmonitor/sensor.py
-    homeassistant/components/fritzbox_netmonitor/sensor.py
+    homeassistant/components/fritzbox_netmonitor/*
     homeassistant/components/fronius/sensor.py
     homeassistant/components/frontier_silicon/media_player.py
     homeassistant/components/futurenow/light.py

--- a/homeassistant/components/fritzbox_netmonitor/__init__.py
+++ b/homeassistant/components/fritzbox_netmonitor/__init__.py
@@ -4,7 +4,7 @@ from functools import partial
 
 from fritzconnection.core.exceptions import FritzConnectionException
 from fritzconnection.lib.fritzstatus import FritzStatus
-from requests.exceptions import ConnectionError
+import requests
 
 from homeassistant.const import CONF_HOST
 
@@ -27,7 +27,7 @@ async def async_setup_entry(hass, entry):
     except (
         ValueError,
         TypeError,
-        ConnectionError,
+        requests.exceptions.ConnectionError,
         FritzConnectionException,
     ) as error:
         LOGGER.error(

--- a/homeassistant/components/fritzbox_netmonitor/__init__.py
+++ b/homeassistant/components/fritzbox_netmonitor/__init__.py
@@ -1,1 +1,61 @@
 """The fritzbox_netmonitor component."""
+import asyncio
+import logging
+
+from fritzconnection.core.exceptions import FritzConnectionException
+from fritzconnection.lib.fritzstatus import FritzStatus
+from requests.exceptions import RequestException
+
+from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    EVENT_HOMEASSISTANT_STOP,
+)
+
+from .const import DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry):
+    """Set up the AVM Fritz!Box platforms."""
+    try:
+        fritzbox_status = FritzStatus(address=entry.data[CONF_HOST])
+    except (ValueError, TypeError, FritzConnectionException):
+        fritzbox_status = None
+
+    if fritzbox_status is None:
+        _LOGGER.error(
+            "Failed to establish connection to FRITZ!Box: %s", entry.data[CONF_HOST]
+        )
+        return False
+
+    hass.data[DOMAIN][entry.entry_id] = fritzbox_status
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unloading the AVM Fritz!Box platforms."""
+    fritz = hass.data[DOMAIN][entry.entry_id]
+    await hass.async_add_executor_job(fritz.logout)
+
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/fritzbox_netmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_netmonitor/config_flow.py
@@ -47,6 +47,10 @@ class FritzboxNetMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return RESULT_NOT_FOUND
         return RESULT_SUCCESS
 
+    async def async_step_import(self, user_input=None):
+        """Handle configuration by yaml file."""
+        return await self.async_step_user(user_input)
+
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         errors = {}

--- a/homeassistant/components/fritzbox_netmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_netmonitor/config_flow.py
@@ -64,8 +64,7 @@ class FritzboxNetMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if result == RESULT_SUCCESS:
                 return self._get_entry()
-            else:
-                return self.async_abort(reason=result)
+            return self.async_abort(reason=result)
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA_USER, errors=errors

--- a/homeassistant/components/fritzbox_netmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_netmonitor/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for fritzbox_netmonitor."""
 from fritzconnection.core.exceptions import FritzConnectionException
 from fritzconnection.lib.fritzstatus import FritzStatus
-from requests.exceptions import ConnectionError
+import requests
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -41,7 +41,7 @@ class FritzboxNetMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except (
             ValueError,
             TypeError,
-            ConnectionError,
+            requests.exceptions.ConnectionError,
             FritzConnectionException,
         ):
             return RESULT_NOT_FOUND
@@ -64,7 +64,7 @@ class FritzboxNetMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if result == RESULT_SUCCESS:
                 return self._get_entry()
-            elif result == RESULT_NOT_FOUND:
+            else:
                 return self.async_abort(reason=result)
 
         return self.async_show_form(

--- a/homeassistant/components/fritzbox_netmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_netmonitor/config_flow.py
@@ -1,0 +1,63 @@
+"""Config flow for fritzbox_netmonitor"""
+from fritzconnection.core.exceptions import FritzConnectionException
+from fritzconnection.lib.fritzstatus import FritzStatus
+from requests.exceptions import RequestException
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+
+# pylint:disable=unused-import
+from .const import CONF_DEFAULT_IP, DOMAIN
+
+DATA_SCHEMA_USER = vol.Schema({vol.Optional(CONF_HOST, default=CONF_DEFAULT_IP): str})
+
+RESULT_SUCCESS = "success"
+RESULT_NOT_FOUND = "not_found"
+
+
+class FritzboxNetMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a fritzbox_netmonitor config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self):
+        """Initialize flow."""
+        self._host = None
+
+    def _get_entry(self):
+        """Create and return an entry."""
+        return self.async_create_entry(title=self._name, data={CONF_HOST: self._host},)
+
+    def _try_connect(self):
+        """Try to connect"""
+        try:
+            fritzbox_status = FritzStatus(address=self._host)
+        except (ValueError, TypeError, FritzConnectionException):
+            return RESULT_NOT_FOUND
+        return RESULT_SUCCESS
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        if user_input is not None:
+
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.data[CONF_HOST] == user_input[CONF_HOST]:
+                    return self.async_abort(reason="already_configured")
+
+            self._host = user_input[CONF_HOST]
+
+            result = await self.hass.async_add_executor_job(self._try_connect)
+
+            if result == RESULT_SUCCESS:
+                return self._get_entry()
+            elif result == RESULT_NOT_FOUND:
+                return self.async_abort(reason=result)
+            errors["base"] = result
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA_USER, errors=errors
+        )

--- a/homeassistant/components/fritzbox_netmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_netmonitor/config_flow.py
@@ -13,7 +13,7 @@ from .const import DEFAULT_HOST, DOMAIN
 DATA_SCHEMA_USER = vol.Schema({vol.Optional(CONF_HOST, default=DEFAULT_HOST): str})
 
 RESULT_SUCCESS = "success"
-RESULT_NOT_FOUND = "not_found"
+RESULT_NO_DEVICES_FOUND = "no_devices_found"
 
 
 class FritzboxNetMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -44,7 +44,7 @@ class FritzboxNetMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             requests.exceptions.ConnectionError,
             FritzConnectionException,
         ):
-            return RESULT_NOT_FOUND
+            return RESULT_NO_DEVICES_FOUND
         return RESULT_SUCCESS
 
     async def async_step_import(self, user_input=None):

--- a/homeassistant/components/fritzbox_netmonitor/const.py
+++ b/homeassistant/components/fritzbox_netmonitor/const.py
@@ -1,11 +1,6 @@
-"""Constants for fritzbox_netmonitor"""
+"""Constants for fritzbox_netmonitor integration."""
 from datetime import timedelta
-
-DOMAIN = "fritzbox_netmonitor"
-PLATFORMS = ["sensor"]
-
-CONF_DEFAULT_NAME = "fritz_netmonitor"
-CONF_DEFAULT_IP = "169.254.1.1"  # This IP is valid for all FRITZ!Box routers.
+import logging
 
 ATTR_BYTES_RECEIVED = "bytes_received"
 ATTR_BYTES_SENT = "bytes_sent"
@@ -18,9 +13,18 @@ ATTR_MAX_BYTE_RATE_DOWN = "max_byte_rate_down"
 ATTR_MAX_BYTE_RATE_UP = "max_byte_rate_up"
 ATTR_UPTIME = "uptime"
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
-
 STATE_ONLINE = "online"
 STATE_OFFLINE = "offline"
 
+DEFAULT_HOST = "169.254.1.1"  # This IP is valid for all FRITZ!Box routers.
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
+
 ICON = "mdi:web"
+
+DOMAIN = "fritzbox_netmonitor"
+MANUFACTURER = "AVM"
+
+LOGGER = logging.getLogger(__package__)
+
+PLATFORMS = ["sensor"]

--- a/homeassistant/components/fritzbox_netmonitor/const.py
+++ b/homeassistant/components/fritzbox_netmonitor/const.py
@@ -1,0 +1,26 @@
+"""Constants for fritzbox_netmonitor"""
+from datetime import timedelta
+
+DOMAIN = "fritzbox_netmonitor"
+PLATFORMS = ["sensor"]
+
+CONF_DEFAULT_NAME = "fritz_netmonitor"
+CONF_DEFAULT_IP = "169.254.1.1"  # This IP is valid for all FRITZ!Box routers.
+
+ATTR_BYTES_RECEIVED = "bytes_received"
+ATTR_BYTES_SENT = "bytes_sent"
+ATTR_TRANSMISSION_RATE_UP = "transmission_rate_up"
+ATTR_TRANSMISSION_RATE_DOWN = "transmission_rate_down"
+ATTR_EXTERNAL_IP = "external_ip"
+ATTR_IS_CONNECTED = "is_connected"
+ATTR_IS_LINKED = "is_linked"
+ATTR_MAX_BYTE_RATE_DOWN = "max_byte_rate_down"
+ATTR_MAX_BYTE_RATE_UP = "max_byte_rate_up"
+ATTR_UPTIME = "uptime"
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
+
+STATE_ONLINE = "online"
+STATE_OFFLINE = "offline"
+
+ICON = "mdi:web"

--- a/homeassistant/components/fritzbox_netmonitor/manifest.json
+++ b/homeassistant/components/fritzbox_netmonitor/manifest.json
@@ -3,5 +3,6 @@
   "name": "AVM FRITZ!Box Net Monitor",
   "documentation": "https://www.home-assistant.io/integrations/fritzbox_netmonitor",
   "requirements": ["fritzconnection==1.2.0"],
-  "codeowners": []
+  "codeowners": [],
+  "config_flow": true
 }

--- a/homeassistant/components/fritzbox_netmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_netmonitor/sensor.py
@@ -1,5 +1,4 @@
 """Support for monitoring an AVM Fritz!Box router."""
-from datetime import timedelta
 import logging
 
 from fritzconnection.core.exceptions import FritzConnectionException
@@ -13,28 +12,26 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
+from .const import (
+    ATTR_BYTES_RECEIVED,
+    ATTR_BYTES_SENT,
+    ATTR_EXTERNAL_IP,
+    ATTR_IS_CONNECTED,
+    ATTR_IS_LINKED,
+    ATTR_MAX_BYTE_RATE_DOWN,
+    ATTR_MAX_BYTE_RATE_UP,
+    ATTR_TRANSMISSION_RATE_DOWN,
+    ATTR_TRANSMISSION_RATE_UP,
+    ATTR_UPTIME,
+    CONF_DEFAULT_IP,
+    CONF_DEFAULT_NAME,
+    ICON,
+    STATE_OFFLINE,
+    STATE_ONLINE,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
-CONF_DEFAULT_NAME = "fritz_netmonitor"
-CONF_DEFAULT_IP = "169.254.1.1"  # This IP is valid for all FRITZ!Box routers.
-
-ATTR_BYTES_RECEIVED = "bytes_received"
-ATTR_BYTES_SENT = "bytes_sent"
-ATTR_TRANSMISSION_RATE_UP = "transmission_rate_up"
-ATTR_TRANSMISSION_RATE_DOWN = "transmission_rate_down"
-ATTR_EXTERNAL_IP = "external_ip"
-ATTR_IS_CONNECTED = "is_connected"
-ATTR_IS_LINKED = "is_linked"
-ATTR_MAX_BYTE_RATE_DOWN = "max_byte_rate_down"
-ATTR_MAX_BYTE_RATE_UP = "max_byte_rate_up"
-ATTR_UPTIME = "uptime"
-
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
-
-STATE_ONLINE = "online"
-STATE_OFFLINE = "offline"
-
-ICON = "mdi:web"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -98,7 +95,7 @@ class FritzboxMonitorSensor(Entity):
         # Don't return attributes if FritzBox is unreachable
         if self._state == STATE_UNAVAILABLE:
             return {}
-        attr = {
+        return {
             ATTR_IS_LINKED: self._is_linked,
             ATTR_IS_CONNECTED: self._is_connected,
             ATTR_EXTERNAL_IP: self._external_ip,
@@ -110,7 +107,6 @@ class FritzboxMonitorSensor(Entity):
             ATTR_MAX_BYTE_RATE_UP: self._max_byte_rate_up,
             ATTR_MAX_BYTE_RATE_DOWN: self._max_byte_rate_down,
         }
-        return attr
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/fritzbox_netmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_netmonitor/sensor.py
@@ -1,9 +1,12 @@
 """Support for monitoring an AVM Fritz!Box router."""
 
-
 from requests.exceptions import RequestException
+import voluptuous as vol
 
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_HOST, STATE_UNAVAILABLE
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -18,6 +21,7 @@ from .const import (
     ATTR_TRANSMISSION_RATE_DOWN,
     ATTR_TRANSMISSION_RATE_UP,
     ATTR_UPTIME,
+    DEFAULT_HOST,
     DOMAIN,
     ICON,
     LOGGER,
@@ -26,6 +30,21 @@ from .const import (
     STATE_OFFLINE,
     STATE_ONLINE,
 )
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    }
+)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Import the platform into a config entry."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/fritzbox_netmonitor/strings.json
+++ b/homeassistant/components/fritzbox_netmonitor/strings.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "flow_title": "AVM FRITZ!Box Net Monitor: {name}",
+    "step": {
+      "user": {
+        "description": "Enter your AVM FRITZ!Box information.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "This AVM FRITZ!Box is already configured.",
+      "not_found": "No supported AVM FRITZ!Box found on the network."
+    }
+  }
+}

--- a/homeassistant/components/fritzbox_netmonitor/strings.json
+++ b/homeassistant/components/fritzbox_netmonitor/strings.json
@@ -10,8 +10,8 @@
       }
     },
     "abort": {
-      "already_configured": "This AVM FRITZ!Box is already configured.",
-      "not_found": "No supported AVM FRITZ!Box found on the network."
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     }
   }
 }

--- a/homeassistant/components/fritzbox_netmonitor/translations/en.json
+++ b/homeassistant/components/fritzbox_netmonitor/translations/en.json
@@ -1,0 +1,17 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "This AVM FRITZ!Box is already configured.",
+            "not_found": "No supported AVM FRITZ!Box found on the network."
+        },
+        "flow_title": "AVM FRITZ!Box Net Monitor: {name}",
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host"
+                },
+                "description": "Enter your AVM FRITZ!Box information."
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -61,6 +61,7 @@ FLOWS = [
     "forked_daapd",
     "freebox",
     "fritzbox",
+    "fritzbox_netmonitor",
     "garmin_connect",
     "gdacs",
     "geofency",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously, `fritzbox_netmonitor` was set up by adding a section to `configuration.yaml`. This has been removed and now uses a config flow to set up the integration via the web interface. Therefore, please remove `fritzbox_netmonitor` from `configuration.yaml` and set it up with its config flow.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the ability to set up the `fritzbox_netmonitor` integration via a config flow and removes the ability to set it up via YAML.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a anymore
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14616

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
