### PR TITLE
Use direct service calls in flux tests instead of switch common

### DIFF
--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -20,7 +20,6 @@ from tests.common import (
     async_mock_service,
     mock_restore_cache,
 )
-from tests.components.switch import common
 
 
 async def test_valid_config(hass):
@@ -224,8 +223,12 @@ async def test_flux_before_sunrise(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        await common.async_turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -278,8 +281,12 @@ async def test_flux_before_sunrise_known_location(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        await common.async_turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -333,8 +340,12 @@ async def test_flux_after_sunrise_before_sunset(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        await common.async_turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -389,8 +400,12 @@ async def test_flux_after_sunset_before_stop(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -444,8 +459,12 @@ async def test_flux_after_stop_before_sunrise(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -501,8 +520,12 @@ async def test_flux_with_custom_start_stop_times(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -559,8 +582,12 @@ async def test_flux_before_sunrise_stop_next_day(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -621,8 +648,12 @@ async def test_flux_after_sunrise_before_sunset_stop_next_day(
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -683,8 +714,12 @@ async def test_flux_after_sunset_before_midnight_stop_next_day(
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -744,8 +779,12 @@ async def test_flux_after_sunset_after_midnight_stop_next_day(
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -805,8 +844,12 @@ async def test_flux_after_stop_before_sunrise_stop_next_day(
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -863,8 +906,12 @@ async def test_flux_with_custom_colortemps(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -920,8 +967,12 @@ async def test_flux_with_custom_brightness(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -993,8 +1044,12 @@ async def test_flux_with_multiple_lights(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -1053,8 +1108,12 @@ async def test_flux_with_mired(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        common.turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
@@ -1106,8 +1165,12 @@ async def test_flux_with_rgb(hass, legacy_patchable_time):
         )
         await hass.async_block_till_done()
         turn_on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-        await common.async_turn_on(hass, "switch.flux")
-        await hass.async_block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.flux"},
+            blocking=True,
+        )
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR updates a couple of tests in the `flux` integration. Common test helpers from the switch module, are replaced with direct service calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
