### PR TITLE
Use common strings for velbus config flow

### DIFF
--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -37,7 +37,7 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             controller = velbus.Controller(prt)
         except Exception:  # pylint: disable=broad-except
-            self._errors[CONF_PORT] = "connection_failed"
+            self._errors[CONF_PORT] = "cannot_connect"
             return False
         controller.stop()
         return True
@@ -58,7 +58,7 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if self._test_connection(prt):
                     return self._create_device(name, prt)
             else:
-                self._errors[CONF_PORT] = "port_exists"
+                self._errors[CONF_PORT] = "already_configured"
         else:
             user_input = {}
             user_input[CONF_NAME] = ""
@@ -82,5 +82,5 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._prt_in_configuration_exists(prt):
             # if the velbus import is already in the config
             # we should not proceed the import
-            return self.async_abort(reason="port_exists")
+            return self.async_abort(reason="already_configured")
         return await self.async_step_user(user_input)

--- a/homeassistant/components/velbus/strings.json
+++ b/homeassistant/components/velbus/strings.json
@@ -10,9 +10,11 @@
       }
     },
     "error": {
-      "port_exists": "This port is already configured",
-      "connection_failed": "The velbus connection failed"
+      "port_exists": "[%key:common::config_flow::abort::already_configured_device%]",
+      "connection_failed": "[%key:common::config_flow::error::cannot_connect%]"
     },
-    "abort": { "port_exists": "This port is already configured" }
+    "abort": {
+        "port_exists": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
   }
 }

--- a/homeassistant/components/velbus/strings.json
+++ b/homeassistant/components/velbus/strings.json
@@ -10,11 +10,11 @@
       }
     },
     "error": {
-      "port_exists": "[%key:common::config_flow::abort::already_configured_device%]",
-      "connection_failed": "[%key:common::config_flow::error::cannot_connect%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-        "port_exists": "[%key:common::config_flow::abort::already_configured_device%]"
+        "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -65,13 +65,13 @@ async def test_user_fail(hass, controller_assert):
         {CONF_NAME: "Velbus Test Serial", CONF_PORT: PORT_SERIAL}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_PORT: "connection_failed"}
+    assert result["errors"] == {CONF_PORT: "cannot_connect"}
 
     result = await flow.async_step_user(
         {CONF_NAME: "Velbus Test TCP", CONF_PORT: PORT_TCP}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_PORT: "connection_failed"}
+    assert result["errors"] == {CONF_PORT: "cannot_connect"}
 
 
 async def test_import(hass, controller):
@@ -94,10 +94,10 @@ async def test_abort_if_already_setup(hass):
         {CONF_PORT: PORT_TCP, CONF_NAME: "velbus import test"}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "port_exists"
+    assert result["reason"] == "already_configured"
 
     result = await flow.async_step_user(
         {CONF_PORT: PORT_TCP, CONF_NAME: "velbus import test"}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {"port": "port_exists"}
+    assert result["errors"] == {"port": "already_configured"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Use of common strings in the velbus configflow. See #40578


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
