### PR TITLE
Rewrite tests for Template Binary Sensor

### DIFF
--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -1,8 +1,6 @@
 """The tests for the Template Binary sensor platform."""
 from datetime import timedelta
 import logging
-import unittest
-from unittest import mock
 
 from homeassistant import setup
 from homeassistant.const import (
@@ -15,206 +13,197 @@ from homeassistant.const import (
 from homeassistant.core import CoreState
 import homeassistant.util.dt as dt_util
 
-from tests.common import (
-    assert_setup_component,
-    async_fire_time_changed,
-    get_test_home_assistant,
-)
+from tests.async_mock import patch
+from tests.common import assert_setup_component, async_fire_time_changed
 
 
-class TestBinarySensorTemplate(unittest.TestCase):
-    """Test for Binary sensor template platform."""
-
-    hass = None
-    # pylint: disable=invalid-name
-
-    def setup_method(self, method):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_setup(self):
-        """Test the setup."""
-        config = {
-            "binary_sensor": {
-                "platform": "template",
-                "sensors": {
-                    "test": {
-                        "friendly_name": "virtual thingy",
-                        "value_template": "{{ foo }}",
-                        "device_class": "motion",
-                    }
-                },
-            }
+async def test_setup(hass):
+    """Test the setup."""
+    config = {
+        "binary_sensor": {
+            "platform": "template",
+            "sensors": {
+                "test": {
+                    "friendly_name": "virtual thingy",
+                    "value_template": "{{ foo }}",
+                    "device_class": "motion",
+                }
+            },
         }
-        with assert_setup_component(1):
-            assert setup.setup_component(self.hass, "binary_sensor", config)
+    }
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(hass, "binary_sensor", config)
 
-    def test_setup_no_sensors(self):
-        """Test setup with no sensors."""
-        with assert_setup_component(0):
-            assert setup.setup_component(
-                self.hass, "binary_sensor", {"binary_sensor": {"platform": "template"}}
-            )
 
-    def test_setup_invalid_device(self):
-        """Test the setup with invalid devices."""
-        with assert_setup_component(0):
-            assert setup.setup_component(
-                self.hass,
-                "binary_sensor",
-                {"binary_sensor": {"platform": "template", "sensors": {"foo bar": {}}}},
-            )
+async def test_setup_no_sensors(hass):
+    """Test setup with no sensors."""
+    with assert_setup_component(0):
+        assert await setup.async_setup_component(
+            hass, "binary_sensor", {"binary_sensor": {"platform": "template"}}
+        )
 
-    def test_setup_invalid_device_class(self):
-        """Test setup with invalid sensor class."""
-        with assert_setup_component(0):
-            assert setup.setup_component(
-                self.hass,
-                "binary_sensor",
-                {
-                    "binary_sensor": {
-                        "platform": "template",
-                        "sensors": {
-                            "test": {
-                                "value_template": "{{ foo }}",
-                                "device_class": "foobarnotreal",
-                            }
-                        },
-                    }
-                },
-            )
 
-    def test_setup_invalid_missing_template(self):
-        """Test setup with invalid and missing template."""
-        with assert_setup_component(0):
-            assert setup.setup_component(
-                self.hass,
-                "binary_sensor",
-                {
-                    "binary_sensor": {
-                        "platform": "template",
-                        "sensors": {"test": {"device_class": "motion"}},
-                    }
-                },
-            )
+async def test_setup_invalid_device(hass):
+    """Test the setup with invalid devices."""
+    with assert_setup_component(0):
+        assert await setup.async_setup_component(
+            hass,
+            "binary_sensor",
+            {"binary_sensor": {"platform": "template", "sensors": {"foo bar": {}}}},
+        )
 
-    def test_icon_template(self):
-        """Test icon template."""
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "binary_sensor",
-                {
-                    "binary_sensor": {
-                        "platform": "template",
-                        "sensors": {
-                            "test_template_sensor": {
-                                "value_template": "{{ states.sensor.xyz.state }}",
-                                "icon_template": "{% if "
-                                "states.binary_sensor.test_state.state == "
-                                "'Works' %}"
-                                "mdi:check"
-                                "{% endif %}",
-                            }
-                        },
-                    }
-                },
-            )
 
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
+async def test_setup_invalid_device_class(hass):
+    """Test setup with invalid sensor class."""
+    with assert_setup_component(0):
+        assert await setup.async_setup_component(
+            hass,
+            "binary_sensor",
+            {
+                "binary_sensor": {
+                    "platform": "template",
+                    "sensors": {
+                        "test": {
+                            "value_template": "{{ foo }}",
+                            "device_class": "foobarnotreal",
+                        }
+                    },
+                }
+            },
+        )
 
-        state = self.hass.states.get("binary_sensor.test_template_sensor")
-        assert state.attributes.get("icon") == ""
 
-        self.hass.states.set("binary_sensor.test_state", "Works")
-        self.hass.block_till_done()
-        state = self.hass.states.get("binary_sensor.test_template_sensor")
-        assert state.attributes["icon"] == "mdi:check"
+async def test_setup_invalid_missing_template(hass):
+    """Test setup with invalid and missing template."""
+    with assert_setup_component(0):
+        assert await setup.async_setup_component(
+            hass,
+            "binary_sensor",
+            {
+                "binary_sensor": {
+                    "platform": "template",
+                    "sensors": {"test": {"device_class": "motion"}},
+                }
+            },
+        )
 
-    def test_entity_picture_template(self):
-        """Test entity_picture template."""
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "binary_sensor",
-                {
-                    "binary_sensor": {
-                        "platform": "template",
-                        "sensors": {
-                            "test_template_sensor": {
-                                "value_template": "{{ states.sensor.xyz.state }}",
-                                "entity_picture_template": "{% if "
-                                "states.binary_sensor.test_state.state == "
-                                "'Works' %}"
-                                "/local/sensor.png"
-                                "{% endif %}",
-                            }
-                        },
-                    }
-                },
-            )
 
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
+async def test_icon_template(hass):
+    """Test icon template."""
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "binary_sensor",
+            {
+                "binary_sensor": {
+                    "platform": "template",
+                    "sensors": {
+                        "test_template_sensor": {
+                            "value_template": "{{ states.sensor.xyz.state }}",
+                            "icon_template": "{% if "
+                            "states.binary_sensor.test_state.state == "
+                            "'Works' %}"
+                            "mdi:check"
+                            "{% endif %}",
+                        }
+                    },
+                }
+            },
+        )
 
-        state = self.hass.states.get("binary_sensor.test_template_sensor")
-        assert state.attributes.get("entity_picture") == ""
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
-        self.hass.states.set("binary_sensor.test_state", "Works")
-        self.hass.block_till_done()
-        state = self.hass.states.get("binary_sensor.test_template_sensor")
-        assert state.attributes["entity_picture"] == "/local/sensor.png"
+    state = hass.states.get("binary_sensor.test_template_sensor")
+    assert state.attributes.get("icon") == ""
 
-    def test_attribute_templates(self):
-        """Test attribute_templates template."""
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "binary_sensor",
-                {
-                    "binary_sensor": {
-                        "platform": "template",
-                        "sensors": {
-                            "test_template_sensor": {
-                                "value_template": "{{ states.sensor.xyz.state }}",
-                                "attribute_templates": {
-                                    "test_attribute": "It {{ states.sensor.test_state.state }}."
-                                },
-                            }
-                        },
-                    }
-                },
-            )
+    hass.states.async_set("binary_sensor.test_state", "Works")
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_template_sensor")
+    assert state.attributes["icon"] == "mdi:check"
 
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
 
-        state = self.hass.states.get("binary_sensor.test_template_sensor")
-        assert state.attributes.get("test_attribute") == "It ."
-        self.hass.states.set("sensor.test_state", "Works2")
-        self.hass.block_till_done()
-        self.hass.states.set("sensor.test_state", "Works")
-        self.hass.block_till_done()
-        state = self.hass.states.get("binary_sensor.test_template_sensor")
-        assert state.attributes["test_attribute"] == "It Works."
+async def test_entity_picture_template(hass):
+    """Test entity_picture template."""
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "binary_sensor",
+            {
+                "binary_sensor": {
+                    "platform": "template",
+                    "sensors": {
+                        "test_template_sensor": {
+                            "value_template": "{{ states.sensor.xyz.state }}",
+                            "entity_picture_template": "{% if "
+                            "states.binary_sensor.test_state.state == "
+                            "'Works' %}"
+                            "/local/sensor.png"
+                            "{% endif %}",
+                        }
+                    },
+                }
+            },
+        )
 
-    @mock.patch(
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_template_sensor")
+    assert state.attributes.get("entity_picture") == ""
+
+    hass.states.async_set("binary_sensor.test_state", "Works")
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_template_sensor")
+    assert state.attributes["entity_picture"] == "/local/sensor.png"
+
+
+async def test_attribute_templates(hass):
+    """Test attribute_templates template."""
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "binary_sensor",
+            {
+                "binary_sensor": {
+                    "platform": "template",
+                    "sensors": {
+                        "test_template_sensor": {
+                            "value_template": "{{ states.sensor.xyz.state }}",
+                            "attribute_templates": {
+                                "test_attribute": "It {{ states.sensor.test_state.state }}."
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_template_sensor")
+    assert state.attributes.get("test_attribute") == "It ."
+    hass.states.async_set("sensor.test_state", "Works2")
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.test_state", "Works")
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_template_sensor")
+    assert state.attributes["test_attribute"] == "It Works."
+
+
+async def test_match_all(hass):
+    """Test template that is rerendered on any state lifecycle."""
+    with patch(
         "homeassistant.components.template.binary_sensor."
         "BinarySensorTemplate._update_state"
-    )
-    def test_match_all(self, _update_state):
-        """Test template that is rerendered on any state lifecycle."""
+    ) as _update_state:
         with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
+            assert await setup.async_setup_component(
+                hass,
                 "binary_sensor",
                 {
                     "binary_sensor": {
@@ -234,43 +223,44 @@ class TestBinarySensorTemplate(unittest.TestCase):
                 },
             )
 
-        self.hass.start()
-        self.hass.block_till_done()
-        init_calls = len(_update_state.mock_calls)
+            await hass.async_start()
+            await hass.async_block_till_done()
+            init_calls = len(_update_state.mock_calls)
 
-        self.hass.states.set("sensor.any_state", "update")
-        self.hass.block_till_done()
-        assert len(_update_state.mock_calls) == init_calls
+            hass.states.async_set("sensor.any_state", "update")
+            await hass.async_block_till_done()
+            assert len(_update_state.mock_calls) == init_calls
 
-    def test_event(self):
-        """Test the event."""
-        config = {
-            "binary_sensor": {
-                "platform": "template",
-                "sensors": {
-                    "test": {
-                        "friendly_name": "virtual thingy",
-                        "value_template": "{{ states.sensor.test_state.state == 'on' }}",
-                        "device_class": "motion",
-                    }
-                },
-            }
+
+async def test_event(hass):
+    """Test the event."""
+    config = {
+        "binary_sensor": {
+            "platform": "template",
+            "sensors": {
+                "test": {
+                    "friendly_name": "virtual thingy",
+                    "value_template": "{{ states.sensor.test_state.state == 'on' }}",
+                    "device_class": "motion",
+                }
+            },
         }
-        with assert_setup_component(1):
-            assert setup.setup_component(self.hass, "binary_sensor", config)
+    }
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(hass, "binary_sensor", config)
 
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get("binary_sensor.test")
-        assert state.state == "off"
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
 
-        self.hass.states.set("sensor.test_state", "on")
-        self.hass.block_till_done()
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get("binary_sensor.test")
-        assert state.state == "on"
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
 
 
 async def test_template_delay_on(hass):

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import logging
 
 from homeassistant import setup
+from homeassistant.components import binary_sensor
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     EVENT_HOMEASSISTANT_START,
@@ -32,14 +33,14 @@ async def test_setup(hass):
         }
     }
     with assert_setup_component(1):
-        assert await setup.async_setup_component(hass, "binary_sensor", config)
+        assert await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
 
 
 async def test_setup_no_sensors(hass):
     """Test setup with no sensors."""
     with assert_setup_component(0):
         assert await setup.async_setup_component(
-            hass, "binary_sensor", {"binary_sensor": {"platform": "template"}}
+            hass, binary_sensor.DOMAIN, {"binary_sensor": {"platform": "template"}}
         )
 
 
@@ -48,7 +49,7 @@ async def test_setup_invalid_device(hass):
     with assert_setup_component(0):
         assert await setup.async_setup_component(
             hass,
-            "binary_sensor",
+            binary_sensor.DOMAIN,
             {"binary_sensor": {"platform": "template", "sensors": {"foo bar": {}}}},
         )
 
@@ -58,7 +59,7 @@ async def test_setup_invalid_device_class(hass):
     with assert_setup_component(0):
         assert await setup.async_setup_component(
             hass,
-            "binary_sensor",
+            binary_sensor.DOMAIN,
             {
                 "binary_sensor": {
                     "platform": "template",
@@ -78,7 +79,7 @@ async def test_setup_invalid_missing_template(hass):
     with assert_setup_component(0):
         assert await setup.async_setup_component(
             hass,
-            "binary_sensor",
+            binary_sensor.DOMAIN,
             {
                 "binary_sensor": {
                     "platform": "template",
@@ -93,7 +94,7 @@ async def test_icon_template(hass):
     with assert_setup_component(1):
         assert await setup.async_setup_component(
             hass,
-            "binary_sensor",
+            binary_sensor.DOMAIN,
             {
                 "binary_sensor": {
                     "platform": "template",
@@ -129,7 +130,7 @@ async def test_entity_picture_template(hass):
     with assert_setup_component(1):
         assert await setup.async_setup_component(
             hass,
-            "binary_sensor",
+            binary_sensor.DOMAIN,
             {
                 "binary_sensor": {
                     "platform": "template",
@@ -165,7 +166,7 @@ async def test_attribute_templates(hass):
     with assert_setup_component(1):
         assert await setup.async_setup_component(
             hass,
-            "binary_sensor",
+            binary_sensor.DOMAIN,
             {
                 "binary_sensor": {
                     "platform": "template",
@@ -204,7 +205,7 @@ async def test_match_all(hass):
         with assert_setup_component(1):
             assert await setup.async_setup_component(
                 hass,
-                "binary_sensor",
+                binary_sensor.DOMAIN,
                 {
                     "binary_sensor": {
                         "platform": "template",
@@ -247,7 +248,7 @@ async def test_event(hass):
         }
     }
     with assert_setup_component(1):
-        assert await setup.async_setup_component(hass, "binary_sensor", config)
+        assert await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
 
     await hass.async_block_till_done()
     await hass.async_start()
@@ -278,7 +279,7 @@ async def test_template_delay_on(hass):
             },
         }
     }
-    await setup.async_setup_component(hass, "binary_sensor", config)
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -338,7 +339,7 @@ async def test_template_delay_off(hass):
         }
     }
     hass.states.async_set("sensor.test_state", "on")
-    await setup.async_setup_component(hass, "binary_sensor", config)
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
     await hass.async_block_till_done()
     await hass.async_start()
 
@@ -397,7 +398,7 @@ async def test_available_without_availability_template(hass):
             },
         }
     }
-    await setup.async_setup_component(hass, "binary_sensor", config)
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
@@ -424,7 +425,7 @@ async def test_availability_template(hass):
             },
         }
     }
-    await setup.async_setup_component(hass, "binary_sensor", config)
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
@@ -449,7 +450,7 @@ async def test_invalid_attribute_template(hass, caplog):
 
     await setup.async_setup_component(
         hass,
-        "binary_sensor",
+        binary_sensor.DOMAIN,
         {
             "binary_sensor": {
                 "platform": "template",
@@ -478,7 +479,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
 
     await setup.async_setup_component(
         hass,
-        "binary_sensor",
+        binary_sensor.DOMAIN,
         {
             "binary_sensor": {
                 "platform": "template",
@@ -507,7 +508,7 @@ async def test_no_update_template_match_all(hass, caplog):
 
     await setup.async_setup_component(
         hass,
-        "binary_sensor",
+        binary_sensor.DOMAIN,
         {
             "binary_sensor": {
                 "platform": "template",
@@ -573,7 +574,7 @@ async def test_unique_id(hass):
     """Test unique_id option only creates one binary sensor per id."""
     await setup.async_setup_component(
         hass,
-        "binary_sensor",
+        binary_sensor.DOMAIN,
         {
             "binary_sensor": {
                 "platform": "template",
@@ -615,7 +616,7 @@ async def test_template_validation_error(hass, caplog):
             },
         },
     }
-    await setup.async_setup_component(hass, "binary_sensor", config)
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Improves the template integration tests for the binary_sensor platform. Rewrote tests to pytest and uses async_mock now instead of unittest.mock.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40899
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
