### PR TITLE
Ensure lights added after group is created have the correct state

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -577,6 +577,7 @@ class Group(Entity):
             return
 
         excluded_domains = self.hass.data[REG_KEY].exclude_domains
+
         tracking = []
         trackable = []
         for ent_id in entity_ids:
@@ -592,6 +593,7 @@ class Group(Entity):
     @callback
     def _async_start(self, *_):
         """Start tracking members and write state."""
+        self._reset_tracked_state()
         self._async_start_tracking()
         self.async_write_ha_state()
 
@@ -625,15 +627,14 @@ class Group(Entity):
 
     async def async_added_to_hass(self):
         """Handle addition to Home Assistant."""
-        if self.tracking:
-            self._reset_tracked_state()
-
         if self.hass.state != CoreState.running:
             self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_START, self._async_start
             )
             return
 
+        if self.tracking:
+            self._reset_tracked_state()
         self._async_start_tracking()
 
     async def async_will_remove_from_hass(self):

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -100,13 +100,13 @@ class GroupIntegrationRegistry:
         self.exclude_domains.add(current_domain.get())
 
     def on_off_states(self, on_states: Set, off_state: str) -> None:
-        """Registry on and off states for the current domain."""
+        """Register on and off states for the current domain."""
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
                 self.on_off_mapping[on_state] = off_state
 
         if len(on_states) == 1 and off_state not in self.off_on_mapping:
-            self.off_on_mapping[off_state] = on_state
+            self.off_on_mapping[off_state] = list(on_states)[0]
 
         self.on_states_by_domain[current_domain.get()] = set(on_states)
 

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -91,6 +91,7 @@ class GroupIntegrationRegistry:
     """Class to hold a registry of integrations."""
 
     on_off_mapping: Dict[str, str] = {STATE_ON: STATE_OFF}
+    off_on_mapping: Dict[str, str] = {STATE_OFF: STATE_ON}
     on_states_by_domain: Dict[str, Set] = {}
     exclude_domains: Set = set()
 
@@ -103,6 +104,9 @@ class GroupIntegrationRegistry:
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
                 self.on_off_mapping[on_state] = off_state
+
+        if len(on_states) == 1 and off_state not in self.off_on_mapping:
+            self.off_on_mapping[off_state] = on_state
 
         self.on_states_by_domain[current_domain.get()] = set(on_states)
 
@@ -543,6 +547,7 @@ class Group(Entity):
         data = {ATTR_ENTITY_ID: self.tracking, ATTR_ORDER: self._order}
         if not self.user_defined:
             data[ATTR_AUTO] = True
+
         return data
 
     @property
@@ -672,19 +677,26 @@ class Group(Entity):
             if state is not None:
                 self._see_state(state)
 
-    def _see_state(self, state):
+    def _see_state(self, new_state):
         """Keep track of the the state."""
-        entity_id = state.entity_id
-        domain = state.domain
+        entity_id = new_state.entity_id
+        domain = new_state.domain
+        state = new_state.state
+        registry = self.hass.data[REG_KEY]
+        self._assumed[entity_id] = new_state.attributes.get(ATTR_ASSUMED_STATE)
 
-        domain_on_state = self.hass.data[REG_KEY].on_states_by_domain.get(
-            domain, {STATE_ON}
-        )
-        self._on_off[entity_id] = state.state in domain_on_state
-        self._assumed[entity_id] = state.attributes.get(ATTR_ASSUMED_STATE)
-
-        if domain in self.hass.data[REG_KEY].on_states_by_domain:
-            self._on_states.update(domain_on_state)
+        if domain not in registry.on_states_by_domain:
+            # Handle the group of a group case
+            if state in registry.on_off_mapping:
+                self._on_states.add(state)
+            elif state in registry.off_on_mapping:
+                self._on_states.add(registry.off_on_mapping[state])
+            self._on_off[entity_id] = state in registry.on_off_mapping
+        else:
+            entity_on_state = registry.on_states_by_domain[domain]
+            if domain in self.hass.data[REG_KEY].on_states_by_domain:
+                self._on_states.update(entity_on_state)
+            self._on_off[entity_id] = state in entity_on_state
 
     @callback
     def _async_update_group_state(self, tr_state=None):
@@ -727,7 +739,6 @@ class Group(Entity):
         # on state, we use STATE_ON/STATE_OFF
         else:
             on_state = STATE_ON
-
         group_is_on = self.mode(self._on_off.values())
         if group_is_on:
             self._state = on_state

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -763,7 +763,6 @@ async def test_group_climate_all_cool(hass):
     hass.states.async_set("climate.two", "cool")
     hass.states.async_set("climate.three", "cool")
 
-    assert await async_setup_component(hass, "climate", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -773,6 +772,7 @@ async def test_group_climate_all_cool(hass):
             }
         },
     )
+    assert await async_setup_component(hass, "climate", {})
     await hass.async_block_till_done()
 
     assert hass.states.get("group.group_zero").state == STATE_ON
@@ -804,8 +804,8 @@ async def test_group_alarm(hass):
     hass.states.async_set("alarm_control_panel.one", "armed_away")
     hass.states.async_set("alarm_control_panel.two", "armed_home")
     hass.states.async_set("alarm_control_panel.three", "armed_away")
+    hass.state = CoreState.stopped
 
-    assert await async_setup_component(hass, "alarm_control_panel", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -817,8 +817,10 @@ async def test_group_alarm(hass):
             }
         },
     )
+    assert await async_setup_component(hass, "alarm_control_panel", {})
     await hass.async_block_till_done()
-
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
     assert hass.states.get("group.group_zero").state == STATE_ON
 
 
@@ -850,8 +852,8 @@ async def test_group_vacuum_off(hass):
     hass.states.async_set("vacuum.one", "docked")
     hass.states.async_set("vacuum.two", "off")
     hass.states.async_set("vacuum.three", "off")
+    hass.state = CoreState.stopped
 
-    assert await async_setup_component(hass, "vacuum", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -861,8 +863,11 @@ async def test_group_vacuum_off(hass):
             }
         },
     )
+    assert await async_setup_component(hass, "vacuum", {})
     await hass.async_block_till_done()
 
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
     assert hass.states.get("group.group_zero").state == STATE_OFF
 
 
@@ -893,7 +898,6 @@ async def test_device_tracker_not_home(hass):
     hass.states.async_set("device_tracker.two", "not_home")
     hass.states.async_set("device_tracker.three", "not_home")
 
-    assert await async_setup_component(hass, "device_tracker", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -916,7 +920,6 @@ async def test_light_removed(hass):
     hass.states.async_set("light.two", "off")
     hass.states.async_set("light.three", "on")
 
-    assert await async_setup_component(hass, "light", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -943,7 +946,6 @@ async def test_switch_removed(hass):
     hass.states.async_set("switch.three", "on")
 
     hass.state = CoreState.stopped
-    assert await async_setup_component(hass, "switch", {})
     assert await async_setup_component(
         hass,
         "group",
@@ -956,6 +958,8 @@ async def test_switch_removed(hass):
     await hass.async_block_till_done()
 
     assert hass.states.get("group.group_zero").state == "unknown"
+    assert await async_setup_component(hass, "switch", {})
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -965,3 +969,98 @@ async def test_switch_removed(hass):
     await hass.async_block_till_done()
 
     assert hass.states.get("group.group_zero").state == "off"
+
+
+async def test_lights_added_after_group(hass):
+    """Test lights added after group."""
+
+    entity_ids = [
+        "light.living_front_ri",
+        "light.living_back_lef",
+        "light.living_back_cen",
+        "light.living_front_le",
+        "light.living_front_ce",
+        "light.living_back_rig",
+    ]
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "living_room_downlights": {"entities": entity_ids},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.living_room_downlights").state == "unknown"
+
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "off")
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.living_room_downlights").state == "off"
+
+
+async def test_lights_added_before_group(hass):
+    """Test lights added before group."""
+
+    entity_ids = [
+        "light.living_front_ri",
+        "light.living_back_lef",
+        "light.living_back_cen",
+        "light.living_front_le",
+        "light.living_front_ce",
+        "light.living_back_rig",
+    ]
+
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "off")
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "living_room_downlights": {"entities": entity_ids},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.living_room_downlights").state == "off"
+
+
+async def test_cover_added_after_group(hass):
+    """Test cover added after group."""
+
+    entity_ids = [
+        "cover.upstairs",
+        "cover.downstairs",
+    ]
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "shades": {"entities": entity_ids},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "open")
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.shades").state == "open"
+
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "closed")
+
+    await hass.async_block_till_done()
+    assert hass.states.get("group.shades").state == "closed"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure lights added after group is created have the correct state.

Also fixes the case where we have a group of a group

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41033
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
