### PR TITLE
Add context to event trigger

### DIFF
--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -15,6 +15,12 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
+@pytest.fixture
+def context_with_user():
+    """Track calls to a mock service."""
+    return Context(user_id="test_user_id")
+
+
 @pytest.fixture(autouse=True)
 def setup_comp(hass):
     """Initialize components."""
@@ -53,8 +59,8 @@ async def test_if_fires_on_event(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_event_extra_data(hass, calls):
-    """Test the firing of events still matches with event data."""
+async def test_if_fires_on_event_extra_data(hass, calls, context_with_user):
+    """Test the firing of events still matches with event data and context."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -65,8 +71,9 @@ async def test_if_fires_on_event_extra_data(hass, calls):
             }
         },
     )
-
-    hass.bus.async_fire("test_event", {"extra_key": "extra_data"})
+    hass.bus.async_fire(
+        "test_event", {"extra_key": "extra_data"}, context=context_with_user
+    )
     await hass.async_block_till_done()
     assert len(calls) == 1
 
@@ -82,8 +89,8 @@ async def test_if_fires_on_event_extra_data(hass, calls):
     assert len(calls) == 1
 
 
-async def test_if_fires_on_event_with_data(hass, calls):
-    """Test the firing of events with data."""
+async def test_if_fires_on_event_with_data_and_context(hass, calls, context_with_user):
+    """Test the firing of events with data and context."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -96,6 +103,7 @@ async def test_if_fires_on_event_with_data(hass, calls):
                         "some_attr": "some_value",
                         "second_attr": "second_value",
                     },
+                    "context": {"user_id": context_with_user.user_id},
                 },
                 "action": {"service": "test.automation"},
             }
@@ -105,17 +113,31 @@ async def test_if_fires_on_event_with_data(hass, calls):
     hass.bus.async_fire(
         "test_event",
         {"some_attr": "some_value", "another": "value", "second_attr": "second_value"},
+        context=context_with_user,
     )
     await hass.async_block_till_done()
     assert len(calls) == 1
 
-    hass.bus.async_fire("test_event", {"some_attr": "some_value", "another": "value"})
+    hass.bus.async_fire(
+        "test_event",
+        {"some_attr": "some_value", "another": "value"},
+        context=context_with_user,
+    )
     await hass.async_block_till_done()
     assert len(calls) == 1  # No new call
 
+    hass.bus.async_fire(
+        "test_event",
+        {"some_attr": "some_value", "another": "value", "second_attr": "second_value"},
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
 
-async def test_if_fires_on_event_with_empty_data_config(hass, calls):
-    """Test the firing of events with empty data config.
+
+async def test_if_fires_on_event_with_empty_data_and_context_config(
+    hass, calls, context_with_user
+):
+    """Test the firing of events with empty data and context config.
 
     The frontend automation editor can produce configurations with an
     empty dict for event_data instead of no key.
@@ -129,13 +151,18 @@ async def test_if_fires_on_event_with_empty_data_config(hass, calls):
                     "platform": "event",
                     "event_type": "test_event",
                     "event_data": {},
+                    "context": {},
                 },
                 "action": {"service": "test.automation"},
             }
         },
     )
 
-    hass.bus.async_fire("test_event", {"some_attr": "some_value", "another": "value"})
+    hass.bus.async_fire(
+        "test_event",
+        {"some_attr": "some_value", "another": "value"},
+        context=context_with_user,
+    )
     await hass.async_block_till_done()
     assert len(calls) == 1
 
@@ -165,7 +192,7 @@ async def test_if_fires_on_event_with_nested_data(hass, calls):
 
 
 async def test_if_not_fires_if_event_data_not_matches(hass, calls):
-    """Test firing of event if no match."""
+    """Test firing of event if no data match."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -182,5 +209,29 @@ async def test_if_not_fires_if_event_data_not_matches(hass, calls):
     )
 
     hass.bus.async_fire("test_event", {"some_attr": "some_other_value"})
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
+async def test_if_not_fires_if_event_context_not_matches(
+    hass, calls, context_with_user
+):
+    """Test firing of event if no context match."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event",
+                    "event_type": "test_event",
+                    "context": {"user_id": "some_user"},
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event", {}, context=context_with_user)
     await hass.async_block_till_done()
     assert len(calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As proposed in https://github.com/home-assistant/architecture/issues/436, this adds backend support for event triggers to filter by context.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
trigger:
  - platform: event
    event_type: test_event_context
    event_data:
    context:
      user_id: my-user-id
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14678

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
