### PR TITLE
Update pyatag to 0.3.4.4

### DIFF
--- a/homeassistant/components/atag/manifest.json
+++ b/homeassistant/components/atag/manifest.json
@@ -3,6 +3,6 @@
   "name": "Atag",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/atag/",
-  "requirements": ["pyatag==0.3.3.4"],
+  "requirements": ["pyatag==0.3.4.4"],
   "codeowners": ["@MatsNL"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1247,7 +1247,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.3.4
+pyatag==0.3.4.4
 
 # homeassistant.components.netatmo
 pyatmo==4.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -613,7 +613,7 @@ pyalmond==0.0.2
 pyarlo==0.2.3
 
 # homeassistant.components.atag
-pyatag==0.3.3.4
+pyatag==0.3.4.4
 
 # homeassistant.components.netatmo
 pyatmo==4.0.0

--- a/tests/components/atag/__init__.py
+++ b/tests/components/atag/__init__.py
@@ -59,7 +59,7 @@ async def init_integration(
 ) -> MockConfigEntry:
     """Set up the Atag integration in Home Assistant."""
 
-    aioclient_mock.get(
+    aioclient_mock.post(
         "http://127.0.0.1:10000/retrieve",
         json=RECEIVE_REPLY,
         headers={"Content-Type": CONTENT_TYPE_JSON},

--- a/tests/components/atag/test_config_flow.py
+++ b/tests/components/atag/test_config_flow.py
@@ -78,12 +78,12 @@ async def test_full_flow_implementation(
 ) -> None:
     """Test registering an integration and finishing flow works."""
     aioclient_mock.post(
-        "http://127.0.0.1:10000/retrieve",
-        json=RECEIVE_REPLY,
-    )
-    aioclient_mock.post(
         "http://127.0.0.1:10000/pair",
         json=PAIR_REPLY,
+    )
+    aioclient_mock.post(
+        "http://127.0.0.1:10000/retrieve",
+        json=RECEIVE_REPLY,
     )
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/atag/test_config_flow.py
+++ b/tests/components/atag/test_config_flow.py
@@ -1,8 +1,9 @@
 """Tests for the Atag config flow."""
+from pyatag import errors
+
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.atag import DOMAIN
 from homeassistant.core import HomeAssistant
-from pyatag import errors
 
 from tests.async_mock import PropertyMock, patch
 from tests.components.atag import (

--- a/tests/components/atag/test_config_flow.py
+++ b/tests/components/atag/test_config_flow.py
@@ -1,9 +1,8 @@
 """Tests for the Atag config flow."""
-from pyatag import errors
-
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.atag import DOMAIN
 from homeassistant.core import HomeAssistant
+from pyatag import errors
 
 from tests.async_mock import PropertyMock, patch
 from tests.components.atag import (
@@ -78,7 +77,7 @@ async def test_full_flow_implementation(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test registering an integration and finishing flow works."""
-    aioclient_mock.get(
+    aioclient_mock.post(
         "http://127.0.0.1:10000/retrieve",
         json=RECEIVE_REPLY,
     )

--- a/tests/components/atag/test_init.py
+++ b/tests/components/atag/test_init.py
@@ -14,7 +14,7 @@ async def test_config_entry_not_ready(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test configuration entry not ready on library error."""
-    aioclient_mock.get("http://127.0.0.1:10000/retrieve", exc=aiohttp.ClientError)
+    aioclient_mock.post("http://127.0.0.1:10000/retrieve", exc=aiohttp.ClientError)
     entry = await init_integration(hass, aioclient_mock)
     assert entry.state == ENTRY_STATE_SETUP_RETRY
 


### PR DESCRIPTION
## Proposed change
Update atag dependency to include a retry function on unexpected server disconnects.

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- link to changelog of dependency: https://github.com/MatsNl/pyatag/blob/master/CHANGELOG.md

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
This i don't know 

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved
