### PR TITLE
Improve command_line switch tests

### DIFF
--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -2,209 +2,240 @@
 import json
 import os
 import tempfile
-import unittest
 
 import homeassistant.components.command_line.switch as command_line
 import homeassistant.components.switch as switch
-from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.setup import setup_component
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant
-from tests.components.switch import common
+
+async def test_state_none(hass):
+    """Test with none state."""
+    with tempfile.TemporaryDirectory() as tempdirname:
+        path = os.path.join(tempdirname, "switch_status")
+        test_switch = {
+            "command_on": f"echo 1 > {path}",
+            "command_off": f"echo 0 > {path}",
+        }
+        assert await async_setup_component(
+            hass,
+            switch.DOMAIN,
+            {
+                "switch": {
+                    "platform": "command_line",
+                    "switches": {"test": test_switch},
+                }
+            },
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("switch.test")
+        assert STATE_OFF == state.state
+
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
+
+        state = hass.states.get("switch.test")
+        assert STATE_ON == state.state
+
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
+
+        state = hass.states.get("switch.test")
+        assert STATE_OFF == state.state
 
 
-# pylint: disable=invalid-name
-class TestCommandSwitch(unittest.TestCase):
-    """Test the command switch."""
+async def test_state_value(hass):
+    """Test with state value."""
+    with tempfile.TemporaryDirectory() as tempdirname:
+        path = os.path.join(tempdirname, "switch_status")
+        test_switch = {
+            "command_state": f"cat {path}",
+            "command_on": f"echo 1 > {path}",
+            "command_off": f"echo 0 > {path}",
+            "value_template": '{{ value=="1" }}',
+        }
+        assert await async_setup_component(
+            hass,
+            switch.DOMAIN,
+            {
+                "switch": {
+                    "platform": "command_line",
+                    "switches": {"test": test_switch},
+                }
+            },
+        )
+        await hass.async_block_till_done()
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
+        state = hass.states.get("switch.test")
+        assert STATE_OFF == state.state
 
-    def test_state_none(self):
-        """Test with none state."""
-        with tempfile.TemporaryDirectory() as tempdirname:
-            path = os.path.join(tempdirname, "switch_status")
-            test_switch = {
-                "command_on": f"echo 1 > {path}",
-                "command_off": f"echo 0 > {path}",
-            }
-            assert setup_component(
-                self.hass,
-                switch.DOMAIN,
-                {
-                    "switch": {
-                        "platform": "command_line",
-                        "switches": {"test": test_switch},
-                    }
-                },
-            )
-            self.hass.block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_OFF == state.state
+        state = hass.states.get("switch.test")
+        assert STATE_ON == state.state
 
-            common.turn_on(self.hass, "switch.test")
-            self.hass.block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_ON == state.state
+        state = hass.states.get("switch.test")
+        assert STATE_OFF == state.state
 
-            common.turn_off(self.hass, "switch.test")
-            self.hass.block_till_done()
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_OFF == state.state
+async def test_state_json_value(hass):
+    """Test with state JSON value."""
+    with tempfile.TemporaryDirectory() as tempdirname:
+        path = os.path.join(tempdirname, "switch_status")
+        oncmd = json.dumps({"status": "ok"})
+        offcmd = json.dumps({"status": "nope"})
+        test_switch = {
+            "command_state": f"cat {path}",
+            "command_on": f"echo '{oncmd}' > {path}",
+            "command_off": f"echo '{offcmd}' > {path}",
+            "value_template": '{{ value_json.status=="ok" }}',
+        }
+        assert await async_setup_component(
+            hass,
+            switch.DOMAIN,
+            {
+                "switch": {
+                    "platform": "command_line",
+                    "switches": {"test": test_switch},
+                }
+            },
+        )
+        await hass.async_block_till_done()
 
-    def test_state_value(self):
-        """Test with state value."""
-        with tempfile.TemporaryDirectory() as tempdirname:
-            path = os.path.join(tempdirname, "switch_status")
-            test_switch = {
-                "command_state": f"cat {path}",
-                "command_on": f"echo 1 > {path}",
-                "command_off": f"echo 0 > {path}",
-                "value_template": '{{ value=="1" }}',
-            }
-            assert setup_component(
-                self.hass,
-                switch.DOMAIN,
-                {
-                    "switch": {
-                        "platform": "command_line",
-                        "switches": {"test": test_switch},
-                    }
-                },
-            )
-            self.hass.block_till_done()
+        state = hass.states.get("switch.test")
+        assert STATE_OFF == state.state
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_OFF == state.state
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
 
-            common.turn_on(self.hass, "switch.test")
-            self.hass.block_till_done()
+        state = hass.states.get("switch.test")
+        assert STATE_ON == state.state
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_ON == state.state
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
 
-            common.turn_off(self.hass, "switch.test")
-            self.hass.block_till_done()
+        state = hass.states.get("switch.test")
+        assert STATE_OFF == state.state
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_OFF == state.state
 
-    def test_state_json_value(self):
-        """Test with state JSON value."""
-        with tempfile.TemporaryDirectory() as tempdirname:
-            path = os.path.join(tempdirname, "switch_status")
-            oncmd = json.dumps({"status": "ok"})
-            offcmd = json.dumps({"status": "nope"})
-            test_switch = {
-                "command_state": f"cat {path}",
-                "command_on": f"echo '{oncmd}' > {path}",
-                "command_off": f"echo '{offcmd}' > {path}",
-                "value_template": '{{ value_json.status=="ok" }}',
-            }
-            assert setup_component(
-                self.hass,
-                switch.DOMAIN,
-                {
-                    "switch": {
-                        "platform": "command_line",
-                        "switches": {"test": test_switch},
-                    }
-                },
-            )
-            self.hass.block_till_done()
+async def test_state_code(hass):
+    """Test with state code."""
+    with tempfile.TemporaryDirectory() as tempdirname:
+        path = os.path.join(tempdirname, "switch_status")
+        test_switch = {
+            "command_state": f"cat {path}",
+            "command_on": f"echo 1 > {path}",
+            "command_off": f"echo 0 > {path}",
+        }
+        assert await async_setup_component(
+            hass,
+            switch.DOMAIN,
+            {
+                "switch": {
+                    "platform": "command_line",
+                    "switches": {"test": test_switch},
+                }
+            },
+        )
+        await hass.async_block_till_done()
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_OFF == state.state
+        state = hass.states.get("switch.test")
+        assert STATE_OFF == state.state
 
-            common.turn_on(self.hass, "switch.test")
-            self.hass.block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_ON == state.state
+        state = hass.states.get("switch.test")
+        assert STATE_ON == state.state
 
-            common.turn_off(self.hass, "switch.test")
-            self.hass.block_till_done()
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test"},
+            blocking=True,
+        )
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_OFF == state.state
+        state = hass.states.get("switch.test")
+        assert STATE_ON == state.state
 
-    def test_state_code(self):
-        """Test with state code."""
-        with tempfile.TemporaryDirectory() as tempdirname:
-            path = os.path.join(tempdirname, "switch_status")
-            test_switch = {
-                "command_state": f"cat {path}",
-                "command_on": f"echo 1 > {path}",
-                "command_off": f"echo 0 > {path}",
-            }
-            assert setup_component(
-                self.hass,
-                switch.DOMAIN,
-                {
-                    "switch": {
-                        "platform": "command_line",
-                        "switches": {"test": test_switch},
-                    }
-                },
-            )
-            self.hass.block_till_done()
-            state = self.hass.states.get("switch.test")
-            assert STATE_OFF == state.state
 
-            common.turn_on(self.hass, "switch.test")
-            self.hass.block_till_done()
+def test_assumed_state_should_be_true_if_command_state_is_none(hass):
+    """Test with state value."""
+    # args: hass, device_name, friendly_name, command_on, command_off,
+    #       command_state, value_template
+    init_args = [
+        hass,
+        "test_device_name",
+        "Test friendly name!",
+        "echo 'on command'",
+        "echo 'off command'",
+        None,
+        None,
+        15,
+    ]
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_ON == state.state
+    no_state_device = command_line.CommandSwitch(*init_args)
+    assert no_state_device.assumed_state
 
-            common.turn_off(self.hass, "switch.test")
-            self.hass.block_till_done()
+    # Set state command
+    init_args[-3] = "cat {}"
 
-            state = self.hass.states.get("switch.test")
-            assert STATE_ON == state.state
+    state_device = command_line.CommandSwitch(*init_args)
+    assert not state_device.assumed_state
 
-    def test_assumed_state_should_be_true_if_command_state_is_none(self):
-        """Test with state value."""
-        # args: hass, device_name, friendly_name, command_on, command_off,
-        #       command_state, value_template
-        init_args = [
-            self.hass,
-            "test_device_name",
-            "Test friendly name!",
-            "echo 'on command'",
-            "echo 'off command'",
-            None,
-            None,
-            15,
-        ]
 
-        no_state_device = command_line.CommandSwitch(*init_args)
-        assert no_state_device.assumed_state
+def test_entity_id_set_correctly(hass):
+    """Test that entity_id is set correctly from object_id."""
+    init_args = [
+        hass,
+        "test_device_name",
+        "Test friendly name!",
+        "echo 'on command'",
+        "echo 'off command'",
+        False,
+        None,
+        15,
+    ]
 
-        # Set state command
-        init_args[-3] = "cat {}"
-
-        state_device = command_line.CommandSwitch(*init_args)
-        assert not state_device.assumed_state
-
-    def test_entity_id_set_correctly(self):
-        """Test that entity_id is set correctly from object_id."""
-        init_args = [
-            self.hass,
-            "test_device_name",
-            "Test friendly name!",
-            "echo 'on command'",
-            "echo 'off command'",
-            False,
-            None,
-            15,
-        ]
-
-        test_switch = command_line.CommandSwitch(*init_args)
-        assert test_switch.entity_id == "switch.test_device_name"
-        assert test_switch.name == "Test friendly name!"
+    test_switch = command_line.CommandSwitch(*init_args)
+    assert test_switch.entity_id == "switch.test_device_name"
+    assert test_switch.name == "Test friendly name!"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improves the `command_line` integration tests for the `switch` platform. Rewrite tests to pytest and removes the use of the switch test helpers by using direct service calls instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
