### PR TITLE
Don't set upnp config_entry.unique_id from setup entry

### DIFF
--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -106,7 +106,7 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry) 
     """Set up UPnP/IGD device from a config entry."""
     _LOGGER.debug("async_setup_entry, config_entry: %s", config_entry.data)
 
-    # discover and construct
+    # Discover and construct.
     udn = config_entry.data.get(CONFIG_ENTRY_UDN)
     st = config_entry.data.get(CONFIG_ENTRY_ST)  # pylint: disable=invalid-name
     try:
@@ -118,8 +118,15 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry) 
         _LOGGER.info("Unable to create UPnP/IGD, aborting")
         raise ConfigEntryNotReady
 
-    # Save device
+    # Save device.
     hass.data[DOMAIN][DOMAIN_DEVICES][device.udn] = device
+
+    # Ensure entry has a unique_id.
+    if not config_entry.unique_id:
+        hass.config_entries.async_update_entry(
+            entry=config_entry,
+            unique_id=device.unique_id,
+        )
 
     # Create device registry entry.
     device_registry = await dr.async_get_registry(hass)

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -56,7 +56,9 @@ async def async_discover_and_construct(
             filtered = [di for di in discovery_infos if di[DISCOVERY_ST] == st]
         if not filtered:
             _LOGGER.warning(
-                'Wanted UPnP/IGD device with UDN "%s" not found, aborting', udn
+                'Wanted UPnP/IGD device with UDN/ST "%s"/"%s" not found, aborting',
+                udn,
+                st,
             )
             return None
 
@@ -118,13 +120,6 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry) 
 
     # Save device
     hass.data[DOMAIN][DOMAIN_DEVICES][device.udn] = device
-
-    # Ensure entry has proper unique_id.
-    if config_entry.unique_id != device.unique_id:
-        hass.config_entries.async_update_entry(
-            entry=config_entry,
-            unique_id=device.unique_id,
-        )
 
     # Create device registry entry.
     device_registry = await dr.async_get_registry(hass)

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -104,19 +104,10 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """
         _LOGGER.debug("async_step_import: import_info: %s", import_info)
 
-        if import_info is None:
-            # Landed here via configuration.yaml entry.
-            # Any device already added, then abort.
-            if self._async_current_entries():
-                _LOGGER.debug("aborting, already configured")
-                return self.async_abort(reason="already_configured")
-
-        # Test if import_info isn't already configured.
-        if import_info is not None and any(
-            import_info["udn"] == entry.data[CONFIG_ENTRY_UDN]
-            and import_info["st"] == entry.data[CONFIG_ENTRY_ST]
-            for entry in self._async_current_entries()
-        ):
+        # Landed here via configuration.yaml entry.
+        # Any device already added, then abort.
+        if self._async_current_entries():
+            _LOGGER.debug("Already configured, aborting")
             return self.async_abort(reason="already_configured")
 
         # Discover devices.

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -111,6 +111,14 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug("aborting, already configured")
                 return self.async_abort(reason="already_configured")
 
+        # Test if import_info isn't already configured.
+        if import_info is not None and any(
+            import_info["udn"] == entry.data[CONFIG_ENTRY_UDN]
+            and import_info["st"] == entry.data[CONFIG_ENTRY_ST]
+            for entry in self._async_current_entries()
+        ):
+            return self.async_abort(reason="already_configured")
+
         # Discover devices.
         self._discoveries = await Device.async_discover(self.hass)
 

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -127,7 +127,6 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # Ensure not already configuring/configured.
         usn = discovery_info[DISCOVERY_USN]
         await self.async_set_unique_id(usn)
-        self._abort_if_unique_id_configured()
 
         return await self._async_create_entry_from_discovery(discovery_info)
 

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -111,14 +111,6 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug("aborting, already configured")
                 return self.async_abort(reason="already_configured")
 
-        # Test if import_info isn't already configured.
-        if import_info is not None and any(
-            import_info["udn"] == entry.data[CONFIG_ENTRY_UDN]
-            and import_info["st"] == entry.data[CONFIG_ENTRY_ST]
-            for entry in self._async_current_entries()
-        ):
-            return self.async_abort(reason="already_configured")
-
         # Discover devices.
         self._discoveries = await Device.async_discover(self.hass)
 

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -98,10 +98,9 @@ async def test_flow_user(hass: HomeAssistantType):
     """Test config flow: discovered + configured through user."""
     udn = "uuid:device_1"
     mock_device = MockDevice(udn)
-    usn = f"{mock_device.udn}::{mock_device.device_type}"
     discovery_infos = [
         {
-            DISCOVERY_USN: usn,
+            DISCOVERY_USN: mock_device.unique_id,
             DISCOVERY_ST: mock_device.device_type,
             DISCOVERY_UDN: mock_device.udn,
             DISCOVERY_LOCATION: "dummy",
@@ -121,7 +120,7 @@ async def test_flow_user(hass: HomeAssistantType):
         # Confirmed via step user.
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"usn": usn},
+            user_input={"usn": mock_device.unique_id},
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -136,10 +135,9 @@ async def test_flow_import(hass: HomeAssistantType):
     """Test config flow: discovered + configured through configuration.yaml."""
     udn = "uuid:device_1"
     mock_device = MockDevice(udn)
-    usn = f"{mock_device.udn}::{mock_device.device_type}"
     discovery_infos = [
         {
-            DISCOVERY_USN: usn,
+            DISCOVERY_USN: mock_device.unique_id,
             DISCOVERY_ST: mock_device.device_type,
             DISCOVERY_UDN: mock_device.udn,
             DISCOVERY_LOCATION: "dummy",
@@ -160,6 +158,42 @@ async def test_flow_import(hass: HomeAssistantType):
             CONFIG_ENTRY_ST: mock_device.device_type,
             CONFIG_ENTRY_UDN: mock_device.udn,
         }
+
+
+async def test_flow_import_duplicate(hass: HomeAssistantType):
+    """Test config flow: discovered, but already configured."""
+    udn = "uuid:device_1"
+    mock_device = MockDevice(udn)
+    discovery_infos = [
+        {
+            DISCOVERY_USN: mock_device.unique_id,
+            DISCOVERY_ST: mock_device.device_type,
+            DISCOVERY_UDN: mock_device.udn,
+            DISCOVERY_LOCATION: "dummy",
+        }
+    ]
+
+    # Existing entry.
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONFIG_ENTRY_UDN: mock_device.udn,
+            CONFIG_ENTRY_ST: mock_device.device_type,
+        },
+        options={CONFIG_ENTRY_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch.object(
+        Device, "async_create_device", AsyncMock(return_value=mock_device)
+    ), patch.object(Device, "async_discover", AsyncMock(return_value=discovery_infos)):
+        # Discovered via step import.
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "already_configured"
 
 
 async def test_flow_import_incomplete(hass: HomeAssistantType):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Do not set `config_entry.unique_id` from `async_setup_entry`. No longer needed as it is now set during the config flow.
Fixes #40168


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40168
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
