### PR TITLE
Improve template test lock

### DIFF
--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -18,11 +18,6 @@ def calls(hass):
     return async_mock_service(hass, "test", "automation")
 
 
-async def teardown_method(hass, method):
-    """Stop everything that was started."""
-    await hass.async_stop()
-
-
 async def test_template_state(hass):
     """Test template."""
     with assert_setup_component(1, lock.DOMAIN):

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -266,7 +266,7 @@ async def test_lock_action(hass, calls):
     """Test lock action."""
     assert await setup.async_setup_component(
         hass,
-        "lock",
+        lock.DOMAIN,
         {
             "lock": {
                 "platform": "template",
@@ -302,7 +302,7 @@ async def test_unlock_action(hass, calls):
     """Test unlock action."""
     assert await setup.async_setup_component(
         hass,
-        "lock",
+        lock.DOMAIN,
         {
             "lock": {
                 "platform": "template",
@@ -339,7 +339,7 @@ async def test_available_template_with_entities(hass):
 
     await setup.async_setup_component(
         hass,
-        "lock",
+        lock.DOMAIN,
         {
             "lock": {
                 "platform": "template",
@@ -377,7 +377,7 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
     """Test that an invalid availability keeps the device available."""
     await setup.async_setup_component(
         hass,
-        "lock",
+        lock.DOMAIN,
         {
             "lock": {
                 "platform": "template",
@@ -404,7 +404,7 @@ async def test_unique_id(hass):
     """Test unique_id option only creates one lock per id."""
     await setup.async_setup_component(
         hass,
-        "lock",
+        lock.DOMAIN,
         {
             "lock": {
                 "platform": "template",
@@ -422,7 +422,7 @@ async def test_unique_id(hass):
 
     await setup.async_setup_component(
         hass,
-        "lock",
+        lock.DOMAIN,
         {
             "lock": {
                 "platform": "template",

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -1,280 +1,43 @@
 """The tests for the Template lock platform."""
 import logging
 
+import pytest
+
 from homeassistant import setup
 from homeassistant.components import lock
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
-from homeassistant.core import callback
 
-from tests.common import assert_setup_component, get_test_home_assistant
+from tests.common import assert_setup_component, async_mock_service
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class TestTemplateLock:
-    """Test the Template lock."""
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
 
-    hass = None
-    calls = None
-    # pylint: disable=invalid-name
 
-    def setup_method(self, method):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.calls = []
+async def teardown_method(hass, method):
+    """Stop everything that was started."""
+    await hass.async_stop()
 
-        @callback
-        def record_call(service):
-            """Track function calls."""
-            self.calls.append(service)
 
-        self.hass.services.register("test", "automation", record_call)
-
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_template_state(self):
-        """Test template."""
-        with assert_setup_component(1, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {
-                    "lock": {
-                        "platform": "template",
-                        "name": "Test template lock",
-                        "value_template": "{{ states.switch.test_state.state }}",
-                        "lock": {
-                            "service": "switch.turn_on",
-                            "entity_id": "switch.test_state",
-                        },
-                        "unlock": {
-                            "service": "switch.turn_off",
-                            "entity_id": "switch.test_state",
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        self.hass.states.set("switch.test_state", STATE_ON)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("lock.test_template_lock")
-        assert state.state == lock.STATE_LOCKED
-
-        self.hass.states.set("switch.test_state", STATE_OFF)
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("lock.test_template_lock")
-        assert state.state == lock.STATE_UNLOCKED
-
-    def test_template_state_boolean_on(self):
-        """Test the setting of the state with boolean on."""
-        with assert_setup_component(1, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {
-                    "lock": {
-                        "platform": "template",
-                        "value_template": "{{ 1 == 1 }}",
-                        "lock": {
-                            "service": "switch.turn_on",
-                            "entity_id": "switch.test_state",
-                        },
-                        "unlock": {
-                            "service": "switch.turn_off",
-                            "entity_id": "switch.test_state",
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("lock.template_lock")
-        assert state.state == lock.STATE_LOCKED
-
-    def test_template_state_boolean_off(self):
-        """Test the setting of the state with off."""
-        with assert_setup_component(1, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {
-                    "lock": {
-                        "platform": "template",
-                        "value_template": "{{ 1 == 2 }}",
-                        "lock": {
-                            "service": "switch.turn_on",
-                            "entity_id": "switch.test_state",
-                        },
-                        "unlock": {
-                            "service": "switch.turn_off",
-                            "entity_id": "switch.test_state",
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("lock.template_lock")
-        assert state.state == lock.STATE_UNLOCKED
-
-    def test_template_syntax_error(self):
-        """Test templating syntax error."""
-        with assert_setup_component(0, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {
-                    "lock": {
-                        "platform": "template",
-                        "value_template": "{% if rubbish %}",
-                        "lock": {
-                            "service": "switch.turn_on",
-                            "entity_id": "switch.test_state",
-                        },
-                        "unlock": {
-                            "service": "switch.turn_off",
-                            "entity_id": "switch.test_state",
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_invalid_name_does_not_create(self):
-        """Test invalid name."""
-        with assert_setup_component(0, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {
-                    "switch": {
-                        "platform": "lock",
-                        "name": "{{%}",
-                        "value_template": "{{ rubbish }",
-                        "lock": {
-                            "service": "switch.turn_on",
-                            "entity_id": "switch.test_state",
-                        },
-                        "unlock": {
-                            "service": "switch.turn_off",
-                            "entity_id": "switch.test_state",
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_invalid_lock_does_not_create(self):
-        """Test invalid lock."""
-        with assert_setup_component(0, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {"lock": {"platform": "template", "value_template": "Invalid"}},
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_missing_template_does_not_create(self):
-        """Test missing template."""
-        with assert_setup_component(0, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {
-                    "lock": {
-                        "platform": "template",
-                        "not_value_template": "{{ states.switch.test_state.state }}",
-                        "lock": {
-                            "service": "switch.turn_on",
-                            "entity_id": "switch.test_state",
-                        },
-                        "unlock": {
-                            "service": "switch.turn_off",
-                            "entity_id": "switch.test_state",
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        assert self.hass.states.all() == []
-
-    def test_template_static(self, caplog):
-        """Test that we allow static templates."""
-        with assert_setup_component(1, "lock"):
-            assert setup.setup_component(
-                self.hass,
-                "lock",
-                {
-                    "lock": {
-                        "platform": "template",
-                        "value_template": "{{ 1 + 1 }}",
-                        "lock": {
-                            "service": "switch.turn_on",
-                            "entity_id": "switch.test_state",
-                        },
-                        "unlock": {
-                            "service": "switch.turn_off",
-                            "entity_id": "switch.test_state",
-                        },
-                    }
-                },
-            )
-
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get("lock.template_lock")
-        assert state.state == lock.STATE_UNLOCKED
-
-        self.hass.states.set("lock.template_lock", lock.STATE_LOCKED)
-        self.hass.block_till_done()
-        state = self.hass.states.get("lock.template_lock")
-        assert state.state == lock.STATE_LOCKED
-
-    def test_lock_action(self):
-        """Test lock action."""
-        assert setup.setup_component(
-            self.hass,
-            "lock",
+async def test_template_state(hass):
+    """Test template."""
+    with assert_setup_component(1, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
             {
                 "lock": {
                     "platform": "template",
+                    "name": "Test template lock",
                     "value_template": "{{ states.switch.test_state.state }}",
-                    "lock": {"service": "test.automation"},
+                    "lock": {
+                        "service": "switch.turn_on",
+                        "entity_id": "switch.test_state",
+                    },
                     "unlock": {
                         "service": "switch.turn_off",
                         "entity_id": "switch.test_state",
@@ -283,57 +46,292 @@ class TestTemplateLock:
             },
         )
 
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
-        self.hass.states.set("switch.test_state", STATE_OFF)
-        self.hass.block_till_done()
+    hass.states.async_set("switch.test_state", STATE_ON)
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get("lock.template_lock")
-        assert state.state == lock.STATE_UNLOCKED
+    state = hass.states.get("lock.test_template_lock")
+    assert state.state == lock.STATE_LOCKED
 
-        self.hass.services.call(
-            lock.DOMAIN, lock.SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.template_lock"}
-        )
-        self.hass.block_till_done()
+    hass.states.async_set("switch.test_state", STATE_OFF)
+    await hass.async_block_till_done()
 
-        assert len(self.calls) == 1
+    state = hass.states.get("lock.test_template_lock")
+    assert state.state == lock.STATE_UNLOCKED
 
-    def test_unlock_action(self):
-        """Test unlock action."""
-        assert setup.setup_component(
-            self.hass,
-            "lock",
+
+async def test_template_state_boolean_on(hass):
+    """Test the setting of the state with boolean on."""
+    with assert_setup_component(1, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
             {
                 "lock": {
                     "platform": "template",
-                    "value_template": "{{ states.switch.test_state.state }}",
+                    "value_template": "{{ 1 == 1 }}",
                     "lock": {
                         "service": "switch.turn_on",
                         "entity_id": "switch.test_state",
                     },
-                    "unlock": {"service": "test.automation"},
+                    "unlock": {
+                        "service": "switch.turn_off",
+                        "entity_id": "switch.test_state",
+                    },
                 }
             },
         )
 
-        self.hass.block_till_done()
-        self.hass.start()
-        self.hass.block_till_done()
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
 
-        self.hass.states.set("switch.test_state", STATE_ON)
-        self.hass.block_till_done()
+    state = hass.states.get("lock.template_lock")
+    assert state.state == lock.STATE_LOCKED
 
-        state = self.hass.states.get("lock.template_lock")
-        assert state.state == lock.STATE_LOCKED
 
-        self.hass.services.call(
-            lock.DOMAIN, lock.SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.template_lock"}
+async def test_template_state_boolean_off(hass):
+    """Test the setting of the state with off."""
+    with assert_setup_component(1, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
+            {
+                "lock": {
+                    "platform": "template",
+                    "value_template": "{{ 1 == 2 }}",
+                    "lock": {
+                        "service": "switch.turn_on",
+                        "entity_id": "switch.test_state",
+                    },
+                    "unlock": {
+                        "service": "switch.turn_off",
+                        "entity_id": "switch.test_state",
+                    },
+                }
+            },
         )
-        self.hass.block_till_done()
 
-        assert len(self.calls) == 1
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lock.template_lock")
+    assert state.state == lock.STATE_UNLOCKED
+
+
+async def test_template_syntax_error(hass):
+    """Test templating syntax error."""
+    with assert_setup_component(0, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
+            {
+                "lock": {
+                    "platform": "template",
+                    "value_template": "{% if rubbish %}",
+                    "lock": {
+                        "service": "switch.turn_on",
+                        "entity_id": "switch.test_state",
+                    },
+                    "unlock": {
+                        "service": "switch.turn_off",
+                        "entity_id": "switch.test_state",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.async_all() == []
+
+
+async def test_invalid_name_does_not_create(hass):
+    """Test invalid name."""
+    with assert_setup_component(0, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
+            {
+                "switch": {
+                    "platform": "lock",
+                    "name": "{{%}",
+                    "value_template": "{{ rubbish }",
+                    "lock": {
+                        "service": "switch.turn_on",
+                        "entity_id": "switch.test_state",
+                    },
+                    "unlock": {
+                        "service": "switch.turn_off",
+                        "entity_id": "switch.test_state",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.async_all() == []
+
+
+async def test_invalid_lock_does_not_create(hass):
+    """Test invalid lock."""
+    with assert_setup_component(0, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
+            {"lock": {"platform": "template", "value_template": "Invalid"}},
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.async_all() == []
+
+
+async def test_missing_template_does_not_create(hass):
+    """Test missing template."""
+    with assert_setup_component(0, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
+            {
+                "lock": {
+                    "platform": "template",
+                    "not_value_template": "{{ states.switch.test_state.state }}",
+                    "lock": {
+                        "service": "switch.turn_on",
+                        "entity_id": "switch.test_state",
+                    },
+                    "unlock": {
+                        "service": "switch.turn_off",
+                        "entity_id": "switch.test_state",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.async_all() == []
+
+
+async def test_template_static(hass, caplog):
+    """Test that we allow static templates."""
+    with assert_setup_component(1, lock.DOMAIN):
+        assert await setup.async_setup_component(
+            hass,
+            lock.DOMAIN,
+            {
+                "lock": {
+                    "platform": "template",
+                    "value_template": "{{ 1 + 1 }}",
+                    "lock": {
+                        "service": "switch.turn_on",
+                        "entity_id": "switch.test_state",
+                    },
+                    "unlock": {
+                        "service": "switch.turn_off",
+                        "entity_id": "switch.test_state",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lock.template_lock")
+    assert state.state == lock.STATE_UNLOCKED
+
+    hass.states.async_set("lock.template_lock", lock.STATE_LOCKED)
+    await hass.async_block_till_done()
+    state = hass.states.get("lock.template_lock")
+    assert state.state == lock.STATE_LOCKED
+
+
+async def test_lock_action(hass, calls):
+    """Test lock action."""
+    assert await setup.async_setup_component(
+        hass,
+        "lock",
+        {
+            "lock": {
+                "platform": "template",
+                "value_template": "{{ states.switch.test_state.state }}",
+                "lock": {"service": "test.automation"},
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            }
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    hass.states.async_set("switch.test_state", STATE_OFF)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lock.template_lock")
+    assert state.state == lock.STATE_UNLOCKED
+
+    await hass.services.async_call(
+        lock.DOMAIN, lock.SERVICE_LOCK, {ATTR_ENTITY_ID: "lock.template_lock"}
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+
+
+async def test_unlock_action(hass, calls):
+    """Test unlock action."""
+    assert await setup.async_setup_component(
+        hass,
+        "lock",
+        {
+            "lock": {
+                "platform": "template",
+                "value_template": "{{ states.switch.test_state.state }}",
+                "lock": {
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {"service": "test.automation"},
+            }
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    hass.states.async_set("switch.test_state", STATE_ON)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lock.template_lock")
+    assert state.state == lock.STATE_LOCKED
+
+    await hass.services.async_call(
+        lock.DOMAIN, lock.SERVICE_UNLOCK, {ATTR_ENTITY_ID: "lock.template_lock"}
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
 
 
 async def test_available_template_with_entities(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Improves the template integration tests for the lock platform. Rewrote tests to async pytest functions and using lock.DOMAIN constant now instead of string "lock".


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40899
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
