### PR TITLE
Add deCONZ service to clean up orphaned device and entity entries 

### DIFF
--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -51,6 +51,7 @@ class DeconzGateway:
         self.ignore_state_updates = False
 
         self.deconz_ids = {}
+        self.device_id = None
         self.entities = {}
         self.events = []
         self.listeners = []
@@ -139,7 +140,7 @@ class DeconzGateway:
     async def async_update_device_registry(self) -> None:
         """Update device registry."""
         device_registry = await self.hass.helpers.device_registry.async_get_registry()
-        device_registry.async_get_or_create(
+        entry = device_registry.async_get_or_create(
             config_entry_id=self.config_entry.entry_id,
             connections={(CONNECTION_NETWORK_MAC, self.api.config.mac)},
             identifiers={(DOMAIN, self.api.config.bridgeid)},
@@ -148,6 +149,7 @@ class DeconzGateway:
             name=self.api.config.name,
             sw_version=self.api.config.swversion,
         )
+        self.device_id = entry.id
 
     async def async_setup(self) -> bool:
         """Set up a deCONZ gateway."""

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -204,24 +204,32 @@ async def async_remove_orphaned_entries_service(hass, data):
         if gateway.config_entry.entry_id in entry.config_entries
     ]
 
+    # Don't remove the Gateway device
     if gateway.device_id in devices_to_be_removed:
         devices_to_be_removed.remove(gateway.device_id)
 
+    # Don't remove devices belonging to available events
     for event in gateway.events:
         if event.device_id in devices_to_be_removed:
             devices_to_be_removed.remove(event.device_id)
 
     for entry in entity_entries:
 
+        # Don't remove available entities
         if entry.unique_id in gateway.entities[entry.domain]:
+
+            # Don't remove devices with available entities
             if entry.device_id in devices_to_be_removed:
                 devices_to_be_removed.remove(entry.device_id)
             continue
+        # Remove entities that are not available
         entities_to_be_removed.append(entry.entity_id)
 
+    # Remove unavailable entities
     for entity_id in entities_to_be_removed:
         entity_registry.async_remove(entity_id)
 
+    # Remove devices that don't belong to any entity
     for device_id in devices_to_be_removed:
         if len(async_entries_for_device(entity_registry, device_id)) == 0:
             device_registry.async_remove_device(device_id)

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -95,6 +95,7 @@ async def async_unload_services(hass):
 
     hass.services.async_remove(DOMAIN, SERVICE_CONFIGURE_DEVICE)
     hass.services.async_remove(DOMAIN, SERVICE_DEVICE_REFRESH)
+    hass.services.async_remove(DOMAIN, SERVICE_REMOVE_ORPHANED_ENTRIES)
 
 
 async def async_configure_service(hass, data):

--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -23,3 +23,10 @@ device_refresh:
     bridgeid:
       description: (Optional) Bridgeid is a string unique for each deCONZ hardware. It can be found as part of the integration name.
       example: "00212EFFFF012345"
+
+remove_orphaned_entries:
+  description: Clean up device and entity registry entries orphaned by deCONZ.
+  fields:
+    bridgeid:
+      description: (Optional) Bridgeid is a string unique for each deCONZ hardware. It can be found as part of the integration name.
+      example: "00212EFFFF012345"

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -52,7 +52,7 @@ async def test_service_setup(hass):
     ) as async_register:
         await deconz.services.async_setup_services(hass)
         assert hass.data[deconz.services.DECONZ_SERVICES] is True
-        assert async_register.call_count == 2
+        assert async_register.call_count == 3
 
 
 async def test_service_setup_already_registered(hass):
@@ -73,7 +73,7 @@ async def test_service_unload(hass):
     ) as async_remove:
         await deconz.services.async_unload_services(hass)
         assert hass.data[deconz.services.DECONZ_SERVICES] is False
-        assert async_remove.call_count == 2
+        assert async_remove.call_count == 3
 
 
 async def test_service_unload_not_registered(hass):


### PR DESCRIPTION
…and entity registry

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are situations where deCONZ entities or devices get left behind, this service will clean up devices which don't have any entities, does not belong to any deCONZ event or the gateway it self and clean up entities which are not loaded in the current session of HASS.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14665

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
