### PR TITLE
Use single_instance_allowed for webhook config flows

### DIFF
--- a/homeassistant/components/dialogflow/strings.json
+++ b/homeassistant/components/dialogflow/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive Dialogflow messages."
     },
     "create_entry": {

--- a/homeassistant/components/geofency/strings.json
+++ b/homeassistant/components/geofency/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Geofency."
     },
     "create_entry": {

--- a/homeassistant/components/gpslogger/strings.json
+++ b/homeassistant/components/gpslogger/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from GPSLogger."
     },
     "create_entry": {

--- a/homeassistant/components/ifttt/strings.json
+++ b/homeassistant/components/ifttt/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive IFTTT messages."
     },
     "create_entry": {

--- a/homeassistant/components/islamic_prayer_times/config_flow.py
+++ b/homeassistant/components/islamic_prayer_times/config_flow.py
@@ -23,7 +23,7 @@ class IslamicPrayerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         if self._async_current_entries():
-            return self.async_abort(reason="one_instance_allowed")
+            return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
             return self.async_show_form(step_id="user")

--- a/homeassistant/components/islamic_prayer_times/strings.json
+++ b/homeassistant/components/islamic_prayer_times/strings.json
@@ -8,7 +8,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "options": {

--- a/homeassistant/components/locative/strings.json
+++ b/homeassistant/components/locative/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Geofency."
     },
     "create_entry": {

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive Mailgun messages."
     },
     "create_entry": {

--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -19,7 +19,7 @@ class OwnTracksFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle a user initiated set up flow to create OwnTracks webhook."""
         if self._async_current_entries():
-            return self.async_abort(reason="one_instance_allowed")
+            return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
             return self.async_show_form(step_id="user")
@@ -52,7 +52,7 @@ class OwnTracksFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, user_input):
         """Import a config flow from configuration."""
         if self._async_current_entries():
-            return self.async_abort(reason="one_instance_allowed")
+            return self.async_abort(reason="single_instance_allowed")
         webhook_id, _webhook_url, cloudhook = await self._get_webhook_id()
         secret = secrets.token_hex(16)
         return self.async_create_entry(

--- a/homeassistant/components/owntracks/strings.json
+++ b/homeassistant/components/owntracks/strings.json
@@ -6,7 +6,9 @@
         "description": "Are you sure you want to set up OwnTracks?"
       }
     },
-    "abort": { "one_instance_allowed": "Only a single instance is necessary." },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
     "create_entry": {
       "default": "\n\nOn Android, open [the OwnTracks app]({android_url}), go to preferences -> connection. Change the following settings:\n - Mode: Private HTTP\n - Host: {webhook_url}\n - Identification:\n   - Username: `'<Your name>'`\n   - Device ID: `'<Your device name>'`\n\nOn iOS, open [the OwnTracks app]({ios_url}), tap (i) icon in top left -> settings. Change the following settings:\n - Mode: HTTP\n - URL: {webhook_url}\n - Turn on authentication\n - UserID: `'<Your name>'`\n\n{secret}\n\nSee [the documentation]({docs_url}) for more information."
     }

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -15,7 +15,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if self._async_current_entries():
-            return self.async_abort(reason="one_instance_allowed")
+            return self.async_abort(reason="single_instance_allowed")
         if "mqtt" not in self.hass.config.components:
             return self.async_abort(reason="mqtt_required")
         if user_input is not None:

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -6,7 +6,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "The integration only supports one Z-Wave instance",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "mqtt_required": "The MQTT integration is not set up"
     }
   }

--- a/homeassistant/components/plaato/strings.json
+++ b/homeassistant/components/plaato/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Plaato Airlock."
     },
     "create_entry": {

--- a/homeassistant/components/speedtestdotnet/config_flow.py
+++ b/homeassistant/components/speedtestdotnet/config_flow.py
@@ -36,7 +36,7 @@ class SpeedTestFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         if self._async_current_entries():
-            return self.async_abort(reason="one_instance_allowed")
+            return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
             return self.async_show_form(step_id="user")

--- a/homeassistant/components/speedtestdotnet/strings.json
+++ b/homeassistant/components/speedtestdotnet/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "wrong_server_id": "Server id is not valid"
     }
   },

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Traccar."
     },
     "create_entry": {

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary.",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive Twilio messages."
     },
     "create_entry": {

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -136,7 +136,7 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
     ) -> Dict[str, Any]:
         """Handle a user initiated set up flow to create a webhook."""
         if not self._allow_multiple and self._async_current_entries():
-            return self.async_abort(reason="one_instance_allowed")
+            return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
             return self.async_show_form(step_id="user")

--- a/tests/components/islamic_prayer_times/test_config_flow.py
+++ b/tests/components/islamic_prayer_times/test_config_flow.py
@@ -83,4 +83,4 @@ async def test_integration_already_configured(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "one_instance_allowed"
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/components/owntracks/test_config_flow.py
+++ b/tests/components/owntracks/test_config_flow.py
@@ -111,12 +111,12 @@ async def test_abort_if_already_setup(hass):
     # Should fail, already setup (import)
     result = await flow.async_step_import({})
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "one_instance_allowed"
+    assert result["reason"] == "single_instance_allowed"
 
     # Should fail, already setup (flow)
     result = await flow.async_step_user({})
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "one_instance_allowed"
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_user_not_supports_encryption(hass, not_supports_encryption):

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -51,4 +51,4 @@ async def test_one_instance_allowed(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == "abort"
-    assert result["reason"] == "one_instance_allowed"
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/components/speedtestdotnet/test_config_flow.py
+++ b/tests/components/speedtestdotnet/test_config_flow.py
@@ -135,4 +135,4 @@ async def test_integration_already_configured(hass):
         speedtestdotnet.DOMAIN, context={"source": "user"}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "one_instance_allowed"
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -238,7 +238,7 @@ async def test_webhook_single_entry_allowed(hass, webhook_flow_conf):
     result = await flow.async_step_user()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "one_instance_allowed"
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_webhook_multiple_entries_allowed(hass, webhook_flow_conf):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following the suggestion in https://github.com/home-assistant/core/pull/40959#discussion_r498179010

Webhook config flows previously used the base string `one_instance_allowed` this has now been replaced by `single_instance_allowed` to be consistent with non-webook config flows.

cc @ludeeus 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #40578
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
