### PR TITLE
Return attribute dict directly without temporary variable

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -175,12 +175,11 @@ class AlarmControlPanelEntity(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes."""
-        state_attr = {
+        return {
             ATTR_CODE_FORMAT: self.code_format,
             ATTR_CHANGED_BY: self.changed_by,
             ATTR_CODE_ARM_REQUIRED: self.code_arm_required,
         }
-        return state_attr
 
 
 class AlarmControlPanel(AlarmControlPanelEntity):

--- a/homeassistant/components/alarmdecoder/binary_sensor.py
+++ b/homeassistant/components/alarmdecoder/binary_sensor.py
@@ -120,8 +120,7 @@ class AlarmDecoderBinarySensor(BinarySensorEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {}
-        attr[CONF_ZONE_NUMBER] = self._zone_number
+        attr = {CONF_ZONE_NUMBER: self._zone_number}
         if self._rfid and self._rfstate is not None:
             attr[ATTR_RF_BIT0] = bool(self._rfstate & 0x01)
             attr[ATTR_RF_LOW_BAT] = bool(self._rfstate & 0x02)

--- a/homeassistant/components/bom/sensor.py
+++ b/homeassistant/components/bom/sensor.py
@@ -175,7 +175,7 @@ class BOMCurrentSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {
+        return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             ATTR_LAST_UPDATE: self.bom_data.last_updated,
             ATTR_SENSOR_ID: self._condition,
@@ -183,8 +183,6 @@ class BOMCurrentSensor(Entity):
             ATTR_STATION_NAME: self.bom_data.latest_data["name"],
             ATTR_ZONE_ID: self.bom_data.latest_data["history_product"],
         }
-
-        return attr
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -86,9 +86,7 @@ class ECCamera(Camera):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {ATTR_ATTRIBUTION: CONF_ATTRIBUTION, ATTR_UPDATED: self.timestamp}
-
-        return attr
+        return {ATTR_ATTRIBUTION: CONF_ATTRIBUTION, ATTR_UPDATED: self.timestamp}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -78,12 +78,11 @@ class Filesize(Entity):
     @property
     def device_state_attributes(self):
         """Return other details about the sensor state."""
-        attr = {
+        return {
             "path": self._path,
             "last_updated": self._last_updated,
             "bytes": self._size,
         }
-        return attr
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/folder/sensor.py
+++ b/homeassistant/components/folder/sensor.py
@@ -94,14 +94,13 @@ class Folder(Entity):
     @property
     def device_state_attributes(self):
         """Return other details about the sensor state."""
-        attr = {
+        return {
             "path": self._folder_path,
             "filter": self._filter_term,
             "number_of_files": self._number_of_files,
             "bytes": self._size,
             "file_list": self._file_list,
         }
-        return attr
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/fritzbox_netmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_netmonitor/sensor.py
@@ -96,21 +96,20 @@ class FritzboxMonitorSensor(Entity):
     def state_attributes(self):
         """Return the device state attributes."""
         # Don't return attributes if FritzBox is unreachable
-        attr = {}
-        if self._state != STATE_UNAVAILABLE:
-            attr = {
-                ATTR_IS_LINKED: self._is_linked,
-                ATTR_IS_CONNECTED: self._is_connected,
-                ATTR_EXTERNAL_IP: self._external_ip,
-                ATTR_UPTIME: self._uptime,
-                ATTR_BYTES_SENT: self._bytes_sent,
-                ATTR_BYTES_RECEIVED: self._bytes_received,
-                ATTR_TRANSMISSION_RATE_UP: self._transmission_rate_up,
-                ATTR_TRANSMISSION_RATE_DOWN: self._transmission_rate_down,
-                ATTR_MAX_BYTE_RATE_UP: self._max_byte_rate_up,
-                ATTR_MAX_BYTE_RATE_DOWN: self._max_byte_rate_down,
-            }
-        return attr
+        if self._state == STATE_UNAVAILABLE:
+            return {}
+        return {
+            ATTR_IS_LINKED: self._is_linked,
+            ATTR_IS_CONNECTED: self._is_connected,
+            ATTR_EXTERNAL_IP: self._external_ip,
+            ATTR_UPTIME: self._uptime,
+            ATTR_BYTES_SENT: self._bytes_sent,
+            ATTR_BYTES_RECEIVED: self._bytes_received,
+            ATTR_TRANSMISSION_RATE_UP: self._transmission_rate_up,
+            ATTR_TRANSMISSION_RATE_DOWN: self._transmission_rate_down,
+            ATTR_MAX_BYTE_RATE_UP: self._max_byte_rate_up,
+            ATTR_MAX_BYTE_RATE_DOWN: self._max_byte_rate_down,
+        }
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/fritzbox_netmonitor/sensor.py
+++ b/homeassistant/components/fritzbox_netmonitor/sensor.py
@@ -96,20 +96,20 @@ class FritzboxMonitorSensor(Entity):
     def state_attributes(self):
         """Return the device state attributes."""
         # Don't return attributes if FritzBox is unreachable
-        if self._state == STATE_UNAVAILABLE:
-            return {}
-        attr = {
-            ATTR_IS_LINKED: self._is_linked,
-            ATTR_IS_CONNECTED: self._is_connected,
-            ATTR_EXTERNAL_IP: self._external_ip,
-            ATTR_UPTIME: self._uptime,
-            ATTR_BYTES_SENT: self._bytes_sent,
-            ATTR_BYTES_RECEIVED: self._bytes_received,
-            ATTR_TRANSMISSION_RATE_UP: self._transmission_rate_up,
-            ATTR_TRANSMISSION_RATE_DOWN: self._transmission_rate_down,
-            ATTR_MAX_BYTE_RATE_UP: self._max_byte_rate_up,
-            ATTR_MAX_BYTE_RATE_DOWN: self._max_byte_rate_down,
-        }
+        attr = {}
+        if self._state != STATE_UNAVAILABLE:
+            attr = {
+                ATTR_IS_LINKED: self._is_linked,
+                ATTR_IS_CONNECTED: self._is_connected,
+                ATTR_EXTERNAL_IP: self._external_ip,
+                ATTR_UPTIME: self._uptime,
+                ATTR_BYTES_SENT: self._bytes_sent,
+                ATTR_BYTES_RECEIVED: self._bytes_received,
+                ATTR_TRANSMISSION_RATE_UP: self._transmission_rate_up,
+                ATTR_TRANSMISSION_RATE_DOWN: self._transmission_rate_down,
+                ATTR_MAX_BYTE_RATE_UP: self._max_byte_rate_up,
+                ATTR_MAX_BYTE_RATE_DOWN: self._max_byte_rate_down,
+            }
         return attr
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/homeassistant/components/hikvision/binary_sensor.py
+++ b/homeassistant/components/hikvision/binary_sensor.py
@@ -255,8 +255,7 @@ class HikvisionBinarySensor(BinarySensorEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {}
-        attr[ATTR_LAST_TRIP_TIME] = self._sensor_last_update()
+        attr = {ATTR_LAST_TRIP_TIME: self._sensor_last_update()}
 
         if self._delay != 0:
             attr[ATTR_DELAY] = self._delay

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -233,8 +233,7 @@ class HMHub(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes."""
-        attr = self._variables.copy()
-        return attr
+        return self._variables.copy()
 
     @property
     def icon(self):

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -173,9 +173,7 @@ class ImageProcessingFaceEntity(ImageProcessingEntity):
     @property
     def state_attributes(self):
         """Return device specific state attributes."""
-        attr = {ATTR_FACES: self.faces, ATTR_TOTAL_FACES: self.total_faces}
-
-        return attr
+        return {ATTR_FACES: self.faces, ATTR_TOTAL_FACES: self.total_faces}
 
     def process_faces(self, faces, total):
         """Send event with detected faces and store data."""

--- a/homeassistant/components/iota/__init__.py
+++ b/homeassistant/components/iota/__init__.py
@@ -72,8 +72,7 @@ class IotaDevice(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {CONF_WALLET_NAME: self._name}
-        return attr
+        return {CONF_WALLET_NAME: self._name}
 
     @property
     def api(self):

--- a/homeassistant/components/lutron/binary_sensor.py
+++ b/homeassistant/components/lutron/binary_sensor.py
@@ -51,6 +51,4 @@ class LutronOccupancySensor(LutronDevice, BinarySensorEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {}
-        attr["lutron_integration_id"] = self._lutron_device.id
-        return attr
+        return {"lutron_integration_id": self._lutron_device.id}

--- a/homeassistant/components/lutron/cover.py
+++ b/homeassistant/components/lutron/cover.py
@@ -66,6 +66,4 @@ class LutronCover(LutronDevice, CoverEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {}
-        attr["Lutron Integration ID"] = self._lutron_device.id
-        return attr
+        return {"Lutron Integration ID": self._lutron_device.id}

--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -71,8 +71,7 @@ class LutronLight(LutronDevice, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {"lutron_integration_id": self._lutron_device.id}
-        return attr
+        return {"lutron_integration_id": self._lutron_device.id}
 
     @property
     def is_on(self):

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -48,9 +48,7 @@ class LutronSwitch(LutronDevice, SwitchEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {}
-        attr["lutron_integration_id"] = self._lutron_device.id
-        return attr
+        return {"lutron_integration_id": self._lutron_device.id}
 
     @property
     def is_on(self):
@@ -83,12 +81,11 @@ class LutronLed(LutronDevice, SwitchEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {
+        return {
             "keypad": self._keypad_name,
             "scene": self._scene_name,
             "led": self._lutron_device.name,
         }
-        return attr
 
     @property
     def is_on(self):

--- a/homeassistant/components/mfi/switch.py
+++ b/homeassistant/components/mfi/switch.py
@@ -114,7 +114,7 @@ class MfiSwitch(SwitchEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes for the device."""
-        attr = {}
-        attr["volts"] = round(self._port.data.get("v_rms", 0), 1)
-        attr["amps"] = round(self._port.data.get("i_rms", 0), 1)
-        return attr
+        return {
+            "volts": round(self._port.data.get("v_rms", 0), 1),
+            "amps": round(self._port.data.get("i_rms", 0), 1),
+        }

--- a/homeassistant/components/miflora/sensor.py
+++ b/homeassistant/components/miflora/sensor.py
@@ -184,8 +184,7 @@ class MiFloraSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {ATTR_LAST_SUCCESSFUL_UPDATE: self.last_successful_update}
-        return attr
+        return {ATTR_LAST_SUCCESSFUL_UPDATE: self.last_successful_update}
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/openalpr_local/image_processing.py
+++ b/homeassistant/components/openalpr_local/image_processing.py
@@ -104,9 +104,7 @@ class ImageProcessingAlprEntity(ImageProcessingEntity):
     @property
     def state_attributes(self):
         """Return device specific state attributes."""
-        attr = {ATTR_PLATES: self.plates, ATTR_VEHICLES: self.vehicles}
-
-        return attr
+        return {ATTR_PLATES: self.plates, ATTR_VEHICLES: self.vehicles}
 
     def process_plates(self, plates, vehicles):
         """Send event with new plates and store data."""

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -597,15 +597,13 @@ class PlexMediaPlayer(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return the scene state attributes."""
-        attr = {
+        return {
             "media_content_rating": self._media_content_rating,
             "session_username": self.username,
             "media_library_name": self._app_name,
             "summary": self.media_summary,
             "player_source": self.player_source,
         }
-
-        return attr
 
     @property
     def device_info(self):

--- a/homeassistant/components/simulated/sensor.py
+++ b/homeassistant/components/simulated/sensor.py
@@ -142,7 +142,7 @@ class SimulatedSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return other details about the sensor state."""
-        attr = {
+        return {
             "amplitude": self._amp,
             "mean": self._mean,
             "period": self._period,
@@ -151,4 +151,3 @@ class SimulatedSensor(Entity):
             "seed": self._seed,
             "relative_to_epoch": self._relative_to_epoch,
         }
-        return attr

--- a/homeassistant/components/swiss_public_transport/sensor.py
+++ b/homeassistant/components/swiss_public_transport/sensor.py
@@ -103,7 +103,7 @@ class SwissPublicTransportSensor(Entity):
             self._opendata.connections[0]["departure"]
         ) - dt_util.as_local(dt_util.utcnow())
 
-        attr = {
+        return {
             ATTR_TRAIN_NUMBER: self._opendata.connections[0]["number"],
             ATTR_PLATFORM: self._opendata.connections[0]["platform"],
             ATTR_TRANSFERS: self._opendata.connections[0]["transfers"],
@@ -116,7 +116,6 @@ class SwissPublicTransportSensor(Entity):
             ATTR_ATTRIBUTION: ATTRIBUTION,
             ATTR_DELAY: self._opendata.connections[0]["delay"],
         }
-        return attr
 
     @property
     def icon(self):

--- a/homeassistant/components/synology_dsm/binary_sensor.py
+++ b/homeassistant/components/synology_dsm/binary_sensor.py
@@ -67,7 +67,4 @@ class SynoDSMStorageBinarySensor(SynologyDSMDeviceEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the state."""
-        attr = getattr(self._api.storage, self.entity_type)(self._device_id)
-        if attr is None:
-            return None
-        return attr
+        return getattr(self._api.storage, self.entity_type)(self._device_id)

--- a/homeassistant/components/tradfri/cover.py
+++ b/homeassistant/components/tradfri/cover.py
@@ -31,8 +31,7 @@ class TradfriCover(TradfriBaseDevice, CoverEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {ATTR_MODEL: self._device.device_info.model_number}
-        return attr
+        return {ATTR_MODEL: self._device.device_info.model_number}
 
     @property
     def current_cover_position(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Just some quick clean up to remove using unnecessary attribute dictionary and then immediately returning them.

```python
# Before
def attributes(self):
    attr = {"key": "value"}
    return attr

# After
def attributes(self):
    return {"key": "value"}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
