### PR TITLE
Refactor zha.permit service to allow joining using install codes

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -90,20 +90,18 @@ SERVICE_WARNING_DEVICE_WARN = "warning_device_warn"
 SERVICE_ZIGBEE_BIND = "service_zigbee_bind"
 IEEE_SERVICE = "ieee_based_service"
 
-SERVICE_SCHEMAS = {
-    SERVICE_PERMIT: vol.Schema(
-        {
-            vol.Optional(ATTR_IEEE_ADDRESS, default=None): EUI64.convert,
-            vol.Optional(ATTR_DURATION, default=60): vol.All(
-                vol.Coerce(int), vol.Range(0, 254)
-            ),
-            vol.Inclusive(ATTR_SOURCE_IEEE, "install_code"): EUI64.convert,
-            vol.Inclusive(ATTR_INSTALL_CODE, "install_code"): convert_install_code,
-            vol.Exclusive(ATTR_QR_CODE, "install_code"): vol.All(
-                str, qr_to_install_code
-            ),
-        }
+SERVICE_PERMIT_PARAMS = {
+    vol.Optional(ATTR_IEEE_ADDRESS, default=None): EUI64.convert,
+    vol.Optional(ATTR_DURATION, default=60): vol.All(
+        vol.Coerce(int), vol.Range(0, 254)
     ),
+    vol.Inclusive(ATTR_SOURCE_IEEE, "install_code"): EUI64.convert,
+    vol.Inclusive(ATTR_INSTALL_CODE, "install_code"): convert_install_code,
+    vol.Exclusive(ATTR_QR_CODE, "install_code"): vol.All(str, qr_to_install_code),
+}
+
+SERVICE_SCHEMAS = {
+    SERVICE_PERMIT: vol.Schema(SERVICE_PERMIT_PARAMS),
     IEEE_SERVICE: vol.Schema({vol.Required(ATTR_IEEE_ADDRESS): EUI64.convert}),
     SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE: vol.Schema(
         {
@@ -181,7 +179,7 @@ ClusterBinding = collections.namedtuple("ClusterBinding", "id endpoint_id type n
 @websocket_api.require_admin
 @websocket_api.async_response
 @websocket_api.websocket_command(
-    {vol.Required("type"): "zha/devices/permit", **SERVICE_SCHEMAS[SERVICE_PERMIT]}
+    {vol.Required("type"): "zha/devices/permit", **SERVICE_PERMIT_PARAMS}
 )
 async def websocket_permit_devices(hass, connection, msg):
     """Permit ZHA zigbee devices."""

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -72,6 +72,7 @@ DEVICE_INFO = "device_info"
 
 ATTR_DURATION = "duration"
 ATTR_GROUP = "group"
+ATTR_IEEE_ADDRESS = "ieee_address"
 ATTR_INSTALL_CODE = "install_code"
 ATTR_SOURCE_IEEE = "source_ieee"
 ATTR_TARGET_IEEE = "target_ieee"
@@ -100,8 +101,18 @@ SERVICE_PERMIT_PARAMS = {
 }
 
 SERVICE_SCHEMAS = {
-    SERVICE_PERMIT: vol.Schema(SERVICE_PERMIT_PARAMS),
-    IEEE_SERVICE: vol.Schema({vol.Required(ATTR_IEEE): EUI64.convert}),
+    SERVICE_PERMIT: vol.Schema(
+        vol.All(
+            cv.deprecated(ATTR_IEEE_ADDRESS, replacement_key=ATTR_IEEE),
+            SERVICE_PERMIT_PARAMS,
+        )
+    ),
+    IEEE_SERVICE: vol.Schema(
+        vol.All(
+            cv.deprecated(ATTR_IEEE_ADDRESS, replacement_key=ATTR_IEEE),
+            {vol.Required(ATTR_IEEE): EUI64.convert},
+        )
+    ),
     SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE: vol.Schema(
         {
             vol.Required(ATTR_IEEE): EUI64.convert,

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -1,7 +1,6 @@
 """Web socket API for Zigbee Home Automation devices."""
 
 import asyncio
-import binascii
 import collections
 from collections.abc import Mapping
 import logging
@@ -9,7 +8,6 @@ from typing import Any
 
 import voluptuous as vol
 from zigpy.types.named import EUI64
-import zigpy.util
 import zigpy.zdo.types as zdo_types
 
 from homeassistant.components import websocket_api
@@ -56,7 +54,11 @@ from .core.const import (
     WARNING_DEVICE_STROBE_YES,
 )
 from .core.group import GroupMember
-from .core.helpers import async_is_bindable_target, get_matched_clusters
+from .core.helpers import (
+    async_is_bindable_target,
+    convert_install_code,
+    get_matched_clusters,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,24 +89,6 @@ SERVICE_WARNING_DEVICE_WARN = "warning_device_warn"
 SERVICE_ZIGBEE_BIND = "service_zigbee_bind"
 IEEE_SERVICE = "ieee_based_service"
 
-
-def _convert_install_code(value: str) -> bytes:
-    """Convert string to install code bytes and validate length."""
-
-    try:
-        code = binascii.unhexlify(value.replace("-", "").lower())
-    except binascii.Error:
-        raise vol.Invalid(f"invalid hex string: {value}")
-
-    if len(code) != 18:  # 16 byte code + 2 crc bytes
-        raise vol.Invalid("invalid length of the install code")
-
-    if zigpy.util.convert_install_code(code) is None:
-        raise vol.Invalid("invalid install code")
-
-    return code
-
-
 SERVICE_SCHEMAS = {
     SERVICE_PERMIT: vol.Schema(
         {
@@ -113,7 +97,7 @@ SERVICE_SCHEMAS = {
                 vol.Coerce(int), vol.Range(0, 254)
             ),
             vol.Inclusive(ATTR_SOURCE_IEEE, "install_code"): EUI64.convert,
-            vol.Inclusive(ATTR_INSTALL_CODE, "install_code"): _convert_install_code,
+            vol.Inclusive(ATTR_INSTALL_CODE, "install_code"): convert_install_code,
             vol.Exclusive(ATTR_QR_CODE, "install_code"): str,
         }
     ),

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -58,6 +58,7 @@ from .core.helpers import (
     async_is_bindable_target,
     convert_install_code,
     get_matched_clusters,
+    qr_to_install_code,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -98,7 +99,9 @@ SERVICE_SCHEMAS = {
             ),
             vol.Inclusive(ATTR_SOURCE_IEEE, "install_code"): EUI64.convert,
             vol.Inclusive(ATTR_INSTALL_CODE, "install_code"): convert_install_code,
-            vol.Exclusive(ATTR_QR_CODE, "install_code"): str,
+            vol.Exclusive(ATTR_QR_CODE, "install_code"): vol.All(
+                str, qr_to_install_code
+            ),
         }
     ),
     IEEE_SERVICE: vol.Schema({vol.Required(ATTR_IEEE_ADDRESS): EUI64.convert}),
@@ -178,10 +181,7 @@ ClusterBinding = collections.namedtuple("ClusterBinding", "id endpoint_id type n
 @websocket_api.require_admin
 @websocket_api.async_response
 @websocket_api.websocket_command(
-    {
-        vol.Required("type"): "zha/devices/permit",
-        **SERVICE_SCHEMAS[SERVICE_PERMIT],
-    }
+    {vol.Required("type"): "zha/devices/permit", **SERVICE_SCHEMAS[SERVICE_PERMIT]}
 )
 async def websocket_permit_devices(hass, connection, msg):
     """Permit ZHA zigbee devices."""

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -841,6 +841,14 @@ def async_load_api(hass):
             )
             return
 
+        if ATTR_QR_CODE in service.data:
+            src_ieee, code = service.data[ATTR_QR_CODE]
+            _LOGGER.info("Allowing join for %s device with install code", src_ieee)
+            await application_controller.permit_with_key(
+                time_s=duration, node=src_ieee, code=code
+            )
+            return
+
         if ieee:
             _LOGGER.info("Permitting joins for %ss on %s device", duration, ieee)
         else:

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -23,6 +23,7 @@ from .core.const import (
     ATTR_COMMAND,
     ATTR_COMMAND_TYPE,
     ATTR_ENDPOINT_ID,
+    ATTR_IEEE,
     ATTR_LEVEL,
     ATTR_MANUFACTURER,
     ATTR_MEMBERS,
@@ -71,8 +72,6 @@ DEVICE_INFO = "device_info"
 
 ATTR_DURATION = "duration"
 ATTR_GROUP = "group"
-ATTR_IEEE_ADDRESS = "ieee_address"
-ATTR_IEEE = "ieee"
 ATTR_INSTALL_CODE = "install_code"
 ATTR_SOURCE_IEEE = "source_ieee"
 ATTR_TARGET_IEEE = "target_ieee"
@@ -91,7 +90,7 @@ SERVICE_ZIGBEE_BIND = "service_zigbee_bind"
 IEEE_SERVICE = "ieee_based_service"
 
 SERVICE_PERMIT_PARAMS = {
-    vol.Optional(ATTR_IEEE_ADDRESS, default=None): EUI64.convert,
+    vol.Optional(ATTR_IEEE, default=None): EUI64.convert,
     vol.Optional(ATTR_DURATION, default=60): vol.All(
         vol.Coerce(int), vol.Range(0, 254)
     ),
@@ -102,7 +101,7 @@ SERVICE_PERMIT_PARAMS = {
 
 SERVICE_SCHEMAS = {
     SERVICE_PERMIT: vol.Schema(SERVICE_PERMIT_PARAMS),
-    IEEE_SERVICE: vol.Schema({vol.Required(ATTR_IEEE_ADDRESS): EUI64.convert}),
+    IEEE_SERVICE: vol.Schema({vol.Required(ATTR_IEEE): EUI64.convert}),
     SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE: vol.Schema(
         {
             vol.Required(ATTR_IEEE): EUI64.convert,
@@ -844,8 +843,8 @@ def async_load_api(hass):
 
     async def permit(service):
         """Allow devices to join this network."""
-        duration = service.data.get(ATTR_DURATION)
-        ieee = service.data.get(ATTR_IEEE_ADDRESS)
+        duration = service.data[ATTR_DURATION]
+        ieee = service.data.get(ATTR_IEEE)
         if ATTR_SOURCE_IEEE in service.data:
             src_ieee = service.data[ATTR_SOURCE_IEEE]
             code = service.data[ATTR_INSTALL_CODE]
@@ -875,7 +874,7 @@ def async_load_api(hass):
 
     async def remove(service):
         """Remove a node from the network."""
-        ieee = service.data[ATTR_IEEE_ADDRESS]
+        ieee = service.data[ATTR_IEEE]
         zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
         zha_device = zha_gateway.get_device(ieee)
         if zha_device is not None and zha_device.is_coordinator:

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -832,6 +832,15 @@ def async_load_api(hass):
         """Allow devices to join this network."""
         duration = service.data.get(ATTR_DURATION)
         ieee = service.data.get(ATTR_IEEE_ADDRESS)
+        if ATTR_SOURCE_IEEE in service.data:
+            src_ieee = service.data[ATTR_SOURCE_IEEE]
+            code = service.data[ATTR_INSTALL_CODE]
+            _LOGGER.info("Allowing join for %s device with install code", src_ieee)
+            await application_controller.permit_with_key(
+                time_s=duration, node=src_ieee, code=code
+            )
+            return
+
         if ieee:
             _LOGGER.info("Permitting joins for %ss on %s device", duration, ieee)
         else:

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -203,7 +203,21 @@ async def websocket_permit_devices(hass, connection, msg):
 
     connection.subscriptions[msg["id"]] = async_cleanup
     zha_gateway.async_enable_debug_mode()
-    await zha_gateway.application_controller.permit(time_s=duration, node=ieee)
+    if ATTR_SOURCE_IEEE in msg:
+        src_ieee = msg[ATTR_SOURCE_IEEE]
+        code = msg[ATTR_INSTALL_CODE]
+        _LOGGER.debug("Allowing join for %s device with install code", src_ieee)
+        await zha_gateway.application_controller.permit_with_key(
+            time_s=duration, node=src_ieee, code=code
+        )
+    elif ATTR_QR_CODE in msg:
+        src_ieee, code = msg[ATTR_QR_CODE]
+        _LOGGER.debug("Allowing join for %s device with install code", src_ieee)
+        await zha_gateway.application_controller.permit_with_key(
+            time_s=duration, node=src_ieee, code=code
+        )
+    else:
+        await zha_gateway.application_controller.permit(time_s=duration, node=ieee)
     connection.send_result(msg["id"])
 
 

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -216,8 +216,8 @@ def convert_install_code(value: str) -> bytes:
 
     try:
         code = binascii.unhexlify(value.replace("-", "").lower())
-    except binascii.Error:
-        raise vol.Invalid(f"invalid hex string: {value}")
+    except binascii.Error as exc:
+        raise vol.Invalid(f"invalid hex string: {value}") from exc
 
     if len(code) != 18:  # 16 byte code + 2 crc bytes
         raise vol.Invalid("invalid length of the install code")

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -229,6 +229,8 @@ def convert_install_code(value: str) -> bytes:
 
 
 QR_CODES = (
+    # Consciot
+    r"^([\da-fA-F]{16})\|([\da-fA-F]{36})$",
     # Enbrighten
     r"""
         ^Z:

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -237,6 +237,14 @@ QR_CODES = (
         ([0-9a-fA-F]{36})  # install code
         $
     """,
+    # Aqara
+    r"""
+        \$A:
+        ([0-9a-fA-F]{16})  # IEEE address
+        \$I:
+        ([0-9a-fA-F]{36})  # install code
+        $
+    """,
 )
 
 
@@ -247,7 +255,7 @@ def qr_to_install_code(qr_code: str) -> Tuple[zigpy.types.EUI64, bytes]:
     """
 
     for code_pattern in QR_CODES:
-        match = re.match(code_pattern, qr_code, re.VERBOSE)
+        match = re.search(code_pattern, qr_code, re.VERBOSE)
         if match is None:
             continue
 

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -240,7 +240,7 @@ QR_CODES = (
 )
 
 
-def qr_to_install_code(qr_code: str) -> Tuple[zigpy.types.EUI64, str]:
+def qr_to_install_code(qr_code: str) -> Tuple[zigpy.types.EUI64, bytes]:
     """Try to parse the QR code.
 
     if successful, return a tuple of a EUI64 address and install code.
@@ -254,7 +254,7 @@ def qr_to_install_code(qr_code: str) -> Tuple[zigpy.types.EUI64, str]:
         ieee = zigpy.types.EUI64.convert(match[1])
         install_code = match[2]
         # install_code sanity check
-        convert_install_code(install_code)
+        install_code = convert_install_code(install_code)
         return ieee, install_code
 
     raise vol.Invalid(f"couldn't convert qr code: {qr_code}")

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -232,9 +232,9 @@ QR_CODES = (
     # Enbrighten
     r"""
         ^Z:
-        ([0-9a-f]{16)  # IEEE address
-        I\$
-        ([0-9a-f]{36})  # install code
+        ([0-9a-fA-F]{16})  # IEEE address
+        \$I:
+        ([0-9a-fA-F]{36})  # install code
         $
     """,
 )
@@ -251,7 +251,8 @@ def qr_to_install_code(qr_code: str) -> Tuple[zigpy.types.EUI64, bytes]:
         if match is None:
             continue
 
-        ieee = zigpy.types.EUI64.convert(match[1])
+        ieee_hex = binascii.unhexlify(match[1])
+        ieee = zigpy.types.EUI64(ieee_hex[::-1])
         install_code = match[2]
         # install_code sanity check
         install_code = convert_install_code(install_code)

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -9,6 +9,15 @@ permit:
     ieee_address:
       description: IEEE address of the node permitting new joins
       example: "00:0d:6f:00:05:7d:2d:34"
+    source_ieee:
+      description: IEEE address of the joining device (must be used with install code)
+      example: "00:0a:bf:00:01:10:23:35"
+    install_code:
+      description: Install code of the joining device (must be used with source_ieee)
+      example: "1234-5678-1234-5678-AABB-CCDD-AABB-CCDD-EEFF"
+    qr_code:
+      description: value of the QR install code (different between vendors)
+      example: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051"
 
 remove:
   description: Remove a node from the Zigbee network.

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -458,6 +458,8 @@ async def test_permit_with_install_code(
                 "3C3C3C3C$I:52797BF4A5084DAA8E1712B61741CA024052"
             )
         },
+        # good consciot regex match, but bad code
+        {ATTR_QR_CODE: "000D6FFFFED4163B|52797BF4A5084DAA8E1712B61741CA024052"},
     ),
 )
 async def test_permit_with_install_code_fail(
@@ -476,6 +478,11 @@ async def test_permit_with_install_code_fail(
 @pytest.mark.parametrize(
     "params, src_ieee, code",
     (
+        (
+            {ATTR_QR_CODE: "000D6FFFFED4163B|52797BF4A5084DAA8E1712B61741CA024051"},
+            zigpy.types.EUI64.convert("00:0D:6F:FF:FE:D4:16:3B"),
+            unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
+        ),
         (
             {ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051"},
             zigpy.types.EUI64.convert("00:0D:6F:FF:FE:D4:16:3B"),

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -430,11 +430,27 @@ async def test_permit_with_install_code(
     "params",
     (
         {
+            # wrong install code
             ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE,
             ATTR_INSTALL_CODE: "5279-7BF4-A508-4DAA-8E17-12B6-1741-CA02-4052",
         },
+        # incorrect service params
         {ATTR_INSTALL_CODE: "5279-7BF4-A508-4DAA-8E17-12B6-1741-CA02-4051"},
         {ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE},
+        {
+            # incorrect service params
+            ATTR_INSTALL_CODE: "5279-7BF4-A508-4DAA-8E17-12B6-1741-CA02-4051",
+            ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051",
+        },
+        {
+            # incorrect service params
+            ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE,
+            ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051",
+        },
+        {
+            # good regex match, but bad code
+            ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024052",
+        },
     ),
 )
 async def test_permit_with_install_code_fail(

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -398,19 +398,27 @@ async def test_permit_ha12(
     assert app_controller.permit_with_key.call_count == 0
 
 
-@pytest.mark.parametrize(
-    "params, src_ieee, code",
+IC_TEST_PARAMS = (
     (
-        (
-            {
-                ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE,
-                ATTR_INSTALL_CODE: "5279-7BF4-A508-4DAA-8E17-12B6-1741-CA02-4051",
-            },
-            zigpy.types.EUI64.convert(IEEE_SWITCH_DEVICE),
-            unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
-        ),
+        {
+            ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE,
+            ATTR_INSTALL_CODE: "5279-7BF4-A508-4DAA-8E17-12B6-1741-CA02-4051",
+        },
+        zigpy.types.EUI64.convert(IEEE_SWITCH_DEVICE),
+        unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
+    ),
+    (
+        {
+            ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE,
+            ATTR_INSTALL_CODE: "52797BF4A5084DAA8E1712B61741CA024051",
+        },
+        zigpy.types.EUI64.convert(IEEE_SWITCH_DEVICE),
+        unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
     ),
 )
+
+
+@pytest.mark.parametrize("params, src_ieee, code", IC_TEST_PARAMS)
 async def test_permit_with_install_code(
     hass, app_controller, hass_admin_user, params, src_ieee, code
 ):
@@ -426,8 +434,7 @@ async def test_permit_with_install_code(
     assert app_controller.permit_with_key.await_args[1]["code"] == code
 
 
-@pytest.mark.parametrize(
-    "params",
+IC_FAIL_PARAMS = (
     (
         {
             # wrong install code
@@ -462,6 +469,9 @@ async def test_permit_with_install_code(
         {ATTR_QR_CODE: "000D6FFFFED4163B|52797BF4A5084DAA8E1712B61741CA024052"},
     ),
 )
+
+
+@pytest.mark.parametrize("params", IC_FAIL_PARAMS)
 async def test_permit_with_install_code_fail(
     hass, app_controller, hass_admin_user, params
 ):
@@ -475,31 +485,31 @@ async def test_permit_with_install_code_fail(
     assert app_controller.permit_with_key.call_count == 0
 
 
-@pytest.mark.parametrize(
-    "params, src_ieee, code",
+IC_QR_CODE_TEST_PARAMS = (
     (
-        (
-            {ATTR_QR_CODE: "000D6FFFFED4163B|52797BF4A5084DAA8E1712B61741CA024051"},
-            zigpy.types.EUI64.convert("00:0D:6F:FF:FE:D4:16:3B"),
-            unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
-        ),
-        (
-            {ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051"},
-            zigpy.types.EUI64.convert("00:0D:6F:FF:FE:D4:16:3B"),
-            unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
-        ),
-        (
-            {
-                ATTR_QR_CODE: (
-                    "G$M:751$S:357S00001579$D:000000000F350FFD%Z$A:04CF8CDF"
-                    "3C3C3C3C$I:52797BF4A5084DAA8E1712B61741CA024051"
-                )
-            },
-            zigpy.types.EUI64.convert("04:CF:8C:DF:3C:3C:3C:3C"),
-            unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
-        ),
+        {ATTR_QR_CODE: "000D6FFFFED4163B|52797BF4A5084DAA8E1712B61741CA024051"},
+        zigpy.types.EUI64.convert("00:0D:6F:FF:FE:D4:16:3B"),
+        unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
+    ),
+    (
+        {ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051"},
+        zigpy.types.EUI64.convert("00:0D:6F:FF:FE:D4:16:3B"),
+        unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
+    ),
+    (
+        {
+            ATTR_QR_CODE: (
+                "G$M:751$S:357S00001579$D:000000000F350FFD%Z$A:04CF8CDF"
+                "3C3C3C3C$I:52797BF4A5084DAA8E1712B61741CA024051"
+            )
+        },
+        zigpy.types.EUI64.convert("04:CF:8C:DF:3C:3C:3C:3C"),
+        unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
     ),
 )
+
+
+@pytest.mark.parametrize("params, src_ieee, code", IC_QR_CODE_TEST_PARAMS)
 async def test_permit_with_qr_code(
     hass, app_controller, hass_admin_user, params, src_ieee, code
 ):

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -449,7 +449,14 @@ async def test_permit_with_install_code(
         },
         {
             # good regex match, but bad code
-            ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024052",
+            ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024052"
+        },
+        {
+            # good aqara regex match, but bad code
+            ATTR_QR_CODE: (
+                "G$M:751$S:357S00001579$D:000000000F350FFD%Z$A:04CF8CDF"
+                "3C3C3C3C$I:52797BF4A5084DAA8E1712B61741CA024052"
+            )
         },
     ),
 )
@@ -472,6 +479,16 @@ async def test_permit_with_install_code_fail(
         (
             {ATTR_QR_CODE: "Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051"},
             zigpy.types.EUI64.convert("00:0D:6F:FF:FE:D4:16:3B"),
+            unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
+        ),
+        (
+            {
+                ATTR_QR_CODE: (
+                    "G$M:751$S:357S00001579$D:000000000F350FFD%Z$A:04CF8CDF"
+                    "3C3C3C3C$I:52797BF4A5084DAA8E1712B61741CA024051"
+                )
+            },
+            zigpy.types.EUI64.convert("04:CF:8C:DF:3C:3C:3C:3C"),
             unhexlify("52797BF4A5084DAA8E1712B61741CA024051"),
         ),
     ),

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -11,7 +11,6 @@ from homeassistant.components.websocket_api import const
 from homeassistant.components.zha import DOMAIN
 from homeassistant.components.zha.api import (
     ATTR_DURATION,
-    ATTR_IEEE_ADDRESS,
     ATTR_INSTALL_CODE,
     ATTR_QR_CODE,
     ATTR_SOURCE_IEEE,
@@ -373,12 +372,12 @@ async def app_controller(hass, setup_zha):
         ({}, 60, None),
         ({ATTR_DURATION: 30}, 30, None),
         (
-            {ATTR_DURATION: 33, ATTR_IEEE_ADDRESS: "aa:bb:cc:dd:aa:bb:cc:dd"},
+            {ATTR_DURATION: 33, ATTR_IEEE: "aa:bb:cc:dd:aa:bb:cc:dd"},
             33,
             zigpy.types.EUI64.convert("aa:bb:cc:dd:aa:bb:cc:dd"),
         ),
         (
-            {ATTR_IEEE_ADDRESS: "aa:bb:cc:dd:aa:bb:cc:d1"},
+            {ATTR_IEEE: "aa:bb:cc:dd:aa:bb:cc:d1"},
             60,
             zigpy.types.EUI64.convert("aa:bb:cc:dd:aa:bb:cc:d1"),
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change, but `ieee_address` parameter was renamed to `ieee` for `zha.permit` and `zha.remove` services. This makes all services to use consistently named parameters. Little impact to the end users, as `zha.permit` and `zha.remove` services are used infrequently.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add extra parameters to allow joining ZB3 devices using install codes. Currently only supported with EZSP based or TI (using  zigpy_znp) radios.

Three new parameters were added:
- `source_ieee` -- IEEE of the joining devices, must be used with `install_code`, can't be used with `qr_code` param
- `install_code` -- Install code of the joining device, must be used with `source_ieee`, can't be used with `qr_code`
- `qr_code` -- QR Code of the install code, containing IEEE and install code. Can't be used with `source_ieee` or `install_code`

`qr_code`  is experimental and since every vendor encodes ieee and install code differently, this would need to be added for every vendor, assuming it can be matched by a regex. Based on a limited samples of QR install codes current attempt is to support the QR codes from the following vendors:
- Aqara
- Consciot
- Embrighten

@dmulcahey can QR code scanning be embedded into ZHA UI?
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14643

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
