### PR TITLE
Rftrx device triggers

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -85,9 +85,11 @@ async def async_get_device_automation_platform(
             f"Integration '{domain}' not found"
         ) from err
     except ImportError as err:
-        raise InvalidDeviceAutomationConfig(
-            f"Integration '{domain}' does not support device automation {automation_type}s"
-        ) from err
+        if str(err.name).split(".")[-1] == platform_name:
+            raise InvalidDeviceAutomationConfig(
+                f"Integration '{domain}' does not support device automation {automation_type}s"
+            ) from err
+        raise err
 
     return platform
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
 from homeassistant.const import (
+    ATTR_DEVICE_ID,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
     CONF_DEVICE,
@@ -312,16 +313,8 @@ async def async_setup_internal(hass, entry: config_entries.ConfigEntry):
             identifiers={(DOMAIN, *device_id)},
             connections=set(),
         )
-
-        if device_entry is None:
-            device_entry = device_registry.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                identifiers={(DOMAIN, *device_id)},
-                name=f"{event.device.type_string} {event.device.id_string}",
-                model=event.device.type_string,
-            )
-
-        event_data["device_id"] = device_entry.id
+        if device_entry:
+            event_data[ATTR_DEVICE_ID] = device_entry.id
 
         # Callback to HA registered components.
         hass.helpers.dispatcher.async_dispatcher_send(SIGNAL_EVENT, event, device_id)

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -1,0 +1,84 @@
+"""Provides device automations for RFXCOM RFXtrx."""
+from typing import List, Optional
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
+from homeassistant.core import Context, HomeAssistant
+import homeassistant.helpers.config_validation as cv
+
+from . import DATA_RFXOBJECT, DOMAIN
+from .helpers import async_get_device_object
+
+CONF_DATA = "data"
+
+ACTION_TYPE_CHIME = "send_chime"
+ACTION_TYPE_COMMAND = "send_command"
+ACTION_TYPE_STATUS = "send_status"
+
+ACTION_TYPES = {
+    ACTION_TYPE_CHIME,
+    ACTION_TYPE_COMMAND,
+    ACTION_TYPE_STATUS,
+}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_DATA): int,
+    }
+)
+
+
+async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device actions for RFXCOM RFXtrx devices."""
+    actions = []
+
+    device = await async_get_device_object(hass, device_id)
+    if device:
+        for action_type in ACTION_TYPES:
+            if hasattr(device, action_type):
+                actions.append(
+                    {
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_TYPE: action_type,
+                    }
+                )
+
+    return actions
+
+
+async def async_get_action_capabilities(hass, config):
+    """List action capabilities."""
+
+    device = await async_get_device_object(hass, config[CONF_DEVICE_ID])
+    if config[CONF_TYPE] == ACTION_TYPE_CHIME:
+        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA, default=1): int})}
+    if config[CONF_TYPE] == ACTION_TYPE_COMMAND:
+        values = getattr(device, "COMMANDS")
+        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): vol.In(values)})}
+    if config[CONF_TYPE] == ACTION_TYPE_STATUS:
+        values = getattr(device, "STATUS")
+        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): vol.In(values)})}
+
+    return {}
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Optional[Context]
+) -> None:
+    """Execute a device action."""
+    config = ACTION_SCHEMA(config)
+
+    rfx = hass.data[DOMAIN][DATA_RFXOBJECT]
+    device = await async_get_device_object(hass, config[CONF_DEVICE_ID])
+
+    send_fun = getattr(device, config[CONF_TYPE])
+
+    if config[CONF_TYPE] == ACTION_TYPE_CHIME:
+        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])
+    elif config[CONF_TYPE] == ACTION_TYPE_COMMAND:
+        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])
+    elif config[CONF_TYPE] == ACTION_TYPE_STATUS:
+        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])

--- a/homeassistant/components/rfxtrx/device_trigger.py
+++ b/homeassistant/components/rfxtrx/device_trigger.py
@@ -1,0 +1,93 @@
+"""Provides device automations for RFXCOM RFXtrx."""
+from typing import List
+
+import voluptuous as vol
+
+from homeassistant.components.automation import AutomationActionType
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import event as event_trigger
+from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+from .helpers import async_get_device_object
+
+CONF_SUBTYPE = "subtype"
+
+TRIGGER_TYPES = {"command", "status"}
+TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Required(CONF_SUBTYPE): str,
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device triggers for RFXCOM RFXtrx devices."""
+    triggers = []
+
+    device = await async_get_device_object(hass, device_id)
+    if device:
+        if hasattr(device, "COMMANDS"):
+            for command in device.COMMANDS.values():
+                triggers.append(
+                    {
+                        CONF_PLATFORM: "device",
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_TYPE: "command",
+                        CONF_SUBTYPE: command,
+                    }
+                )
+        if hasattr(device, "STATUS"):
+            for status in device.STATUS.values():
+                triggers.append(
+                    {
+                        CONF_PLATFORM: "device",
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_TYPE: "status",
+                        CONF_SUBTYPE: status,
+                    }
+                )
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+
+    event_data = {ATTR_DEVICE_ID: config[CONF_DEVICE_ID]}
+
+    if config[CONF_TYPE] == "command":
+        event_data["values"] = {"Command": config[CONF_SUBTYPE]}
+    elif config[CONF_TYPE] == "status":
+        event_data["values"] = {"Status": config[CONF_SUBTYPE]}
+    else:
+        return None
+
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: EVENT_RFXTRX_EVENT,
+            event_trigger.CONF_EVENT_DATA: event_data,
+        }
+    )
+
+    return await event_trigger.async_attach_trigger(
+        hass, event_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/rfxtrx/helpers.py
+++ b/homeassistant/components/rfxtrx/helpers.py
@@ -1,0 +1,20 @@
+"""Provides helpers for RFXtrx."""
+
+
+from RFXtrx import get_device
+
+
+async def async_get_device_object(hass, device_id):
+    """Get a device for the given device registry id."""
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    registry_device = device_registry.async_get(device_id)
+    if registry_device is None:
+        return None
+
+    device_tuple = list(list(registry_device.identifiers)[0])
+    try:
+        return get_device(
+            int(device_tuple[1], 16), int(device_tuple[2], 16), device_tuple[3]
+        )
+    except ValueError:
+        return None

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -75,6 +75,13 @@
       "send_status": "Trigger status on device",
       "send_sound": "Trigger a sound on device",
       "send_command": "Trigger a command on device"
+    },
+    "trigger_type": {
+      "status": "Device received {subtype} status",
+      "command": "Device received {subtype} command"
+    },
+    "trigger_subtype": {
+      "Panic": "Panic"
     }
   }
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -69,5 +69,12 @@
       "invalid_input_off_delay": "Invalid input for off delay",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "send_status": "Trigger status on device",
+      "send_sound": "Trigger a sound on device",
+      "send_command": "Trigger a command on device"
+    }
   }
 }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -69,5 +69,13 @@
                 "title": "Configure device options"
             }
         }
-    }
+    },
+    "device_automation": {
+        "action_type": {
+            "send_status": "Trigger status on device",
+            "send_sound": "Trigger a sound on device",
+            "send_command": "Trigger a command on device"
+        }
+    },
+    "title": "Rfxtrx"
 }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -75,6 +75,13 @@
             "send_status": "Trigger status on device",
             "send_sound": "Trigger a sound on device",
             "send_command": "Trigger a command on device"
+        },
+        "trigger_type": {
+          "status": "Device received {subtype} status",
+          "command": "Device received {subtype} command"
+        },
+        "trigger_subtype": {
+          "Panic": "Panic"
         }
     },
     "title": "Rfxtrx"

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -1,0 +1,142 @@
+"""The tests for RFXCOM RFXtrx device actions."""
+from typing import NamedTuple, Set, Tuple
+
+import RFXtrx
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    mock_device_registry,
+    mock_registry,
+)
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
+
+
+@pytest.fixture(name="device_reg")
+def device_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture(name="entity_reg")
+def entity_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+class DeviceTestData(NamedTuple):
+    """Test data linked to a device."""
+
+    code: str
+    device_identifiers: Set[Tuple[str]]
+
+
+DEVICE_SECURITY_1 = DeviceTestData(
+    "08200300a109000670", {("rfxtrx", "20", "3", "a10900:32")}
+)
+
+DEVICE_TEMPHUM_1 = DeviceTestData(
+    "0a52080705020095220269", {("rfxtrx", "52", "8", "05:02")}
+)
+
+DEVICE_CHIME_1 = DeviceTestData(
+    "0a16000000000000000000", {("rfxtrx", "16", "0", "00:00")}
+)
+
+
+@pytest.mark.parametrize(
+    "device", [DEVICE_SECURITY_1, DEVICE_TEMPHUM_1, DEVICE_CHIME_1]
+)
+async def test_device_test_data(rfxtrx, device: DeviceTestData):
+    """Verify that our testing data remains correct."""
+    pkt: RFXtrx.lowlevel.Packet = RFXtrx.lowlevel.parse(bytearray.fromhex(device.code))
+    assert device.device_identifiers == {
+        ("rfxtrx", f"{pkt.packettype:x}", f"{pkt.subtype:x}", pkt.id_string)
+    }
+
+
+async def setup_entry(hass, devices):
+    """Construct a config setup."""
+    entry_data = create_rfx_test_cfg(devices=devices)
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+
+@pytest.mark.parametrize(
+    "device,expected",
+    [
+        [DEVICE_SECURITY_1, [{"type": "send_status"}]],
+        [DEVICE_TEMPHUM_1, []],
+        [DEVICE_CHIME_1, [{"type": "send_chime"}]],
+    ],
+)
+async def test_get_actions(hass, device_reg: DeviceRegistry, device, expected):
+    """Test we get the expected actions from a rfxtrx."""
+    await setup_entry(hass, {device.code: {}})
+
+    device_entry = device_reg.async_get_device(device.device_identifiers, set())
+
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+
+    expected_actions = [
+        {"domain": DOMAIN, "device_id": device_entry.id, **action_type}
+        for action_type in expected
+    ]
+
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "device,config,expected",
+    [
+        [DEVICE_SECURITY_1, {"type": "send_status", "data": 1}, "08200300a109000100"],
+        [DEVICE_SECURITY_1, {"type": "send_status", "data": 10}, "08200300a109000a00"],
+        [DEVICE_CHIME_1, {"type": "send_chime", "data": 1}, "0716000000000100"],
+        [DEVICE_CHIME_1, {"type": "send_chime", "data": 10}, "0716000000000a00"],
+    ],
+)
+async def test_action(
+    hass, device_reg: DeviceRegistry, rfxtrx: RFXtrx.Connect, device, config, expected
+):
+    """Test for turn_on and turn_off actions."""
+
+    await setup_entry(hass, {device.code: {}})
+
+    device_entry = device_reg.async_get_device(device.device_identifiers, set())
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": device_entry.id,
+                        **config,
+                    },
+                },
+            ]
+        },
+    )
+
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+
+    rfxtrx.transport.send.assert_called_once_with(bytearray.fromhex(expected))

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -1,0 +1,157 @@
+"""The tests for RFXCOM RFXtrx device triggers."""
+from typing import NamedTuple, Set, Tuple
+
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+)
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
+
+
+class EventTestData(NamedTuple):
+    """Test data linked to a device."""
+
+    code: str
+    device_identifiers: Set[Tuple[str]]
+    type: str
+    subtype: str
+
+
+DEVICE_SECURITY_1 = {("rfxtrx", "20", "3", "a10900:32")}
+EVENT_SECURITY_1 = EventTestData(
+    "08200300a109000670", DEVICE_SECURITY_1, "status", "Panic"
+)
+
+DEVICE_CHIME_1 = {("rfxtrx", "16", "0", "00:00")}
+EVENT_CHIME_1 = EventTestData(
+    "0a16000000000000000000", DEVICE_CHIME_1, "command", "Chime"
+)
+
+
+@pytest.fixture(name="device_reg")
+def device_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+async def setup_entry(hass, devices):
+    """Construct a config setup."""
+    entry_data = create_rfx_test_cfg(devices=devices)
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+
+@pytest.mark.parametrize(
+    "event,expected",
+    [
+        [
+            EVENT_SECURITY_1,
+            [
+                {"type": "status", "subtype": subtype}
+                for subtype in [
+                    "Normal",
+                    "Normal Delayed",
+                    "Alarm",
+                    "Alarm Delayed",
+                    "Motion",
+                    "No Motion",
+                    "Panic",
+                    "End Panic",
+                    "IR",
+                    "Arm Away",
+                    "Arm Away Delayed",
+                    "Arm Home",
+                    "Arm Home Delayed",
+                    "Disarm",
+                    "Light 1 Off",
+                    "Light 1 On",
+                    "Light 2 Off",
+                    "Light 2 On",
+                    "Dark Detected",
+                    "Light Detected",
+                    "Battery low",
+                    "Pairing KD101",
+                    "Normal Tamper",
+                    "Normal Delayed Tamper",
+                    "Alarm Tamper",
+                    "Alarm Delayed Tamper",
+                    "Motion Tamper",
+                    "No Motion Tamper",
+                ]
+            ],
+        ]
+    ],
+)
+async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
+    """Test we get the expected triggers from a rfxtrx."""
+    await setup_entry(hass, {event.code: {}})
+
+    device_entry = device_reg.async_get_device(event.device_identifiers, set())
+
+    expected_triggers = [
+        {"domain": DOMAIN, "device_id": device_entry.id, "platform": "device", **expect}
+        for expect in expected
+    ]
+
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = [value for value in triggers if value["domain"] == "rfxtrx"]
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        EVENT_SECURITY_1,
+        EVENT_CHIME_1,
+    ],
+)
+async def test_firing_event(hass, device_reg, rfxtrx, event):
+    """Test for turn_on and turn_off triggers firing."""
+
+    await setup_entry(hass, {event.code: {"fire_event": True}})
+
+    device_entry = device_reg.async_get_device(event.device_identifiers, set())
+
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device_entry.id,
+                        "type": event.type,
+                        "subtype": event.subtype,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": ("{{trigger.platform}}")},
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    await rfxtrx.signal(event.code)
+
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "device"

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -3,6 +3,10 @@
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import (
+    DeviceRegistry,
+    async_get_registry as async_get_device_registry,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import call
@@ -74,6 +78,8 @@ async def test_fire_event(hass, rfxtrx):
     await hass.async_block_till_done()
     await hass.async_start()
 
+    device_registry: DeviceRegistry = await async_get_device_registry(hass)
+
     calls = []
 
     @callback
@@ -87,6 +93,16 @@ async def test_fire_event(hass, rfxtrx):
     await rfxtrx.signal("0b1100cd0213c7f210010f51")
     await rfxtrx.signal("0716000100900970")
 
+    device_id_1 = device_registry.async_get_device(
+        identifiers={("rfxtrx", "11", "0", "213c7f2:16")}, connections=set()
+    )
+    assert device_id_1
+
+    device_id_2 = device_registry.async_get_device(
+        identifiers={("rfxtrx", "16", "0", "00:90")}, connections=set()
+    )
+    assert device_id_2
+
     assert calls == [
         {
             "packet_type": 17,
@@ -95,6 +111,7 @@ async def test_fire_event(hass, rfxtrx):
             "id_string": "213c7f2:16",
             "data": "0b1100cd0213c7f210010f51",
             "values": {"Command": "On", "Rssi numeric": 5},
+            "device_id": device_id_1.id,
         },
         {
             "packet_type": 22,
@@ -103,6 +120,7 @@ async def test_fire_event(hass, rfxtrx):
             "id_string": "00:90",
             "data": "0716000100900970",
             "values": {"Command": "Chime", "Rssi numeric": 7, "Sound": 9},
+            "device_id": device_id_2.id,
         },
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for using device triggers and actions directly on rfxtrx devices. This way we can trigger any of the supported commands for devices like pairing group/on/off and such.

Device triggers allow reaction to any of the standard commands from remotes instead of triggering on changes in some last received sensor value.

### Open issues/questions
* This does require events to be turned on for the device as it is now. We'd need a way to do that automatically.
* I'm not entirely convinced device triggers this way is a good idea. Might be better to expose a sensor like we already do and trigger on it's events. It's much easier for a user to understand what events a device might trigger.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
