### PR TITLE
Update xknx to 0.15.1

### DIFF
--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -246,7 +246,7 @@ def _create_binary_sensor(knx_module: XKNX, config: ConfigType) -> XknxBinarySen
         sync_state=config[BinarySensorSchema.CONF_SYNC_STATE],
         device_class=config.get(CONF_DEVICE_CLASS),
         ignore_internal_state=config[BinarySensorSchema.CONF_IGNORE_INTERNAL_STATE],
-        context_timeout=config[BinarySensorSchema.CONF_CONTEXT_TIMEOUT],
+        context_timeout=config.get(BinarySensorSchema.CONF_CONTEXT_TIMEOUT),
         reset_after=config.get(BinarySensorSchema.CONF_RESET_AFTER),
     )
 

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.15.0"],
+  "requirements": ["xknx==0.15.1"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "silver"
 }

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -102,10 +102,10 @@ class BinarySensorSchema:
                     cv.string,
                 ),
                 vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=True): cv.boolean,
-                vol.Optional(CONF_CONTEXT_TIMEOUT, default=1.0): vol.All(
+                vol.Required(CONF_STATE_ADDRESS): cv.string,
+                vol.Optional(CONF_CONTEXT_TIMEOUT): vol.All(
                     vol.Coerce(float), vol.Range(min=0, max=10)
                 ),
-                vol.Required(CONF_STATE_ADDRESS): cv.string,
                 vol.Optional(CONF_DEVICE_CLASS): cv.string,
                 vol.Optional(CONF_RESET_AFTER): cv.positive_int,
             }

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -107,7 +107,9 @@ class BinarySensorSchema:
                     vol.Coerce(float), vol.Range(min=0, max=10)
                 ),
                 vol.Optional(CONF_DEVICE_CLASS): cv.string,
-                vol.Optional(CONF_RESET_AFTER): cv.positive_int,
+                vol.Optional(CONF_RESET_AFTER): vol.All(
+                    vol.Coerce(float), vol.Range(min=0)
+                ),     
             }
         ),
     )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2277,7 +2277,7 @@ xboxapi==2.0.1
 xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
-xknx==0.15.0
+xknx==0.15.1
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**This PR should supersede #40304 - the breaking change section should be taken from below - if that's possible**

We changed the way how we handle binary sensors in the underlying library. It is no longer possible to support automations based on the binary_sensor schema. Instead, you can use the new `counter` state attribute for any given KNX binary sensor.

Before this change:

```
-  name: cover_abstell
   state_address: "2/0/33"
   automation:
     - counter: 1
       hook: 'on'
       action:
         - entity_id: cover.sonne_abstellkammer
           service: cover.open_cover
     - counter: 1
       hook: 'off'
       action:
         - entity_id: cover.sonne_abstellkammer
           service: cover.close_cover
    - counter: 2
       hook: 'off'
       action:
         - entity_id: light.office
           service: light.turn_on
```

After this change:

binary_sensor.yaml:

```
- name: cover_abstell
  state_address: "2/0/33"
  context_timeout: 1.0
```

automation.yaml:

```
automation:
  - alias: 'Binary sensor test counter=1 on'
    trigger:
      platform: numeric_state
      entity_id: binary_sensor.cover_abstell
      attribute: counter
      above: 0
      below: 2
    condition: 
      - condition: state
        entity_id: binary_sensor.cover_abstell
        state: 'on'
    action:
      - service: cover.open_cover
        entity_id: cover.sonne_abstellkammer

  - alias: 'Binary sensor test counter=1 off'
    trigger:
      platform: numeric_state
      entity_id: binary_sensor.cover_abstell
      attribute: counter
      above: 0
      below: 2
    condition:
      - condition: state
        entity_id: binary_sensor.cover_abstell
        state: 'off'
    action:
      - service: cover.close_cover
        entity_id: cover.sonne_abstellkammer

  - alias: 'Binary sensor test counter=2 off'
    trigger:
      platform: numeric_state
      entity_id: binary_sensor.cover_abstell
      attribute: counter
      above: 1
      below: 3
    condition:
      - condition: state
        entity_id: binary_sensor.cover_abstell
        state: 'off'
    action:
      - service: light.turn_on
        entity_id: light.office
```

If you intend to use the counter feature (counter > 1) make sure you also enable `ignore_internal_state` (default: True) for your binary_sensor and set the new `context_timeout` attribute to the time in between you want it to react to your sensor clicks (defaults to None - meaning that it is disabled). The counter feature for anything beyond 1 will only work if you set the `context_timeout` attribute. `reset_after` now also uses seconds and no longer milliseconds.



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since the release of the beta we have received reports that the binary_sensor automations trigger twice for some users. This was an issue in the underlying library and is fixed with the dependency update: https://github.com/XKNX/xknx/releases/tag/0.15.1

Apart from that we also received reports that there is now a delay of one second for triggering automations that _do not_ use the counter feature. Therefore we decided to let `context_timeout` default to None per default and disable the feature. Users can still enable it if they need it.

**If possible, it would be great if this would make it in the current beta to avoid another breaking change after the 0.116.0 release.**

I also added an example where the counter is actually > 1.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: -
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14830

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] The breaking change section doesn't link to an external website.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
