### PR TITLE
Add persistent_notification service to the notify platform

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 import voluptuous as vol
 
+import homeassistant.components.persistent_notification as pn
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.core import ServiceCall
 from homeassistant.exceptions import HomeAssistantError
@@ -36,6 +37,7 @@ ATTR_TITLE_DEFAULT = "Home Assistant"
 DOMAIN = "notify"
 
 SERVICE_NOTIFY = "notify"
+SERVICE_PERSISTENT_NOTIFICATION = "persistent_notification"
 
 NOTIFY_SERVICES = "notify_services"
 
@@ -50,6 +52,13 @@ NOTIFY_SERVICE_SCHEMA = vol.Schema(
         vol.Optional(ATTR_TITLE): cv.template,
         vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(ATTR_DATA): dict,
+    }
+)
+
+PERSISTENT_NOTIFICATION_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_MESSAGE): cv.template,
+        vol.Optional(ATTR_TITLE): cv.template,
     }
 )
 
@@ -215,6 +224,20 @@ async def async_setup(hass, config):
     """Set up the notify services."""
     hass.data.setdefault(NOTIFY_SERVICES, {})
 
+    async def persistent_notification(service: ServiceCall) -> None:
+        """Send notification via the built-in persistsent_notify integration."""
+        payload = {}
+        message = service.data[ATTR_MESSAGE]
+        message.hass = hass
+        payload[ATTR_MESSAGE] = message.async_render()
+
+        title = service.data.get(ATTR_TITLE)
+        if title:
+            title.hass = hass
+            payload[ATTR_TITLE] = title.async_render()
+
+        await hass.services.async_call(pn.DOMAIN, pn.SERVICE_CREATE, payload)
+
     async def async_setup_platform(
         integration_name, p_config=None, discovery_info=None
     ):
@@ -273,6 +296,13 @@ async def async_setup(hass, config):
         hass.config.components.add(f"{DOMAIN}.{integration_name}")
 
         return True
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_PERSISTENT_NOTIFICATION,
+        persistent_notification,
+        schema=PERSISTENT_NOTIFICATION_SERVICE_SCHEMA,
+    )
 
     setup_tasks = [
         async_setup_platform(integration_name, p_config)

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -236,7 +236,9 @@ async def async_setup(hass, config):
             title.hass = hass
             payload[ATTR_TITLE] = title.async_render()
 
-        await hass.services.async_call(pn.DOMAIN, pn.SERVICE_CREATE, payload, blocking=True)
+        await hass.services.async_call(
+            pn.DOMAIN, pn.SERVICE_CREATE, payload, blocking=True
+        )
 
     async def async_setup_platform(
         integration_name, p_config=None, discovery_info=None

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -236,7 +236,7 @@ async def async_setup(hass, config):
             title.hass = hass
             payload[ATTR_TITLE] = title.async_render()
 
-        await hass.services.async_call(pn.DOMAIN, pn.SERVICE_CREATE, payload)
+        await hass.services.async_call(pn.DOMAIN, pn.SERVICE_CREATE, payload, blocking=True)
 
     async def async_setup_platform(
         integration_name, p_config=None, discovery_info=None

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -16,6 +16,16 @@ notify:
       description: Extended information for notification. Optional depending on the platform.
       example: platform specific
 
+persistent_notification:
+  description: Sends a notification to the visible in the front-end.
+  fields:
+    message:
+      description: Message body of the notification.
+      example: The garage door has been open for 10 minutes.
+    title:
+      description: Optional title for your notification.
+      example: "Your Garage Door Friend"
+
 apns_register:
   description: Registers a device to receive push notifications.
   fields:

--- a/tests/components/notify/test_persistent_notification.py
+++ b/tests/components/notify/test_persistent_notification.py
@@ -1,0 +1,25 @@
+"""The tests for the notify.persistent_notification service."""
+from homeassistant.components import notify
+import homeassistant.components.persistent_notification as pn
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+async def test_async_send_message(hass: HomeAssistant):
+    """Test sending a message to notify.persistent_notification service."""
+    await async_setup_component(hass, pn.DOMAIN, {"core": {}})
+    await async_setup_component(hass, notify.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    message = {"message": "Hello", "title": "Test notification"}
+    await hass.services.async_call(
+        notify.DOMAIN, notify.SERVICE_PERSISTENT_NOTIFICATION, message
+    )
+    await hass.async_block_till_done()
+
+    entity_ids = hass.states.async_entity_ids(pn.DOMAIN)
+    assert len(entity_ids) == 1
+
+    state = hass.states.get(entity_ids[0])
+    assert state.attributes.get("message") == "Hello"
+    assert state.attributes.get("title") == "Test notification"


### PR DESCRIPTION
## Breaking change

A new `persistent_notification` service has been added to the notify intergration. This could break any users who has registered a notifier with that name.

## Proposed change
Add `persistent_notification` service to notify integration.

This was [requested in a WTH](https://community.home-assistant.io/t/why-the-heck-is-there-no-notify-persistent-notification-service/220160), where some good points are made, especially with respect to notification groups and the alert integration.

The existing services are still needed, both for compatibility, and because you cannot delete/mark as read via the `notify` base integration. Therefore, the implementation of this new service is trivial, merely delegating to the existing service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

No configuration is available.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
