### PR TITLE
Accept new Plex websocket callback payloads

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -155,14 +155,18 @@ async def async_setup_entry(hass, entry):
         if signal == SIGNAL_CONNECTION_STATE:
 
             if data == STATE_CONNECTED:
-                _LOGGER.debug("Plex websocket connection successful")
+                _LOGGER.debug("Websocket to %s successful", entry.data[CONF_SERVER])
 
             if data == STATE_DISCONNECTED:
-                _LOGGER.debug("Connection to Plex websocket failed, retrying")
+                _LOGGER.debug(
+                    "Websocket to %s disconnected, retrying", entry.data[CONF_SERVER]
+                )
 
             if data == STATE_STOPPED and error:
                 _LOGGER.error(
-                    "Plex server connection failed, aborting [Error: %s]", error
+                    "Websocket to %s failed, aborting [Error: %s]",
+                    entry.data[CONF_SERVER],
+                    error,
                 )
                 asyncio.run_coroutine_threadsafe(
                     hass.config_entries.async_reload(entry.entry_id), hass.loop

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -156,13 +156,12 @@ async def async_setup_entry(hass, entry):
 
             if data == STATE_CONNECTED:
                 _LOGGER.debug("Websocket to %s successful", entry.data[CONF_SERVER])
-
-            if data == STATE_DISCONNECTED:
+            elif data == STATE_DISCONNECTED:
                 _LOGGER.debug(
                     "Websocket to %s disconnected, retrying", entry.data[CONF_SERVER]
                 )
-
-            if data == STATE_STOPPED and error:
+            # Stopped websockets without errors are expected during shutdown and ignored
+            elif data == STATE_STOPPED and error:
                 _LOGGER.error(
                     "Websocket to %s failed, aborting [Error: %s]",
                     entry.data[CONF_SERVER],

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -5,7 +5,14 @@ import json
 import logging
 
 import plexapi.exceptions
-from plexwebsocket import PlexWebsocket
+from plexwebsocket import (
+    SIGNAL_CONNECTION_STATE,
+    SIGNAL_DATA,
+    STATE_CONNECTED,
+    STATE_DISCONNECTED,
+    STATE_STOPPED,
+    PlexWebsocket,
+)
 import requests.exceptions
 import voluptuous as vol
 
@@ -14,7 +21,7 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
 )
-from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY, SOURCE_REAUTH
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_SOURCE,
@@ -95,11 +102,12 @@ async def async_setup_entry(hass, entry):
             entry, data={**entry.data, PLEX_SERVER_CONFIG: new_server_data}
         )
     except requests.exceptions.ConnectionError as error:
-        _LOGGER.error(
-            "Plex server (%s) could not be reached: [%s]",
-            server_config[CONF_URL],
-            error,
-        )
+        if entry.state != ENTRY_STATE_SETUP_RETRY:
+            _LOGGER.error(
+                "Plex server (%s) could not be reached: [%s]",
+                server_config[CONF_URL],
+                error,
+            )
         raise ConfigEntryNotReady from error
     except plexapi.exceptions.Unauthorized:
         hass.async_create_task(
@@ -142,13 +150,34 @@ async def async_setup_entry(hass, entry):
     hass.data[PLEX_DOMAIN][DISPATCHERS].setdefault(server_id, [])
     hass.data[PLEX_DOMAIN][DISPATCHERS][server_id].append(unsub)
 
-    def update_plex():
-        async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
+    def plex_websocket_callback(signal, data, error):
+        """Handle callbacks from plexwebsocket library."""
+        if signal == SIGNAL_CONNECTION_STATE:
+
+            if data == STATE_CONNECTED:
+                _LOGGER.debug("Plex websocket connection successful")
+
+            if data == STATE_DISCONNECTED:
+                _LOGGER.debug("Connection to Plex websocket failed, retrying")
+
+            if data == STATE_STOPPED and error:
+                _LOGGER.error(
+                    "Plex server connection failed, aborting [Error: %s]", error
+                )
+                asyncio.run_coroutine_threadsafe(
+                    hass.config_entries.async_reload(entry.entry_id), hass.loop
+                )
+
+        elif signal == SIGNAL_DATA:
+            async_dispatcher_send(hass, PLEX_UPDATE_PLATFORMS_SIGNAL.format(server_id))
 
     session = async_get_clientsession(hass)
     verify_ssl = server_config.get(CONF_VERIFY_SSL)
     websocket = PlexWebsocket(
-        plex_server.plex_server, update_plex, session=session, verify_ssl=verify_ssl
+        plex_server.plex_server,
+        plex_websocket_callback,
+        session=session,
+        verify_ssl=verify_ssl,
     )
     hass.data[PLEX_DOMAIN][WEBSOCKETS][server_id] = websocket
 

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -6,7 +6,7 @@
   "requirements": [
       "plexapi==4.1.1",
       "plexauth==0.0.5",
-      "plexwebsocket==0.0.11"
+      "plexwebsocket==0.0.12"
   ],
   "dependencies": ["http"],
   "after_dependencies": ["sonos"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1116,7 +1116,7 @@ plexapi==4.1.1
 plexauth==0.0.5
 
 # homeassistant.components.plex
-plexwebsocket==0.0.11
+plexwebsocket==0.0.12
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -533,7 +533,7 @@ plexapi==4.1.1
 plexauth==0.0.5
 
 # homeassistant.components.plex
-plexwebsocket==0.0.11
+plexwebsocket==0.0.12
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/tests/components/plex/helpers.py
+++ b/tests/components/plex/helpers.py
@@ -1,7 +1,8 @@
 """Helper methods for Plex tests."""
+from plexwebsocket import SIGNAL_DATA
 
 
 def trigger_plex_update(mock_websocket):
     """Call the websocket callback method."""
     callback = mock_websocket.call_args[0][1]
-    callback()
+    callback(SIGNAL_DATA, None, None)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Relies on changes in library: https://github.com/jjlawren/python-plexwebsocket/compare/v0.0.11...v0.0.12

Accepts new payloads in callbacks provided by websocket library. Allows to differentiate between connection status changes, receive the actual payload data, and know which errors may have occurred.

If an error occurs in the websocket connection the integration will reload itself and rely on the standard config flow setup fallback mechanism. Transient errors are still handled in the library, so this should be a rare event.

To go along with this reload, the logging is reduced on initial connection failures as the core logging is sufficient.

Hopefully addresses setups with not-always-up Plex servers: https://github.com/home-assistant/core/issues/39979.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39979
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
