### PR TITLE
Use common strings for FritzBox config flow

### DIFF
--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -31,8 +31,8 @@ DATA_SCHEMA_CONFIRM = vol.Schema(
     }
 )
 
-RESULT_AUTH_FAILED = "auth_failed"
-RESULT_NOT_FOUND = "not_found"
+RESULT_AUTH_FAILED = "invalid_auth"
+RESULT_NOT_FOUND = "no_devices_found"
 RESULT_NOT_SUPPORTED = "not_supported"
 RESULT_SUCCESS = "success"
 
@@ -91,7 +91,7 @@ class FritzboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             for entry in self.hass.config_entries.async_entries(DOMAIN):
                 if entry.data[CONF_HOST] == user_input[CONF_HOST]:
-                    return self.async_abort(reason="already_configured")
+                    return self.async_abort(reason="already_configured_device")
 
             self._host = user_input[CONF_HOST]
             self._name = user_input[CONF_HOST]
@@ -131,7 +131,7 @@ class FritzboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if entry.data[CONF_HOST] == host:
                 if uuid and not entry.unique_id:
                     self.hass.config_entries.async_update_entry(entry, unique_id=uuid)
-                return self.async_abort(reason="already_configured")
+                return self.async_abort(reason="already_configured_device")
 
         self._host = host
         self._name = discovery_info.get(ATTR_UPNP_FRIENDLY_NAME) or host

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -20,12 +20,12 @@
     },
     "abort": {
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "already_configured": "This AVM FRITZ!Box is already configured.",
-      "not_found": "No supported AVM FRITZ!Box found on the network.",
+      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "not_supported": "Connected to AVM FRITZ!Box but it's unable to control Smart Home devices."
     },
     "error": {
-      "auth_failed": "Username and/or password are incorrect."
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     }
   }
 }

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -61,7 +61,7 @@ async def test_user_auth_failed(hass: HomeAssistantType, fritz: Mock):
     )
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"]["base"] == "auth_failed"
+    assert result["errors"]["base"] == "invalid_auth"
 
 
 async def test_user_not_successful(hass: HomeAssistantType, fritz: Mock):
@@ -72,7 +72,7 @@ async def test_user_not_successful(hass: HomeAssistantType, fritz: Mock):
         DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
     )
     assert result["type"] == "abort"
-    assert result["reason"] == "not_found"
+    assert result["reason"] == "no_devices_found"
 
 
 async def test_user_already_configured(hass: HomeAssistantType, fritz: Mock):
@@ -87,7 +87,7 @@ async def test_user_already_configured(hass: HomeAssistantType, fritz: Mock):
         DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
     )
     assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "already_configured_device"
 
 
 async def test_import(hass: HomeAssistantType, fritz: Mock):
@@ -162,7 +162,7 @@ async def test_ssdp_auth_failed(hass: HomeAssistantType, fritz: Mock):
     )
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
-    assert result["errors"]["base"] == "auth_failed"
+    assert result["errors"]["base"] == "invalid_auth"
 
 
 async def test_ssdp_not_successful(hass: HomeAssistantType, fritz: Mock):
@@ -180,7 +180,7 @@ async def test_ssdp_not_successful(hass: HomeAssistantType, fritz: Mock):
         user_input={CONF_PASSWORD: "whatever", CONF_USERNAME: "whatever"},
     )
     assert result["type"] == "abort"
-    assert result["reason"] == "not_found"
+    assert result["reason"] == "no_devices_found"
 
 
 async def test_ssdp_not_supported(hass: HomeAssistantType, fritz: Mock):
@@ -245,5 +245,5 @@ async def test_ssdp_already_configured(hass: HomeAssistantType, fritz: Mock):
         DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
     )
     assert result2["type"] == "abort"
-    assert result2["reason"] == "already_configured"
+    assert result2["reason"] == "already_configured_device"
     assert result["result"].unique_id == "only-a-test"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use of reference strings in FritzBox config flow. See #40578

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
