### PR TITLE
Ensure all jinja2 errors are trapped and displayed in the developer tools

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -279,6 +279,15 @@ def handle_render_template(hass, connection, msg):
             _template_listener,
             raise_on_template_error=True,
         )
+    except vol.Invalid as ex:
+        connection.send_message(
+            messages.error_message(
+                msg["id"],
+                const.ERR_TEMPLATE_ERROR,
+                vol.humanize.humanize_error(msg, ex),
+            )
+        )
+        return
     except TemplateError as ex:
         connection.send_message(
             messages.error_message(msg["id"], const.ERR_TEMPLATE_ERROR, str(ex))

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -275,9 +275,15 @@ def handle_render_template(hass, connection, msg):
             )
         )
 
-    info = async_track_template_result(
-        hass, [TrackTemplate(template, variables)], _template_listener
-    )
+    try:
+        info = async_track_template_result(
+            hass,
+            [TrackTemplate(template, variables)],
+            _template_listener,
+            raise_on_template_error=True,
+        )
+    except TemplateError as ex:
+        raise vol.Invalid(f"invalid template ({ex})") from ex
 
     connection.subscriptions[msg["id"]] = info.async_remove
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -261,13 +261,10 @@ def handle_render_template(hass, connection, msg):
         track_template_result = updates.pop()
         result = track_template_result.result
         if isinstance(result, TemplateError):
-            _LOGGER.error(
-                "TemplateError('%s') " "while processing template '%s'",
-                result,
-                track_template_result.template,
+            connection.send_message(
+                messages.error_message(msg["id"], const.ERR_TEMPLATE_ERROR, str(result))
             )
-
-            result = None
+            return
 
         connection.send_message(
             messages.event_message(
@@ -283,7 +280,10 @@ def handle_render_template(hass, connection, msg):
             raise_on_template_error=True,
         )
     except TemplateError as ex:
-        raise vol.Invalid(f"invalid template ({ex})") from ex
+        connection.send_message(
+            messages.error_message(msg["id"], const.ERR_TEMPLATE_ERROR, str(ex))
+        )
+        return
 
     connection.subscriptions[msg["id"]] = info.async_remove
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -261,9 +261,7 @@ def handle_render_template(hass, connection, msg):
         track_template_result = updates.pop()
         result = track_template_result.result
         if isinstance(result, TemplateError):
-            connection.send_error(
-                msg["id"], const.ERR_TEMPLATE_ERROR, str(result)
-            )
+            connection.send_error(msg["id"], const.ERR_TEMPLATE_ERROR, str(result))
             return
 
         connection.send_message(
@@ -280,9 +278,7 @@ def handle_render_template(hass, connection, msg):
             raise_on_template_error=True,
         )
     except TemplateError as ex:
-        connection.send_error(
-            msg["id"], const.ERR_TEMPLATE_ERROR, str(ex)
-        )
+        connection.send_error(msg["id"], const.ERR_TEMPLATE_ERROR, str(ex))
         return
 
     connection.subscriptions[msg["id"]] = info.async_remove

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -280,8 +280,8 @@ def handle_render_template(hass, connection, msg):
             raise_on_template_error=True,
         )
     except TemplateError as ex:
-        connection.send_message(
-            messages.error_message(msg["id"], const.ERR_TEMPLATE_ERROR, str(ex))
+        connection.send_error(
+            msg["id"], const.ERR_TEMPLATE_ERROR, str(ex)
         )
         return
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -261,8 +261,8 @@ def handle_render_template(hass, connection, msg):
         track_template_result = updates.pop()
         result = track_template_result.result
         if isinstance(result, TemplateError):
-            connection.send_message(
-                messages.error_message(msg["id"], const.ERR_TEMPLATE_ERROR, str(result))
+            connection.send_error(
+                msg["id"], const.ERR_TEMPLATE_ERROR, str(result)
             )
             return
 

--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -29,6 +29,7 @@ ERR_UNKNOWN_COMMAND = "unknown_command"
 ERR_UNKNOWN_ERROR = "unknown_error"
 ERR_UNAUTHORIZED = "unauthorized"
 ERR_TIMEOUT = "timeout"
+ERR_TEMPLATE_ERROR = "template_error"
 
 TYPE_RESULT = "result"
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -565,7 +565,7 @@ class _TrackTemplateResultInfo:
         self._last_domains: Set = set()
         self._last_entities: Set = set()
 
-    def async_setup(self) -> None:
+    def async_setup(self, raise_on_template_error: bool) -> None:
         """Activation of template tracking."""
         for track_template_ in self._track_templates:
             template = track_template_.template
@@ -573,6 +573,8 @@ class _TrackTemplateResultInfo:
 
             self._info[template] = template.async_render_to_info(variables)
             if self._info[template].exception:
+                if raise_on_template_error:
+                    raise self._info[template].exception
                 _LOGGER.error(
                     "Error while processing template: %s",
                     track_template_.template,
@@ -801,6 +803,7 @@ def async_track_template_result(
     hass: HomeAssistant,
     track_templates: Iterable[TrackTemplate],
     action: TrackTemplateResultListener,
+    raise_on_template_error: bool = False,
 ) -> _TrackTemplateResultInfo:
     """Add a listener that fires when a the result of a template changes.
 
@@ -822,9 +825,13 @@ def async_track_template_result(
         Home assistant object.
     track_templates
         An iterable of TrackTemplate.
-
     action
         Callable to call with results.
+    raise_on_template_error
+        When set to True, if there is an exception
+        processing the template during setup, the system
+        will raise the exception instead of setting up
+        tracking.
 
     Returns
     -------
@@ -832,7 +839,7 @@ def async_track_template_result(
 
     """
     tracker = _TrackTemplateResultInfo(hass, track_templates, action)
-    tracker.async_setup()
+    tracker.async_setup(raise_on_template_error)
     return tracker
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -244,7 +244,7 @@ class Template:
 
         try:
             self._compiled_code = self._env.compile(self.template)
-        except jinja2.exceptions.TemplateSyntaxError as err:
+        except jinja2.TemplateError as err:
             raise TemplateError(err) from err
 
     def extract_entities(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -486,19 +486,10 @@ async def test_render_template_with_error(
     msg = await websocket_client.receive_json()
     assert msg["id"] == 5
     assert msg["type"] == const.TYPE_RESULT
-    assert msg["success"]
+    assert not msg["success"]
+    assert msg["error"]["code"] == const.ERR_TEMPLATE_ERROR
 
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 5
-    assert msg["type"] == "event"
-    event = msg["event"]
-    assert event == {
-        "result": None,
-        "listeners": {"all": True, "domains": [], "entities": []},
-    }
-
-    assert "my_unknown_var" in caplog.text
-    assert "TemplateError" in caplog.text
+    assert "TemplateError" not in caplog.text
 
 
 async def test_render_template_returns_with_match_all(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -492,6 +492,53 @@ async def test_render_template_with_error(
     assert "TemplateError" not in caplog.text
 
 
+async def test_render_template_with_delayed_error(
+    hass, websocket_client, hass_admin_user, caplog
+):
+    """Test a template with an error that only happens after a state change."""
+    hass.states.async_set("sensor.test", "on")
+    await hass.async_block_till_done()
+
+    template_str = """
+{% if states.sensor.test.state %}
+   on
+{% else %}
+   {{ explode + 1 }}
+{% endif %}
+    """
+
+    await websocket_client.send_json(
+        {"id": 5, "type": "render_template", "template": template_str}
+    )
+    await hass.async_block_till_done()
+
+    msg = await websocket_client.receive_json()
+
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    hass.states.async_remove("sensor.test")
+    await hass.async_block_till_done()
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    event = msg["event"]
+    assert event == {
+        "result": "on",
+        "listeners": {"all": False, "domains": [], "entities": ["sensor.test"]},
+    }
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert not msg["success"]
+    assert msg["error"]["code"] == const.ERR_TEMPLATE_ERROR
+
+    assert "TemplateError" not in caplog.text
+
+
 async def test_render_template_returns_with_match_all(
     hass, websocket_client, hass_admin_user
 ):

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1460,6 +1460,25 @@ async def test_async_track_template_result_multiple_templates_mixing_domain(hass
     ]
 
 
+async def test_async_track_template_result_raise_on_template_error(hass):
+    """Test that we raise as soon as we encounter a failed template."""
+
+    with pytest.raises(TemplateError):
+        async_track_template_result(
+            hass,
+            [
+                TrackTemplate(
+                    Template(
+                        "{{ states.switch | function_that_does_not_exist | list }}"
+                    ),
+                    None,
+                ),
+            ],
+            ha.callback(lambda event, updates: None),
+            raise_on_template_error=True,
+        )
+
+
 async def test_track_same_state_simple_no_trigger(hass):
     """Test track_same_change with no trigger."""
     callback_runs = []


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some of the exceptions were not being trapped which resulted in the error
ending up in the log instead of being displayed in the template dev tools.


Before

<img width="1020" alt="Screen Shot 2020-09-26 at 9 09 37 AM" src="https://user-images.githubusercontent.com/663432/94345642-0554d880-ffed-11ea-86b8-16c07fba603e.png">

After


<img width="461" alt="Screen Shot 2020-09-26 at 12 17 10 PM" src="https://user-images.githubusercontent.com/663432/94346433-3b488b80-fff2-11ea-93b8-eecc121f2e9a.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40621
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
