### PR TITLE
Use common strings for oauth config flows

### DIFF
--- a/homeassistant/components/almond/strings.json
+++ b/homeassistant/components/almond/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "pick_implementation": { "title": "Pick Authentication Method" },
+      "pick_implementation": { "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]" },
       "hassio_confirm": {
         "title": "Almond via Hass.io add-on",
         "description": "Do you want to configure Home Assistant to connect to Almond provided by the Hass.io add-on: {addon}?"

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "pick_implementation": {
-        "title": "Pick Authentication Method"
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       }
     },
     "abort": {

--- a/homeassistant/components/smappee/strings.json
+++ b/homeassistant/components/smappee/strings.json
@@ -19,7 +19,7 @@
         "title": "Discovered Smappee device"
       },
       "pick_implementation": {
-        "title": "Pick Authentication Method"
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       }
     },
     "abort": {

--- a/homeassistant/components/somfy/strings.json
+++ b/homeassistant/components/somfy/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "pick_implementation": { "title": "Pick Authentication Method" }
+      "pick_implementation": { "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]" }
     },
     "abort": {
       "already_setup": "You can only configure one Somfy account.",

--- a/homeassistant/components/spotify/strings.json
+++ b/homeassistant/components/spotify/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "pick_implementation": { "title": "Pick Authentication Method" },
+      "pick_implementation": { "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]" },
       "reauth_confirm": {
         "title": "Re-authenticate with Spotify",
         "description": "The Spotify integration needs to re-authenticate with Spotify for account: {account}"

--- a/homeassistant/components/withings/strings.json
+++ b/homeassistant/components/withings/strings.json
@@ -7,7 +7,7 @@
         "description": "Provide a unique profile name for this data. Typically this is the name of the profile you selected in the previous step.",
         "data": { "profile": "Profile Name" }
       },
-      "pick_implementation": { "title": "Pick Authentication Method" },
+      "pick_implementation": { "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]" },
       "reauth": {
         "title": "Re-authenticate Profile",
         "description": "The \"{profile}\" profile needs to be re-authenticated in order to continue receiving Withings data."


### PR DESCRIPTION

## Proposed change
Replace the string "Pick Authentication Method" across string.json files


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
Like to hear if this is the right way to go about it, so I can replace the rest of the common strings.json values across files

- This PR is related to issue: #40578

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
