### PR TITLE
Fix slack message icon override

### DIFF
--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -209,8 +209,9 @@ class SlackNotificationService(BaseNotificationService):
             "username": username,
         }
 
-        if self._icon:
-            if self._icon.lower().startswith(("http://", "https://")):
+        icon = icon or self._icon
+        if icon:
+            if icon.lower().startswith(("http://", "https://")):
                 icon_type = "url"
             else:
                 icon_type = "emoji"

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -938,6 +938,9 @@ simplehound==0.3
 # homeassistant.components.simplisafe
 simplisafe-python==9.3.3
 
+# homeassistant.components.slack
+slackclient==2.5.0
+
 # homeassistant.components.sleepiq
 sleepyq==0.7
 

--- a/tests/components/slack/__init__.py
+++ b/tests/components/slack/__init__.py
@@ -1,0 +1,1 @@
+"""Slack notification tests"""

--- a/tests/components/slack/__init__.py
+++ b/tests/components/slack/__init__.py
@@ -1,1 +1,1 @@
-"""Slack notification tests"""
+"""Slack notification tests."""

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -1,0 +1,56 @@
+"""Test slack notifications"""
+from homeassistant.components.slack.notify import SlackNotificationService
+
+from tests.async_mock import AsyncMock
+
+
+async def test_message_includes_default_emoji():
+    """Tests that overriding the default icon emoji when sending a message works."""
+    mock_client = AsyncMock()
+    expected_icon = ":robot_face:"
+    service = SlackNotificationService(None, mock_client, "_", "_", expected_icon)
+
+    await service.async_send_message("test")
+
+    mock_fn = mock_client.chat_postMessage
+    mock_fn.assert_called_once()
+    assert mock_fn.mock_calls[0].kwargs["icon_emoji"] == expected_icon
+
+
+async def test_message_emoji_overrides_default():
+    """Tests that overriding the default icon emoji when sending a message works."""
+    mock_client = AsyncMock()
+    service = SlackNotificationService(None, mock_client, "_", "_", "default_icon")
+
+    expected_icon = ":new:"
+    await service.async_send_message("test", data={"icon": expected_icon})
+
+    mock_fn = mock_client.chat_postMessage
+    mock_fn.assert_called_once()
+    assert mock_fn.mock_calls[0].kwargs["icon_emoji"] == expected_icon
+
+
+async def test_message_includes_default_icon_url():
+    """Tests that overriding the default icon url when sending a message works."""
+    mock_client = AsyncMock()
+    expected_icon = "https://example.com/hass.png"
+    service = SlackNotificationService(None, mock_client, "_", "_", expected_icon)
+
+    await service.async_send_message("test")
+
+    mock_fn = mock_client.chat_postMessage
+    mock_fn.assert_called_once()
+    assert mock_fn.mock_calls[0].kwargs["icon_url"] == expected_icon
+
+
+async def test_message_icon_url_overrides_default():
+    """Tests that overriding the default icon url when sending a message works."""
+    mock_client = AsyncMock()
+    service = SlackNotificationService(None, mock_client, "_", "_", "default_icon")
+
+    expected_icon = "https://example.com/hass.png"
+    await service.async_send_message("test", data={"icon": expected_icon})
+
+    mock_fn = mock_client.chat_postMessage
+    mock_fn.assert_called_once()
+    assert mock_fn.mock_calls[0].kwargs["icon_url"] == expected_icon

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -7,6 +7,7 @@ from tests.async_mock import AsyncMock
 async def test_message_includes_default_emoji():
     """Tests that overriding the default icon emoji when sending a message works."""
     mock_client = AsyncMock()
+    mock_client.chat_postMessage = AsyncMock()
     expected_icon = ":robot_face:"
     service = SlackNotificationService(None, mock_client, "_", "_", expected_icon)
 
@@ -20,6 +21,7 @@ async def test_message_includes_default_emoji():
 async def test_message_emoji_overrides_default():
     """Tests that overriding the default icon emoji when sending a message works."""
     mock_client = AsyncMock()
+    mock_client.chat_postMessage = AsyncMock()
     service = SlackNotificationService(None, mock_client, "_", "_", "default_icon")
 
     expected_icon = ":new:"
@@ -33,6 +35,7 @@ async def test_message_emoji_overrides_default():
 async def test_message_includes_default_icon_url():
     """Tests that overriding the default icon url when sending a message works."""
     mock_client = AsyncMock()
+    mock_client.chat_postMessage = AsyncMock()
     expected_icon = "https://example.com/hass.png"
     service = SlackNotificationService(None, mock_client, "_", "_", expected_icon)
 
@@ -46,6 +49,7 @@ async def test_message_includes_default_icon_url():
 async def test_message_icon_url_overrides_default():
     """Tests that overriding the default icon url when sending a message works."""
     mock_client = AsyncMock()
+    mock_client.chat_postMessage = AsyncMock()
     service = SlackNotificationService(None, mock_client, "_", "_", "default_icon")
 
     expected_icon = "https://example.com/hass.png"

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -7,7 +7,7 @@ from tests.async_mock import AsyncMock
 
 
 async def test_message_includes_default_emoji():
-    """Tests that overriding the default icon emoji when sending a message works."""
+    """Tests that default icon is used when no message icon is given."""
     mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
     expected_icon = ":robot_face:"

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -1,4 +1,4 @@
-"""Test slack notifications"""
+"""Test slack notifications."""
 from homeassistant.components.slack.notify import SlackNotificationService
 
 from tests.async_mock import AsyncMock

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -1,4 +1,6 @@
 """Test slack notifications."""
+from unittest.mock import Mock
+
 from homeassistant.components.slack.notify import SlackNotificationService
 
 from tests.async_mock import AsyncMock
@@ -6,7 +8,7 @@ from tests.async_mock import AsyncMock
 
 async def test_message_includes_default_emoji():
     """Tests that overriding the default icon emoji when sending a message works."""
-    mock_client = AsyncMock()
+    mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
     expected_icon = ":robot_face:"
     service = SlackNotificationService(None, mock_client, "_", "_", expected_icon)
@@ -15,12 +17,13 @@ async def test_message_includes_default_emoji():
 
     mock_fn = mock_client.chat_postMessage
     mock_fn.assert_called_once()
-    assert mock_fn.mock_calls[0].kwargs["icon_emoji"] == expected_icon
+    _, kwargs = mock_fn.call_args
+    assert kwargs["icon_emoji"] == expected_icon
 
 
 async def test_message_emoji_overrides_default():
     """Tests that overriding the default icon emoji when sending a message works."""
-    mock_client = AsyncMock()
+    mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
     service = SlackNotificationService(None, mock_client, "_", "_", "default_icon")
 
@@ -29,12 +32,13 @@ async def test_message_emoji_overrides_default():
 
     mock_fn = mock_client.chat_postMessage
     mock_fn.assert_called_once()
-    assert mock_fn.mock_calls[0].kwargs["icon_emoji"] == expected_icon
+    _, kwargs = mock_fn.call_args
+    assert kwargs["icon_emoji"] == expected_icon
 
 
 async def test_message_includes_default_icon_url():
     """Tests that overriding the default icon url when sending a message works."""
-    mock_client = AsyncMock()
+    mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
     expected_icon = "https://example.com/hass.png"
     service = SlackNotificationService(None, mock_client, "_", "_", expected_icon)
@@ -43,12 +47,13 @@ async def test_message_includes_default_icon_url():
 
     mock_fn = mock_client.chat_postMessage
     mock_fn.assert_called_once()
-    assert mock_fn.mock_calls[0].kwargs["icon_url"] == expected_icon
+    _, kwargs = mock_fn.call_args
+    assert kwargs["icon_url"] == expected_icon
 
 
 async def test_message_icon_url_overrides_default():
     """Tests that overriding the default icon url when sending a message works."""
-    mock_client = AsyncMock()
+    mock_client = Mock()
     mock_client.chat_postMessage = AsyncMock()
     service = SlackNotificationService(None, mock_client, "_", "_", "default_icon")
 
@@ -57,4 +62,5 @@ async def test_message_icon_url_overrides_default():
 
     mock_fn = mock_client.chat_postMessage
     mock_fn.assert_called_once()
-    assert mock_fn.mock_calls[0].kwargs["icon_url"] == expected_icon
+    _, kwargs = mock_fn.call_args
+    assert kwargs["icon_url"] == expected_icon


### PR DESCRIPTION
Allows overriding the icon for individual slack messages using either an emoji or a URL.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The data section for slack notify service takes an `icon` element to allow for overriding the default icon stored in the component configuration, but it was not being used. This update fixes the `_async_send_text_only_message` method to use the local `icon` variable if it exists and the default component icon if it doesn't. The [documentation](https://www.home-assistant.io/integrations/slack/) already reflects the expected behavior.

```yaml
# Example service data (unchanged)
message: 'Test icon message'
data:
  username: 'TestBot'
  icon: ':robot_face:'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
notify
  - name: test_slack
    platform: slack
    api_key: !secret slack_token
    default_channel: testing
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
