### PR TITLE
Improve deCONZ state updates

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -82,7 +82,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
         """Update the sensor's state."""
         keys = {"on", "reachable", "state"}
         if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback()
+            super().async_update_callback(force_update=force_update)
 
     @property
     def is_on(self):

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -80,12 +80,9 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the sensor's state."""
-        if ignore_update:
-            return
-
         keys = {"on", "reachable", "state"}
         if force_update or self._device.changed_keys.intersection(keys):
-            self.async_write_ha_state()
+            super().async_update_callback(ignore_update=ignore_update)
 
     @property
     def is_on(self):

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -78,11 +78,11 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     TYPE = DOMAIN
 
     @callback
-    def async_update_callback(self, force_update=False, ignore_update=False):
+    def async_update_callback(self, force_update=False):
         """Update the sensor's state."""
         keys = {"on", "reachable", "state"}
         if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(ignore_update=ignore_update)
+            super().async_update_callback()
 
     @property
     def is_on(self):

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -88,7 +88,7 @@ class DeconzDevice(DeconzBase, Entity):
     @callback
     def async_update_callback(self, force_update=False):
         """Update the device's state."""
-        if self.gateway.ignore_state_updates:
+        if not force_update and self.gateway.ignore_state_updates:
             return
 
         self.async_write_ha_state()

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -86,7 +86,7 @@ class DeconzDevice(DeconzBase, Entity):
         self.gateway.entities[self.TYPE].remove(self.unique_id)
 
     @callback
-    def async_update_callback(self, force_update=False, ignore_update=False):
+    def async_update_callback(self, force_update=False):
         """Update the device's state."""
         if self.gateway.ignore_state_updates:
             return

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -88,7 +88,7 @@ class DeconzDevice(DeconzBase, Entity):
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the device's state."""
-        if ignore_update:
+        if self.gateway.ignore_state_updates:
             return
 
         self.async_write_ha_state()

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -80,9 +80,12 @@ class DeconzEvent(DeconzBase):
         self._device.remove_callback(self.async_update_callback)
 
     @callback
-    def async_update_callback(self, force_update=False, ignore_update=False):
+    def async_update_callback(self, force_update=False):
         """Fire the event if reason is that state is updated."""
-        if ignore_update or "state" not in self._device.changed_keys:
+        if (
+            self.gateway.ignore_state_updates
+            or "state" not in self._device.changed_keys
+        ):
             return
 
         data = {

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -120,6 +120,7 @@ class DeconzGateway:
     def async_connection_status_callback(self, available) -> None:
         """Handle signals of gateway connection status."""
         self.available = available
+        self.ignore_state_updates = False
         async_dispatcher_send(self.hass, self.signal_reachable, True)
 
     @callback

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -45,13 +45,14 @@ class DeconzGateway:
         self.hass = hass
         self.config_entry = config_entry
 
-        self.available = True
         self.api = None
+
+        self.available = True
+
         self.deconz_ids = {}
+        self.entities = {}
         self.events = []
         self.listeners = []
-
-        self.entities = {}
 
         self._current_option_allow_clip_sensor = self.option_allow_clip_sensor
         self._current_option_allow_deconz_groups = self.option_allow_deconz_groups

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -48,6 +48,7 @@ class DeconzGateway:
         self.api = None
 
         self.available = True
+        self.ignore_state_updates = False
 
         self.deconz_ids = {}
         self.entities = {}

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -62,9 +62,16 @@ class DeconzGateway:
         return self.config_entry.unique_id
 
     @property
+    def host(self) -> str:
+        """Return the host of the gateway."""
+        return self.config_entry.data[CONF_HOST]
+
+    @property
     def master(self) -> bool:
         """Gateway which is used with deCONZ services without defining id."""
         return self.config_entry.options[CONF_MASTER_GATEWAY]
+
+    # Options
 
     @property
     def option_allow_clip_sensor(self) -> bool:
@@ -85,6 +92,45 @@ class DeconzGateway:
         """Allow automatic adding of new devices."""
         return self.config_entry.options.get(
             CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES
+        )
+
+    # Signals
+
+    @property
+    def signal_reachable(self) -> str:
+        """Gateway specific event to signal a change in connection status."""
+        return f"deconz-reachable-{self.bridgeid}"
+
+    @callback
+    def async_signal_new_device(self, device_type) -> str:
+        """Gateway specific event to signal new device."""
+        new_device = {
+            NEW_GROUP: f"deconz_new_group_{self.bridgeid}",
+            NEW_LIGHT: f"deconz_new_light_{self.bridgeid}",
+            NEW_SCENE: f"deconz_new_scene_{self.bridgeid}",
+            NEW_SENSOR: f"deconz_new_sensor_{self.bridgeid}",
+        }
+        return new_device[device_type]
+
+    # Callbacks
+
+    @callback
+    def async_connection_status_callback(self, available) -> None:
+        """Handle signals of gateway connection status."""
+        self.available = available
+        async_dispatcher_send(self.hass, self.signal_reachable, True)
+
+    @callback
+    def async_add_device_callback(self, device_type, device) -> None:
+        """Handle event of new device creation in deCONZ."""
+        if not self.option_allow_new_devices:
+            return
+
+        if not isinstance(device, list):
+            device = [device]
+
+        async_dispatcher_send(
+            self.hass, self.async_signal_new_device(device_type), device
         )
 
     async def async_update_device_registry(self) -> None:
@@ -140,11 +186,13 @@ class DeconzGateway:
         Causes for this is either discovery updating host address or config entry options changing.
         """
         gateway = get_gateway_from_config_entry(hass, entry)
+
         if not gateway:
             return
-        if gateway.api.host != entry.data[CONF_HOST]:
+
+        if gateway.api.host != gateway.host:
             gateway.api.close()
-            gateway.api.host = entry.data[CONF_HOST]
+            gateway.api.host = gateway.host
             gateway.api.start()
             return
 
@@ -187,41 +235,6 @@ class DeconzGateway:
                 # Removing an entity from the entity registry will also remove them
                 # from Home Assistant
                 entity_registry.async_remove(entity_id)
-
-    @property
-    def signal_reachable(self) -> str:
-        """Gateway specific event to signal a change in connection status."""
-        return f"deconz-reachable-{self.bridgeid}"
-
-    @callback
-    def async_connection_status_callback(self, available) -> None:
-        """Handle signals of gateway connection status."""
-        self.available = available
-        async_dispatcher_send(self.hass, self.signal_reachable, True)
-
-    @callback
-    def async_signal_new_device(self, device_type) -> str:
-        """Gateway specific event to signal new device."""
-        new_device = {
-            NEW_GROUP: f"deconz_new_group_{self.bridgeid}",
-            NEW_LIGHT: f"deconz_new_light_{self.bridgeid}",
-            NEW_SCENE: f"deconz_new_scene_{self.bridgeid}",
-            NEW_SENSOR: f"deconz_new_sensor_{self.bridgeid}",
-        }
-        return new_device[device_type]
-
-    @callback
-    def async_add_device_callback(self, device_type, device) -> None:
-        """Handle event of new device creation in deCONZ."""
-        if not self.option_allow_new_devices:
-            return
-
-        if not isinstance(device, list):
-            device = [device]
-
-        async_dispatcher_send(
-            self.hass, self.async_signal_new_device(device_type), device
-        )
 
     @callback
     def shutdown(self, event) -> None:

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -133,12 +133,9 @@ class DeconzSensor(DeconzDevice):
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the sensor's state."""
-        if ignore_update:
-            return
-
         keys = {"on", "reachable", "state"}
         if force_update or self._device.changed_keys.intersection(keys):
-            self.async_write_ha_state()
+            super().async_update_callback(ignore_update=ignore_update)
 
     @property
     def state(self):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -131,11 +131,11 @@ class DeconzSensor(DeconzDevice):
     TYPE = DOMAIN
 
     @callback
-    def async_update_callback(self, force_update=False, ignore_update=False):
+    def async_update_callback(self, force_update=False):
         """Update the sensor's state."""
         keys = {"on", "reachable", "state"}
         if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(ignore_update=ignore_update)
+            super().async_update_callback()
 
     @property
     def state(self):
@@ -195,11 +195,11 @@ class DeconzBattery(DeconzDevice):
     TYPE = DOMAIN
 
     @callback
-    def async_update_callback(self, force_update=False, ignore_update=False):
+    def async_update_callback(self, force_update=False):
         """Update the battery's state, if needed."""
         keys = {"battery", "reachable"}
         if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(ignore_update=ignore_update)
+            super().async_update_callback()
 
     @property
     def unique_id(self):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -197,12 +197,9 @@ class DeconzBattery(DeconzDevice):
     @callback
     def async_update_callback(self, force_update=False, ignore_update=False):
         """Update the battery's state, if needed."""
-        if ignore_update:
-            return
-
         keys = {"battery", "reachable"}
         if force_update or self._device.changed_keys.intersection(keys):
-            self.async_write_ha_state()
+            super().async_update_callback(ignore_update=ignore_update)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -135,7 +135,7 @@ class DeconzSensor(DeconzDevice):
         """Update the sensor's state."""
         keys = {"on", "reachable", "state"}
         if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback()
+            super().async_update_callback(force_update=force_update)
 
     @property
     def state(self):
@@ -199,7 +199,7 @@ class DeconzBattery(DeconzDevice):
         """Update the battery's state, if needed."""
         keys = {"battery", "reachable"}
         if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback()
+            super().async_update_callback(force_update=force_update)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -127,7 +127,9 @@ async def async_refresh_devices_service(hass, data):
     scenes = set(gateway.api.scenes.keys())
     sensors = set(gateway.api.sensors.keys())
 
+    gateway.ignore_state_updates = True
     await gateway.api.refresh_state(ignore_update=True)
+    gateway.ignore_state_updates = False
 
     gateway.async_add_device_callback(
         NEW_GROUP,

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -128,7 +128,7 @@ async def async_refresh_devices_service(hass, data):
     sensors = set(gateway.api.sensors.keys())
 
     gateway.ignore_state_updates = True
-    await gateway.api.refresh_state(ignore_update=True)
+    await gateway.api.refresh_state()
     gateway.ignore_state_updates = False
 
     gateway.async_add_device_callback(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move away from ugly solution to pass kwargs through the library to have entities ignore state updates
Improve priorities between force update and ignore update
Move some gateway methods around to more logical grouping

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
