### PR TITLE
Abort deCONZ config flow if no radio hardware is connected

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -172,6 +172,9 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except asyncio.TimeoutError:
                 return self.async_abort(reason="no_bridges")
 
+        if self.bridge_id == "0000000000000000":
+            return self.async_abort(reason="no_hardware_available")
+
         return self.async_create_entry(title=self.bridge_id, data=self.deconz_config)
 
     async def async_step_ssdp(self, discovery_info):

--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -29,6 +29,7 @@
       "already_configured": "Bridge is already configured",
       "already_in_progress": "Config flow for bridge is already in progress.",
       "no_bridges": "No deCONZ bridges discovered",
+      "no_hardware_available": "No radio hardware connected to deCONZ",
       "not_deconz_bridge": "Not a deCONZ bridge",
       "one_instance_only": "Component only supports one deCONZ instance",
       "updated_instance": "Updated deCONZ instance with new host address"

--- a/homeassistant/components/deconz/translations/en.json
+++ b/homeassistant/components/deconz/translations/en.json
@@ -4,6 +4,7 @@
             "already_configured": "Bridge is already configured",
             "already_in_progress": "Config flow for bridge is already in progress.",
             "no_bridges": "No deCONZ bridges discovered",
+            "no_hardware_available": "No radio hardware connected to deCONZ",
             "not_deconz_bridge": "Not a deCONZ bridge",
             "one_instance_only": "Component only supports one deCONZ instance",
             "updated_instance": "Updated deCONZ instance with new host address"

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -24,6 +24,8 @@ from .test_gateway import API_KEY, BRIDGEID, setup_deconz_integration
 
 from tests.async_mock import patch
 
+BAD_BRIDGEID = "0000000000000000"
+
 
 async def test_flow_discovered_bridges(hass, aioclient_mock):
     """Test that config flow works for discovered bridges."""
@@ -389,6 +391,35 @@ async def test_flow_ssdp_discovery(hass, aioclient_mock):
         CONF_PORT: 80,
         CONF_API_KEY: API_KEY,
     }
+
+
+async def test_flow_ssdp_discovery_bad_bridge_id_aborts(hass, aioclient_mock):
+    """Test that config flow aborts if deCONZ signals no radio hardware available."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data={
+            ssdp.ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
+            ssdp.ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
+            ssdp.ATTR_UPNP_SERIAL: BAD_BRIDGEID,
+        },
+        context={"source": "ssdp"},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "link"
+
+    aioclient_mock.post(
+        "http://1.2.3.4:80/api",
+        json=[{"success": {"username": API_KEY}}],
+        headers={"content-type": CONTENT_TYPE_JSON},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "no_hardware_available"
 
 
 async def test_ssdp_discovery_not_deconz_bridge(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make sure that config flow can't create a new config entry if not a proper bridge id is present. This is important since the config entry unique id is based on the bridge id. I don't view this as a bug fix since there has been no bug reports tied to this possible issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
