### PR TITLE
Rewrite london_air tests in pytest style

### DIFF
--- a/homeassistant/components/london_air/sensor.py
+++ b/homeassistant/components/london_air/sensor.py
@@ -128,19 +128,21 @@ class AirSensor(Entity):
         """Return other details about the sensor state."""
         attrs = {}
         attrs["updated"] = self._updated
-        attrs["sites"] = len(self._site_data)
+        attrs["sites"] = len(self._site_data) if self._site_data is not None else 0
         attrs["data"] = self._site_data
         return attrs
 
     def update(self):
         """Update the sensor."""
-        self._api_data.update()
-        self._site_data = self._api_data.data[self._name]
-        self._updated = self._site_data[0]["updated"]
         sites_status = []
-        for site in self._site_data:
-            if site["pollutants_status"] != "no_species_data":
-                sites_status.append(site["pollutants_status"])
+        self._api_data.update()
+        if self._api_data.data:
+            self._site_data = self._api_data.data[self._name]
+            self._updated = self._site_data[0]["updated"]
+            for site in self._site_data:
+                if site["pollutants_status"] != "no_species_data":
+                    sites_status.append(site["pollutants_status"])
+
         if sites_status:
             self._state = max(set(sites_status), key=sites_status.count)
         else:

--- a/tests/components/london_air/test_sensor.py
+++ b/tests/components/london_air/test_sensor.py
@@ -1,80 +1,51 @@
 """The tests for the london_air platform."""
-import json
-
-from homeassistant.components.london_air.sensor import CONF_LOCATIONS
+from homeassistant.components.london_air.sensor import CONF_LOCATIONS, URL
 from homeassistant.const import HTTP_OK, HTTP_SERVICE_UNAVAILABLE
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import patch
 from tests.common import load_fixture
 
 VALID_CONFIG = {"sensor": {"platform": "london_air", CONF_LOCATIONS: ["Merton"]}}
 
 
-class MockResponse:
-    """Class to represent a mocked response."""
-
-    def __init__(self, json_data, status_code):
-        """Initialize the mock response class."""
-        self.json_data = json_data
-        self.status_code = status_code
-
-    def json(self):
-        """Return the json of the response."""
-        return self.json_data
-
-
-def mocked_requests_get(*args, **kwargs):
-    """Mock requests.get invocations."""
-    url = str(args[0])
-
-    if "GroupName=London/Json" in url:
-        return MockResponse(json.loads(load_fixture("london_air.json")), HTTP_OK)
-
-
-def mocked_requests_get_failed(*args, **kwargs):
-    """Mock requests.get failure."""
-    return MockResponse({}, status_code=HTTP_SERVICE_UNAVAILABLE)
-
-
-async def test_valid_state(hass):
+async def test_valid_state(hass, requests_mock):
     """Test for operational london_air sensor with proper attributes."""
-    with patch("requests.get", mocked_requests_get):
-        assert await async_setup_component(hass, "sensor", VALID_CONFIG)
-        await hass.async_block_till_done()
+    requests_mock.get(URL, text=load_fixture("london_air.json"), status_code=HTTP_OK)
+    assert await async_setup_component(hass, "sensor", VALID_CONFIG)
+    await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.merton")
-        assert state is not None
-        assert state.state == "Low"
-        assert state.attributes["icon"] == "mdi:cloud-outline"
-        assert state.attributes["updated"] == "2017-08-03 03:00:00"
-        assert state.attributes["sites"] == 2
-        assert state.attributes["friendly_name"] == "Merton"
+    state = hass.states.get("sensor.merton")
+    assert state is not None
+    assert state.state == "Low"
+    assert state.attributes["icon"] == "mdi:cloud-outline"
+    assert state.attributes["updated"] == "2017-08-03 03:00:00"
+    assert state.attributes["sites"] == 2
+    assert state.attributes["friendly_name"] == "Merton"
 
-        sites = state.attributes["data"]
-        assert sites is not None
-        assert len(sites) == 2
-        assert sites[0]["site_code"] == "ME2"
-        assert sites[0]["site_type"] == "Roadside"
-        assert sites[0]["site_name"] == "Merton Road"
-        assert sites[0]["pollutants_status"] == "Low"
+    sites = state.attributes["data"]
+    assert sites is not None
+    assert len(sites) == 2
+    assert sites[0]["site_code"] == "ME2"
+    assert sites[0]["site_type"] == "Roadside"
+    assert sites[0]["site_name"] == "Merton Road"
+    assert sites[0]["pollutants_status"] == "Low"
 
-        pollutants = sites[0]["pollutants"]
-        assert pollutants is not None
-        assert len(pollutants) == 1
-        assert pollutants[0]["code"] == "PM10"
-        assert pollutants[0]["quality"] == "Low"
-        assert int(pollutants[0]["index"]) == 2
-        assert pollutants[0]["summary"] == "PM10 is Low"
+    pollutants = sites[0]["pollutants"]
+    assert pollutants is not None
+    assert len(pollutants) == 1
+    assert pollutants[0]["code"] == "PM10"
+    assert pollutants[0]["quality"] == "Low"
+    assert int(pollutants[0]["index"]) == 2
+    assert pollutants[0]["summary"] == "PM10 is Low"
 
 
-async def test_api_failure(hass):
+async def test_api_failure(hass, requests_mock):
     """Test for failure in the API."""
-    with patch("requests.get", mocked_requests_get_failed):
-        assert await async_setup_component(hass, "sensor", VALID_CONFIG)
-        await hass.async_block_till_done()
+    requests_mock.get(URL, status_code=HTTP_SERVICE_UNAVAILABLE)
+    assert await async_setup_component(hass, "sensor", VALID_CONFIG)
+    await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.merton")
-        assert state is not None
-        assert state.attributes["updated"] is None
-        assert state.attributes["sites"] == 0
+    state = hass.states.get("sensor.merton")
+    assert state is not None
+    assert state.attributes["updated"] is None
+    assert state.attributes["sites"] == 0

--- a/tests/components/london_air/test_sensor.py
+++ b/tests/components/london_air/test_sensor.py
@@ -1,34 +1,80 @@
-"""The tests for the tube_state platform."""
-import unittest
+"""The tests for the london_air platform."""
+import json
 
-import requests_mock
+from homeassistant.components.london_air.sensor import CONF_LOCATIONS
+from homeassistant.const import HTTP_OK, HTTP_SERVICE_UNAVAILABLE
+from homeassistant.setup import async_setup_component
 
-from homeassistant.components.london_air.sensor import CONF_LOCATIONS, URL
-from homeassistant.setup import setup_component
+from tests.async_mock import patch
+from tests.common import load_fixture
 
-from tests.common import get_test_home_assistant, load_fixture
-
-VALID_CONFIG = {"platform": "london_air", CONF_LOCATIONS: ["Merton"]}
+VALID_CONFIG = {"sensor": {"platform": "london_air", CONF_LOCATIONS: ["Merton"]}}
 
 
-class TestLondonAirSensor(unittest.TestCase):
-    """Test the tube_state platform."""
+class MockResponse:
+    """Class to represent a mocked response."""
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        self.config = VALID_CONFIG
-        self.addCleanup(self.hass.stop)
+    def __init__(self, json_data, status_code):
+        """Initialize the mock response class."""
+        self.json_data = json_data
+        self.status_code = status_code
 
-    @requests_mock.Mocker()
-    def test_setup(self, mock_req):
-        """Test for operational tube_state sensor with proper attributes."""
-        mock_req.get(URL, text=load_fixture("london_air.json"))
-        assert setup_component(self.hass, "sensor", {"sensor": self.config})
-        self.hass.block_till_done()
+    def json(self):
+        """Return the json of the response."""
+        return self.json_data
 
-        state = self.hass.states.get("sensor.merton")
-        assert state.state == "Low"
-        assert state.attributes.get("updated") == "2017-08-03 03:00:00"
-        assert state.attributes.get("sites") == 2
-        assert state.attributes.get("data")[0]["site_code"] == "ME2"
+
+def mocked_requests_get(*args, **kwargs):
+    """Mock requests.get invocations."""
+    url = str(args[0])
+
+    if "GroupName=London/Json" in url:
+        return MockResponse(json.loads(load_fixture("london_air.json")), HTTP_OK)
+
+
+def mocked_requests_get_failed(*args, **kwargs):
+    """Mock requests.get failure."""
+    return MockResponse({}, status_code=HTTP_SERVICE_UNAVAILABLE)
+
+
+async def test_valid_state(hass):
+    """Test for operational london_air sensor with proper attributes."""
+    with patch("requests.get", mocked_requests_get):
+        assert await async_setup_component(hass, "sensor", VALID_CONFIG)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.merton")
+        assert state is not None
+        assert "Low" == state.state
+        assert "mdi:cloud-outline" == state.attributes["icon"]
+        assert "2017-08-03 03:00:00" == state.attributes["updated"]
+        assert 2 == state.attributes["sites"]
+        assert "Merton" == state.attributes["friendly_name"]
+
+        sites = state.attributes["data"]
+        assert sites is not None
+        assert 2 == len(sites)
+        assert "ME2" == sites[0]["site_code"]
+        assert "Roadside" == sites[0]["site_type"]
+        assert "Merton Road" == sites[0]["site_name"]
+        assert "Low" == sites[0]["pollutants_status"]
+
+        pollutants = sites[0]["pollutants"]
+        assert pollutants is not None
+        assert 1 == len(pollutants)
+        assert "PM10" == pollutants[0]["code"]
+        assert "Low" == pollutants[0]["quality"]
+        assert 2 == int(pollutants[0]["index"])
+        assert "PM10 is Low" == pollutants[0]["summary"]
+
+
+async def test_api_failure(hass):
+    """Test for failure in the API."""
+    with patch("requests.get", mocked_requests_get_failed):
+        assert await async_setup_component(hass, "sensor", VALID_CONFIG)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.merton")
+        assert state is not None
+        assert None is state.attributes["updated"]
+        assert 0 == state.attributes["sites"]

--- a/tests/components/london_air/test_sensor.py
+++ b/tests/components/london_air/test_sensor.py
@@ -45,27 +45,27 @@ async def test_valid_state(hass):
 
         state = hass.states.get("sensor.merton")
         assert state is not None
-        assert "Low" == state.state
-        assert "mdi:cloud-outline" == state.attributes["icon"]
-        assert "2017-08-03 03:00:00" == state.attributes["updated"]
-        assert 2 == state.attributes["sites"]
-        assert "Merton" == state.attributes["friendly_name"]
+        assert state.state == "Low"
+        assert state.attributes["icon"] == "mdi:cloud-outline"
+        assert state.attributes["updated"] == "2017-08-03 03:00:00"
+        assert state.attributes["sites"] == 2
+        assert state.attributes["friendly_name"] == "Merton"
 
         sites = state.attributes["data"]
         assert sites is not None
-        assert 2 == len(sites)
-        assert "ME2" == sites[0]["site_code"]
-        assert "Roadside" == sites[0]["site_type"]
-        assert "Merton Road" == sites[0]["site_name"]
-        assert "Low" == sites[0]["pollutants_status"]
+        assert len(sites) == 2
+        assert sites[0]["site_code"] == "ME2"
+        assert sites[0]["site_type"] == "Roadside"
+        assert sites[0]["site_name"] == "Merton Road"
+        assert sites[0]["pollutants_status"] == "Low"
 
         pollutants = sites[0]["pollutants"]
         assert pollutants is not None
-        assert 1 == len(pollutants)
-        assert "PM10" == pollutants[0]["code"]
-        assert "Low" == pollutants[0]["quality"]
-        assert 2 == int(pollutants[0]["index"])
-        assert "PM10 is Low" == pollutants[0]["summary"]
+        assert len(pollutants) == 1
+        assert pollutants[0]["code"] == "PM10"
+        assert pollutants[0]["quality"] == "Low"
+        assert int(pollutants[0]["index"]) == 2
+        assert pollutants[0]["summary"] == "PM10 is Low"
 
 
 async def test_api_failure(hass):
@@ -76,5 +76,5 @@ async def test_api_failure(hass):
 
         state = hass.states.get("sensor.merton")
         assert state is not None
-        assert None is state.attributes["updated"]
-        assert 0 == state.attributes["sites"]
+        assert state.attributes["updated"] is None
+        assert state.attributes["sites"] == 0


### PR DESCRIPTION
 * improved handling of api endpoint failure
 * included new test to exercise api endpoint failure

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40863
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
