### PR TITLE
Handle Shelly channel names (if available) for emeters devices

### DIFF
--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -23,7 +23,12 @@ def temperature_unit(block_info: dict) -> str:
 def shelly_naming(self, block, entity_type: str):
     """Naming for switch and sensors."""
 
+    entity_name = self.wrapper.name
+    if not block:
+        return f"{entity_name} {self.description.name}"
+
     channels = 0
+    mode = "relays"
     if "num_outputs" in self.wrapper.device.shelly:
         channels = self.wrapper.device.shelly["num_outputs"]
         if (
@@ -31,10 +36,15 @@ def shelly_naming(self, block, entity_type: str):
             and self.wrapper.device.settings["mode"] == "roller"
         ):
             channels = 1
-
-    entity_name = self.wrapper.name
+        if block.type == "emeter" and "num_emeters" in self.wrapper.device.shelly:
+            channels = self.wrapper.device.shelly["num_emeters"]
+            mode = "emeters"
     if channels > 1 and block.type != "device":
-        entity_name = self.wrapper.device.settings["relays"][int(block.channel)]["name"]
+        # Shelly EM (SHEM) with firmware with firmware v1.8.1 doesn't have "name" key; will be fixed in next firmware release
+        if "name" in self.wrapper.device.settings[mode][int(block.channel)]:
+            entity_name = self.wrapper.device.settings[mode][int(block.channel)]["name"]
+        else:
+            entity_name = None
         if not entity_name:
             entity_name = f"{self.wrapper.name} channel {int(block.channel)+1}"
 

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -40,16 +40,16 @@ def shelly_naming(self, block, entity_type: str):
             channels = self.wrapper.device.shelly["num_emeters"]
             mode = "emeters"
     if channels > 1 and block.type != "device":
-        # Shelly EM (SHEM) with firmware with firmware v1.8.1 doesn't have "name" key; will be fixed in next firmware release
+        # Shelly EM (SHEM) with firmware v1.8.1 doesn't have "name" key; will be fixed in next firmware release
         if "name" in self.wrapper.device.settings[mode][int(block.channel)]:
             entity_name = self.wrapper.device.settings[mode][int(block.channel)]["name"]
         else:
             entity_name = None
         if not entity_name:
             if self.wrapper.model == "SHEM-3":
-                base = 65  # 65 = 'A'
+                base = ord("A")
             else:
-                base = 49  # 49 = '1'
+                base = ord("1")
             entity_name = f"{self.wrapper.name} channel {chr(int(block.channel)+base)}"
 
     if entity_type == "switch":

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -46,7 +46,11 @@ def shelly_naming(self, block, entity_type: str):
         else:
             entity_name = None
         if not entity_name:
-            entity_name = f"{self.wrapper.name} channel {int(block.channel)+1}"
+            if self.wrapper.model == "SHEM-3":
+                base = 65  # 65 = 'A'
+            else:
+                base = 49  # 49 = '1'
+            entity_name = f"{self.wrapper.name} channel {chr(int(block.channel)+base)}"
 
     if entity_type == "switch":
         return entity_name


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Shelly devices use a different block, "emeters", than the others.
This change will handle those in the same way we already do for the others.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
