### PR TITLE
Normalise headers on onewire integration

### DIFF
--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -119,14 +119,10 @@ def hb_info_from_type(dev_type="std"):
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the one wire Sensors."""
+    """Set up 1-Wire platform."""
     base_dir = config[CONF_MOUNT_DIR]
     owport = config[CONF_PORT]
     owhost = config.get(CONF_HOST)
-    if owhost:
-        _LOGGER.debug("Initializing using %s:%s", owhost, owport)
-    else:
-        _LOGGER.debug("Initializing using %s", base_dir)
 
     devs = []
     device_names = {}
@@ -136,6 +132,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # We have an owserver on a remote(or local) host/port
     if owhost:
+        _LOGGER.debug("Initializing using %s:%s", owhost, owport)
         try:
             owproxy = protocol.proxy(host=owhost, port=owport)
             devices = owproxy.dir()
@@ -180,6 +177,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # We have a raw GPIO ow sensor on a Pi
     elif base_dir == DEFAULT_SYSBUS_MOUNT_DIR:
+        _LOGGER.debug("Initializing using SysBus %s", base_dir)
         for device_family in DEVICE_SENSORS:
             for device_folder in glob(os.path.join(base_dir, f"{device_family}[.-]*")):
                 sensor_id = os.path.split(device_folder)[1]
@@ -194,6 +192,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # We have an owfs mounted
     else:
+        _LOGGER.debug("Initializing using OWFS %s", base_dir)
         for family_file_path in glob(os.path.join(base_dir, "*", "family")):
             with open(family_file_path) as family_file:
                 family = family_file.read()
@@ -225,7 +224,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class OneWire(Entity):
-    """Implementation of an One wire Sensor."""
+    """Implementation of a 1-Wire sensor."""
 
     def __init__(self, name, device_file, sensor_type):
         """Initialize the sensor."""
@@ -270,10 +269,10 @@ class OneWire(Entity):
 
 
 class OneWireProxy(OneWire):
-    """Implementation of a One wire Sensor through owserver."""
+    """Implementation of a 1-Wire sensor through owserver."""
 
     def __init__(self, name, device_file, sensor_type, owproxy):
-        """Initialize the onewire sensor via owserver."""
+        """Initialize the sensor."""
         super().__init__(name, device_file, sensor_type)
         self._owproxy = owproxy
 
@@ -299,7 +298,7 @@ class OneWireProxy(OneWire):
 
 
 class OneWireDirect(OneWire):
-    """Implementation of an One wire Sensor directly connected to RPI GPIO."""
+    """Implementation of a 1-Wire sensor directly connected to RPI GPIO."""
 
     def update(self):
         """Get the latest data from the device."""
@@ -317,7 +316,7 @@ class OneWireDirect(OneWire):
 
 
 class OneWireOWFS(OneWire):
-    """Implementation of an One wire Sensor through owfs."""
+    """Implementation of a 1-Wire sensor through owfs."""
 
     def update(self):
         """Get the latest data from the device."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Normalise method and class headers, with minor logging tweaks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
