### PR TITLE
Refactor group to extend domains that can be grouped

### DIFF
--- a/homeassistant/components/air_quality/group.py
+++ b/homeassistant/components/air_quality/group.py
@@ -1,0 +1,13 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states(None, None)

--- a/homeassistant/components/air_quality/group.py
+++ b/homeassistant/components/air_quality/group.py
@@ -1,13 +1,14 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states(None, None)
+    registry.exclude_domain()

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_CUSTOM_BYPASS,
@@ -15,10 +16,10 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states(
+    registry.on_off_states(
         [
             STATE_ALARM_ARMED_AWAY,
             STATE_ALARM_ARMED_CUSTOM_BYPASS,

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -1,0 +1,30 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_TRIGGERED,
+    STATE_OFF,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states(
+        [
+            STATE_ALARM_ARMED_AWAY,
+            STATE_ALARM_ARMED_CUSTOM_BYPASS,
+            STATE_ALARM_ARMED_HOME,
+            STATE_ALARM_ARMED_NIGHT,
+            STATE_ALARM_TRIGGERED,
+        ],
+        STATE_OFF,
+    )

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -20,12 +20,12 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        [
+        {
             STATE_ALARM_ARMED_AWAY,
             STATE_ALARM_ARMED_CUSTOM_BYPASS,
             STATE_ALARM_ARMED_HOME,
             STATE_ALARM_ARMED_NIGHT,
             STATE_ALARM_TRIGGERED,
-        ],
+        },
         STATE_OFF,
     )

--- a/homeassistant/components/binary_sensor/group.py
+++ b/homeassistant/components/binary_sensor/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/binary_sensor/group.py
+++ b/homeassistant/components/binary_sensor/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/binary_sensor/group.py
+++ b/homeassistant/components/binary_sensor/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/climate/group.py
+++ b/homeassistant/components/climate/group.py
@@ -1,7 +1,7 @@
 """Describe group states."""
 
-from typing import Callable
 
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -11,10 +11,10 @@ from .const import HVAC_MODE_OFF, HVAC_MODES
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states(
+    registry.on_off_states(
         set(HVAC_MODES) - {HVAC_MODE_OFF},
         STATE_OFF,
     )

--- a/homeassistant/components/climate/group.py
+++ b/homeassistant/components/climate/group.py
@@ -1,0 +1,20 @@
+"""Describe group states."""
+
+from typing import Callable
+
+from homeassistant.const import STATE_OFF
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import HVAC_MODE_OFF, HVAC_MODES
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states(
+        set(HVAC_MODES) - {HVAC_MODE_OFF},
+        STATE_OFF,
+    )

--- a/homeassistant/components/config/group.py
+++ b/homeassistant/components/config/group.py
@@ -1,8 +1,14 @@
 """Provide configuration end points for Groups."""
-from homeassistant.components.group import DOMAIN, GROUP_SCHEMA
+from homeassistant.components.group import (
+    DOMAIN,
+    GROUP_SCHEMA,
+    GroupIntegrationRegistry,
+)
 from homeassistant.config import GROUP_CONFIG_PATH
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import HomeAssistantType
 
 from . import EditKeyBasedConfigView
 
@@ -25,3 +31,11 @@ async def async_setup(hass):
         )
     )
     return True
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+) -> None:
+    """Describe group on off states."""
+    return

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -12,4 +12,5 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_OPEN], STATE_CLOSED)
+    # On means open, Off means closed
+    registry.on_off_states({STATE_OPEN}, STATE_CLOSED)

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_CLOSED, STATE_OPEN
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_OPEN], STATE_CLOSED)

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_OPEN], STATE_CLOSED)
+    registry.on_off_states([STATE_OPEN], STATE_CLOSED)

--- a/homeassistant/components/device_tracker/group.py
+++ b/homeassistant/components/device_tracker/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_HOME], STATE_NOT_HOME)
+    registry.on_off_states([STATE_HOME], STATE_NOT_HOME)

--- a/homeassistant/components/device_tracker/group.py
+++ b/homeassistant/components/device_tracker/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_HOME], STATE_NOT_HOME)

--- a/homeassistant/components/device_tracker/group.py
+++ b/homeassistant/components/device_tracker/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_HOME], STATE_NOT_HOME)
+    registry.on_off_states({STATE_HOME}, STATE_NOT_HOME)

--- a/homeassistant/components/fan/group.py
+++ b/homeassistant/components/fan/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/fan/group.py
+++ b/homeassistant/components/fan/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/fan/group.py
+++ b/homeassistant/components/fan/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -321,14 +321,6 @@ async def async_setup(hass, config):
         schema=vol.Schema({vol.Required(ATTR_OBJECT_ID): cv.slug}),
     )
 
-    hass.data[DATA_KEY] = {
-        ON_OFF_MAPPING: {STATE_ON: STATE_OFF},
-        ON_STATES_BY_DOMAIN: {},
-        EXCLUDE_DOMAINS: set(),
-    }
-
-    await async_process_integration_platforms(hass, DOMAIN, _process_group_platform)
-
     return True
 
 

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -92,6 +92,10 @@ EXCLUDE_DOMAINS = "exclude_domains"
 @bind_hass
 def is_on(hass, entity_id):
     """Test if the group state is in its ON-state."""
+    if DATA_KEY not in hass.data:
+        # Integration not setup yet, it cannot be on
+        return False
+
     state = hass.states.get(entity_id)
 
     if state is not None:

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -1,11 +1,22 @@
 """Provide the functionality to group entities."""
 import asyncio
+from itertools import chain
 import logging
 from typing import Any, Iterable, List, Optional, cast
 
 import voluptuous as vol
 
 from homeassistant import core as ha
+from homeassistant.components.climate.const import HVAC_MODE_OFF, HVAC_MODES
+from homeassistant.components.vacuum import STATE_CLEANING, STATE_ERROR, STATE_RETURNING
+from homeassistant.components.water_heater import (
+    STATE_ECO,
+    STATE_ELECTRIC,
+    STATE_GAS,
+    STATE_HEAT_PUMP,
+    STATE_HIGH_DEMAND,
+    STATE_PERFORMANCE,
+)
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
@@ -17,6 +28,11 @@ from homeassistant.const import (
     ENTITY_MATCH_NONE,
     EVENT_HOMEASSISTANT_START,
     SERVICE_RELOAD,
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_TRIGGERED,
     STATE_CLOSED,
     STATE_HOME,
     STATE_LOCKED,
@@ -29,7 +45,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
-from homeassistant.core import CoreState, callback
+from homeassistant.core import CoreState, callback, split_entity_id
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
@@ -87,23 +103,64 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-# List of ON/OFF state tuples for groupable states
-_GROUP_TYPES = [
-    (STATE_ON, STATE_OFF),
-    (STATE_HOME, STATE_NOT_HOME),
-    (STATE_OPEN, STATE_CLOSED),
-    (STATE_LOCKED, STATE_UNLOCKED),
-    (STATE_PROBLEM, STATE_OK),
-]
+# We will skip tracking these domains
+# since they will always result in STATE_UNKNOWN
+_EXCLUDE_DOMAINS = {"air_quality", "sensor", "weather"}
 
+_ALARM_CONTROL_PANEL_ON = {
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_TRIGGERED,
+}
+_CLIMATE_ON = set(HVAC_MODES) - {HVAC_MODE_OFF}
+_VACUUM_ON = {STATE_ON, STATE_CLEANING, STATE_RETURNING, STATE_ERROR}
+_WATER_HEATER_ON = {
+    STATE_ECO,
+    STATE_ELECTRIC,
+    STATE_PERFORMANCE,
+    STATE_HIGH_DEMAND,
+    STATE_HEAT_PUMP,
+    STATE_GAS,
+}
 
-def _get_group_on_off(state):
-    """Determine the group on/off states based on a state."""
-    for states in _GROUP_TYPES:
-        if state in states:
-            return states
+# Maps an on state to an off state
+_ON_OFF_MAPPING = {
+    STATE_ON: STATE_OFF,
+    STATE_HOME: STATE_NOT_HOME,
+    STATE_OPEN: STATE_CLOSED,
+    STATE_LOCKED: STATE_UNLOCKED,
+    STATE_PROBLEM: STATE_OK,
+    STATE_CLEANING: STATE_OFF,
+    **{
+        k: STATE_OFF
+        for k in chain(
+            _ALARM_CONTROL_PANEL_ON, _CLIMATE_ON, _VACUUM_ON, _WATER_HEATER_ON
+        )
+    },
+}
 
-    return None, None
+# The on states for known domains
+# an off state must be in the _ON_OFF_MAPPING
+# for every on state
+_ON_STATES_BY_DOMAIN = {
+    "alarm_control_panel": _ALARM_CONTROL_PANEL_ON,
+    "binary_sensor": {STATE_ON},
+    "climate": _CLIMATE_ON,
+    "cover": {STATE_OPEN},
+    "device_tracker": {STATE_HOME},
+    "fan": {STATE_ON},
+    "humidifier": {STATE_ON},
+    "light": {STATE_ON},
+    "lock": {STATE_LOCKED},
+    "media_player": {STATE_PROBLEM},
+    "person": {STATE_HOME},
+    "remote": {STATE_ON},
+    "switch": {STATE_ON},
+    "vacuum": _VACUUM_ON,
+    "water_heater": _WATER_HEATER_ON,
+}
 
 
 @bind_hass
@@ -111,11 +168,8 @@ def is_on(hass, entity_id):
     """Test if the group state is in its ON-state."""
     state = hass.states.get(entity_id)
 
-    if state:
-        group_on, _ = _get_group_on_off(state.state)
-
-        # If we found a group_type, compare to ON-state
-        return group_on is not None and state.state == group_on
+    if state is not None:
+        return state.state in _ON_OFF_MAPPING
 
     return False
 
@@ -416,12 +470,10 @@ class Group(Entity):
         self._name = name
         self._state = STATE_UNKNOWN
         self._icon = icon
-        if entity_ids:
-            self.tracking = tuple(ent_id.lower() for ent_id in entity_ids)
-        else:
-            self.tracking = ()
-        self.group_on = None
-        self.group_off = None
+        self._set_tracked(entity_ids)
+        self._on_off = None
+        self._assumed = None
+        self._on_states = None
         self.user_defined = user_defined
         self.mode = any
         if mode:
@@ -492,7 +544,7 @@ class Group(Entity):
         if component is None:
             component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
 
-        await component.async_add_entities([group], True)
+        await component.async_add_entities([group])
 
         return group
 
@@ -551,11 +603,32 @@ class Group(Entity):
         This method must be run in the event loop.
         """
         await self.async_stop()
-        self.tracking = tuple(ent_id.lower() for ent_id in entity_ids)
-        self.group_on, self.group_off = None, None
-
+        self._set_tracked(entity_ids)
+        self._reset_tracked_state()
         await self.async_update_ha_state(True)
         self.async_start()
+
+    def _set_tracked(self, entity_ids):
+        """Tuple of entities to be tracked."""
+        # tracking are the entities we want to track
+        # trackable are the entities we actually watch
+
+        if not entity_ids:
+            self.tracking = ()
+            self.trackable = ()
+            return
+
+        tracking = []
+        trackable = []
+        for ent_id in entity_ids:
+            ent_id_lower = ent_id.lower()
+            domain = split_entity_id(ent_id_lower)[0]
+            tracking.append(ent_id_lower)
+            if domain not in _EXCLUDE_DOMAINS:
+                trackable.append(ent_id_lower)
+
+        self.trackable = tuple(trackable)
+        self.tracking = tuple(tracking)
 
     @callback
     def async_start(self):
@@ -563,9 +636,12 @@ class Group(Entity):
 
         This method must be run in the event loop.
         """
+        if not self.trackable:
+            return
+
         if self._async_unsub_state_changed is None:
             self._async_unsub_state_changed = async_track_state_change_event(
-                self.hass, self.tracking, self._async_state_changed_listener
+                self.hass, self.trackable, self._async_state_changed_listener
             )
 
     async def async_stop(self):
@@ -585,7 +661,10 @@ class Group(Entity):
     async def async_added_to_hass(self):
         """Handle addition to Home Assistant."""
         if self.tracking:
-            self.async_start()
+            self._reset_tracked_state()
+
+        self._async_update_group_state()
+        self.async_start()
 
     async def async_will_remove_from_hass(self):
         """Handle removal from Home Assistant."""
@@ -603,21 +682,38 @@ class Group(Entity):
             return
 
         self.async_set_context(event.context)
-        self._async_update_group_state(event.data.get("new_state"))
+        new_state = event.data.get("new_state")
+
+        if new_state is None:
+            # The state was removed from the state machine
+            self._reset_tracked_state()
+
+        self._async_update_group_state(new_state)
         self.async_write_ha_state()
 
-    @property
-    def _tracking_states(self):
-        """Return the states that the group is tracking."""
-        states = []
+    def _reset_tracked_state(self):
+        """Reset tracked state."""
+        self._on_off = {}
+        self._assumed = {}
+        self._on_states = set()
 
-        for entity_id in self.tracking:
+        for entity_id in self.trackable:
             state = self.hass.states.get(entity_id)
 
             if state is not None:
-                states.append(state)
+                self._see_state(state)
 
-        return states
+    def _see_state(self, state):
+        """Keep track of the the state."""
+        entity_id = state.entity_id
+        domain = state.domain
+
+        domain_on_state = _ON_STATES_BY_DOMAIN.get(domain, {STATE_ON})
+        self._on_off[entity_id] = state.state in domain_on_state
+        self._assumed[entity_id] = state.attributes.get(ATTR_ASSUMED_STATE)
+
+        if domain in _ON_STATES_BY_DOMAIN:
+            self._on_states.update(domain_on_state)
 
     @callback
     def _async_update_group_state(self, tr_state=None):
@@ -629,57 +725,38 @@ class Group(Entity):
         This method must be run in the event loop.
         """
         # To store current states of group entities. Might not be needed.
-        states = None
-        gr_state = self._state
-        gr_on = self.group_on
-        gr_off = self.group_off
+        if tr_state:
+            self._see_state(tr_state)
 
-        # We have not determined type of group yet
-        if gr_on is None:
-            if tr_state is None:
-                states = self._tracking_states
-
-                for state in states:
-                    gr_on, gr_off = _get_group_on_off(state.state)
-                    if gr_on is not None:
-                        break
-            else:
-                gr_on, gr_off = _get_group_on_off(tr_state.state)
-
-            if gr_on is not None:
-                self.group_on, self.group_off = gr_on, gr_off
-
-        # We cannot determine state of the group
-        if gr_on is None:
+        if not self._on_off:
             return
-
-        if tr_state is None or (
-            (gr_state == gr_on and tr_state.state == gr_off)
-            or (gr_state == gr_off and tr_state.state == gr_on)
-            or tr_state.state not in (gr_on, gr_off)
-        ):
-            if states is None:
-                states = self._tracking_states
-
-            if self.mode(state.state == gr_on for state in states):
-                self._state = gr_on
-            else:
-                self._state = gr_off
-
-        elif tr_state.state in (gr_on, gr_off):
-            self._state = tr_state.state
 
         if (
             tr_state is None
             or self._assumed_state
             and not tr_state.attributes.get(ATTR_ASSUMED_STATE)
         ):
-            if states is None:
-                states = self._tracking_states
-
-            self._assumed_state = self.mode(
-                state.attributes.get(ATTR_ASSUMED_STATE) for state in states
-            )
+            self._assumed_state = self.mode(self._assumed.values())
 
         elif tr_state.attributes.get(ATTR_ASSUMED_STATE):
             self._assumed_state = True
+
+        num_on_states = len(self._on_states)
+        # If all the entity domains we are tracking
+        # have the same on state we use this state
+        # and its _ON_OFF_MAPPING to off
+        if num_on_states == 1:
+            on_state = list(self._on_states)[0]
+        # If we do not have an on state for any domains
+        # we use STATE_UNKNOWN
+        elif num_on_states == 0:
+            self._state = STATE_UNKNOWN
+            return
+        # If the entity domains have more than one
+        # on state, we use STATE_ON/STATE_OFF
+        else:
+            on_state = STATE_ON
+
+        group_is_on = self.mode(self._on_off.values())
+
+        self._state = on_state if group_is_on else _ON_OFF_MAPPING[on_state]

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -99,7 +99,7 @@ class GroupIntegrationRegistry:
         """Exclude the current domain."""
         self.exclude_domains.add(current_domain.get())
 
-    def on_off_states(self, on_states: List, off_state: str) -> None:
+    def on_off_states(self, on_states: Set, off_state: str) -> None:
         """Registry on and off states for the current domain."""
         for on_state in on_states:
             if on_state not in self.on_off_mapping:

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -591,7 +591,7 @@ class Group(Entity):
         self.tracking = tuple(tracking)
 
     @callback
-    def _async_start(self):
+    def _async_start(self, *_):
         """Start tracking members and write state."""
         self._async_start_tracking()
         self.async_write_ha_state()

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -189,6 +189,14 @@ async def async_setup(hass, config):
     if component is None:
         component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
 
+    hass.data[DATA_KEY] = {
+        ON_OFF_MAPPING: {STATE_ON: STATE_OFF},
+        ON_STATES_BY_DOMAIN: {},
+        EXCLUDE_DOMAINS: set(),
+    }
+
+    await async_process_integration_platforms(hass, DOMAIN, _process_group_platform)
+
     await _async_process_config(hass, config, component)
 
     async def reload_service_handler(service):
@@ -308,14 +316,6 @@ async def async_setup(hass, config):
         groups_service_handler,
         schema=vol.Schema({vol.Required(ATTR_OBJECT_ID): cv.slug}),
     )
-
-    hass.data[DATA_KEY] = {
-        ON_OFF_MAPPING: {STATE_ON: STATE_OFF},
-        ON_STATES_BY_DOMAIN: {},
-        EXCLUDE_DOMAINS: set(),
-    }
-
-    await async_process_integration_platforms(hass, DOMAIN, _process_group_platform)
 
     return True
 

--- a/homeassistant/components/humidifier/group.py
+++ b/homeassistant/components/humidifier/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/humidifier/group.py
+++ b/homeassistant/components/humidifier/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/humidifier/group.py
+++ b/homeassistant/components/humidifier/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/lock/group.py
+++ b/homeassistant/components/lock/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_LOCKED], STATE_UNLOCKED)
+    registry.on_off_states({STATE_LOCKED}, STATE_UNLOCKED)

--- a/homeassistant/components/lock/group.py
+++ b/homeassistant/components/lock/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_LOCKED], STATE_UNLOCKED)
+    registry.on_off_states([STATE_LOCKED], STATE_UNLOCKED)

--- a/homeassistant/components/lock/group.py
+++ b/homeassistant/components/lock/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_LOCKED], STATE_UNLOCKED)

--- a/homeassistant/components/media_player/group.py
+++ b/homeassistant/components/media_player/group.py
@@ -2,9 +2,11 @@
 
 
 from homeassistant.components.group import GroupIntegrationRegistry
-from homeassistant.const import STATE_OK, STATE_PROBLEM
+from homeassistant.const import STATE_OFF
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
+
+from . import STATE_IDLE, STATE_PLAYING
 
 
 @callback
@@ -12,4 +14,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_PROBLEM], STATE_OK)
+    registry.on_off_states({STATE_PLAYING, STATE_IDLE}, STATE_OFF)

--- a/homeassistant/components/media_player/group.py
+++ b/homeassistant/components/media_player/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OK, STATE_PROBLEM
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_PROBLEM], STATE_OK)

--- a/homeassistant/components/media_player/group.py
+++ b/homeassistant/components/media_player/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OK, STATE_PROBLEM
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_PROBLEM], STATE_OK)
+    registry.on_off_states([STATE_PROBLEM], STATE_OK)

--- a/homeassistant/components/person/group.py
+++ b/homeassistant/components/person/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_HOME], STATE_NOT_HOME)
+    registry.on_off_states([STATE_HOME], STATE_NOT_HOME)

--- a/homeassistant/components/person/group.py
+++ b/homeassistant/components/person/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_HOME], STATE_NOT_HOME)

--- a/homeassistant/components/person/group.py
+++ b/homeassistant/components/person/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_HOME], STATE_NOT_HOME)
+    registry.on_off_states({STATE_HOME}, STATE_NOT_HOME)

--- a/homeassistant/components/remote/group.py
+++ b/homeassistant/components/remote/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/remote/group.py
+++ b/homeassistant/components/remote/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/remote/group.py
+++ b/homeassistant/components/remote/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/sensor/group.py
+++ b/homeassistant/components/sensor/group.py
@@ -1,0 +1,13 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states(None, None)

--- a/homeassistant/components/sensor/group.py
+++ b/homeassistant/components/sensor/group.py
@@ -1,13 +1,14 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states(None, None)
+    registry.exclude_domain()

--- a/homeassistant/components/switch/group.py
+++ b/homeassistant/components/switch/group.py
@@ -12,4 +12,4 @@ def async_describe_on_off_states(
     hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/switch/group.py
+++ b/homeassistant/components/switch/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -8,7 +9,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states([STATE_ON], STATE_OFF)
+    registry.on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/switch/group.py
+++ b/homeassistant/components/switch/group.py
@@ -1,0 +1,14 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states([STATE_ON], STATE_OFF)

--- a/homeassistant/components/vacuum/group.py
+++ b/homeassistant/components/vacuum/group.py
@@ -15,5 +15,5 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        [STATE_CLEANING, STATE_ON, STATE_RETURNING, STATE_ERROR], STATE_OFF
+        {STATE_CLEANING, STATE_ON, STATE_RETURNING, STATE_ERROR}, STATE_OFF
     )

--- a/homeassistant/components/vacuum/group.py
+++ b/homeassistant/components/vacuum/group.py
@@ -1,0 +1,18 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import STATE_CLEANING, STATE_ERROR, STATE_RETURNING
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states(
+        [STATE_CLEANING, STATE_ON, STATE_RETURNING, STATE_ERROR], STATE_OFF
+    )

--- a/homeassistant/components/vacuum/group.py
+++ b/homeassistant/components/vacuum/group.py
@@ -1,6 +1,7 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -10,9 +11,9 @@ from . import STATE_CLEANING, STATE_ERROR, STATE_RETURNING
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states(
+    registry.on_off_states(
         [STATE_CLEANING, STATE_ON, STATE_RETURNING, STATE_ERROR], STATE_OFF
     )

--- a/homeassistant/components/vacuum/group.py
+++ b/homeassistant/components/vacuum/group.py
@@ -5,7 +5,7 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import STATE_CLEANING, STATE_ERROR, STATE_RETURNING
+from . import STATE_CLEANING, STATE_ERROR, STATE_RETURNING
 
 
 @callback

--- a/homeassistant/components/water_heater/group.py
+++ b/homeassistant/components/water_heater/group.py
@@ -1,7 +1,7 @@
 """Describe group states."""
 
-from typing import Callable
 
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -18,10 +18,10 @@ from . import (
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states(
+    registry.on_off_states(
         [
             STATE_ECO,
             STATE_ELECTRIC,

--- a/homeassistant/components/water_heater/group.py
+++ b/homeassistant/components/water_heater/group.py
@@ -22,13 +22,13 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        [
+        {
             STATE_ECO,
             STATE_ELECTRIC,
             STATE_PERFORMANCE,
             STATE_HIGH_DEMAND,
             STATE_HEAT_PUMP,
             STATE_GAS,
-        ],
+        },
         STATE_OFF,
     )

--- a/homeassistant/components/water_heater/group.py
+++ b/homeassistant/components/water_heater/group.py
@@ -1,0 +1,34 @@
+"""Describe group states."""
+
+from typing import Callable
+
+from homeassistant.const import STATE_OFF
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import (
+    STATE_ECO,
+    STATE_ELECTRIC,
+    STATE_GAS,
+    STATE_HEAT_PUMP,
+    STATE_HIGH_DEMAND,
+    STATE_PERFORMANCE,
+)
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states(
+        [
+            STATE_ECO,
+            STATE_ELECTRIC,
+            STATE_PERFORMANCE,
+            STATE_HIGH_DEMAND,
+            STATE_HEAT_PUMP,
+            STATE_GAS,
+        ],
+        STATE_OFF,
+    )

--- a/homeassistant/components/weather/group.py
+++ b/homeassistant/components/weather/group.py
@@ -1,0 +1,13 @@
+"""Describe group states."""
+from typing import Callable
+
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, async_on_off_states: Callable
+) -> None:
+    """Describe group on off states."""
+    async_on_off_states(None, None)

--- a/homeassistant/components/weather/group.py
+++ b/homeassistant/components/weather/group.py
@@ -1,13 +1,14 @@
 """Describe group states."""
-from typing import Callable
 
+
+from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, async_on_off_states: Callable
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    async_on_off_states(None, None)
+    registry.exclude_domain()

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -176,6 +176,8 @@ async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanne
             {"person": [{"id": "me", "name": "Me", "device_trackers": [device_1]}]},
         )
 
+        assert await async_setup_component(hass, "group", {})
+        await hass.async_block_till_done()
         await group.Group.async_create_group(hass, "person_me", ["person.me"])
 
         assert await async_setup_component(

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -620,7 +620,7 @@ async def test_group_persons(hass):
 
 
 async def test_group_persons_and_device_trackers(hass):
-    """Test group of persons."""
+    """Test group of persons and device_tracker."""
     hass.states.async_set("person.one", "Work")
     hass.states.async_set("person.two", "Work")
     hass.states.async_set("person.three", "Work")

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -619,6 +619,31 @@ async def test_group_persons(hass):
     assert hass.states.get("group.group_zero").state == "home"
 
 
+async def test_group_persons_and_device_trackers(hass):
+    """Test group of persons."""
+    hass.states.async_set("person.one", "Work")
+    hass.states.async_set("person.two", "Work")
+    hass.states.async_set("person.three", "Work")
+    hass.states.async_set("device_tracker.one", "home")
+
+    assert await async_setup_component(hass, "person", {})
+    assert await async_setup_component(hass, "device_tracker", {})
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {
+                    "entities": "device_tracker.one, person.one, person.two, person.three"
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "home"
+
+
 async def test_group_mixed_domains_on(hass):
     """Test group of mixed domains that is on."""
     hass.states.async_set("lock.alexander_garage_exit_door", "locked")

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -633,7 +633,8 @@ async def test_group_mixed_domains_on(hass):
         {
             "group": {
                 "group_zero": {
-                    "entities": "lock.alexander_garage_exit_door, binary_sensor.alexander_garage_side_door_open, cover.small_garage_door"
+                    "all": "true",
+                    "entities": "lock.alexander_garage_exit_door, binary_sensor.alexander_garage_side_door_open, cover.small_garage_door",
                 },
             }
         },
@@ -657,7 +658,8 @@ async def test_group_mixed_domains_off(hass):
         {
             "group": {
                 "group_zero": {
-                    "entities": "lock.alexander_garage_exit_door, binary_sensor.alexander_garage_side_door_open, cover.small_garage_door"
+                    "all": "true",
+                    "entities": "lock.alexander_garage_exit_door, binary_sensor.alexander_garage_side_door_open, cover.small_garage_door",
                 },
             }
         },
@@ -665,6 +667,27 @@ async def test_group_mixed_domains_off(hass):
     await hass.async_block_till_done()
 
     assert hass.states.get("group.group_zero").state == "off"
+
+
+async def test_group_locks(hass):
+    """Test group of locks."""
+    hass.states.async_set("lock.one", "locked")
+    hass.states.async_set("lock.two", "locked")
+    hass.states.async_set("lock.three", "unlocked")
+
+    assert await async_setup_component(hass, "lock", {})
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "lock.one, lock.two, lock.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "locked"
 
 
 async def test_group_sensors(hass):

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -29,6 +29,8 @@ class TestComponentsGroup(unittest.TestCase):
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+        for domain in ["device_tracker", "light", "group"]:
+            setup_component(self.hass, domain, {})
         self.addCleanup(self.hass.stop)
 
     def test_setup_group_with_mixed_groupable_states(self):
@@ -495,6 +497,7 @@ async def test_group_order(hass):
     """Test that order gets incremented when creating a new group."""
     hass.states.async_set("light.bowl", STATE_ON)
 
+    assert await async_setup_component(hass, "light", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -517,6 +520,7 @@ async def test_group_order_with_dynamic_creation(hass):
     """Test that order gets incremented when creating a new group."""
     hass.states.async_set("light.bowl", STATE_ON)
 
+    assert await async_setup_component(hass, "light", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -570,6 +574,7 @@ async def test_group_persons(hass):
     hass.states.async_set("person.two", "Work")
     hass.states.async_set("person.three", "home")
 
+    assert await async_setup_component(hass, "person", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -590,6 +595,8 @@ async def test_group_mixed_domains_on(hass):
     hass.states.async_set("binary_sensor.alexander_garage_side_door_open", "on")
     hass.states.async_set("cover.small_garage_door", "open")
 
+    for domain in ["lock", "binary_sensor", "cover"]:
+        assert await async_setup_component(hass, domain, {})
     assert await async_setup_component(
         hass,
         "group",
@@ -612,6 +619,8 @@ async def test_group_mixed_domains_off(hass):
     hass.states.async_set("binary_sensor.alexander_garage_side_door_open", "off")
     hass.states.async_set("cover.small_garage_door", "closed")
 
+    for domain in ["lock", "binary_sensor", "cover"]:
+        assert await async_setup_component(hass, domain, {})
     assert await async_setup_component(
         hass,
         "group",
@@ -634,6 +643,7 @@ async def test_group_sensors(hass):
     hass.states.async_set("sensor.two", "on")
     hass.states.async_set("sensor.three", "closed")
 
+    assert await async_setup_component(hass, "sensor", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -654,6 +664,7 @@ async def test_group_climate_mixed(hass):
     hass.states.async_set("climate.two", "cool")
     hass.states.async_set("climate.three", "heat")
 
+    assert await async_setup_component(hass, "climate", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -674,6 +685,7 @@ async def test_group_climate_all_cool(hass):
     hass.states.async_set("climate.two", "cool")
     hass.states.async_set("climate.three", "cool")
 
+    assert await async_setup_component(hass, "climate", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -694,6 +706,7 @@ async def test_group_climate_all_off(hass):
     hass.states.async_set("climate.two", "off")
     hass.states.async_set("climate.three", "off")
 
+    assert await async_setup_component(hass, "climate", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -714,6 +727,7 @@ async def test_group_alarm(hass):
     hass.states.async_set("alarm_control_panel.two", "armed_home")
     hass.states.async_set("alarm_control_panel.three", "armed_away")
 
+    assert await async_setup_component(hass, "alarm_control_panel", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -736,6 +750,7 @@ async def test_group_alarm_disarmed(hass):
     hass.states.async_set("alarm_control_panel.two", "disarmed")
     hass.states.async_set("alarm_control_panel.three", "disarmed")
 
+    assert await async_setup_component(hass, "alarm_control_panel", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -758,6 +773,7 @@ async def test_group_vacuum_off(hass):
     hass.states.async_set("vacuum.two", "off")
     hass.states.async_set("vacuum.three", "off")
 
+    assert await async_setup_component(hass, "vacuum", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -778,6 +794,7 @@ async def test_group_vacuum_on(hass):
     hass.states.async_set("vacuum.two", "off")
     hass.states.async_set("vacuum.three", "off")
 
+    assert await async_setup_component(hass, "vacuum", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -798,6 +815,7 @@ async def test_device_tracker_not_home(hass):
     hass.states.async_set("device_tracker.two", "not_home")
     hass.states.async_set("device_tracker.three", "not_home")
 
+    assert await async_setup_component(hass, "device_tracker", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -820,6 +838,7 @@ async def test_light_removed(hass):
     hass.states.async_set("light.two", "off")
     hass.states.async_set("light.three", "on")
 
+    assert await async_setup_component(hass, "light", {})
     assert await async_setup_component(
         hass,
         "group",

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -393,7 +393,6 @@ class TestComponentsGroup(unittest.TestCase):
         ]
         assert self.hass.bus.listeners["state_changed"] == 1
         assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["hello.world"]) == 1
-        assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["sensor.happy"]) == 1
         assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["light.bowl"]) == 1
         assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["test.one"]) == 1
         assert len(self.hass.data[TRACK_STATE_CHANGE_CALLBACKS]["test.two"]) == 1
@@ -563,3 +562,278 @@ async def test_group_order_with_dynamic_creation(hass):
     await hass.async_block_till_done()
 
     assert hass.states.get("group.new_group2").attributes["order"] == 4
+
+
+async def test_group_persons(hass):
+    """Test group of persons."""
+    hass.states.async_set("person.one", "Work")
+    hass.states.async_set("person.two", "Work")
+    hass.states.async_set("person.three", "home")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "person.one, person.two, person.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "home"
+
+
+async def test_group_mixed_domains_on(hass):
+    """Test group of mixed domains that is on."""
+    hass.states.async_set("lock.alexander_garage_exit_door", "locked")
+    hass.states.async_set("binary_sensor.alexander_garage_side_door_open", "on")
+    hass.states.async_set("cover.small_garage_door", "open")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {
+                    "entities": "lock.alexander_garage_exit_door, binary_sensor.alexander_garage_side_door_open, cover.small_garage_door"
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "on"
+
+
+async def test_group_mixed_domains_off(hass):
+    """Test group of mixed domains that is off."""
+    hass.states.async_set("lock.alexander_garage_exit_door", "unlocked")
+    hass.states.async_set("binary_sensor.alexander_garage_side_door_open", "off")
+    hass.states.async_set("cover.small_garage_door", "closed")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {
+                    "entities": "lock.alexander_garage_exit_door, binary_sensor.alexander_garage_side_door_open, cover.small_garage_door"
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "off"
+
+
+async def test_group_sensors(hass):
+    """Test group of sensors."""
+    hass.states.async_set("sensor.one", "locked")
+    hass.states.async_set("sensor.two", "on")
+    hass.states.async_set("sensor.three", "closed")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "sensor.one, sensor.two, sensor.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "unknown"
+
+
+async def test_group_climate_mixed(hass):
+    """Test group of climate with mixed states."""
+    hass.states.async_set("climate.one", "off")
+    hass.states.async_set("climate.two", "cool")
+    hass.states.async_set("climate.three", "heat")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "climate.one, climate.two, climate.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == STATE_ON
+
+
+async def test_group_climate_all_cool(hass):
+    """Test group of climate all set to cool."""
+    hass.states.async_set("climate.one", "cool")
+    hass.states.async_set("climate.two", "cool")
+    hass.states.async_set("climate.three", "cool")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "climate.one, climate.two, climate.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == STATE_ON
+
+
+async def test_group_climate_all_off(hass):
+    """Test group of climate all set to off."""
+    hass.states.async_set("climate.one", "off")
+    hass.states.async_set("climate.two", "off")
+    hass.states.async_set("climate.three", "off")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "climate.one, climate.two, climate.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == STATE_OFF
+
+
+async def test_group_alarm(hass):
+    """Test group of alarm control panels."""
+    hass.states.async_set("alarm_control_panel.one", "armed_away")
+    hass.states.async_set("alarm_control_panel.two", "armed_home")
+    hass.states.async_set("alarm_control_panel.three", "armed_away")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {
+                    "entities": "alarm_control_panel.one, alarm_control_panel.two, alarm_control_panel.three"
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == STATE_ON
+
+
+async def test_group_alarm_disarmed(hass):
+    """Test group of alarm control panels disarmed."""
+    hass.states.async_set("alarm_control_panel.one", "disarmed")
+    hass.states.async_set("alarm_control_panel.two", "disarmed")
+    hass.states.async_set("alarm_control_panel.three", "disarmed")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {
+                    "entities": "alarm_control_panel.one, alarm_control_panel.two, alarm_control_panel.three"
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == STATE_OFF
+
+
+async def test_group_vacuum_off(hass):
+    """Test group of vacuums."""
+    hass.states.async_set("vacuum.one", "docked")
+    hass.states.async_set("vacuum.two", "off")
+    hass.states.async_set("vacuum.three", "off")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "vacuum.one, vacuum.two, vacuum.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == STATE_OFF
+
+
+async def test_group_vacuum_on(hass):
+    """Test group of vacuums."""
+    hass.states.async_set("vacuum.one", "cleaning")
+    hass.states.async_set("vacuum.two", "off")
+    hass.states.async_set("vacuum.three", "off")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "vacuum.one, vacuum.two, vacuum.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == STATE_ON
+
+
+async def test_device_tracker_not_home(hass):
+    """Test group of device_tracker not_home."""
+    hass.states.async_set("device_tracker.one", "not_home")
+    hass.states.async_set("device_tracker.two", "not_home")
+    hass.states.async_set("device_tracker.three", "not_home")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {
+                    "entities": "device_tracker.one, device_tracker.two, device_tracker.three"
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "not_home"
+
+
+async def test_light_removed(hass):
+    """Test group of lights when one is removed."""
+    hass.states.async_set("light.one", "off")
+    hass.states.async_set("light.two", "off")
+    hass.states.async_set("light.three", "on")
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "light.one, light.two, light.three"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "on"
+
+    hass.states.async_remove("light.three")
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.group_zero").state == "off"

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -267,6 +267,8 @@ async def test_extract_entity_ids(hass):
     hass.states.async_set("light.Ceiling", STATE_OFF)
     hass.states.async_set("light.Kitchen", STATE_OFF)
 
+    assert await async_setup_component(hass, "group", {})
+    await hass.async_block_till_done()
     await hass.components.group.Group.async_create_group(
         hass, "test", ["light.Ceiling", "light.Kitchen"]
     )

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import UnitSystem
 
@@ -1333,6 +1334,8 @@ async def test_closest_function_home_vs_group_entity_id(hass):
         {"latitude": hass.config.latitude, "longitude": hass.config.longitude},
     )
 
+    assert await async_setup_component(hass, "group", {})
+    await hass.async_block_till_done()
     await group.Group.async_create_group(hass, "location group", ["test_domain.object"])
 
     info = render_to_info(hass, '{{ closest("group.location_group").entity_id }}')
@@ -1358,6 +1361,8 @@ async def test_closest_function_home_vs_group_state(hass):
         {"latitude": hass.config.latitude, "longitude": hass.config.longitude},
     )
 
+    assert await async_setup_component(hass, "group", {})
+    await hass.async_block_till_done()
     await group.Group.async_create_group(hass, "location group", ["test_domain.object"])
 
     info = render_to_info(hass, '{{ closest("group.location_group").entity_id }}')
@@ -1397,6 +1402,8 @@ async def test_expand(hass):
     )
     assert_result_info(info, "", [], ["group"])
 
+    assert await async_setup_component(hass, "group", {})
+    await hass.async_block_till_done()
     await group.Group.async_create_group(hass, "new group", ["test.object"])
 
     info = render_to_info(
@@ -1429,6 +1436,9 @@ async def test_expand(hass):
     hass.states.async_set("sensor.power_1", 0)
     hass.states.async_set("sensor.power_2", 200.2)
     hass.states.async_set("sensor.power_3", 400.4)
+
+    assert await async_setup_component(hass, "group", {})
+    await hass.async_block_till_done()
     await group.Group.async_create_group(
         hass, "power sensors", ["sensor.power_1", "sensor.power_2", "sensor.power_3"]
     )
@@ -2095,6 +2105,8 @@ states.sensor.pick_humidity.state ~ " %"
         )
     )
 
+    assert await async_setup_component(hass, "group", {})
+    await hass.async_block_till_done()
     await group.Group.async_create_group(hass, "empty group", [])
 
     assert ["group.empty_group"] == template.extract_entities(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor group to extend domains that can be grouped

Improves performance by not tracking state changes for domains
that will always have an unknown state:

   air_quality, sensor, weather

The following domains can be now grouped:

   alarm_control_panel, climate, person, vacuum, water_heater

in addition to the domains that can already be grouped:

   binary_sensor, cover, device_tracker, fan, humidifier,
   light, lock, media_player, remote, switch

When groups are mixed with entities that report on state
differently or have multiple on states, the state of the group
is reported as either "on" or "off"


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37871, fixes #38126, fixes #40405
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14620

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
