### PR TITLE
Abort execution of template renders that overwhelm the system

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -261,7 +261,7 @@ async def handle_render_template(hass, connection, msg):
         connection.send_error(
             msg["id"],
             const.ERR_TEMPLATE_ERROR,
-            "Exceeded maximum execution time of {timeout}s",
+            f"Exceeded maximum execution time of {timeout}s",
         )
         return
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -245,7 +245,7 @@ def handle_ping(hass, connection, msg):
         vol.Required("template"): str,
         vol.Optional("entity_ids"): cv.entity_ids,
         vol.Optional("variables"): dict,
-        vol.Optional("timeout"): float,
+        vol.Optional("timeout"): vol.Coerce(float),
     }
 )
 @decorators.async_response

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -245,6 +245,7 @@ def handle_ping(hass, connection, msg):
         vol.Required("template"): str,
         vol.Optional("entity_ids"): cv.entity_ids,
         vol.Optional("variables"): dict,
+        vol.Optional("timeout"): float,
     }
 )
 @decorators.async_response

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -249,6 +249,7 @@ def handle_ping(hass, connection, msg):
         vol.Optional("variables"): dict,
     }
 )
+@decorators.async_response
 async def handle_render_template(hass, connection, msg):
     """Handle render_template command."""
     template_str = msg["template"]

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -24,8 +24,6 @@ from . import const, decorators, messages
 
 _LOGGER = logging.getLogger(__name__)
 
-MAX_TEMPLATE_RENDER_TIME = 3
-
 # mypy: allow-untyped-calls, allow-untyped-defs
 
 
@@ -255,13 +253,14 @@ async def handle_render_template(hass, connection, msg):
     template_str = msg["template"]
     template = Template(template_str, hass)
     variables = msg.get("variables")
+    timeout = msg.get("timeout")
     info = None
 
-    if await template.async_render_will_timeout(MAX_TEMPLATE_RENDER_TIME):
+    if timeout and await template.async_render_will_timeout(timeout):
         connection.send_error(
             msg["id"],
             const.ERR_TEMPLATE_ERROR,
-            "Exceeded maximum execution time of {MAX_TEMPLATE_RENDER_TIME}s",
+            "Exceeded maximum execution time of {timeout}s",
         )
         return
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -344,7 +344,8 @@ class Template:
                 compiled.render(kwargs)
             except TimeoutError:
                 pass
-            run_callback_threadsafe(self.hass.loop, finish_event.set).result()
+            finally:
+                run_callback_threadsafe(self.hass.loop, finish_event.set)
 
         try:
             template_render_thread = ThreadWithException(target=_render_template)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -344,7 +344,7 @@ class Template:
                 compiled.render(kwargs)
             except TimeoutError:
                 pass
-            run_callback_threadsafe(self.hass.loop, finish_event.set)
+            run_callback_threadsafe(self.hass.loop, finish_event.set).result()
 
         try:
             template_render_thread = ThreadWithException(target=_render_template)
@@ -353,6 +353,8 @@ class Template:
         except asyncio.TimeoutError:
             template_render_thread.raise_exc(TimeoutError)
             return True
+        finally:
+            template_render_thread.join()
 
         return False
 

--- a/homeassistant/util/thread.py
+++ b/homeassistant/util/thread.py
@@ -38,8 +38,6 @@ def _async_raise(tid: int, exctype: Any) -> None:
 
     if res == 1:
         return
-    if res == 0:
-        raise ValueError("Invalid thread id")
 
     # "if it returns a number greater than one, you're in trouble,
     # and you should call it again with exc=NULL to revert the effect"

--- a/homeassistant/util/thread.py
+++ b/homeassistant/util/thread.py
@@ -32,16 +32,20 @@ def _async_raise(tid: int, exctype: Any) -> None:
     """Raise an exception in the threads with id tid."""
     if not inspect.isclass(exctype):
         raise TypeError("Only types can be raised (not instances)")
+
     res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
         ctypes.c_long(tid), ctypes.py_object(exctype)
     )
+
+    if res == 1:
+        return
     if res == 0:
         raise ValueError("Invalid thread id")
-    elif res != 1:
-        # "if it returns a number greater than one, you're in trouble,
-        # and you should call it again with exc=NULL to revert the effect"
-        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(tid), None)
-        raise SystemError("PyThreadState_SetAsyncExc failed")
+
+    # "if it returns a number greater than one, you're in trouble,
+    # and you should call it again with exc=NULL to revert the effect"
+    ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(tid), None)
+    raise SystemError("PyThreadState_SetAsyncExc failed")
 
 
 class ThreadWithException(threading.Thread):

--- a/homeassistant/util/thread.py
+++ b/homeassistant/util/thread.py
@@ -33,9 +33,8 @@ def _async_raise(tid: int, exctype: Any) -> None:
     if not inspect.isclass(exctype):
         raise TypeError("Only types can be raised (not instances)")
 
-    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
-        ctypes.c_long(tid), ctypes.py_object(exctype)
-    )
+    c_tid = ctypes.c_long(tid)
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(c_tid, ctypes.py_object(exctype))
 
     if res == 1:
         return
@@ -44,7 +43,7 @@ def _async_raise(tid: int, exctype: Any) -> None:
 
     # "if it returns a number greater than one, you're in trouble,
     # and you should call it again with exc=NULL to revert the effect"
-    ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(tid), None)
+    ctypes.pythonapi.PyThreadState_SetAsyncExc(c_tid, None)
     raise SystemError("PyThreadState_SetAsyncExc failed")
 
 

--- a/homeassistant/util/thread.py
+++ b/homeassistant/util/thread.py
@@ -1,4 +1,6 @@
 """Threading util helpers."""
+import ctypes
+import inspect
 import sys
 import threading
 from typing import Any
@@ -24,3 +26,33 @@ def fix_threading_exception_logging() -> None:
             sys.excepthook(*sys.exc_info())
 
     threading.Thread.run = run  # type: ignore
+
+
+def _async_raise(tid: int, exctype: Any) -> None:
+    """Raise an exception in the threads with id tid."""
+    if not inspect.isclass(exctype):
+        raise TypeError("Only types can be raised (not instances)")
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_long(tid), ctypes.py_object(exctype)
+    )
+    if res == 0:
+        raise ValueError("Invalid thread id")
+    elif res != 1:
+        # "if it returns a number greater than one, you're in trouble,
+        # and you should call it again with exc=NULL to revert the effect"
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(tid), None)
+        raise SystemError("PyThreadState_SetAsyncExc failed")
+
+
+class ThreadWithException(threading.Thread):
+    """A thread class that supports raising exception in the thread from another thread.
+
+    Based on
+    https://stackoverflow.com/questions/323972/is-there-any-way-to-kill-a-thread/49877671
+
+    """
+
+    def raise_exc(self, exctype: Any) -> None:
+        """Raise the given exception type in the context of this thread."""
+        assert self.ident
+        _async_raise(self.ident, exctype)

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -397,9 +397,7 @@ async def test_subscribe_unsubscribe_events_state_changed(
     assert msg["event"]["data"]["entity_id"] == "light.permitted"
 
 
-async def test_render_template_renders_template(
-    hass, websocket_client, hass_admin_user
-):
+async def test_render_template_renders_template(hass, websocket_client):
     """Test simple template is rendered and updated."""
     hass.states.async_set("light.test", "on")
 
@@ -437,7 +435,7 @@ async def test_render_template_renders_template(
 
 
 async def test_render_template_manual_entity_ids_no_longer_needed(
-    hass, websocket_client, hass_admin_user
+    hass, websocket_client
 ):
     """Test that updates to specified entity ids cause a template rerender."""
     hass.states.async_set("light.test", "on")
@@ -475,9 +473,7 @@ async def test_render_template_manual_entity_ids_no_longer_needed(
     }
 
 
-async def test_render_template_with_error(
-    hass, websocket_client, hass_admin_user, caplog
-):
+async def test_render_template_with_error(hass, websocket_client, caplog):
     """Test a template with an error."""
     await websocket_client.send_json(
         {"id": 5, "type": "render_template", "template": "{{ my_unknown_var() + 1 }}"}
@@ -492,9 +488,7 @@ async def test_render_template_with_error(
     assert "TemplateError" not in caplog.text
 
 
-async def test_render_template_with_delayed_error(
-    hass, websocket_client, hass_admin_user, caplog
-):
+async def test_render_template_with_delayed_error(hass, websocket_client, caplog):
     """Test a template with an error that only happens after a state change."""
     hass.states.async_set("sensor.test", "on")
     await hass.async_block_till_done()
@@ -539,9 +533,36 @@ async def test_render_template_with_delayed_error(
     assert "TemplateError" not in caplog.text
 
 
-async def test_render_template_returns_with_match_all(
-    hass, websocket_client, hass_admin_user
-):
+async def test_render_template_with_timeout(hass, websocket_client, caplog):
+    """Test a template that will timeout."""
+
+    slow_template_str = """
+{% for var in range(1000) -%}
+  {% for var in range(1000) -%}
+    {{ var }}
+  {%- endfor %}
+{%- endfor %}
+"""
+
+    await websocket_client.send_json(
+        {
+            "id": 5,
+            "type": "render_template",
+            "timeout": 0.000001,
+            "template": slow_template_str,
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert not msg["success"]
+    assert msg["error"]["code"] == const.ERR_TEMPLATE_ERROR
+
+    assert "TemplateError" not in caplog.text
+
+
+async def test_render_template_returns_with_match_all(hass, websocket_client):
     """Test that a template that would match with all entities still return success."""
     await websocket_client.send_json(
         {"id": 5, "type": "render_template", "template": "State is: {{ 42 }}"}

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 import math
 import random
-import time
 
 import pytest
 import pytz
@@ -2466,8 +2465,15 @@ async def test_template_timeout(hass):
     tmp = template.Template("{{ states | count }}", hass)
     assert await tmp.async_render_will_timeout(3) is False
 
-    def _sleep():
-        time.sleep(0.000002)
+    tmp2 = template.Template("{{ error_invalid + 1 }}", hass)
+    assert await tmp2.async_render_will_timeout(3) is False
 
-    with patch("jinja2.environment.Template.render", side_effect=_sleep):
-        assert await tmp.async_render_will_timeout(0.000001) is True
+    slow_template_str = """
+{% for var in range(1000) -%}
+  {% for var in range(1000) -%}
+    {{ var }}
+  {%- endfor %}
+{%- endfor %}
+"""
+    tmp3 = template.Template(slow_template_str, hass)
+    assert await tmp3.async_render_will_timeout(0.000001) is True

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2468,6 +2468,12 @@ async def test_template_timeout(hass):
     tmp2 = template.Template("{{ error_invalid + 1 }}", hass)
     assert await tmp2.async_render_will_timeout(3) is False
 
+    tmp3 = template.Template("static", hass)
+    assert await tmp3.async_render_will_timeout(3) is False
+
+    tmp4 = template.Template("{{ var1 }}", hass)
+    assert await tmp4.async_render_will_timeout(3, {"var1": "ok"}) is False
+
     slow_template_str = """
 {% for var in range(1000) -%}
   {% for var in range(1000) -%}
@@ -2475,5 +2481,5 @@ async def test_template_timeout(hass):
   {%- endfor %}
 {%- endfor %}
 """
-    tmp3 = template.Template(slow_template_str, hass)
-    assert await tmp3.async_render_will_timeout(0.000001) is True
+    tmp5 = template.Template(slow_template_str, hass)
+    assert await tmp5.async_render_will_timeout(0.000001) is True

--- a/tests/util/test_thread.py
+++ b/tests/util/test_thread.py
@@ -1,0 +1,38 @@
+"""Test Home Assistant thread utils."""
+
+import asyncio
+
+import pytest
+
+from homeassistant.util.async_ import run_callback_threadsafe
+from homeassistant.util.thread import ThreadWithException
+
+
+async def test_thread_with_exception_invalid(hass):
+    """Test throwing an invalid thread exception."""
+
+    finish_event = asyncio.Event()
+
+    def _do_nothing(*_):
+        run_callback_threadsafe(hass.loop, finish_event.set)
+
+    test_thread = ThreadWithException(target=_do_nothing)
+    test_thread.start()
+    await asyncio.wait_for(finish_event.wait(), timeout=0.1)
+
+    with pytest.raises(TypeError):
+        test_thread.raise_exc(_EmptyClass())
+    test_thread.join()
+
+
+async def test_thread_not_started(hass):
+    """Test throwing when the thread is not started."""
+
+    test_thread = ThreadWithException(target=lambda *_: None)
+
+    with pytest.raises(AssertionError):
+        test_thread.raise_exc(TimeoutError)
+
+
+class _EmptyClass:
+    """An empty class."""

--- a/tests/util/test_thread.py
+++ b/tests/util/test_thread.py
@@ -34,5 +34,22 @@ async def test_thread_not_started(hass):
         test_thread.raise_exc(TimeoutError)
 
 
+async def test_thread_fails_raise(hass):
+    """Test throwing after already ended."""
+
+    finish_event = asyncio.Event()
+
+    def _do_nothing(*_):
+        run_callback_threadsafe(hass.loop, finish_event.set)
+
+    test_thread = ThreadWithException(target=_do_nothing)
+    test_thread.start()
+    await asyncio.wait_for(finish_event.wait(), timeout=0.1)
+    test_thread.join()
+
+    with pytest.raises(SystemError):
+        test_thread.raise_exc(ValueError)
+
+
 class _EmptyClass:
     """An empty class."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This only affects templates render requests from the websocket api that request a timeout.

jinja attempts to detect these type of templates in advance and will
raise OverflowError for cases it knows will overwhelm the system,
however it cannot detect all cases. 

Example: `OverflowError: Range too big. The sandbox blocks ranges larger than MAX_RANGE (100000).`

This solution pre-tests each initial render request to ensure a template
can be rendered in requested timeout in seconds. If the template
takes too long, execution is canceled and the subscription is not
setup.

Pasting 
```
{% for var in range(10000) -%}
  {% for var in range(10000) -%}
    {{ var }}
  {%- endfor %}
{%- endfor %}
```

into the template developer tools before this change would cause
the entire system to lock up and run out of memory.

`25440 root      20   0 9834.1m 5.171g 100.7 26.7   1:00.92 R python3 -m homeassistant --config /config                                                                                                                                                                     `

<img width="830" alt="Screen Shot 2020-09-26 at 7 21 23 PM" src="https://user-images.githubusercontent.com/663432/94352655-7ddb8980-002d-11eb-80ac-89370fd919b3.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
