### PR TITLE
Rewrite nsw_fuel_station tests to pytest style

### DIFF
--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -1,11 +1,9 @@
 """The tests for the NSW Fuel Station sensor platform."""
-import unittest
-
 from homeassistant.components import sensor
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
-from tests.common import assert_setup_component, get_test_home_assistant
+from tests.common import assert_setup_component
 
 VALID_CONFIG = {
     "platform": "nsw_fuel_station",
@@ -72,39 +70,33 @@ class FuelCheckClientMock:
         )
 
 
-class TestNSWFuelStation(unittest.TestCase):
-    """Test the NSW Fuel Station sensor platform."""
+@patch(
+    "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
+    new=FuelCheckClientMock,
+)
+async def test_setup(hass):
+    """Test the setup with custom settings."""
+    with assert_setup_component(1, sensor.DOMAIN):
+        assert await async_setup_component(
+            hass, sensor.DOMAIN, {"sensor": VALID_CONFIG}
+        )
+        await hass.async_block_till_done()
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.config = VALID_CONFIG
-        self.addCleanup(self.hass.stop)
+    fake_entities = ["my_fake_station_p95", "my_fake_station_e10"]
 
-    @patch(
-        "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
-        new=FuelCheckClientMock,
-    )
-    def test_setup(self):
-        """Test the setup with custom settings."""
-        with assert_setup_component(1, sensor.DOMAIN):
-            assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
-            self.hass.block_till_done()
+    for entity_id in fake_entities:
+        state = hass.states.get(f"sensor.{entity_id}")
+        assert state is not None
 
-        fake_entities = ["my_fake_station_p95", "my_fake_station_e10"]
 
-        for entity_id in fake_entities:
-            state = self.hass.states.get(f"sensor.{entity_id}")
-            assert state is not None
+@patch(
+    "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
+    new=FuelCheckClientMock,
+)
+async def test_sensor_values(hass):
+    """Test retrieval of sensor values."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
+    await hass.async_block_till_done()
 
-    @patch(
-        "homeassistant.components.nsw_fuel_station.sensor.FuelCheckClient",
-        new=FuelCheckClientMock,
-    )
-    def test_sensor_values(self):
-        """Test retrieval of sensor values."""
-        assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
-        self.hass.block_till_done()
-
-        assert "140.0" == self.hass.states.get("sensor.my_fake_station_e10").state
-        assert "150.0" == self.hass.states.get("sensor.my_fake_station_p95").state
+    assert "140.0" == hass.states.get("sensor.my_fake_station_e10").state
+    assert "150.0" == hass.states.get("sensor.my_fake_station_p95").state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40872
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
