### PR TITLE
Filter rfxtrx configure devices option flow on existing config entry

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -2,6 +2,7 @@
 import asyncio
 import binascii
 from collections import OrderedDict
+import copy
 import logging
 
 import RFXtrx as rfxtrxmod
@@ -303,6 +304,7 @@ async def async_setup_internal(hass, entry: config_entries.ConfigEntry):
         config[CONF_DEVICE_ID] = device_id
 
         data = entry.data.copy()
+        data[CONF_DEVICES] = copy.deepcopy(entry.data[CONF_DEVICES])
         event_code = binascii.hexlify(event.data).decode("ASCII")
         data[CONF_DEVICES][event_code] = config
         hass.config_entries.async_update_entry(entry=entry, data=data)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -109,7 +109,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                         f"{DOMAIN}_{CONF_REMOVE_DEVICE}_{device_id}"
                     )
                     self._device_registry.async_remove_device(entry_id)
-                    devices[event_code] = None
+                    if event_code is not None:
+                        devices[event_code] = None
 
                 self.update_config_data(
                     global_options=self._global_options, devices=devices
@@ -142,9 +143,15 @@ class OptionsFlow(config_entries.OptionsFlow):
         self._device_registry = device_registry
         self._device_entries = device_entries
 
-        devices = {
+        remove_devices = {
             entry.id: entry.name_by_user if entry.name_by_user else entry.name
             for entry in device_entries
+        }
+
+        configure_devices = {
+            entry.id: entry.name_by_user if entry.name_by_user else entry.name
+            for entry in device_entries
+            if self._get_device_event_code(entry.id) is not None
         }
 
         options = {
@@ -153,8 +160,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                 default=self._config_entry.data[CONF_AUTOMATIC_ADD],
             ): bool,
             vol.Optional(CONF_EVENT_CODE): str,
-            vol.Optional(CONF_DEVICE): vol.In(devices),
-            vol.Optional(CONF_REMOVE_DEVICE): cv.multi_select(devices),
+            vol.Optional(CONF_DEVICE): vol.In(configure_devices),
+            vol.Optional(CONF_REMOVE_DEVICE): cv.multi_select(remove_devices),
         }
 
         return self.async_show_form(
@@ -365,6 +372,11 @@ class OptionsFlow(config_entries.OptionsFlow):
             return True
 
         return False
+
+    def _get_device_event_code(self, entry_id):
+        data = self._get_device_data(entry_id)
+
+        return data[CONF_EVENT_CODE]
 
     def _get_device_data(self, entry_id):
         """Get event code based on device identifier."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In some exceptional cases a device can be present in the device registry but there could be a missing config entry key for that device. In that case, when selecting the device and trying to configure options, the option flow will throw an exception.

This PR will not present devices in the list with devices to configure unless it has a config entry key.

The way to solve it when a device misses an entry key (one of the options will work):
1. Remove it (when not needed anymore)
2. The event code is detected through automatic add, the config entry key is added automatically
3. Manually enter a valid event code for the device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15331

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
