### PR TITLE
Add support for removing entities in service `group.set`

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -287,14 +287,18 @@ async def async_setup(hass, config):
         if service.service == SERVICE_SET:
             need_update = False
 
-            if ATTR_REMOVE_ENTITIES in service.data:
-                delta = service.data[ATTR_REMOVE_ENTITIES]
-                entity_ids = set(group.tracking) - set(delta)
-                await group.async_update_tracked_entity_ids(entity_ids)
-
-            if ATTR_ADD_ENTITIES in service.data:
-                delta = service.data[ATTR_ADD_ENTITIES]
-                entity_ids = set(group.tracking) | set(delta)
+            if ATTR_ADD_ENTITIES in service.data or ATTR_REMOVE_ENTITIES in service.data:
+                entity_ids = set(group.tracking)
+                
+                if ATTR_ADD_ENTITIES in service.data:
+                    delta = service.data[ATTR_ADD_ENTITIES]
+                    entity_ids |= set(delta)
+                    
+                if ATTR_REMOVE_ENTITIES in service.data:
+                    # note: if an entity was included in both add and remove lists in the same service call, the entity will be removed
+                    delta = service.data[ATTR_REMOVE_ENTITIES]
+                    entity_ids -= set(delta)
+            
                 await group.async_update_tracked_entity_ids(entity_ids)
 
             if ATTR_ENTITIES in service.data:

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -287,18 +287,21 @@ async def async_setup(hass, config):
         if service.service == SERVICE_SET:
             need_update = False
 
-            if ATTR_ADD_ENTITIES in service.data or ATTR_REMOVE_ENTITIES in service.data:
+            if (
+                ATTR_ADD_ENTITIES in service.data
+                or ATTR_REMOVE_ENTITIES in service.data
+            ):
                 entity_ids = set(group.tracking)
-                
+
                 if ATTR_ADD_ENTITIES in service.data:
                     delta = service.data[ATTR_ADD_ENTITIES]
                     entity_ids |= set(delta)
-                    
+
                 if ATTR_REMOVE_ENTITIES in service.data:
                     # note: if an entity was included in both add and remove lists in the same service call, the entity will be removed
                     delta = service.data[ATTR_REMOVE_ENTITIES]
                     entity_ids -= set(delta)
-            
+
                 await group.async_update_tracked_entity_ids(entity_ids)
 
             if ATTR_ENTITIES in service.data:

--- a/homeassistant/components/group/services.yaml
+++ b/homeassistant/components/group/services.yaml
@@ -15,10 +15,13 @@ set:
       description: Name of icon for the group.
       example: "mdi:camera"
     entities:
-      description: List of all members in the group. Not compatible with 'delta'.
+      description: List of all members in the group. Not compatible with 'add_entities'.
       example: domain.entity_id1, domain.entity_id2
     add_entities:
-      description: List of members they will change on group listening.
+      description: List of members to add to a group.
+      example: domain.entity_id1, domain.entity_id2
+    remove_entities:
+      description: List of members to remove from an existing group.
       example: domain.entity_id1, domain.entity_id2
     all:
       description: Enable this option if the group should only turn on when all entities are on.

--- a/tests/components/group/common.py
+++ b/tests/components/group/common.py
@@ -5,6 +5,7 @@ components. Instead call the service directly.
 """
 from homeassistant.components.group import (
     ATTR_ADD_ENTITIES,
+    ATTR_REMOVE_ENTITIES,
     ATTR_ENTITIES,
     ATTR_OBJECT_ID,
     DOMAIN,
@@ -59,6 +60,7 @@ def async_set_group(
     entity_ids=None,
     icon=None,
     add=None,
+    remove=None,
 ):
     """Create/Update a group."""
     data = {
@@ -69,6 +71,7 @@ def async_set_group(
             (ATTR_ENTITIES, entity_ids),
             (ATTR_ICON, icon),
             (ATTR_ADD_ENTITIES, add),
+            (ATTR_REMOVE_ENTITIES, remove),
         ]
         if value is not None
     }

--- a/tests/components/group/common.py
+++ b/tests/components/group/common.py
@@ -5,9 +5,9 @@ components. Instead call the service directly.
 """
 from homeassistant.components.group import (
     ATTR_ADD_ENTITIES,
-    ATTR_REMOVE_ENTITIES,
     ATTR_ENTITIES,
     ATTR_OBJECT_ID,
+    ATTR_REMOVE_ENTITIES,
     DOMAIN,
     SERVICE_REMOVE,
     SERVICE_SET,

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -522,6 +522,8 @@ async def test_service_group_set_group_remove_group(hass):
         remove=["test.entity_id2"],
     )
     await hass.async_block_till_done()
+
+    group_state = hass.states.get("group.user_test_group")
     assert list(group_state.attributes["entity_id"]) == ["test.entity_bla1"]
 
     common.async_remove(hass, "user_test_group")

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -516,6 +516,14 @@ async def test_service_group_set_group_remove_group(hass):
         ["test.entity_bla1", "test.entity_id2"]
     )
 
+    common.async_set_group(
+        hass,
+        "user_test_group",
+        remove=["test.entity_id2"],
+    )
+    await hass.async_block_till_done()
+    assert list(group_state.attributes["entity_id"]) == ["test.entity_bla1"]
+
     common.async_remove(hass, "user_test_group")
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dynamically adding entities to a group is already possible with the `add_entities` argument to the `group.set` service. This PR adds equivalent support for dynamically removing entities from a group, with a `remove_entities` argument in `group.set`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
