### PR TITLE
Use of reference strings in Transmission config flow

### DIFF
--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -59,18 +59,14 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 if (
                     entry.data[CONF_HOST] == user_input[CONF_HOST]
                     and entry.data[CONF_PORT] == user_input[CONF_PORT]
-                ):
-                    return self.async_abort(reason="already_configured")
-                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
-                    errors[CONF_NAME] = "name_exists"
-                    break
-
+                ) or (entry.data[CONF_NAME] == user_input[CONF_NAME]):
+                    return self.async_abort(reason="single_instance_allowed")
             try:
                 await get_api(self.hass, user_input)
 
             except AuthenticationError:
-                errors[CONF_USERNAME] = "wrong_credentials"
-                errors[CONF_PASSWORD] = "wrong_credentials"
+                errors[CONF_USERNAME] = "invalid_auth"
+                errors[CONF_PASSWORD] = "invalid_auth"
             except (CannotConnect, UnknownError):
                 errors["base"] = "cannot_connect"
 

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -60,7 +60,7 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     entry.data[CONF_HOST] == user_input[CONF_HOST]
                     and entry.data[CONF_PORT] == user_input[CONF_PORT]
                 ) or (entry.data[CONF_NAME] == user_input[CONF_NAME]):
-                    return self.async_abort(reason="single_instance_allowed")
+                    return self.async_abort(reason="already_configured_device")
             try:
                 await get_api(self.hass, user_input)
 

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -59,8 +59,11 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 if (
                     entry.data[CONF_HOST] == user_input[CONF_HOST]
                     and entry.data[CONF_PORT] == user_input[CONF_PORT]
-                ) or (entry.data[CONF_NAME] == user_input[CONF_NAME]):
-                    return self.async_abort(reason="already_configured_device")
+                ):
+                    return self.async_abort(reason="already_configured")
+                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                    errors[CONF_NAME] = "name_exists"
+                    break
             try:
                 await get_api(self.hass, user_input)
 

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -17,7 +17,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "options": {

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -13,12 +13,11 @@
       }
     },
     "error": {
-      "name_exists": "Name already exists",
-      "wrong_credentials": "Wrong username or password",
-      "cannot_connect": "Unable to Connect to host"
+      "wrong_credentials": "[%key:common::config_flow::error::invalid_auth%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "already_configured": "Host is already configured."
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "options": {

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -13,7 +13,7 @@
       }
     },
     "error": {
-      "wrong_credentials": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -18,7 +18,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "options": {

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -13,6 +13,7 @@
       }
     },
     "error": {
+      "name_exists": "[%key:common::config_flow::data::name%] already exists",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -211,7 +211,7 @@ async def test_host_already_configured(hass, api):
         transmission.DOMAIN, context={"source": "user"}, data=mock_entry_unique_name
     )
     assert result["type"] == "abort"
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured_device"
 
     mock_entry_unique_port = MOCK_ENTRY.copy()
     mock_entry_unique_port[CONF_PORT] = 9092
@@ -246,7 +246,7 @@ async def test_name_already_configured(hass, api):
     )
 
     assert result["type"] == "abort"
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured_device"
 
 
 async def test_error_on_wrong_credentials(hass, auth_error):

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -211,7 +211,7 @@ async def test_host_already_configured(hass, api):
         transmission.DOMAIN, context={"source": "user"}, data=mock_entry_unique_name
     )
     assert result["type"] == "abort"
-    assert result["reason"] == "already_configured_device"
+    assert result["reason"] == "already_configured"
 
     mock_entry_unique_port = MOCK_ENTRY.copy()
     mock_entry_unique_port[CONF_PORT] = 9092
@@ -245,8 +245,8 @@ async def test_name_already_configured(hass, api):
         transmission.DOMAIN, context={"source": "user"}, data=mock_entry
     )
 
-    assert result["type"] == "abort"
-    assert result["reason"] == "already_configured_device"
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_NAME: "name_exists"}
 
 
 async def test_error_on_wrong_credentials(hass, auth_error):

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -211,7 +211,7 @@ async def test_host_already_configured(hass, api):
         transmission.DOMAIN, context={"source": "user"}, data=mock_entry_unique_name
     )
     assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
 
     mock_entry_unique_port = MOCK_ENTRY.copy()
     mock_entry_unique_port[CONF_PORT] = 9092
@@ -245,8 +245,8 @@ async def test_name_already_configured(hass, api):
         transmission.DOMAIN, context={"source": "user"}, data=mock_entry
     )
 
-    assert result["type"] == "form"
-    assert result["errors"] == {CONF_NAME: "name_exists"}
+    assert result["type"] == "abort"
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_error_on_wrong_credentials(hass, auth_error):
@@ -264,8 +264,8 @@ async def test_error_on_wrong_credentials(hass, auth_error):
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {
-        CONF_USERNAME: "wrong_credentials",
-        CONF_PASSWORD: "wrong_credentials",
+        CONF_USERNAME: "invalid_auth",
+        CONF_PASSWORD: "invalid_auth",
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use of reference strings in Transmission config flow. See #40578
Unified how already existing entry is handled.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
