### PR TITLE
Update devolo-home-control-api to 0.15.0

### DIFF
--- a/homeassistant/components/devolo_home_control/devolo_device.py
+++ b/homeassistant/components/devolo_home_control/devolo_device.py
@@ -17,7 +17,7 @@ class DevoloDeviceEntity(Entity):
         self._device_instance = device_instance
         self._unique_id = element_uid
         self._homecontrol = homecontrol
-        self._name = device_instance.item_name
+        self._name = device_instance.settings_property["general_device_settings"].name
         self._device_class = None
         self._value = None
         self._unit = None
@@ -34,9 +34,7 @@ class DevoloDeviceEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
-        self.subscriber = Subscriber(
-            self._device_instance.item_name, callback=self.sync_callback
-        )
+        self.subscriber = Subscriber(self._name, callback=self.sync_callback)
         self._homecontrol.publisher.register(
             self._device_instance.uid, self.subscriber, self.sync_callback
         )
@@ -57,7 +55,7 @@ class DevoloDeviceEntity(Entity):
         """Return the device info."""
         return {
             "identifiers": {(DOMAIN, self._device_instance.uid)},
-            "name": self._device_instance.item_name,
+            "name": self._name,
             "manufacturer": self._brand,
             "model": self._model,
         }

--- a/homeassistant/components/devolo_home_control/manifest.json
+++ b/homeassistant/components/devolo_home_control/manifest.json
@@ -2,7 +2,7 @@
   "domain": "devolo_home_control",
   "name": "devolo Home Control",
   "documentation": "https://www.home-assistant.io/integrations/devolo_home_control",
-  "requirements": ["devolo-home-control-api==0.13.0"],
+  "requirements": ["devolo-home-control-api==0.15.0"],
   "config_flow": true,
   "codeowners": ["@2Fake", "@Shutgun"],
   "quality_scale": "silver"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -484,7 +484,7 @@ deluge-client==1.7.1
 denonavr==0.9.4
 
 # homeassistant.components.devolo_home_control
-devolo-home-control-api==0.13.0
+devolo-home-control-api==0.15.0
 
 # homeassistant.components.directv
 directv==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -254,7 +254,7 @@ defusedxml==0.6.0
 denonavr==0.9.4
 
 # homeassistant.components.devolo_home_control
-devolo-home-control-api==0.13.0
+devolo-home-control-api==0.15.0
 
 # homeassistant.components.directv
 directv==0.3.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This API bump enables us a couple of new possibilities, but most important allows us to reuse Home Assistant's Zeroconf instance. A full change log is available at https://github.com/2Fake/devolo_home_control_api/releases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
