### PR TITLE
Remove unnecessary should poll from switch classes

### DIFF
--- a/homeassistant/components/anel_pwrctrl/switch.py
+++ b/homeassistant/components/anel_pwrctrl/switch.py
@@ -67,11 +67,6 @@ class PwrCtrlSwitch(SwitchEntity):
         self._parent_device = parent_device
 
     @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
-
-    @property
     def unique_id(self):
         """Return the unique ID of the device."""
         return f"{self._port.device.host}-{self._port.get_index()}"

--- a/homeassistant/components/digitalloggers/switch.py
+++ b/homeassistant/components/digitalloggers/switch.py
@@ -95,11 +95,6 @@ class DINRelay(SwitchEntity):
         """Return true if relay is on."""
         return self._state
 
-    @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
-
     def turn_on(self, **kwargs):
         """Instruct the relay to turn on."""
         self._outlet.on()

--- a/homeassistant/components/hikvisioncam/switch.py
+++ b/homeassistant/components/hikvisioncam/switch.py
@@ -69,11 +69,6 @@ class HikvisionMotionSwitch(SwitchEntity):
         self._state = STATE_OFF
 
     @property
-    def should_poll(self):
-        """Poll for status regularly."""
-        return True
-
-    @property
     def name(self):
         """Return the name of the device if any."""
         return self._name

--- a/homeassistant/components/kankun/switch.py
+++ b/homeassistant/components/kankun/switch.py
@@ -95,11 +95,6 @@ class KankunSwitch(SwitchEntity):
             _LOGGER.error("State query failed")
 
     @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
-
-    @property
     def name(self):
         """Return the name of the switch."""
         return self._name

--- a/homeassistant/components/mfi/switch.py
+++ b/homeassistant/components/mfi/switch.py
@@ -70,11 +70,6 @@ class MfiSwitch(SwitchEntity):
         self._target_state = None
 
     @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
-
-    @property
     def unique_id(self):
         """Return the unique ID of the device."""
         return self._port.ident

--- a/homeassistant/components/orvibo/switch.py
+++ b/homeassistant/components/orvibo/switch.py
@@ -74,11 +74,6 @@ class S20Switch(SwitchEntity):
         self._exc = S20Exception
 
     @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
-
-    @property
     def name(self):
         """Return the name of the switch."""
         return self._name

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -236,11 +236,6 @@ class XiaomiPlugGenericSwitch(SwitchEntity):
         self._skip_update = False
 
     @property
-    def should_poll(self):
-        """Poll the plug."""
-        return True
-
-    @property
     def unique_id(self):
         """Return an unique ID."""
         return self._unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch classes inherit from [SwitchEntity](https://github.com/home-assistant/core/blob/b8ed9fb4c0ec6d54a341fb336a9d28456d72b686/homeassistant/components/switch/__init__.py#L81) class, which inherits from [ToggleEntity](https://github.com/home-assistant/core/blob/b8ed9fb4c0ec6d54a341fb336a9d28456d72b686/homeassistant/helpers/entity.py#L661) class, which inherits from [Entity](https://github.com/home-assistant/core/blob/b8ed9fb4c0ec6d54a341fb336a9d28456d72b686/homeassistant/helpers/entity.py#L87) class.
The [default value for `should_poll` in Entity class is True](https://github.com/home-assistant/core/blob/b8ed9fb4c0ec6d54a341fb336a9d28456d72b686/homeassistant/helpers/entity.py#L126-L132), so it is unnecessary to declare the `should_poll` property with the same value. This PR removes these unnecessary declarations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
