### PR TITLE
Add Profiler integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -334,6 +334,7 @@ homeassistant/components/plum_lightpad/* @ColinHarrington @prystupa
 homeassistant/components/point/* @fredrike
 homeassistant/components/poolsense/* @haemishkyd
 homeassistant/components/powerwall/* @bdraco @jrester
+homeassistant/components/profiler/* @bdraco
 homeassistant/components/progettihwsw/* @ardaseremet
 homeassistant/components/prometheus/* @knyar
 homeassistant/components/proxmoxve/* @k4ds3 @jhollowe

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -12,10 +12,10 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 
+from .const import DOMAIN
+
 SERVICE_START = "start"
 CONF_SECONDS = "seconds"
-
-DOMAIN = "profiler"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
     )
     profiler = cProfile.Profile()
     profiler.enable()
-    await asyncio.sleep(float(call.data.get(CONF_SECONDS)))
+    await asyncio.sleep(float(call.data[CONF_SECONDS]))
     profiler.disable()
 
     cprofile_path = hass.config.path(f"profile.{start_time}.cprof")

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -1,0 +1,83 @@
+"""The profiler integration."""
+import asyncio
+import cProfile
+import logging
+import time
+
+from pyprof2calltree import convert
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.helpers.typing import ConfigType
+
+SERVICE_START = "start"
+CONF_SECONDS = "seconds"
+
+DOMAIN = "profiler"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the profiler component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Profiler from a config entry."""
+
+    lock = asyncio.Lock()
+
+    async def _async_run_profile(call: ServiceCall):
+        async with lock:
+            await _async_generate_profile(hass, call)
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_START,
+        _async_run_profile,
+        schema=vol.Schema(
+            {vol.Optional(CONF_SECONDS, default=60.0): vol.Coerce(float)}
+        ),
+    )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    hass.services.async_remove(domain=DOMAIN, service=SERVICE_START)
+    return True
+
+
+async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
+    start_time = int(time.time() * 1000000)
+    hass.components.persistent_notification.async_create(
+        "The profile started. This notification will be updated when it is complete.",
+        title="Profile Started",
+        notification_id=f"profiler_{start_time}",
+    )
+    profiler = cProfile.Profile()
+    profiler.enable()
+    await asyncio.sleep(float(call.data.get(CONF_SECONDS)))
+    profiler.disable()
+
+    cprofile_path = hass.config.path(f"profile.{start_time}.cprof")
+    callgrind_path = hass.config.path(f"callgrind.out.{start_time}")
+    await hass.async_add_executor_job(
+        _write_profile, profiler, cprofile_path, callgrind_path
+    )
+    hass.components.persistent_notification.async_create(
+        f"Wrote cProfile data to {cprofile_path} and callgrind data to {callgrind_path}",
+        title="Profile Complete",
+        notification_id=f"profiler_{start_time}",
+    )
+
+
+def _write_profile(profiler, cprofile_path, callgrind_path):
+    profiler.create_stats()
+    profiler.dump_stats(cprofile_path)
+    convert(profiler.getstats(), callgrind_path)

--- a/homeassistant/components/profiler/config_flow.py
+++ b/homeassistant/components/profiler/config_flow.py
@@ -1,0 +1,28 @@
+"""Config flow for Profiler integration."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+
+from .const import DEFAULT_NAME
+from .const import DOMAIN  # pylint: disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Profiler."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_UNKNOWN
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            return self.async_create_entry(title=DEFAULT_NAME, data={})
+
+        return self.async_show_form(step_id="user", data_schema=vol.Schema({}))

--- a/homeassistant/components/profiler/const.py
+++ b/homeassistant/components/profiler/const.py
@@ -1,0 +1,4 @@
+"""Consts used by profiler."""
+
+DOMAIN = "profiler"
+DEFAULT_NAME = "Profiler"

--- a/homeassistant/components/profiler/manifest.json
+++ b/homeassistant/components/profiler/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "profiler",
+  "name": "Profiler",
+  "documentation": "https://www.home-assistant.io/integrations/profiler",
+  "requirements": [
+    "pyprof2calltree==1.4.5"
+  ],
+  "codeowners": [
+    "@bdraco"
+  ],
+  "quality_scale": "internal",
+  "config_flow": true
+}

--- a/homeassistant/components/profiler/services.yaml
+++ b/homeassistant/components/profiler/services.yaml
@@ -1,0 +1,6 @@
+start:
+  description: Start the Profiler
+  fields:
+    seconds:
+      description: The number of seconds to run the profiler.
+      example: 60.0

--- a/homeassistant/components/profiler/strings.json
+++ b/homeassistant/components/profiler/strings.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Are you sure you want to set up the Profiler?"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    }
+  }
+}

--- a/homeassistant/components/profiler/translations/en.json
+++ b/homeassistant/components/profiler/translations/en.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Are you sure you want to set up the Profiler?"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -145,6 +145,7 @@ FLOWS = [
     "point",
     "poolsense",
     "powerwall",
+    "profiler",
     "progettihwsw",
     "ps4",
     "pvpc_hourly_pricing",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1588,6 +1588,9 @@ pypjlink2==1.2.1
 # homeassistant.components.point
 pypoint==1.1.2
 
+# homeassistant.components.profiler
+pyprof2calltree==1.4.5
+
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -774,6 +774,9 @@ pyowm==2.10.0
 # homeassistant.components.point
 pypoint==1.1.2
 
+# homeassistant.components.profiler
+pyprof2calltree==1.4.5
+
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.1.1
 

--- a/tests/components/profiler/__init__.py
+++ b/tests/components/profiler/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Profiler integration."""

--- a/tests/components/profiler/test_config_flow.py
+++ b/tests/components/profiler/test_config_flow.py
@@ -1,0 +1,45 @@
+"""Test the Profiler config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.profiler.const import DOMAIN
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_form_user(hass):
+    """Test we can setup by the user."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.profiler.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.profiler.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Profiler"
+    assert result2["data"] == {}
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_user_only_once(hass):
+    """Test we can setup by the user only once."""
+    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -1,0 +1,41 @@
+"""Test the Profiler config flow."""
+import os
+
+from homeassistant import setup
+from homeassistant.components.profiler import CONF_SECONDS, SERVICE_START
+from homeassistant.components.profiler.const import DOMAIN
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_basic_usage(hass, tmpdir):
+    """Test we can setup and the service is registered."""
+    test_dir = tmpdir.mkdir("profiles")
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.services.has_service(DOMAIN, SERVICE_START)
+
+    last_filename = None
+
+    def _mock_path(filename):
+        nonlocal last_filename
+        last_filename = f"{test_dir}/{filename}"
+        return last_filename
+
+    with patch("homeassistant.components.profiler.cProfile.Profile"), patch.object(
+        hass.config, "path", _mock_path
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_START, {CONF_SECONDS: 0.000001})
+        await hass.async_block_till_done()
+
+    assert os.path.exists(last_filename)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Provides a way to generate profiles to help track down performance issues.

A config flow is used which allows the integration to be setup without a restart when the problem is occurring.

Example usage: https://github.com/bdraco/profiler

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14856

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
