### PR TITLE
Rewrite worldclock unittest tests to pytest style test functions

### DIFF
--- a/tests/components/worldclock/test_sensor.py
+++ b/tests/components/worldclock/test_sensor.py
@@ -1,49 +1,52 @@
 """The test for the World clock sensor platform."""
-import unittest
+import pytest
 
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import get_test_home_assistant
+
+@pytest.fixture
+def time_zone():
+    """Fixture for time zone."""
+    return dt_util.get_time_zone("America/New_York")
 
 
-class TestWorldClockSensor(unittest.TestCase):
-    """Test the World clock sensor."""
+async def test_time(hass, time_zone):
+    """Test the time at a different location."""
+    config = {"sensor": {"platform": "worldclock", "time_zone": "America/New_York"}}
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.time_zone = dt_util.get_time_zone("America/New_York")
+    assert await async_setup_component(
+        hass,
+        "sensor",
+        config,
+    )
+    await hass.async_block_till_done()
 
-    def test_time(self):
-        """Test the time at a different location."""
-        config = {"sensor": {"platform": "worldclock", "time_zone": "America/New_York"}}
-        assert setup_component(self.hass, "sensor", config)
-        self.hass.block_till_done()
-        self.addCleanup(self.hass.stop)
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None
 
-        state = self.hass.states.get("sensor.worldclock_sensor")
-        assert state is not None
+    assert state.state == dt_util.now(time_zone=time_zone).strftime("%H:%M")
 
-        assert state.state == dt_util.now(time_zone=self.time_zone).strftime("%H:%M")
 
-    def test_time_format(self):
-        """Test time_format setting."""
-        time_format = "%a, %b %d, %Y %I:%M %p"
-        config = {
-            "sensor": {
-                "platform": "worldclock",
-                "time_zone": "America/New_York",
-                "time_format": time_format,
-            }
+async def test_time_format(hass, time_zone):
+    """Test time_format setting."""
+    time_format = "%a, %b %d, %Y %I:%M %p"
+    config = {
+        "sensor": {
+            "platform": "worldclock",
+            "time_zone": "America/New_York",
+            "time_format": time_format,
         }
-        assert setup_component(self.hass, "sensor", config)
-        self.hass.block_till_done()
-        self.addCleanup(self.hass.stop)
+    }
 
-        state = self.hass.states.get("sensor.worldclock_sensor")
-        assert state is not None
+    assert await async_setup_component(
+        hass,
+        "sensor",
+        config,
+    )
+    await hass.async_block_till_done()
 
-        assert state.state == dt_util.now(time_zone=self.time_zone).strftime(
-            time_format
-        )
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None
+
+    assert state.state == dt_util.now(time_zone=time_zone).strftime(time_format)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Rewrite worldclock unittest tests to pytest style test functions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40910
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
