### PR TITLE
Remove deprecated host & platform configuration for cast

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -40,7 +40,6 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import (
     CAST_APP_ID_HOMEASSISTANT,
-    CONF_HOST,
     EVENT_HOMEASSISTANT_STOP,
     STATE_IDLE,
     STATE_OFF,
@@ -59,7 +58,6 @@ from homeassistant.util.logging import async_create_catching_coro
 from .const import (
     ADDED_CAST_DEVICES_KEY,
     CAST_MULTIZONE_MANAGER_KEY,
-    DEFAULT_PORT,
     DOMAIN as CAST_DOMAIN,
     KNOWN_CHROMECAST_INFO_KEY,
     SIGNAL_CAST_DISCOVERED,
@@ -154,8 +152,6 @@ async def _async_setup_platform(
         )
     elif CONF_UUID in config:
         info = ChromecastInfo(uuid=config[CONF_UUID], services=None)
-    elif CONF_HOST in config:
-        info = ChromecastInfo(host=config[CONF_HOST], port=DEFAULT_PORT, services=None)
 
     @callback
     def async_cast_discovered(discover: ChromecastInfo) -> None:

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -19,7 +19,7 @@ import voluptuous as vol
 from homeassistant.auth.models import RefreshToken
 from homeassistant.components import media_source, zeroconf
 from homeassistant.components.http.auth import async_sign_path
-from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
+from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_EXTRA,
     MEDIA_TYPE_MOVIE,
@@ -87,21 +87,8 @@ SUPPORT_CAST = (
 
 
 ENTITY_SCHEMA = vol.All(
-    cv.deprecated(CONF_HOST, invalidation_version="0.116"),
     vol.Schema(
         {
-            vol.Exclusive(CONF_HOST, "device_identifier"): cv.string,
-            vol.Exclusive(CONF_UUID, "device_identifier"): cv.string,
-            vol.Optional(CONF_IGNORE_CEC): vol.All(cv.ensure_list, [cv.string]),
-        }
-    ),
-)
-
-PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_HOST, invalidation_version="0.116"),
-    PLATFORM_SCHEMA.extend(
-        {
-            vol.Exclusive(CONF_HOST, "device_identifier"): cv.string,
             vol.Exclusive(CONF_UUID, "device_identifier"): cv.string,
             vol.Optional(CONF_IGNORE_CEC): vol.All(cv.ensure_list, [cv.string]),
         }
@@ -131,21 +118,6 @@ def _async_create_cast_device(hass: HomeAssistantType, info: ChromecastInfo):
     return CastDevice(info)
 
 
-async def async_setup_platform(
-    hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
-):
-    """Set up the Cast platform.
-
-    Deprecated.
-    """
-    _LOGGER.warning(
-        "Setting configuration for Cast via platform is deprecated. "
-        "Configure via Cast integration instead."
-        "This option will become invalid in version 0.116"
-    )
-    await _async_setup_platform(hass, config, async_add_entities, discovery_info)
-
-
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Cast from a config entry."""
     config = hass.data[CAST_DOMAIN].get("media_player") or {}
@@ -159,7 +131,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             for cfg in config
         ]
     )
-    if any([task.exception() for task in done]):
+    if any(task.exception() for task in done):
         exceptions = [task.exception() for task in done]
         for exception in exceptions:
             _LOGGER.debug("Failed to setup chromecast", exc_info=exception)

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -149,7 +149,7 @@ async def async_setup_media_player_cast(hass: HomeAssistantType, info: Chromecas
         return_value=zconf,
     ):
         await async_setup_component(
-            hass, "cast", {"cast": {"media_player": {"host": info.host}}}
+            hass, "cast", {"cast": {"media_player": {"uuid": info.uuid}}}
         )
         await hass.async_block_till_done()
 
@@ -236,7 +236,7 @@ async def test_create_cast_device_with_uuid(hass):
 
 async def test_replay_past_chromecasts(hass):
     """Test cast platform re-playing past chromecasts when adding new one."""
-    cast_group1 = get_fake_chromecast_info(host="host1", port=8009)
+    cast_group1 = get_fake_chromecast_info(host="host1", port=8009, uuid=FakeUUID)
     cast_group2 = get_fake_chromecast_info(
         host="host2", port=8009, uuid=UUID("9462202c-e747-4af5-a66b-7dce0e1ebc09")
     )
@@ -244,7 +244,7 @@ async def test_replay_past_chromecasts(hass):
     zconf_2 = get_fake_zconf(host="host2", port=8009)
 
     discover_cast, add_dev1 = await async_setup_cast_internal_discovery(
-        hass, config={"host": "host1"}
+        hass, config={"uuid": FakeUUID}
     )
 
     with patch(
@@ -273,14 +273,14 @@ async def test_replay_past_chromecasts(hass):
 
 async def test_manual_cast_chromecasts_host(hass):
     """Test only wanted casts are added for manual configuration."""
-    cast_1 = get_fake_chromecast_info(host="configured_host")
+    cast_1 = get_fake_chromecast_info(host="configured_host", uuid=FakeUUID)
     cast_2 = get_fake_chromecast_info(host="other_host", uuid=FakeUUID2)
     zconf_1 = get_fake_zconf(host="configured_host")
     zconf_2 = get_fake_zconf(host="other_host")
 
     # Manual configuration of media player with host "configured_host"
     discover_cast, add_dev1 = await async_setup_cast_internal_discovery(
-        hass, config={"host": "configured_host"}
+        hass, config={"uuid": FakeUUID}
     )
     with patch(
         "homeassistant.components.cast.discovery.ChromeCastZeroconf.get_zeroconf",
@@ -729,7 +729,7 @@ async def test_entry_setup_no_config(hass: HomeAssistantType):
 async def test_entry_setup_single_config(hass: HomeAssistantType):
     """Test setting up entry and having a single config option."""
     await async_setup_component(
-        hass, "cast", {"cast": {"media_player": {"host": "bla"}}}
+        hass, "cast", {"cast": {"media_player": {"uuid": "bla"}}}
     )
     await hass.async_block_till_done()
 
@@ -739,13 +739,13 @@ async def test_entry_setup_single_config(hass: HomeAssistantType):
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
-    assert mock_setup.mock_calls[0][1][1] == {"host": "bla"}
+    assert mock_setup.mock_calls[0][1][1] == {"uuid": "bla"}
 
 
 async def test_entry_setup_list_config(hass: HomeAssistantType):
     """Test setting up entry and having multiple config options."""
     await async_setup_component(
-        hass, "cast", {"cast": {"media_player": [{"host": "bla"}, {"host": "blu"}]}}
+        hass, "cast", {"cast": {"media_player": [{"uuid": "bla"}, {"uuid": "blu"}]}}
     )
     await hass.async_block_till_done()
 
@@ -755,14 +755,14 @@ async def test_entry_setup_list_config(hass: HomeAssistantType):
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 2
-    assert mock_setup.mock_calls[0][1][1] == {"host": "bla"}
-    assert mock_setup.mock_calls[1][1][1] == {"host": "blu"}
+    assert mock_setup.mock_calls[0][1][1] == {"uuid": "bla"}
+    assert mock_setup.mock_calls[1][1][1] == {"uuid": "blu"}
 
 
 async def test_entry_setup_platform_not_ready(hass: HomeAssistantType):
     """Test failed setting up entry will raise PlatformNotReady."""
     await async_setup_component(
-        hass, "cast", {"cast": {"media_player": {"host": "bla"}}}
+        hass, "cast", {"cast": {"media_player": {"uuid": "bla"}}}
     )
     await hass.async_block_till_done()
 
@@ -774,4 +774,4 @@ async def test_entry_setup_platform_not_ready(hass: HomeAssistantType):
             await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
-    assert mock_setup.mock_calls[0][1][1] == {"host": "bla"}
+    assert mock_setup.mock_calls[0][1][1] == {"uuid": "bla"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `host` option for the cast integration has previously been deprecated and is now removed. Configuring media players via the `media_player` platform was also deprecated before, and removed in this release as well.

If you use any of those above, you'll need to migrate to use the new configuration method. Please see the cast documentation on how to set this up.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `host` configuration option and the configuration via the `media_player` platform, has been deprecated and now removed.

Unblocks #40928
This PR block the release of Home Assistant 0.116.0.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
