### PR TITLE
Lutron Caseta: update for light transition and cover stop

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -64,9 +64,9 @@ async def async_setup_entry(hass, config_entry):
     """Set up a bridge from a config entry."""
 
     host = config_entry.data[CONF_HOST]
-    keyfile = config_entry.data[CONF_KEYFILE]
-    certfile = config_entry.data[CONF_CERTFILE]
-    ca_certs = config_entry.data[CONF_CA_CERTS]
+    keyfile = hass.config.path(config_entry.data[CONF_KEYFILE])
+    certfile = hass.config.path(config_entry.data[CONF_CERTFILE])
+    ca_certs = hass.config.path(config_entry.data[CONF_CA_CERTS])
 
     bridge = Smartbridge.create_tls(
         hostname=host, keyfile=keyfile, certfile=certfile, ca_certs=ca_certs

--- a/homeassistant/components/lutron_caseta/config_flow.py
+++ b/homeassistant/components/lutron_caseta/config_flow.py
@@ -83,9 +83,9 @@ class LutronCasetaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             bridge = Smartbridge.create_tls(
                 hostname=self.data[CONF_HOST],
-                keyfile=self.data[CONF_KEYFILE],
-                certfile=self.data[CONF_CERTFILE],
-                ca_certs=self.data[CONF_CA_CERTS],
+                keyfile=self.hass.config.path(self.data[CONF_KEYFILE]),
+                certfile=self.hass.config.path(self.data[CONF_CERTFILE]),
+                ca_certs=self.hass.config.path(self.data[CONF_CA_CERTS]),
             )
 
             await bridge.connect()

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -7,6 +7,7 @@ from homeassistant.components.cover import (
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
+    SUPPORT_STOP,
     CoverEntity,
 )
 
@@ -39,7 +40,7 @@ class LutronCasetaCover(LutronCasetaDevice, CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
 
     @property
     def is_closed(self):
@@ -51,13 +52,21 @@ class LutronCasetaCover(LutronCasetaDevice, CoverEntity):
         """Return the current position of cover."""
         return self._device["current_state"]
 
+    async def async_stop_cover(self, **kwargs):
+        """Top the cover."""
+        await self._smartbridge.stop_cover(self.device_id)
+
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        await self._smartbridge.set_value(self.device_id, 0)
+        await self._smartbridge.lower_cover(self.device_id)
+        self.async_update()
+        self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        await self._smartbridge.set_value(self.device_id, 100)
+        await self._smartbridge.raise_cover(self.device_id)
+        self.async_update()
+        self.async_write_ha_state()
 
     async def async_set_cover_position(self, **kwargs):
         """Move the shade to a specific position."""

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -53,17 +53,17 @@ class LutronCasetaCover(LutronCasetaDevice, CoverEntity):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        self._smartbridge.set_value(self.device_id, 0)
+        await self._smartbridge.set_value(self.device_id, 0)
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        self._smartbridge.set_value(self.device_id, 100)
+        await self._smartbridge.set_value(self.device_id, 100)
 
     async def async_set_cover_position(self, **kwargs):
         """Move the shade to a specific position."""
         if ATTR_POSITION in kwargs:
             position = kwargs[ATTR_POSITION]
-            self._smartbridge.set_value(self.device_id, position)
+            await self._smartbridge.set_value(self.device_id, position)
 
     async def async_update(self):
         """Call when forcing a refresh of the device."""

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -84,7 +84,7 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
 
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
-        self._smartbridge.set_fan(self.device_id, SPEED_TO_VALUE[speed])
+        await self._smartbridge.set_fan(self.device_id, SPEED_TO_VALUE[speed])
 
     @property
     def is_on(self):

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -57,11 +57,11 @@ class LutronCasetaLight(LutronCasetaDevice, LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-        self._smartbridge.set_value(self.device_id, to_lutron_level(brightness))
+        await self._smartbridge.set_value(self.device_id, to_lutron_level(brightness))
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
-        self._smartbridge.set_value(self.device_id, 0)
+        await self._smartbridge.set_value(self.device_id, 0)
 
     @property
     def is_on(self):

--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -1,10 +1,13 @@
 """Support for Lutron Caseta lights."""
+from datetime import timedelta
 import logging
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_TRANSITION,
     DOMAIN,
     SUPPORT_BRIGHTNESS,
+    SUPPORT_TRANSITION,
     LightEntity,
 )
 
@@ -47,21 +50,31 @@ class LutronCasetaLight(LutronCasetaDevice, LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_BRIGHTNESS
+        return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 
     @property
     def brightness(self):
         """Return the brightness of the light."""
         return to_hass_level(self._device["current_state"])
 
+    async def _set_brightness(self, brightness, **kwargs):
+        args = {}
+        if ATTR_TRANSITION in kwargs:
+            args["fade_time"] = timedelta(seconds=kwargs[ATTR_TRANSITION])
+
+        await self._smartbridge.set_value(
+            self.device_id, to_lutron_level(brightness), **args
+        )
+
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
-        brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-        await self._smartbridge.set_value(self.device_id, to_lutron_level(brightness))
+        brightness = kwargs.pop(ATTR_BRIGHTNESS, 255)
+
+        await self._set_brightness(brightness, **kwargs)
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
-        await self._smartbridge.set_value(self.device_id, 0)
+        await self._set_brightness(0, **kwargs)
 
     @property
     def is_on(self):

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -3,7 +3,7 @@
   "name": "Lutron Caséta",
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
   "requirements": [
-    "pylutron-caseta==0.6.1"
+    "pylutron-caseta==0.7.0"
   ],
   "codeowners": [
     "@swails"

--- a/homeassistant/components/lutron_caseta/scene.py
+++ b/homeassistant/components/lutron_caseta/scene.py
@@ -43,4 +43,4 @@ class LutronCasetaScene(Scene):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
-        self._bridge.activate_scene(self._scene_id)
+        await self._bridge.activate_scene(self._scene_id)

--- a/homeassistant/components/lutron_caseta/switch.py
+++ b/homeassistant/components/lutron_caseta/switch.py
@@ -32,11 +32,11 @@ class LutronCasetaLight(LutronCasetaDevice, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
-        self._smartbridge.turn_on(self.device_id)
+        await self._smartbridge.turn_on(self.device_id)
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
-        self._smartbridge.turn_off(self.device_id)
+        await self._smartbridge.turn_off(self.device_id)
 
     @property
     def is_on(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1461,7 +1461,7 @@ pylitejet==0.1
 pyloopenergy==0.2.1
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.6.1
+pylutron-caseta==0.7.0
 
 # homeassistant.components.lutron
 pylutron==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -707,7 +707,7 @@ pylibrespot-java==0.1.0
 pylitejet==0.1
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.6.1
+pylutron-caseta==0.7.0
 
 # homeassistant.components.mailgun
 pymailgunner==1.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

pylutron_caseta now supports sending an optional `fade_time` parameter to `set_value` `turn_on` and `turn_off`. For dimmable lights, this causes the light to fade between the current level and the requested level over the specified duration. The Home Assistant component uses this to support light transitions.

### Covers

#34736 depends on the pylutron_caseta update for shade stop commands.

### Other

There's been a substantial change to the way pylutron_caseta works internally. All methods that send commands to the Caséta bridge are now coroutines, and any network errors or error responses sent by the Caséta bridge will be exposed as exceptions. I've been using this for a few weeks now and it seems okay.

When I was updating the Home Assistant component, I ran into a problem in my development environment where the certificate files were being loaded from the working directory, not from the configuration directory. I've fixed this also.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes gurumitts/pylutron-caseta#50
- This PR is related to issue: gurumitts/pylutron-caseta#37
- Link to documentation pull request: home-assistant/home-assistant.io#14846

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
