### PR TITLE
Add lock support to deCONZ

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -23,6 +23,7 @@ SUPPORTED_PLATFORMS = [
     "climate",
     "cover",
     "light",
+    "lock",
     "scene",
     "sensor",
     "switch",
@@ -38,10 +39,16 @@ ATTR_OFFSET = "offset"
 ATTR_ON = "on"
 ATTR_VALVE = "valve"
 
+# Covers
 DAMPERS = ["Level controllable output"]
 WINDOW_COVERS = ["Window covering device", "Window covering controller"]
 COVER_TYPES = DAMPERS + WINDOW_COVERS
 
+# Locks
+LOCKS = ["Door Lock"]
+LOCK_TYPES = LOCKS
+
+# Switches
 POWER_PLUGS = ["On/Off light", "On/Off plug-in unit", "Smart plug"]
 SIRENS = ["Warning device"]
 SWITCH_TYPES = POWER_PLUGS + SIRENS

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_GROUP_ID_BASE,
     COVER_TYPES,
     DOMAIN as DECONZ_DOMAIN,
+    LOCK_TYPES,
     NEW_GROUP,
     NEW_LIGHT,
     SWITCH_TYPES,
@@ -50,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for light in lights:
             if (
-                light.type not in COVER_TYPES + SWITCH_TYPES
+                light.type not in COVER_TYPES + LOCK_TYPES + SWITCH_TYPES
                 and light.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLight(light, gateway))

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -8,10 +8,6 @@ from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Old way of setting up deCONZ platforms."""
-
-
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up locks for deCONZ component.
 
@@ -30,7 +26,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if light.type in LOCKS and light.uniqueid not in gateway.entities[DOMAIN]:
                 entities.append(DeconzLock(light, gateway))
 
-        async_add_entities(entities, True)
+        if entities:
+            async_add_entities(entities, True)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -1,0 +1,62 @@
+"""Support for deCONZ locks."""
+from homeassistant.components.lock import DOMAIN, LockEntity
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import LOCKS, NEW_LIGHT
+from .deconz_device import DeconzDevice
+from .gateway import get_gateway_from_config_entry
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Old way of setting up deCONZ platforms."""
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up locks for deCONZ component.
+
+    Locks are based on the same device class as lights in deCONZ.
+    """
+    gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = set()
+
+    @callback
+    def async_add_lock(lights):
+        """Add lock from deCONZ."""
+        entities = []
+
+        for light in lights:
+
+            if light.type in LOCKS and light.uniqueid not in gateway.entities[DOMAIN]:
+                entities.append(DeconzLock(light, gateway))
+
+        async_add_entities(entities, True)
+
+    gateway.listeners.append(
+        async_dispatcher_connect(
+            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_lock
+        )
+    )
+
+    async_add_lock(gateway.api.lights.values())
+
+
+class DeconzLock(DeconzDevice, LockEntity):
+    """Representation of a deCONZ lock."""
+
+    TYPE = DOMAIN
+
+    @property
+    def is_locked(self):
+        """Return true if lock is on."""
+        return self._device.state
+
+    async def async_lock(self, **kwargs):
+        """Lock the lock."""
+        data = {"on": True}
+        await self._device.async_set_state(data)
+
+    async def async_unlock(self, **kwargs):
+        """Unlock the lock."""
+        data = {"on": False}
+        await self._device.async_set_state(data)

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -91,9 +91,10 @@ async def test_gateway_setup(hass):
         assert forward_entry_setup.mock_calls[1][1] == (entry, "climate")
         assert forward_entry_setup.mock_calls[2][1] == (entry, "cover")
         assert forward_entry_setup.mock_calls[3][1] == (entry, "light")
-        assert forward_entry_setup.mock_calls[4][1] == (entry, "scene")
-        assert forward_entry_setup.mock_calls[5][1] == (entry, "sensor")
-        assert forward_entry_setup.mock_calls[6][1] == (entry, "switch")
+        assert forward_entry_setup.mock_calls[4][1] == (entry, "lock")
+        assert forward_entry_setup.mock_calls[5][1] == (entry, "scene")
+        assert forward_entry_setup.mock_calls[6][1] == (entry, "sensor")
+        assert forward_entry_setup.mock_calls[7][1] == (entry, "switch")
 
 
 async def test_gateway_retry(hass):

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -1,0 +1,96 @@
+"""deCONZ lock platform tests."""
+from copy import deepcopy
+
+from homeassistant.components import deconz
+import homeassistant.components.lock as lock
+from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.setup import async_setup_component
+
+from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
+
+from tests.async_mock import patch
+
+LOCKS = {
+    "1": {
+        "etag": "5c2ec06cde4bd654aef3a555fcd8ad12",
+        "hascolor": False,
+        "lastannounced": None,
+        "lastseen": "2020-08-22T15:29:03Z",
+        "manufacturername": "Danalock",
+        "modelid": "V3-BTZB",
+        "name": "Door lock",
+        "state": {"alert": "none", "on": False, "reachable": True},
+        "swversion": "19042019",
+        "type": "Door Lock",
+        "uniqueid": "00:00:00:00:00:00:00:00-00",
+    }
+}
+
+
+async def test_platform_manually_configured(hass):
+    """Test that we do not discover anything or try to set up a gateway."""
+    assert (
+        await async_setup_component(
+            hass, lock.DOMAIN, {"lock": {"platform": deconz.DOMAIN}}
+        )
+        is True
+    )
+    assert deconz.DOMAIN not in hass.data
+
+
+async def test_no_locks(hass):
+    """Test that no lock entities are created."""
+    gateway = await setup_deconz_integration(hass)
+    assert len(gateway.deconz_ids) == 0
+    assert len(hass.states.async_all()) == 0
+
+
+async def test_locks(hass):
+    """Test that all supported lock entities are created."""
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["lights"] = deepcopy(LOCKS)
+    gateway = await setup_deconz_integration(hass, get_state_response=data)
+    assert "lock.door_lock" in gateway.deconz_ids
+    assert len(hass.states.async_all()) == 1
+
+    door_lock = hass.states.get("lock.door_lock")
+    assert door_lock.state == STATE_UNLOCKED
+
+    state_changed_event = {
+        "t": "event",
+        "e": "changed",
+        "r": "lights",
+        "id": "1",
+        "state": {"on": True},
+    }
+    gateway.api.event_handler(state_changed_event)
+    await hass.async_block_till_done()
+
+    door_lock = hass.states.get("lock.door_lock")
+    assert door_lock.state == STATE_LOCKED
+
+    door_lock_device = gateway.api.lights["1"]
+
+    with patch.object(door_lock_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            lock.DOMAIN,
+            lock.SERVICE_LOCK,
+            {"entity_id": "lock.door_lock"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        set_callback.assert_called_with("put", "/lights/1/state", json={"on": True})
+
+    with patch.object(door_lock_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            lock.DOMAIN,
+            lock.SERVICE_UNLOCK,
+            {"entity_id": "lock.door_lock"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        set_callback.assert_called_with("put", "/lights/1/state", json={"on": False})
+
+    await gateway.async_reset()
+
+    assert len(hass.states.async_all()) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support locks such as the Danalock to deCONZ.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14671

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
