### PR TITLE
Add active voltage sensors to Sense integration

### DIFF
--- a/homeassistant/components/emulated_kasa/manifest.json
+++ b/homeassistant/components/emulated_kasa/manifest.json
@@ -2,7 +2,7 @@
   "domain": "emulated_kasa",
   "name": "Emulated Kasa",
   "documentation": "https://www.home-assistant.io/integrations/emulated_kasa",
-  "requirements": ["sense_energy==0.8.0"],
+  "requirements": ["sense_energy==0.8.1"],
   "codeowners": ["@kbickar"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -110,6 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     sense_devices_data = SenseDevicesData()
     try:
         sense_discovered_devices = await gateway.get_discovered_device_data()
+        await gateway.update_realtime()
     except SENSE_TIMEOUT_EXCEPTIONS as err:
         raise ConfigEntryNotReady from err
 

--- a/homeassistant/components/sense/manifest.json
+++ b/homeassistant/components/sense/manifest.json
@@ -2,7 +2,7 @@
   "domain": "sense",
   "name": "Sense",
   "documentation": "https://www.home-assistant.io/integrations/sense",
-  "requirements": ["sense_energy==0.8.0"],
+  "requirements": ["sense_energy==0.8.1"],
   "codeowners": ["@kbickar"],
   "config_flow": true
 }

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -212,7 +212,10 @@ class SenseVoltageSensor(Entity):
     """Implementation of a Sense energy voltage sensor."""
 
     def __init__(
-        self, data, index, sense_monitor_id,
+        self, 
+        data, 
+        index, 
+        sense_monitor_id,
     ):
         """Initialize the Sense sensor."""
         line_num = index + 1

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.const import (
     DEVICE_CLASS_POWER,
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT,
+    VOLT,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -95,6 +96,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 data, name, sensor_type, is_production, sense_monitor_id, var, unique_id
             )
         )
+
+    for i in range(len(data.active_voltage)):
+        devices.append(SenseVoltageSensor(data, i, sense_monitor_id))
 
     for type_id in TRENDS_SENSOR_TYPES:
         typ = TRENDS_SENSOR_TYPES[type_id]
@@ -200,6 +204,80 @@ class SenseActiveSensor(Entity):
             if self._is_production
             else self._data.active_power
         )
+        self._available = True
+        self.async_write_ha_state()
+
+
+class SenseVoltageSensor(Entity):
+    """Implementation of a Sense energy voltage sensor."""
+
+    def __init__(
+        self, data, index, sense_monitor_id,
+    ):
+        """Initialize the Sense sensor."""
+        line_num = index + 1
+        self._name = f"L{line_num} Voltage"
+        self._unique_id = f"{sense_monitor_id}-L{line_num}"
+        self._available = False
+        self._data = data
+        self._sense_monitor_id = sense_monitor_id
+        self._voltage_index = index
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return the availability of the sensor."""
+        return self._available
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return VOLT
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {ATTR_ATTRIBUTION: ATTRIBUTION}
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ICON
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
+
+    @property
+    def should_poll(self):
+        """Return the device should not poll for updates."""
+        return False
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SENSE_DEVICE_UPDATE}-{self._sense_monitor_id}",
+                self._async_update_from_data,
+            )
+        )
+
+    @callback
+    def _async_update_from_data(self):
+        """Update the sensor from the data. Must not do I/O."""
+        self._state = round(self._data.active_voltage[self._voltage_index], 1)
         self._available = True
         self.async_write_ha_state()
 

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -212,9 +212,9 @@ class SenseVoltageSensor(Entity):
     """Implementation of a Sense energy voltage sensor."""
 
     def __init__(
-        self, 
-        data, 
-        index, 
+        self,
+        data,
+        index,
         sense_monitor_id,
     ):
         """Initialize the Sense sensor."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1979,7 +1979,7 @@ sense-hat==2.2.0
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.8.0
+sense_energy==0.8.1
 
 # homeassistant.components.sentry
 sentry-sdk==0.18.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -924,7 +924,7 @@ samsungtvws==1.4.0
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.8.0
+sense_energy==0.8.1
 
 # homeassistant.components.sentry
 sentry-sdk==0.18.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds voltage sensors (L1, L2...possibly others if they are implemented) that show the realtime voltage from the Sense monitor.

These show up as `sensor.l1_voltage`

Also updates the sense_energy module to the latest version to prevent an error if voltage is not available

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
