### PR TITLE
Improve RemoteEntity class

### DIFF
--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -30,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_ACTIVITY = "activity"
 ATTR_COMMAND = "command"
+ATTR_COMMAND_TYPE = "command_type"
 ATTR_DEVICE = "device"
 ATTR_NUM_REPEATS = "num_repeats"
 ATTR_DELAY_SECS = "delay_secs"
@@ -103,6 +104,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         {
             vol.Optional(ATTR_DEVICE): cv.string,
             vol.Optional(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(ATTR_COMMAND_TYPE): cv.string,
             vol.Optional(ATTR_ALTERNATIVE): cv.boolean,
             vol.Optional(ATTR_TIMEOUT): cv.positive_int,
         },

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -47,6 +47,7 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 SERVICE_SEND_COMMAND = "send_command"
 SERVICE_LEARN_COMMAND = "learn_command"
+SERVICE_DELETE_COMMAND = "delete_command"
 SERVICE_SYNC = "sync"
 
 DEFAULT_NUM_REPEATS = 1
@@ -54,6 +55,7 @@ DEFAULT_DELAY_SECS = 0.4
 DEFAULT_HOLD_SECS = 0
 
 SUPPORT_LEARN_COMMAND = 1
+SUPPORT_DELETE_COMMAND = 2
 
 REMOTE_SERVICE_ACTIVITY_SCHEMA = make_entity_service_schema(
     {vol.Optional(ATTR_ACTIVITY): cv.string}
@@ -111,6 +113,15 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         "async_learn_command",
     )
 
+    component.async_register_entity_service(
+        SERVICE_DELETE_COMMAND,
+        {
+            vol.Required(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(ATTR_DEVICE): cv.string,
+        },
+        "async_delete_command",
+    )
+
     return True
 
 
@@ -151,6 +162,17 @@ class RemoteEntity(ToggleEntity):
         """Learn a command from a device."""
         assert self.hass is not None
         await self.hass.async_add_executor_job(ft.partial(self.learn_command, **kwargs))
+
+    def delete_command(self, **kwargs: Any) -> None:
+        """Delete commands from the database."""
+        raise NotImplementedError()
+
+    async def async_delete_command(self, **kwargs: Any) -> None:
+        """Delete commands from the database."""
+        assert self.hass is not None
+        await self.hass.async_add_executor_job(
+            ft.partial(self.delete_command, **kwargs)
+        )
 
 
 class RemoteDevice(RemoteEntity):

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -58,6 +58,9 @@ learn_command:
     command:
       description: A single command or a list of commands to learn.
       example: "Turn on"
+    command_type:
+      description: The type of command to be learned.
+      example: "rf"
     alternative:
       description: If code must be stored as alternative (useful for discrete remotes).
       example: "True"

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -67,3 +67,16 @@ learn_command:
     timeout:
       description: Timeout, in seconds, for the command to be learned.
       example: "30"
+
+delete_command:
+  description: Deletes a command or a list of commands from the database.
+  fields:
+    entity_id:
+      description: Name(s) of the remote entities holding the database.
+      example: "remote.bedroom"
+    device:
+      description: Name of the device from which commands will be deleted.
+      example: "television"
+    command:
+      description: A single command or a list of commands to delete.
+      example: "Mute"

--- a/tests/components/remote/common.py
+++ b/tests/components/remote/common.py
@@ -7,6 +7,7 @@ from homeassistant.components.remote import (
     ATTR_ACTIVITY,
     ATTR_ALTERNATIVE,
     ATTR_COMMAND,
+    ATTR_COMMAND_TYPE,
     ATTR_DELAY_SECS,
     ATTR_DEVICE,
     ATTR_NUM_REPEATS,
@@ -81,6 +82,7 @@ def learn_command(
     device=None,
     command=None,
     alternative=None,
+    command_type=None,
     timeout=None,
 ):
     """Learn a command from a device."""
@@ -93,6 +95,9 @@ def learn_command(
 
     if command:
         data[ATTR_COMMAND] = command
+
+    if command_type:
+        data[ATTR_COMMAND_TYPE] = command_type
 
     if alternative:
         data[ATTR_ALTERNATIVE] = alternative

--- a/tests/components/remote/common.py
+++ b/tests/components/remote/common.py
@@ -13,6 +13,7 @@ from homeassistant.components.remote import (
     ATTR_NUM_REPEATS,
     ATTR_TIMEOUT,
     DOMAIN,
+    SERVICE_DELETE_COMMAND,
     SERVICE_LEARN_COMMAND,
     SERVICE_SEND_COMMAND,
 )
@@ -106,3 +107,24 @@ def learn_command(
         data[ATTR_TIMEOUT] = timeout
 
     hass.services.call(DOMAIN, SERVICE_LEARN_COMMAND, data)
+
+
+@bind_hass
+def delete_command(
+    hass,
+    entity_id=ENTITY_MATCH_ALL,
+    device=None,
+    command=None,
+):
+    """Delete commands from the database."""
+    data = {}
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    if device:
+        data[ATTR_DEVICE] = device
+
+    if command:
+        data[ATTR_COMMAND] = command
+
+    hass.services.call(DOMAIN, SERVICE_DELETE_COMMAND, data)

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -101,6 +101,7 @@ class TestRemote(unittest.TestCase):
             entity_id="entity_id_val",
             device="test_device",
             command=["test_command"],
+            command_type="rf",
             alternative=True,
             timeout=20,
         )

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -19,6 +19,7 @@ from tests.components.remote import common
 TEST_PLATFORM = {remote.DOMAIN: {CONF_PLATFORM: "test"}}
 SERVICE_SEND_COMMAND = "send_command"
 SERVICE_LEARN_COMMAND = "learn_command"
+SERVICE_DELETE_COMMAND = "delete_command"
 
 
 class TestRemote(unittest.TestCase):
@@ -113,6 +114,28 @@ class TestRemote(unittest.TestCase):
 
         assert call.domain == remote.DOMAIN
         assert call.service == SERVICE_LEARN_COMMAND
+        assert call.data[ATTR_ENTITY_ID] == "entity_id_val"
+
+    def test_delete_command(self):
+        """Test delete_command."""
+        delete_command_calls = mock_service(
+            self.hass, remote.DOMAIN, SERVICE_DELETE_COMMAND
+        )
+
+        common.delete_command(
+            self.hass,
+            entity_id="entity_id_val",
+            device="test_device",
+            command=["test_command"],
+        )
+
+        self.hass.block_till_done()
+
+        assert len(delete_command_calls) == 1
+        call = delete_command_calls[-1]
+
+        assert call.domain == remote.DOMAIN
+        assert call.service == SERVICE_DELETE_COMMAND
         assert call.data[ATTR_ENTITY_ID] == "entity_id_val"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is based on [this discussion](https://github.com/home-assistant/architecture/issues/438). We are improving the RemoteEntity. These are the proposed changes:

- Add the `command_type` option to `remote.learn_command`.
- Create `remote.delete_command` service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

### Learn RF command
```yaml
# Example configuration.yaml
script:
  learn_car_lock:
    sequence:
      - service: remote.learn_command
        data:
          entity_id: remote.garage
          device: car
          command: unlock
          command_type: rf
```

### Delete a command
```yaml
# Example configuration.yaml
script:
  delete_car_lock:
    sequence:
      - service: remote.delete_command
        data:
          entity_id: remote.garage
          device: car
          command: unlock
```

### Delete a list of commands
```yaml
# Example configuration.yaml
script:
  delete_tv_commands:
    sequence:
      - service: remote.delete_command
        data:
          entity_id: remote.bedroom
          device: television
          command:
            - power
            - volume up
            - volume down
            - channel up
            - channel down
```
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/architecture/issues/438
- This PR is related to issue: https://community.home-assistant.io/t/where-broadlink-remote-commands-are-stored/165464/12
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
