### PR TITLE
Add unique_id to the light switch

### DIFF
--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
@@ -32,6 +33,7 @@ DEFAULT_NAME = "Light Switch"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Required(CONF_ENTITY_ID): cv.entity_domain(switch.DOMAIN),
     }
 )
@@ -45,17 +47,18 @@ async def async_setup_platform(
 ) -> None:
     """Initialize Light Switch platform."""
     async_add_entities(
-        [LightSwitch(cast(str, config.get(CONF_NAME)), config[CONF_ENTITY_ID])], True
+        [LightSwitch(cast(str, config.get(CONF_NAME)), config[CONF_ENTITY_ID], config.get(CONF_UNIQUE_ID))], True
     )
 
 
 class LightSwitch(LightEntity):
     """Represents a Switch as a Light."""
 
-    def __init__(self, name: str, switch_entity_id: str) -> None:
+    def __init__(self, name: str, switch_entity_id: str, unique_id: str) -> None:
         """Initialize Light Switch."""
         self._name = name
         self._switch_entity_id = switch_entity_id
+        self._unique_id = unique_id
         self._is_on = False
         self._available = False
         self._async_unsub_state_changed: Optional[CALLBACK_TYPE] = None
@@ -79,6 +82,11 @@ class LightSwitch(LightEntity):
     def should_poll(self) -> bool:
         """No polling needed for a light switch."""
         return False
+    
+    @property
+    def unique_id(self):
+        """Return the unique id of the light switch."""
+        return self._unique_id
 
     async def async_turn_on(self, **kwargs):
         """Forward the turn_on command to the switch in this light switch."""

--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
     CONF_NAME,
-    CONF_UNIQUE_ID,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
@@ -33,7 +32,6 @@ DEFAULT_NAME = "Light Switch"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Required(CONF_ENTITY_ID): cv.entity_domain(switch.DOMAIN),
     }
 )
@@ -46,12 +44,17 @@ async def async_setup_platform(
     discovery_info: Optional[DiscoveryInfoType] = None,
 ) -> None:
     """Initialize Light Switch platform."""
+
+    registry = await hass.helpers.entity_registry.async_get_registry()
+    wrapped_switch = registry.entities.get(config[CONF_ENTITY_ID])
+    unique_id = wrapped_switch.unique_id if wrapped_switch else None
+
     async_add_entities(
         [
             LightSwitch(
                 cast(str, config.get(CONF_NAME)),
                 config[CONF_ENTITY_ID],
-                cast(str, config.get(CONF_UNIQUE_ID)),
+                unique_id,
             )
         ],
         True,

--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -47,7 +47,14 @@ async def async_setup_platform(
 ) -> None:
     """Initialize Light Switch platform."""
     async_add_entities(
-        [LightSwitch(cast(str, config.get(CONF_NAME)), config[CONF_ENTITY_ID], config.get(CONF_UNIQUE_ID))], True
+        [
+            LightSwitch(
+                cast(str, config.get(CONF_NAME)),
+                config[CONF_ENTITY_ID],
+                cast(str, config.get(CONF_UNIQUE_ID)),
+            )
+        ],
+        True,
     )
 
 
@@ -82,7 +89,7 @@ class LightSwitch(LightEntity):
     def should_poll(self) -> bool:
         """No polling needed for a light switch."""
         return False
-    
+
     @property
     def unique_id(self):
         """Return the unique id of the light switch."""

--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -46,7 +46,7 @@ async def async_setup_platform(
     """Initialize Light Switch platform."""
 
     registry = await hass.helpers.entity_registry.async_get_registry()
-    wrapped_switch = registry.entities.get(config[CONF_ENTITY_ID])
+    wrapped_switch = registry.async_get(config[CONF_ENTITY_ID])
     unique_id = wrapped_switch.unique_id if wrapped_switch else None
 
     async_add_entities(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Add the ability to customize a light switch directly from the UI. The unique_id is retrieved from the wrapped switch. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
light:
  - platform: switch
    entity_id: switch.christmas_tree_lights
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
