### PR TITLE
Rewrite alert test to pytest

### DIFF
--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -1,7 +1,6 @@
 """The tests for the Alert component."""
 # pylint: disable=protected-access
 from copy import deepcopy
-import unittest
 
 import homeassistant.components.alert as alert
 from homeassistant.components.alert import DOMAIN
@@ -19,9 +18,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import callback
-from homeassistant.setup import setup_component
-
-from tests.common import get_test_home_assistant
+from homeassistant.setup import async_setup_component
 
 NAME = "alert_test"
 DONE_MESSAGE = "alert_gone"
@@ -63,14 +60,6 @@ TEST_NOACK = [
 ENTITY_ID = f"{alert.DOMAIN}.{NAME}"
 
 
-def turn_on(hass, entity_id):
-    """Reset the alert.
-
-    This is a legacy helper method. Do not use it for new tests.
-    """
-    hass.add_job(async_turn_on, hass, entity_id)
-
-
 @callback
 def async_turn_on(hass, entity_id):
     """Async reset the alert.
@@ -79,14 +68,6 @@ def async_turn_on(hass, entity_id):
     """
     data = {ATTR_ENTITY_ID: entity_id}
     hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_TURN_ON, data))
-
-
-def turn_off(hass, entity_id):
-    """Acknowledge alert.
-
-    This is a legacy helper method. Do not use it for new tests.
-    """
-    hass.add_job(async_turn_off, hass, entity_id)
 
 
 @callback
@@ -99,14 +80,6 @@ def async_turn_off(hass, entity_id):
     hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_TURN_OFF, data))
 
 
-def toggle(hass, entity_id):
-    """Toggle acknowledgment of alert.
-
-    This is a legacy helper method. Do not use it for new tests.
-    """
-    hass.add_job(async_toggle, hass, entity_id)
-
-
 @callback
 def async_toggle(hass, entity_id):
     """Async toggle acknowledgment of alert.
@@ -117,239 +90,249 @@ def async_toggle(hass, entity_id):
     hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_TOGGLE, data))
 
 
-# pylint: disable=invalid-name
-class TestAlert(unittest.TestCase):
-    """Test the alert module."""
+def _setup_notify(hass):
+    events = []
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self._setup_notify()
-        self.addCleanup(self.hass.stop)
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
 
-    def _setup_notify(self):
-        events = []
+    hass.services.async_register(notify.DOMAIN, NOTIFIER, record_event)
 
-        @callback
-        def record_event(event):
-            """Add recorded event to set."""
-            events.append(event)
+    return events
 
-        self.hass.services.register(notify.DOMAIN, NOTIFIER, record_event)
 
-        return events
+async def test_is_on(hass):
+    """Test is_on method."""
+    hass.states.async_set(ENTITY_ID, STATE_ON)
+    await hass.async_block_till_done()
+    assert alert.is_on(hass, ENTITY_ID)
+    hass.states.async_set(ENTITY_ID, STATE_OFF)
+    await hass.async_block_till_done()
+    assert not alert.is_on(hass, ENTITY_ID)
 
-    def test_is_on(self):
-        """Test is_on method."""
-        self.hass.states.set(ENTITY_ID, STATE_ON)
-        self.hass.block_till_done()
-        assert alert.is_on(self.hass, ENTITY_ID)
-        self.hass.states.set(ENTITY_ID, STATE_OFF)
-        self.hass.block_till_done()
-        assert not alert.is_on(self.hass, ENTITY_ID)
 
-    def test_setup(self):
-        """Test setup method."""
-        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
-        assert STATE_IDLE == self.hass.states.get(ENTITY_ID).state
+async def test_setup(hass):
+    """Test setup method."""
+    assert await async_setup_component(hass, alert.DOMAIN, TEST_CONFIG)
+    assert STATE_IDLE == hass.states.get(ENTITY_ID).state
 
-    def test_fire(self):
-        """Test the alert firing."""
-        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        assert STATE_ON == self.hass.states.get(ENTITY_ID).state
 
-    def test_silence(self):
-        """Test silencing the alert."""
-        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        turn_off(self.hass, ENTITY_ID)
-        self.hass.block_till_done()
-        assert STATE_OFF == self.hass.states.get(ENTITY_ID).state
+async def test_fire(hass):
+    """Test the alert firing."""
+    _setup_notify(hass)
+    assert await async_setup_component(hass, alert.DOMAIN, TEST_CONFIG)
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert STATE_ON == hass.states.get(ENTITY_ID).state
 
-        # alert should not be silenced on next fire
-        self.hass.states.set("sensor.test", STATE_OFF)
-        self.hass.block_till_done()
-        assert STATE_IDLE == self.hass.states.get(ENTITY_ID).state
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        assert STATE_ON == self.hass.states.get(ENTITY_ID).state
 
-    def test_reset(self):
-        """Test resetting the alert."""
-        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        turn_off(self.hass, ENTITY_ID)
-        self.hass.block_till_done()
-        assert STATE_OFF == self.hass.states.get(ENTITY_ID).state
-        turn_on(self.hass, ENTITY_ID)
-        self.hass.block_till_done()
-        assert STATE_ON == self.hass.states.get(ENTITY_ID).state
+async def test_silence(hass):
+    """Test silencing the alert."""
+    _setup_notify(hass)
+    assert await async_setup_component(hass, alert.DOMAIN, TEST_CONFIG)
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    async_turn_off(hass, ENTITY_ID)
+    await hass.async_block_till_done()
+    assert STATE_OFF == hass.states.get(ENTITY_ID).state
 
-    def test_toggle(self):
-        """Test toggling alert."""
-        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        assert STATE_ON == self.hass.states.get(ENTITY_ID).state
-        toggle(self.hass, ENTITY_ID)
-        self.hass.block_till_done()
-        assert STATE_OFF == self.hass.states.get(ENTITY_ID).state
-        toggle(self.hass, ENTITY_ID)
-        self.hass.block_till_done()
-        assert STATE_ON == self.hass.states.get(ENTITY_ID).state
+    # alert should not be silenced on next fire
+    hass.states.async_set("sensor.test", STATE_OFF)
+    await hass.async_block_till_done()
+    assert STATE_IDLE == hass.states.get(ENTITY_ID).state
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert STATE_ON == hass.states.get(ENTITY_ID).state
 
-    def test_notification_no_done_message(self):
-        """Test notifications."""
-        events = []
-        config = deepcopy(TEST_CONFIG)
-        del config[alert.DOMAIN][NAME][alert.CONF_DONE_MESSAGE]
 
-        @callback
-        def record_event(event):
-            """Add recorded event to set."""
-            events.append(event)
+async def test_reset(hass):
+    """Test resetting the alert."""
+    _setup_notify(hass)
+    assert await async_setup_component(hass, alert.DOMAIN, TEST_CONFIG)
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    async_turn_off(hass, ENTITY_ID)
+    await hass.async_block_till_done()
+    assert STATE_OFF == hass.states.get(ENTITY_ID).state
+    async_turn_on(hass, ENTITY_ID)
+    await hass.async_block_till_done()
+    assert STATE_ON == hass.states.get(ENTITY_ID).state
 
-        self.hass.services.register(notify.DOMAIN, NOTIFIER, record_event)
 
-        assert setup_component(self.hass, alert.DOMAIN, config)
-        assert len(events) == 0
+async def test_toggle(hass):
+    """Test toggling alert."""
+    _setup_notify(hass)
+    assert await async_setup_component(hass, alert.DOMAIN, TEST_CONFIG)
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert STATE_ON == hass.states.get(ENTITY_ID).state
+    async_toggle(hass, ENTITY_ID)
+    await hass.async_block_till_done()
+    assert STATE_OFF == hass.states.get(ENTITY_ID).state
+    async_toggle(hass, ENTITY_ID)
+    await hass.async_block_till_done()
+    assert STATE_ON == hass.states.get(ENTITY_ID).state
 
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        assert len(events) == 1
 
-        self.hass.states.set("sensor.test", STATE_OFF)
-        self.hass.block_till_done()
-        assert len(events) == 1
+async def test_notification_no_done_message(hass):
+    """Test notifications."""
+    events = []
+    config = deepcopy(TEST_CONFIG)
+    del config[alert.DOMAIN][NAME][alert.CONF_DONE_MESSAGE]
 
-    def test_notification(self):
-        """Test notifications."""
-        events = []
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
 
-        @callback
-        def record_event(event):
-            """Add recorded event to set."""
-            events.append(event)
+    hass.services.async_register(notify.DOMAIN, NOTIFIER, record_event)
 
-        self.hass.services.register(notify.DOMAIN, NOTIFIER, record_event)
+    assert await async_setup_component(hass, alert.DOMAIN, config)
+    assert len(events) == 0
 
-        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
-        assert len(events) == 0
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(events) == 1
 
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        assert len(events) == 1
+    hass.states.async_set("sensor.test", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(events) == 1
 
-        self.hass.states.set("sensor.test", STATE_OFF)
-        self.hass.block_till_done()
-        assert len(events) == 2
 
-    def test_sending_non_templated_notification(self):
-        """Test notifications."""
-        events = self._setup_notify()
+async def test_notification(hass):
+    """Test notifications."""
+    events = []
 
-        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
 
-        self.hass.states.set(TEST_ENTITY, STATE_ON)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(events))
-        last_event = events[-1]
-        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], NAME)
+    hass.services.async_register(notify.DOMAIN, NOTIFIER, record_event)
 
-    def test_sending_templated_notification(self):
-        """Test templated notification."""
-        events = self._setup_notify()
+    assert await async_setup_component(hass, alert.DOMAIN, TEST_CONFIG)
+    assert len(events) == 0
 
-        config = deepcopy(TEST_CONFIG)
-        config[alert.DOMAIN][NAME][alert.CONF_ALERT_MESSAGE] = TEMPLATE
-        assert setup_component(self.hass, alert.DOMAIN, config)
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(events) == 1
 
-        self.hass.states.set(TEST_ENTITY, STATE_ON)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(events))
-        last_event = events[-1]
-        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], TEST_ENTITY)
+    hass.states.async_set("sensor.test", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(events) == 2
 
-    def test_sending_templated_done_notification(self):
-        """Test templated notification."""
-        events = self._setup_notify()
 
-        config = deepcopy(TEST_CONFIG)
-        config[alert.DOMAIN][NAME][alert.CONF_DONE_MESSAGE] = TEMPLATE
-        assert setup_component(self.hass, alert.DOMAIN, config)
+async def test_sending_non_templated_notification(hass):
+    """Test notifications."""
+    events = _setup_notify(hass)
 
-        self.hass.states.set(TEST_ENTITY, STATE_ON)
-        self.hass.block_till_done()
-        self.hass.states.set(TEST_ENTITY, STATE_OFF)
-        self.hass.block_till_done()
-        self.assertEqual(2, len(events))
-        last_event = events[-1]
-        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], TEST_ENTITY)
+    assert await async_setup_component(hass, alert.DOMAIN, TEST_CONFIG)
 
-    def test_sending_titled_notification(self):
-        """Test notifications."""
-        events = self._setup_notify()
+    hass.states.async_set(TEST_ENTITY, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    last_event = events[-1]
+    assert last_event.data[notify.ATTR_MESSAGE] == NAME
 
-        config = deepcopy(TEST_CONFIG)
-        config[alert.DOMAIN][NAME][alert.CONF_TITLE] = TITLE
-        assert setup_component(self.hass, alert.DOMAIN, config)
 
-        self.hass.states.set(TEST_ENTITY, STATE_ON)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(events))
-        last_event = events[-1]
-        self.assertEqual(last_event.data[notify.ATTR_TITLE], TEST_TITLE)
+async def test_sending_templated_notification(hass):
+    """Test templated notification."""
+    events = _setup_notify(hass)
 
-    def test_sending_data_notification(self):
-        """Test notifications."""
-        events = self._setup_notify()
+    config = deepcopy(TEST_CONFIG)
+    config[alert.DOMAIN][NAME][alert.CONF_ALERT_MESSAGE] = TEMPLATE
+    assert await async_setup_component(hass, alert.DOMAIN, config)
 
-        config = deepcopy(TEST_CONFIG)
-        config[alert.DOMAIN][NAME][alert.CONF_DATA] = TEST_DATA
-        assert setup_component(self.hass, alert.DOMAIN, config)
+    hass.states.async_set(TEST_ENTITY, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    last_event = events[-1]
+    assert last_event.data[notify.ATTR_MESSAGE] == TEST_ENTITY
 
-        self.hass.states.set(TEST_ENTITY, STATE_ON)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(events))
-        last_event = events[-1]
-        self.assertEqual(last_event.data[notify.ATTR_DATA], TEST_DATA)
 
-    def test_skipfirst(self):
-        """Test skipping first notification."""
-        config = deepcopy(TEST_CONFIG)
-        config[alert.DOMAIN][NAME][alert.CONF_SKIP_FIRST] = True
-        events = []
+async def test_sending_templated_done_notification(hass):
+    """Test templated notification."""
+    events = _setup_notify(hass)
 
-        @callback
-        def record_event(event):
-            """Add recorded event to set."""
-            events.append(event)
+    config = deepcopy(TEST_CONFIG)
+    config[alert.DOMAIN][NAME][alert.CONF_DONE_MESSAGE] = TEMPLATE
+    assert await async_setup_component(hass, alert.DOMAIN, config)
 
-        self.hass.services.register(notify.DOMAIN, NOTIFIER, record_event)
+    hass.states.async_set(TEST_ENTITY, STATE_ON)
+    await hass.async_block_till_done()
+    hass.states.async_set(TEST_ENTITY, STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(events) == 2
+    last_event = events[-1]
+    assert last_event.data[notify.ATTR_MESSAGE] == TEST_ENTITY
 
-        assert setup_component(self.hass, alert.DOMAIN, config)
-        assert len(events) == 0
 
-        self.hass.states.set("sensor.test", STATE_ON)
-        self.hass.block_till_done()
-        assert len(events) == 0
+async def test_sending_titled_notification(hass):
+    """Test notifications."""
+    events = _setup_notify(hass)
 
-    def test_noack(self):
-        """Test no ack feature."""
-        entity = alert.Alert(self.hass, *TEST_NOACK)
-        self.hass.add_job(entity.begin_alerting)
-        self.hass.block_till_done()
+    config = deepcopy(TEST_CONFIG)
+    config[alert.DOMAIN][NAME][alert.CONF_TITLE] = TITLE
+    assert await async_setup_component(hass, alert.DOMAIN, config)
 
-    def test_done_message_state_tracker_reset_on_cancel(self):
-        """Test that the done message is reset when canceled."""
-        entity = alert.Alert(self.hass, *TEST_NOACK)
-        entity._cancel = lambda *args: None
-        assert entity._send_done_message is False
-        entity._send_done_message = True
-        self.hass.add_job(entity.end_alerting)
-        self.hass.block_till_done()
-        assert entity._send_done_message is False
+    hass.states.async_set(TEST_ENTITY, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    last_event = events[-1]
+    assert last_event.data[notify.ATTR_TITLE] == TEST_TITLE
+
+
+async def test_sending_data_notification(hass):
+    """Test notifications."""
+    events = _setup_notify(hass)
+
+    config = deepcopy(TEST_CONFIG)
+    config[alert.DOMAIN][NAME][alert.CONF_DATA] = TEST_DATA
+    assert await async_setup_component(hass, alert.DOMAIN, config)
+
+    hass.states.async_set(TEST_ENTITY, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    last_event = events[-1]
+    assert last_event.data[notify.ATTR_DATA] == TEST_DATA
+
+
+async def test_skipfirst(hass):
+    """Test skipping first notification."""
+    config = deepcopy(TEST_CONFIG)
+    config[alert.DOMAIN][NAME][alert.CONF_SKIP_FIRST] = True
+    events = []
+
+    @callback
+    def record_event(event):
+        """Add recorded event to set."""
+        events.append(event)
+
+    hass.services.async_register(notify.DOMAIN, NOTIFIER, record_event)
+
+    assert await async_setup_component(hass, alert.DOMAIN, config)
+    assert len(events) == 0
+
+    hass.states.async_set("sensor.test", STATE_ON)
+    await hass.async_block_till_done()
+    assert len(events) == 0
+
+
+async def test_noack(hass):
+    """Test no ack feature."""
+    entity = alert.Alert(hass, *TEST_NOACK)
+    hass.async_add_job(entity.begin_alerting)
+    await hass.async_block_till_done()
+
+
+async def test_done_message_state_tracker_reset_on_cancel(hass):
+    """Test that the done message is reset when canceled."""
+    entity = alert.Alert(hass, *TEST_NOACK)
+    entity._cancel = lambda *args: None
+    assert entity._send_done_message is False
+    entity._send_done_message = True
+    hass.async_add_job(entity.end_alerting)
+    await hass.async_block_till_done()
+    assert entity._send_done_message is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'm not sure about all this async function. But it seems tests don't work without. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #40822
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
