### PR TITLE
Rewrite imap_email_content tests to use pytest

### DIFF
--- a/tests/components/imap_email_content/test_sensor.py
+++ b/tests/components/imap_email_content/test_sensor.py
@@ -4,13 +4,10 @@ import datetime
 import email
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import unittest
 
 from homeassistant.components.imap_email_content import sensor as imap_email_content
-from homeassistant.helpers.event import track_state_change
+from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.template import Template
-
-from tests.common import get_test_home_assistant
 
 
 class FakeEMailReader:
@@ -31,207 +28,203 @@ class FakeEMailReader:
         return self._messages.popleft()
 
 
-class EmailContentSensor(unittest.TestCase):
-    """Test the IMAP email content sensor."""
+async def test_allowed_sender(hass):
+    """Test emails from allowed sender."""
+    test_message = email.message.Message()
+    test_message["From"] = "sender@test.com"
+    test_message["Subject"] = "Test"
+    test_message["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
+    test_message.set_payload("Test Message")
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
+    sensor = imap_email_content.EmailContentSensor(
+        hass,
+        FakeEMailReader(deque([test_message])),
+        "test_emails_sensor",
+        ["sender@test.com"],
+        None,
+    )
 
-    def test_allowed_sender(self):
-        """Test emails from allowed sender."""
-        test_message = email.message.Message()
-        test_message["From"] = "sender@test.com"
-        test_message["Subject"] = "Test"
-        test_message["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
-        test_message.set_payload("Test Message")
+    sensor.entity_id = "sensor.emailtest"
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
+    assert "Test" == sensor.state
+    assert "Test Message" == sensor.device_state_attributes["body"]
+    assert "sender@test.com" == sensor.device_state_attributes["from"]
+    assert "Test" == sensor.device_state_attributes["subject"]
+    assert (
+        datetime.datetime(2016, 1, 1, 12, 44, 57)
+        == sensor.device_state_attributes["date"]
+    )
 
-        sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([test_message])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None,
-        )
 
-        sensor.entity_id = "sensor.emailtest"
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
-        assert "Test" == sensor.state
-        assert "Test Message" == sensor.device_state_attributes["body"]
-        assert "sender@test.com" == sensor.device_state_attributes["from"]
-        assert "Test" == sensor.device_state_attributes["subject"]
-        assert (
-            datetime.datetime(2016, 1, 1, 12, 44, 57)
-            == sensor.device_state_attributes["date"]
-        )
+async def test_multi_part_with_text(hass):
+    """Test multi part emails."""
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Link"
+    msg["From"] = "sender@test.com"
 
-    def test_multi_part_with_text(self):
-        """Test multi part emails."""
-        msg = MIMEMultipart("alternative")
-        msg["Subject"] = "Link"
-        msg["From"] = "sender@test.com"
+    text = "Test Message"
+    html = "<html><head></head><body>Test Message</body></html>"
 
-        text = "Test Message"
-        html = "<html><head></head><body>Test Message</body></html>"
+    textPart = MIMEText(text, "plain")
+    htmlPart = MIMEText(html, "html")
 
-        textPart = MIMEText(text, "plain")
-        htmlPart = MIMEText(html, "html")
+    msg.attach(textPart)
+    msg.attach(htmlPart)
 
-        msg.attach(textPart)
-        msg.attach(htmlPart)
+    sensor = imap_email_content.EmailContentSensor(
+        hass,
+        FakeEMailReader(deque([msg])),
+        "test_emails_sensor",
+        ["sender@test.com"],
+        None,
+    )
 
-        sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([msg])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None,
-        )
+    sensor.entity_id = "sensor.emailtest"
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
+    assert "Link" == sensor.state
+    assert "Test Message" == sensor.device_state_attributes["body"]
 
-        sensor.entity_id = "sensor.emailtest"
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
-        assert "Link" == sensor.state
-        assert "Test Message" == sensor.device_state_attributes["body"]
 
-    def test_multi_part_only_html(self):
-        """Test multi part emails with only HTML."""
-        msg = MIMEMultipart("alternative")
-        msg["Subject"] = "Link"
-        msg["From"] = "sender@test.com"
+async def test_multi_part_only_html(hass):
+    """Test multi part emails with only HTML."""
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Link"
+    msg["From"] = "sender@test.com"
 
-        html = "<html><head></head><body>Test Message</body></html>"
+    html = "<html><head></head><body>Test Message</body></html>"
 
-        htmlPart = MIMEText(html, "html")
+    htmlPart = MIMEText(html, "html")
 
-        msg.attach(htmlPart)
+    msg.attach(htmlPart)
 
-        sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([msg])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None,
-        )
+    sensor = imap_email_content.EmailContentSensor(
+        hass,
+        FakeEMailReader(deque([msg])),
+        "test_emails_sensor",
+        ["sender@test.com"],
+        None,
+    )
 
-        sensor.entity_id = "sensor.emailtest"
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
-        assert "Link" == sensor.state
-        assert (
-            "<html><head></head><body>Test Message</body></html>"
-            == sensor.device_state_attributes["body"]
-        )
+    sensor.entity_id = "sensor.emailtest"
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
+    assert "Link" == sensor.state
+    assert (
+        "<html><head></head><body>Test Message</body></html>"
+        == sensor.device_state_attributes["body"]
+    )
 
-    def test_multi_part_only_other_text(self):
-        """Test multi part emails with only other text."""
-        msg = MIMEMultipart("alternative")
-        msg["Subject"] = "Link"
-        msg["From"] = "sender@test.com"
 
-        other = "Test Message"
+async def test_multi_part_only_other_text(hass):
+    """Test multi part emails with only other text."""
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Link"
+    msg["From"] = "sender@test.com"
 
-        htmlPart = MIMEText(other, "other")
+    other = "Test Message"
 
-        msg.attach(htmlPart)
+    htmlPart = MIMEText(other, "other")
 
-        sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([msg])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None,
-        )
+    msg.attach(htmlPart)
 
-        sensor.entity_id = "sensor.emailtest"
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
-        assert "Link" == sensor.state
-        assert "Test Message" == sensor.device_state_attributes["body"]
+    sensor = imap_email_content.EmailContentSensor(
+        hass,
+        FakeEMailReader(deque([msg])),
+        "test_emails_sensor",
+        ["sender@test.com"],
+        None,
+    )
 
-    def test_multiple_emails(self):
-        """Test multiple emails."""
-        states = []
+    sensor.entity_id = "sensor.emailtest"
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
+    assert "Link" == sensor.state
+    assert "Test Message" == sensor.device_state_attributes["body"]
 
-        test_message1 = email.message.Message()
-        test_message1["From"] = "sender@test.com"
-        test_message1["Subject"] = "Test"
-        test_message1["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
-        test_message1.set_payload("Test Message")
 
-        test_message2 = email.message.Message()
-        test_message2["From"] = "sender@test.com"
-        test_message2["Subject"] = "Test 2"
-        test_message2["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
-        test_message2.set_payload("Test Message 2")
+async def test_multiple_emails(hass):
+    """Test multiple emails."""
+    states = []
 
-        def state_changed_listener(entity_id, from_s, to_s):
-            states.append(to_s)
+    test_message1 = email.message.Message()
+    test_message1["From"] = "sender@test.com"
+    test_message1["Subject"] = "Test"
+    test_message1["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
+    test_message1.set_payload("Test Message")
 
-        track_state_change(self.hass, ["sensor.emailtest"], state_changed_listener)
+    test_message2 = email.message.Message()
+    test_message2["From"] = "sender@test.com"
+    test_message2["Subject"] = "Test 2"
+    test_message2["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
+    test_message2.set_payload("Test Message 2")
 
-        sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([test_message1, test_message2])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            None,
-        )
+    def state_changed_listener(entity_id, from_s, to_s):
+        states.append(to_s)
 
-        sensor.entity_id = "sensor.emailtest"
+    async_track_state_change(hass, ["sensor.emailtest"], state_changed_listener)
 
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
+    sensor = imap_email_content.EmailContentSensor(
+        hass,
+        FakeEMailReader(deque([test_message1, test_message2])),
+        "test_emails_sensor",
+        ["sender@test.com"],
+        None,
+    )
 
-        assert "Test" == states[0].state
-        assert "Test 2" == states[1].state
+    sensor.entity_id = "sensor.emailtest"
 
-        assert "Test Message 2" == sensor.device_state_attributes["body"]
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
 
-    def test_sender_not_allowed(self):
-        """Test not whitelisted emails."""
-        test_message = email.message.Message()
-        test_message["From"] = "sender@test.com"
-        test_message["Subject"] = "Test"
-        test_message["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
-        test_message.set_payload("Test Message")
+    assert "Test" == states[0].state
+    assert "Test 2" == states[1].state
 
-        sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([test_message])),
-            "test_emails_sensor",
-            ["other@test.com"],
-            None,
-        )
+    assert "Test Message 2" == sensor.device_state_attributes["body"]
 
-        sensor.entity_id = "sensor.emailtest"
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
-        assert sensor.state is None
 
-    def test_template(self):
-        """Test value template."""
-        test_message = email.message.Message()
-        test_message["From"] = "sender@test.com"
-        test_message["Subject"] = "Test"
-        test_message["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
-        test_message.set_payload("Test Message")
+async def test_sender_not_allowed(hass):
+    """Test not whitelisted emails."""
+    test_message = email.message.Message()
+    test_message["From"] = "sender@test.com"
+    test_message["Subject"] = "Test"
+    test_message["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
+    test_message.set_payload("Test Message")
 
-        sensor = imap_email_content.EmailContentSensor(
-            self.hass,
-            FakeEMailReader(deque([test_message])),
-            "test_emails_sensor",
-            ["sender@test.com"],
-            Template(
-                "{{ subject }} from {{ from }} with message {{ body }}", self.hass
-            ),
-        )
+    sensor = imap_email_content.EmailContentSensor(
+        hass,
+        FakeEMailReader(deque([test_message])),
+        "test_emails_sensor",
+        ["other@test.com"],
+        None,
+    )
 
-        sensor.entity_id = "sensor.emailtest"
-        sensor.schedule_update_ha_state(True)
-        self.hass.block_till_done()
-        assert "Test from sender@test.com with message Test Message" == sensor.state
+    sensor.entity_id = "sensor.emailtest"
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
+    assert sensor.state is None
+
+
+async def test_template(hass):
+    """Test value template."""
+    test_message = email.message.Message()
+    test_message["From"] = "sender@test.com"
+    test_message["Subject"] = "Test"
+    test_message["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
+    test_message.set_payload("Test Message")
+
+    sensor = imap_email_content.EmailContentSensor(
+        hass,
+        FakeEMailReader(deque([test_message])),
+        "test_emails_sensor",
+        ["sender@test.com"],
+        Template("{{ subject }} from {{ from }} with message {{ body }}", hass),
+    )
+
+    sensor.entity_id = "sensor.emailtest"
+    sensor.async_schedule_update_ha_state(True)
+    await hass.async_block_till_done()
+    assert "Test from sender@test.com with message Test Message" == sensor.state


### PR DESCRIPTION
## Proposed change
Refactor tests for the imap_email_content component from unittest to pytest.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #40858
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved