### PR TITLE
Fallback to mac in Shelly config flow title

### DIFF
--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -83,7 +83,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors["base"] = "unknown"
                 else:
                     return self.async_create_entry(
-                        title=device_info["title"] or self.host,
+                        title=device_info["title"] or device_info["mac"],
                         data=user_input,
                     )
 
@@ -109,7 +109,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 return self.async_create_entry(
-                    title=device_info["title"] or self.host,
+                    title=device_info["title"] or device_info["mac"],
                     data={**user_input, CONF_HOST: self.host},
                 )
         else:
@@ -142,7 +142,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured({CONF_HOST: zeroconf_info["host"]})
         self.host = zeroconf_info["host"]
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-        self.context["title_placeholders"] = {"name": zeroconf_info["host"]}
+        self.context["title_placeholders"] = {"name": info["mac"]}
         return await self.async_step_confirm_discovery()
 
     async def async_step_confirm_discovery(self, user_input=None):
@@ -161,7 +161,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 return self.async_create_entry(
-                    title=device_info["title"] or self.host, data={"host": self.host}
+                    title=device_info["title"] or device_info["mac"],
+                    data={"host": self.host},
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -1,7 +1,7 @@
 {
   "title": "Shelly",
   "config": {
-    "flow_title": "Shelly: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "description": "Before set up, the battery-powered device must be woken up by pressing the button on the device.",

--- a/homeassistant/components/shelly/translations/en.json
+++ b/homeassistant/components/shelly/translations/en.json
@@ -10,7 +10,7 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Shelly: {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm_discovery": {
                 "description": "Do you want to set up the {model} at {host}?\n\nBefore set up, the battery-powered device must be woken up by pressing the button on the device."

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -11,6 +11,21 @@ from homeassistant.components.shelly.const import DOMAIN
 from tests.async_mock import AsyncMock, Mock, patch
 from tests.common import MockConfigEntry
 
+MOCK_SETTINGS = {
+    "name": "Test name",
+    "device": {"mac": "test-mac", "hostname": "test-host"},
+}
+DISCOVERY_INFO = {
+    "host": "1.1.1.1",
+    "name": "shelly1pm-12345",
+    "properties": {"id": "shelly1pm-12345"},
+}
+SWITCH25_DISCOVERY_INFO = {
+    "host": "1.1.1.1",
+    "name": "shellyswitch25-12345",
+    "properties": {"id": "shellyswitch25-12345"},
+}
+
 
 async def test_form(hass):
     """Test we get the form."""
@@ -29,7 +44,7 @@ async def test_form(hass):
         new=AsyncMock(
             return_value=Mock(
                 shutdown=AsyncMock(),
-                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+                settings=MOCK_SETTINGS,
             )
         ),
     ), patch(
@@ -45,6 +60,51 @@ async def test_form(hass):
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Test name"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_title_without_name_and_prefix(hass):
+    """Test we set the title to the hostname when the device doesn't have a name."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    settings = MOCK_SETTINGS.copy()
+    settings["name"] = None
+    settings["device"] = settings["device"].copy()
+    settings["device"]["hostname"] = "shelly1pm-12345"
+    with patch(
+        "aioshelly.get_info",
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
+    ), patch(
+        "aioshelly.Device.create",
+        new=AsyncMock(
+            return_value=Mock(
+                shutdown=AsyncMock(),
+                settings=settings,
+            )
+        ),
+    ), patch(
+        "homeassistant.components.shelly.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.shelly.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "1.1.1.1"},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "shelly1pm-12345"
     assert result2["data"] == {
         "host": "1.1.1.1",
     }
@@ -78,7 +138,7 @@ async def test_form_auth(hass):
         new=AsyncMock(
             return_value=Mock(
                 shutdown=AsyncMock(),
-                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+                settings=MOCK_SETTINGS,
             )
         ),
     ), patch(
@@ -234,18 +294,23 @@ async def test_zeroconf(hass):
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
         assert result["type"] == "form"
         assert result["errors"] == {}
-
+        context = next(
+            flow["context"]
+            for flow in hass.config_entries.flow.async_progress()
+            if flow["flow_id"] == result["flow_id"]
+        )
+        assert context["title_placeholders"]["name"] == "shelly1pm-12345"
     with patch(
         "aioshelly.Device.create",
         new=AsyncMock(
             return_value=Mock(
                 shutdown=AsyncMock(),
-                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+                settings=MOCK_SETTINGS,
             )
         ),
     ), patch(
@@ -269,6 +334,29 @@ async def test_zeroconf(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_zeroconf_with_switch_prefix(hass):
+    """Test we get remove shelly from the prefix."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "aioshelly.get_info",
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=SWITCH25_DISCOVERY_INFO,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+        assert result["type"] == "form"
+        assert result["errors"] == {}
+        context = next(
+            flow["context"]
+            for flow in hass.config_entries.flow.async_progress()
+            if flow["flow_id"] == result["flow_id"]
+        )
+        assert context["title_placeholders"]["name"] == "switch25-12345"
+
+
 @pytest.mark.parametrize(
     "error", [(asyncio.TimeoutError, "cannot_connect"), (ValueError, "unknown")]
 )
@@ -283,7 +371,7 @@ async def test_zeroconf_confirm_error(hass, error):
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
         assert result["type"] == "form"
@@ -316,7 +404,7 @@ async def test_zeroconf_already_configured(hass):
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
         assert result["type"] == "abort"
@@ -331,7 +419,7 @@ async def test_zeroconf_firmware_unsupported(hass):
     with patch("aioshelly.get_info", side_effect=aioshelly.FirmwareUnsupported):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
 
@@ -344,7 +432,7 @@ async def test_zeroconf_cannot_connect(hass):
     with patch("aioshelly.get_info", side_effect=asyncio.TimeoutError):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
         assert result["type"] == "abort"
@@ -361,7 +449,7 @@ async def test_zeroconf_require_auth(hass):
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            data={"host": "1.1.1.1", "name": "shelly1pm-12345"},
+            data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
         assert result["type"] == "form"
@@ -379,7 +467,7 @@ async def test_zeroconf_require_auth(hass):
         new=AsyncMock(
             return_value=Mock(
                 shutdown=AsyncMock(),
-                settings={"name": "Test name", "device": {"mac": "test-mac"}},
+                settings=MOCK_SETTINGS,
             )
         ),
     ), patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a Shelly device doesn't have a name, we currently fallback to the IP address for the config flow title. In a DHCP environment this can lead to strange outcomes (a config entry having the IP of a device from a different config entry as a title).
Additionally, Shelly uses the mac address as a unique id, so I believe it's a better fit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
