### PR TITLE
Add new features to template light - support for effects, support for transition/brightness parameters along with color, temperature, white value or effect

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -8,11 +8,15 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
     ATTR_WHITE_VALUE,
+    ATTR_EFFECT,
+    ATTR_EFFECT_LIST,
+    ATTR_TRANSITION,
     ENTITY_ID_FORMAT,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
     SUPPORT_WHITE_VALUE,
+    SUPPORT_EFFECT,
     LightEntity,
 )
 from homeassistant.const import (
@@ -50,6 +54,8 @@ CONF_COLOR_TEMPLATE = "color_template"
 CONF_COLOR_ACTION = "set_color"
 CONF_WHITE_VALUE_TEMPLATE = "white_value_template"
 CONF_WHITE_VALUE_ACTION = "set_white_value"
+CONF_EFFECT_ACTION = "set_effect"
+CONF_EFFECT_LIST_TEMPLATE = "effect_list_template"
 
 LIGHT_SCHEMA = vol.All(
     cv.deprecated(CONF_ENTITY_ID),
@@ -71,6 +77,8 @@ LIGHT_SCHEMA = vol.All(
             vol.Optional(CONF_COLOR_ACTION): cv.SCRIPT_SCHEMA,
             vol.Optional(CONF_WHITE_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_WHITE_VALUE_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_EFFECT_LIST_TEMPLATE): cv.template,
+            vol.Optional(CONF_EFFECT_ACTION): cv.SCRIPT_SCHEMA,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
     ),
@@ -109,6 +117,9 @@ async def _async_create_entities(hass, config):
         white_value_action = device_config.get(CONF_WHITE_VALUE_ACTION)
         white_value_template = device_config.get(CONF_WHITE_VALUE_TEMPLATE)
 
+        effect_action = device_config.get(CONF_EFFECT_ACTION)
+        effect_list_template = device_config.get(CONF_EFFECT_LIST_TEMPLATE)
+
         lights.append(
             LightTemplate(
                 hass,
@@ -128,6 +139,8 @@ async def _async_create_entities(hass, config):
                 color_template,
                 white_value_action,
                 white_value_template,
+                effect_action,
+                effect_list_template,
                 unique_id,
             )
         )
@@ -164,6 +177,8 @@ class LightTemplate(TemplateEntity, LightEntity):
         color_template,
         white_value_action,
         white_value_template,
+        effect_action,
+        effect_list_template,
         unique_id,
     ):
         """Initialize the light."""
@@ -200,12 +215,20 @@ class LightTemplate(TemplateEntity, LightEntity):
                 hass, white_value_action, friendly_name, domain
             )
         self._white_value_template = white_value_template
+        self._effect_script = None
+        if effect_action is not None:
+            self._effect_script = Script(
+                hass, effect_action, friendly_name, domain
+            )
+        self._effect_list_template = effect_list_template     
 
         self._state = False
         self._brightness = None
         self._temperature = None
         self._color = None
         self._white_value = None
+        self._effect = None
+        self._effect_list = None
         self._unique_id = unique_id
 
     @property
@@ -229,6 +252,16 @@ class LightTemplate(TemplateEntity, LightEntity):
         return self._color
 
     @property
+    def effect(self):
+        """Return the effect."""
+        return self._effect
+
+    @property
+    def effect_list(self):
+        """Return the effect list."""
+        return self._effect_list
+
+    @property
     def name(self):
         """Return the display name of this light."""
         return self._name
@@ -250,6 +283,8 @@ class LightTemplate(TemplateEntity, LightEntity):
             supported_features |= SUPPORT_COLOR
         if self._white_value_script is not None:
             supported_features |= SUPPORT_WHITE_VALUE
+        if self._effect_script is not None:
+            supported_features |= SUPPORT_EFFECT
         return supported_features
 
     @property
@@ -296,11 +331,20 @@ class LightTemplate(TemplateEntity, LightEntity):
                 self._update_white_value,
                 none_on_template_error=True,
             )
+        if self._effect_list_template:
+            self.add_template_attribute(
+                "_effect_list",
+                self._effect_list_template,
+                None,
+                self._update_effect_list,
+                none_on_template_error=True,
+            )
         await super().async_added_to_hass()
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
         optimistic_set = False
+
         # set optimistic states
         if self._template is None:
             self._state = True
@@ -320,6 +364,13 @@ class LightTemplate(TemplateEntity, LightEntity):
             self._white_value = kwargs[ATTR_WHITE_VALUE]
             optimistic_set = True
 
+        if self._effect_list_template is None and ATTR_EFFECT in kwargs:
+            _LOGGER.info(
+                "Optimistically setting white value to %s", kwargs[ATTR_EFFECT]
+            )
+            self._effect = kwargs[ATTR_EFFECT]
+            optimistic_set = True
+
         if self._temperature_template is None and ATTR_COLOR_TEMP in kwargs:
             _LOGGER.info(
                 "Optimistically setting color temperature to %s",
@@ -328,23 +379,45 @@ class LightTemplate(TemplateEntity, LightEntity):
             self._temperature = kwargs[ATTR_COLOR_TEMP]
             optimistic_set = True
 
-        if ATTR_BRIGHTNESS in kwargs and self._level_script:
-            await self._level_script.async_run(
-                {"brightness": kwargs[ATTR_BRIGHTNESS]}, context=self._context
-            )
-        elif ATTR_COLOR_TEMP in kwargs and self._temperature_script:
+        common_params = {}
+
+        if ATTR_BRIGHTNESS in kwargs:
+            common_params['brightness'] = kwargs[ATTR_BRIGHTNESS]
+
+        if ATTR_TRANSITION in kwargs:
+            common_params['transition'] = kwargs[ATTR_TRANSITION]
+
+        if ATTR_COLOR_TEMP in kwargs and self._temperature_script:
+            common_params["color_temp"] = kwargs[ATTR_COLOR_TEMP]
+
             await self._temperature_script.async_run(
-                {"color_temp": kwargs[ATTR_COLOR_TEMP]}, context=self._context
+                common_params, context=self._context
             )
         elif ATTR_WHITE_VALUE in kwargs and self._white_value_script:
+            common_params["white_value"] = kwargs[ATTR_WHITE_VALUE]
+
             await self._white_value_script.async_run(
-                {"white_value": kwargs[ATTR_WHITE_VALUE]}, context=self._context
+                common_params, context=self._context
+            )
+        elif ATTR_EFFECT in kwargs and self._effect_script:
+            common_params["effect"] = kwargs[ATTR_EFFECT]
+
+            await self._effect_script.async_run(
+                common_params, context=self._context
             )
         elif ATTR_HS_COLOR in kwargs and self._color_script:
             hs_value = kwargs[ATTR_HS_COLOR]
+            common_params["hs"] = hs_value
+            common_params["h"] = int(hs_value[0])
+            common_params["s"] = int(hs_value[1])
+
             await self._color_script.async_run(
-                {"hs": hs_value, "h": int(hs_value[0]), "s": int(hs_value[1])},
+                common_params,
                 context=self._context,
+            )
+        elif ATTR_BRIGHTNESS in kwargs and self._level_script:
+            await self._level_script.async_run(
+                common_params, context=self._context
             )
         else:
             await self._on_script.async_run(context=self._context)
@@ -400,6 +473,25 @@ class LightTemplate(TemplateEntity, LightEntity):
                 exc_info=True,
             )
             self._white_value = None
+
+    @callback
+    def _update_effect_list(self, effect_list):
+        """Update the effect list from the template."""
+        try:
+            if effect_list in ("None", ""):
+                self._effect_list = None
+                return
+            self._effect_list = eval(effect_list)
+
+            _LOGGER.info(
+                "_update_effect_list %s", eval(effect_list)
+            )
+        except ValueError:
+            _LOGGER.error(
+                "Template must supply a list of effects, or 'None'",
+                exc_info=True,
+            )
+            self._effect_list = None
 
     @callback
     def _update_state(self, result):


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No breaking change


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is my first PR :)
With this change it is possible to pass transition/brightness parameters along with color, temperature, white value or effect.
Also there is an option to specify effect list template to support effects in template light.
I use it to group two or more led strips and then control group of lights at the same time
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
    salon_leds:
      value_template: "{{ is_state('binary_sensor.salon_leds', 'on') }}"
      turn_on:
        service: switch.turn_on
        data:
          entity_id: switch.smart_salon_all_led
      turn_off:
        service: switch.turn_off
        data:
          entity_id: switch.smart_salon_all_led
      level_template: "{{ state_attr('light.yeelight_strip2_7c49ebb119e5', 'brightness') | int }}"
      set_level:
        - service: light.turn_on
          data_template:
            entity_id:
              - light.yeelight_strip2_7c49ebb115f8
              - light.yeelight_strip2_7c49ebb119e5
            transition: >-
              {% if not transition is defined or transition == None or transition == 'undefined' %}{{ 1 | float }}
              {% else %}{{ transition | float }}
              {% endif %}
            brightness: "{{ brightness }}"
      color_template: >-
        {% set color = state_attr('light.yeelight_strip2_7c49ebb119e5', 'hs_color') %}
        {% if color == None or color == 'undefined' %}None
        {% else %}({{color[0] | float}}, {{color[1] | float}})
        {% endif %}
      set_color:
        - service: light.turn_on
          data_template:
            entity_id:
              - light.yeelight_strip2_7c49ebb115f8
              - light.yeelight_strip2_7c49ebb119e5
            transition: >-
              {% if not transition is defined or transition == None or transition == 'undefined' %}{{ 1 | float }}
              {% else %}{{ transition | float }}
              {% endif %}
            hs_color:
              - "{{ hs[0] }}"
              - "{{ hs[1] }}"
      effect_list_template: >-
        {{ state_attr('light.yeelight_strip2_7c49ebb119e5', 'effect_list') }}
      set_effect:
        - service: light.turn_on
          data_template:
            entity_id:
              - light.yeelight_strip2_7c49ebb115f8
              - light.yeelight_strip2_7c49ebb119e5
              - light.yeelight_c2_7c49ebae794c
            transition: >-
              {% if not transition is defined or transition == None or transition == 'undefined' %}{{ 1 | float }}
              {% else %}{{ transition | float }}
              {% endif %}
            effect: "{{ effect }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
