### PR TITLE
Convert States to dicts via as_dict only once

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -65,7 +65,7 @@ class Events(Base):  # type: ignore
         return Events(
             event_type=event.event_type,
             event_data=event_data or json.dumps(event.data, cls=JSONEncoder),
-            origin=str(event.origin),
+            origin=str(event.origin.value),
             time_fired=event.time_fired,
             context_id=event.context.id,
             context_user_id=event.context.user_id,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -826,12 +826,17 @@ class State:
         Ensures: state == State.from_dict(state.as_dict())
         """
         if not self._as_dict:
+            last_changed_isoformat = self.last_changed.isoformat()
+            if self.last_changed == self.last_updated:
+                last_updated_isoformat = last_changed_isoformat
+            else:
+                last_updated_isoformat = self.last_updated.isoformat()
             self._as_dict = {
                 "entity_id": self.entity_id,
                 "state": self.state,
                 "attributes": dict(self.attributes),
-                "last_changed": self.last_changed.isoformat(),
-                "last_updated": self.last_updated.isoformat(),
+                "last_changed": last_changed_isoformat,
+                "last_updated": last_updated_isoformat,
                 "context": self.context.as_dict(),
             }
         return self._as_dict

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -562,7 +562,7 @@ class Event:
         return {
             "event_type": self.event_type,
             "data": dict(self.data),
-            "origin": str(self.origin),
+            "origin": str(self.origin.value),
             "time_fired": self.time_fired.isoformat(),
             "context": self.context.as_dict(),
         }

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -532,15 +532,7 @@ class EventOrigin(enum.Enum):
 class Event:
     """Representation of an event within the bus."""
 
-    __slots__ = [
-        "__weakref__",
-        "event_type",
-        "data",
-        "origin",
-        "time_fired",
-        "context",
-        "_as_dict",
-    ]
+    __slots__ = ["__weakref__", "event_type", "data", "origin", "time_fired", "context"]
 
     def __init__(
         self,
@@ -556,7 +548,6 @@ class Event:
         self.origin = origin
         self.time_fired = time_fired or dt_util.utcnow()
         self.context: Context = context or Context()
-        self._as_dict: Optional[Dict[str, Collection[Any]]] = None
 
     def __hash__(self) -> int:
         """Make hashable."""
@@ -568,15 +559,13 @@ class Event:
 
         Async friendly.
         """
-        if not self._as_dict:
-            self._as_dict = {
-                "event_type": self.event_type,
-                "data": dict(self.data),
-                "origin": str(self.origin),
-                "time_fired": self.time_fired.isoformat(),
-                "context": self.context.as_dict(),
-            }
-        return self._as_dict
+        return {
+            "event_type": self.event_type,
+            "data": dict(self.data),
+            "origin": str(self.origin),
+            "time_fired": self.time_fired.isoformat(),
+            "context": self.context.as_dict(),
+        }
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -532,7 +532,7 @@ class EventOrigin(enum.Enum):
 class Event:
     """Representation of an event within the bus."""
 
-    __slots__ = ["__weakref__", "event_type", "data", "origin", "time_fired", "context"]
+    __slots__ = ["event_type", "data", "origin", "time_fired", "context"]
 
     def __init__(
         self,

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -201,10 +201,7 @@ async def test_get_states(hass, websocket_client):
 
     states = []
     for state in hass.states.async_all():
-        state = state.as_dict()
-        state["last_changed"] = state["last_changed"].isoformat()
-        state["last_updated"] = state["last_updated"].isoformat()
-        states.append(state)
+        states.append(state.as_dict())
 
     assert msg["result"] == states
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -338,6 +338,7 @@ def test_state_as_dict():
     assert state.as_dict() == expected
     # 2nd time to verify cache
     assert state.as_dict() == expected
+    assert state.as_dict() is state.as_dict()
 
 
 class TestEventBus(unittest.TestCase):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -291,7 +291,7 @@ def test_event_repr():
 
 
 def test_event_as_dict():
-    """Test as Event as dictionary."""
+    """Test an Event as dictionary."""
     event_type = "some_type"
     now = dt_util.utcnow()
     data = {"some": "attr"}
@@ -301,7 +301,7 @@ def test_event_as_dict():
         "event_type": event_type,
         "data": data,
         "origin": "LOCAL",
-        "time_fired": now,
+        "time_fired": now.isoformat(),
         "context": {
             "id": event.context.id,
             "parent_id": None,
@@ -309,6 +309,35 @@ def test_event_as_dict():
         },
     }
     assert event.as_dict() == expected
+    # 2nd time to verify cache
+    assert event.as_dict() == expected
+
+
+def test_state_as_dict():
+    """Test a State as dictionary."""
+    last_time = datetime(1984, 12, 8, 12, 0, 0)
+    state = ha.State(
+        "happy.happy",
+        "on",
+        {"pig": "dog"},
+        last_updated=last_time,
+        last_changed=last_time,
+    )
+    expected = {
+        "context": {
+            "id": state.context.id,
+            "parent_id": None,
+            "user_id": state.context.user_id,
+        },
+        "entity_id": "happy.happy",
+        "attributes": {"pig": "dog"},
+        "last_changed": last_time.isoformat(),
+        "last_updated": last_time.isoformat(),
+        "state": "on",
+    }
+    assert state.as_dict() == expected
+    # 2nd time to verify cache
+    assert state.as_dict() == expected
 
 
 class TestEventBus(unittest.TestCase):


### PR DESCRIPTION
Noticed while reviewing the `py-spy` in #40292

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change assumes that the intent is for `State` objects
to be immutable.

Since we convert every State to json at least
twice, we can avoid the conversion overhead by remembering the first
as_dict call.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
