### PR TITLE
Support single select with keys in config flow

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -677,6 +677,20 @@ class multi_select:
         return selected
 
 
+class single_select:
+    """Single select validator returning list of selected values."""
+
+    def __init__(self, options: dict) -> None:
+        """Initialize multi select."""
+        self.options = options
+
+    def __call__(self, selected: Any) -> Any:
+        """Validate input."""
+        if selected not in self.options:
+            raise vol.Invalid(f"{selected} is not a valid option")
+        return selected
+
+
 def deprecated(
     key: str,
     replacement_key: Optional[str] = None,
@@ -830,6 +844,12 @@ def custom_serializer(schema: Any) -> Any:
 
     if isinstance(schema, multi_select):
         return {"type": "multi_select", "options": schema.options}
+
+    if isinstance(schema, single_select):
+        return {
+            "type": "select",
+            "options": [[key, value] for key, value in schema.options.items()],
+        }
 
     return voluptuous_serialize.UNSUPPORTED
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -681,7 +681,7 @@ class single_select:
     """Single select validator returning list of selected values."""
 
     def __init__(self, options: dict) -> None:
-        """Initialize multi select."""
+        """Initialize single select."""
         self.options = options
 
     def __call__(self, selected: Any) -> Any:

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -571,6 +571,32 @@ def test_multi_select_in_serializer():
     }
 
 
+def test_single_select():
+    """Test single select validation.
+
+    Expected behavior:
+        - Will not accept any that is not part of it's keys
+    """
+    schema = vol.Schema(cv.single_select({"key1": "Data 1", "key2": "Data 2"}))
+
+    with pytest.raises(vol.Invalid):
+        schema("key3")
+        schema(["key1"])
+
+    schema("key1")
+    schema("key1")
+
+
+def test_single_select_in_serializer():
+    """Test single_select with custom_serializer."""
+    assert cv.custom_serializer(
+        cv.single_select({"key1": "Data 1", "key2": "Data 2"})
+    ) == {
+        "type": "select",
+        "options": [["key1", "Data 1"], ["key2", "Data 2"]],
+    }
+
+
 @pytest.fixture
 def schema():
     """Create a schema used for testing deprecation."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hook into already existing single selection logic in frontend with voluptious validation serializes. This allow config flow or device actions to list stuff like a list of entities displayed with their friendly name, but storing the entity_id in the backend.

It avoids the need to do stuff like reversing dicts to and looking through their values to figure out what key was selected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
