### PR TITLE
Indicate to user that remote was turned off when call was attempted

### DIFF
--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -244,7 +244,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
 
         if not self._state:
             _LOGGER.warning(
-                "Unable to send to command to turned of entity %s", self.entity_id
+                "remote.send_command canceled: %s entity is turned off", self.entity_id
             )
             return
 
@@ -289,7 +289,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
 
         if not self._state:
             _LOGGER.warning(
-                "Unable to learn command from turned of entity %s", self.entity_id
+                "remote.learn_command canceled: %s entity is turned off", self.entity_id
             )
             return
 

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -243,7 +243,10 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         delay = kwargs[ATTR_DELAY_SECS]
 
         if not self._state:
-            raise Exception(f"Remote {self.entity_id} is turned off or unavailable")
+            _LOGGER.warning(
+                "Unable to send to command to turned of entity %s", self.entity_id
+            )
+            return
 
         should_delay = False
 
@@ -285,6 +288,9 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         toggle = kwargs[ATTR_ALTERNATIVE]
 
         if not self._state:
+            _LOGGER.warning(
+                "Unable to learn command from turned of entity %s", self.entity_id
+            )
             return
 
         should_store = False

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -243,7 +243,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         delay = kwargs[ATTR_DELAY_SECS]
 
         if not self._state:
-            return
+            raise Exception(f"Remote {self.entity_id} is turned off or unavailable")
 
         should_delay = False
 

--- a/tests/components/broadlink/test_remote.py
+++ b/tests/components/broadlink/test_remote.py
@@ -1,6 +1,8 @@
 """Tests for Broadlink remotes."""
 from base64 import b64decode
 
+from pytest import raises
+
 from homeassistant.components.broadlink.const import DOMAIN, REMOTE_DOMAIN
 from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
@@ -93,12 +95,13 @@ async def test_remote_turn_off_turn_on(hass):
         )
         assert hass.states.get(remote.entity_id).state == STATE_OFF
 
-        await hass.services.async_call(
-            REMOTE_DOMAIN,
-            SERVICE_SEND_COMMAND,
-            {"entity_id": remote.entity_id, "command": "b64:" + IR_PACKET},
-            blocking=True,
-        )
+        with raises(Exception):
+            await hass.services.async_call(
+                REMOTE_DOMAIN,
+                SERVICE_SEND_COMMAND,
+                {"entity_id": remote.entity_id, "command": "b64:" + IR_PACKET},
+                blocking=True,
+            )
         assert mock_api.send_data.call_count == 0
 
         await hass.services.async_call(

--- a/tests/components/broadlink/test_remote.py
+++ b/tests/components/broadlink/test_remote.py
@@ -1,8 +1,6 @@
 """Tests for Broadlink remotes."""
 from base64 import b64decode
 
-from pytest import raises
-
 from homeassistant.components.broadlink.const import DOMAIN, REMOTE_DOMAIN
 from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
@@ -95,13 +93,12 @@ async def test_remote_turn_off_turn_on(hass):
         )
         assert hass.states.get(remote.entity_id).state == STATE_OFF
 
-        with raises(Exception):
-            await hass.services.async_call(
-                REMOTE_DOMAIN,
-                SERVICE_SEND_COMMAND,
-                {"entity_id": remote.entity_id, "command": "b64:" + IR_PACKET},
-                blocking=True,
-            )
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {"entity_id": remote.entity_id, "command": "b64:" + IR_PACKET},
+            blocking=True,
+        )
         assert mock_api.send_data.call_count == 0
 
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trigger log when send_command is called when entity would reject the data due to state

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Currently the broadlink component will silently reject attempts to send IR codes if the remote entity is in a turned off state. It gives no indication to user that the request was completely ignored.

Imho it can be debated if the request should be ignored at all unless it's in an unavailable state. Not sure why it has an on/off state at all

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
