### PR TITLE
Use common strings for zwave config flow

### DIFF
--- a/homeassistant/components/zwave/strings.json
+++ b/homeassistant/components/zwave/strings.json
@@ -14,7 +14,7 @@
       "option_error": "Z-Wave validation failed. Is the path to the USB stick correct?"
     },
     "abort": {
-      "already_configured": "[%key:common::abort::single_instance_allowed%]",
+      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "one_instance_only": "[%key:common::abort::already_configured_device%]"
     }
   },

--- a/homeassistant/components/zwave/strings.json
+++ b/homeassistant/components/zwave/strings.json
@@ -14,8 +14,8 @@
       "option_error": "Z-Wave validation failed. Is the path to the USB stick correct?"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "one_instance_only": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "one_instance_only": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "state": {

--- a/homeassistant/components/zwave/strings.json
+++ b/homeassistant/components/zwave/strings.json
@@ -15,7 +15,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "one_instance_only": "[%key:common::abort::already_configured_device%]"
+      "one_instance_only": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "state": {

--- a/homeassistant/components/zwave/strings.json
+++ b/homeassistant/components/zwave/strings.json
@@ -14,7 +14,7 @@
       "option_error": "Z-Wave validation failed. Is the path to the USB stick correct?"
     },
     "abort": {
-      "already_configured": "Z-Wave is already configured",
+      "already_configured": "[%key:common::abort::single_instance_allowed%]",
       "one_instance_only": "Component only supports one Z-Wave instance"
     }
   },

--- a/homeassistant/components/zwave/strings.json
+++ b/homeassistant/components/zwave/strings.json
@@ -15,7 +15,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::abort::single_instance_allowed%]",
-      "one_instance_only": "Component only supports one Z-Wave instance"
+      "one_instance_only": "[%key:common::abort::already_configured_device%]"
     }
   },
   "state": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use of reference strings in zwave config flow. See #40578

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40578 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
