### PR TITLE
Rewrite statsd unittest tests to pytest style test functions

### DIFF
--- a/tests/components/statsd/test_init.py
+++ b/tests/components/statsd/test_init.py
@@ -2,7 +2,6 @@
 from unittest import mock
 
 import pytest
-import statsd as statsdlib
 import voluptuous as vol
 
 import homeassistant.components.statsd as statsd
@@ -10,13 +9,13 @@ from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import MagicMock
+from tests.async_mock import MagicMock, patch
 
 
 @pytest.fixture
 def mock_client():
     """Pytest fixture for statsd library."""
-    with mock.patch("statsd.StatsClient") as mock_client:
+    with patch("statsd.StatsClient") as mock_client:
         yield mock_client.return_value
 
 
@@ -34,13 +33,9 @@ async def test_statsd_setup_full(hass):
     """Test setup with all data."""
     config = {"statsd": {"host": "host", "port": 123, "rate": 1, "prefix": "foo"}}
     hass.bus.listen = MagicMock()
-    with mock.patch.object(
-        statsdlib.StatsClient, "__init__", return_value=None
-    ) as mock_init:
+    with patch("statsd.StatsClient") as mock_init:
         assert await async_setup_component(hass, statsd.DOMAIN, config)
 
-        for attr in dir(mock_client):
-            print("mock_client.{} = {!r}".format(attr, getattr(mock_client, attr)))
         assert mock_init.call_count == 1
         assert mock_init.call_args == mock.call(host="host", port=123, prefix="foo")
 
@@ -56,9 +51,7 @@ async def test_statsd_setup_defaults(hass):
     config["statsd"][statsd.CONF_PREFIX] = statsd.DEFAULT_PREFIX
 
     hass.bus.listen = MagicMock()
-    with mock.patch.object(
-        statsdlib.StatsClient, "__init__", return_value=None
-    ) as mock_init:
+    with patch("statsd.StatsClient") as mock_init:
         assert await async_setup_component(hass, statsd.DOMAIN, config)
 
         assert mock_init.call_count == 1

--- a/tests/components/statsd/test_init.py
+++ b/tests/components/statsd/test_init.py
@@ -8,133 +8,127 @@ import voluptuous as vol
 import homeassistant.components.statsd as statsd
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
 import homeassistant.core as ha
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component, setup_component
 
-from tests.common import get_test_home_assistant
+from tests.async_mock import MagicMock, Mock, patch
 
 
-class TestStatsd(unittest.TestCase):
-    """Test the StatsD component."""
+@pytest.fixture
+def mock_client():
+    with patch("statsd.StatsClient") as mock_client:
+        yield mock_client.return_value
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.tear_down_cleanup)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+def test_invalid_config():
+    """Test configuration with defaults."""
+    config = {"statsd": {"host1": "host1"}}
 
-    def test_invalid_config(self):
-        """Test configuration with defaults."""
-        config = {"statsd": {"host1": "host1"}}
+    with pytest.raises(vol.Invalid):
+        statsd.CONFIG_SCHEMA(None)
+    with pytest.raises(vol.Invalid):
+        statsd.CONFIG_SCHEMA(config)
 
-        with pytest.raises(vol.Invalid):
-            statsd.CONFIG_SCHEMA(None)
-        with pytest.raises(vol.Invalid):
-            statsd.CONFIG_SCHEMA(config)
 
-    @mock.patch("statsd.StatsClient")
-    def test_statsd_setup_full(self, mock_connection):
-        """Test setup with all data."""
-        config = {"statsd": {"host": "host", "port": 123, "rate": 1, "prefix": "foo"}}
-        self.hass.bus.listen = mock.MagicMock()
-        assert setup_component(self.hass, statsd.DOMAIN, config)
-        assert mock_connection.call_count == 1
-        assert mock_connection.call_args == mock.call(
-            host="host", port=123, prefix="foo"
+async def test_statsd_setup_full(hass, mock_client):
+    """Test setup with all data."""
+    config = {"statsd": {"host": "host", "port": 123, "rate": 1, "prefix": "foo"}}
+    hass.bus.listen = MagicMock()
+    assert await async_setup_component(hass, statsd.DOMAIN, config)
+
+    for attr in dir(mock_client):
+        print("mock_client.{} = {!r}".format(attr, getattr(mock_client, attr)))
+    assert mock_client.call_count == 1
+    assert mock_client.call_args == mock.call(host="host", port=123, prefix="foo")
+
+    assert hass.bus.listen.called
+    assert EVENT_STATE_CHANGED == hass.bus.listen.call_args_list[0][0][0]
+
+
+async def test_statsd_setup_defaults(hass, mock_client):
+    """Test setup with defaults."""
+    config = {"statsd": {"host": "host"}}
+
+    config["statsd"][statsd.CONF_PORT] = statsd.DEFAULT_PORT
+    config["statsd"][statsd.CONF_PREFIX] = statsd.DEFAULT_PREFIX
+
+    hass.bus.listen = MagicMock()
+    assert await async_setup_component(hass, statsd.DOMAIN, config)
+
+    assert mock_client.call_count == 1
+    assert mock_client.call_args == mock.call(host="host", port=8125, prefix="hass")
+    assert hass.bus.listen.called
+
+
+async def test_event_listener_defaults(hass, mock_client):
+    """Test event listener."""
+    config = {"statsd": {"host": "host", "value_mapping": {"custom": 3}}}
+
+    config["statsd"][statsd.CONF_RATE] = statsd.DEFAULT_RATE
+
+    hass.bus.listen = MagicMock()
+    await async_setup_component(hass, statsd.DOMAIN, config)
+    assert hass.bus.listen.called
+    handler_method = hass.bus.listen.call_args_list[0][0][1]
+
+    valid = {"1": 1, "1.0": 1.0, "custom": 3, STATE_ON: 1, STATE_OFF: 0}
+    for in_, out in valid.items():
+        state = MagicMock(state=in_, attributes={"attribute key": 3.2})
+        handler_method(MagicMock(data={"new_state": state}))
+        mock_client.gauge.assert_has_calls(
+            [mock.call(state.entity_id, out, statsd.DEFAULT_RATE)]
         )
 
-        assert self.hass.bus.listen.called
-        assert EVENT_STATE_CHANGED == self.hass.bus.listen.call_args_list[0][0][0]
+        mock_client.gauge.reset_mock()
 
-    @mock.patch("statsd.StatsClient")
-    def test_statsd_setup_defaults(self, mock_connection):
-        """Test setup with defaults."""
-        config = {"statsd": {"host": "host"}}
-
-        config["statsd"][statsd.CONF_PORT] = statsd.DEFAULT_PORT
-        config["statsd"][statsd.CONF_PREFIX] = statsd.DEFAULT_PREFIX
-
-        self.hass.bus.listen = mock.MagicMock()
-        assert setup_component(self.hass, statsd.DOMAIN, config)
-        assert mock_connection.call_count == 1
-        assert mock_connection.call_args == mock.call(
-            host="host", port=8125, prefix="hass"
+        assert mock_client.incr.call_count == 1
+        assert mock_client.incr.call_args == mock.call(
+            state.entity_id, rate=statsd.DEFAULT_RATE
         )
-        assert self.hass.bus.listen.called
+        mock_client.incr.reset_mock()
 
-    @mock.patch("statsd.StatsClient")
-    def test_event_listener_defaults(self, mock_client):
-        """Test event listener."""
-        config = {"statsd": {"host": "host", "value_mapping": {"custom": 3}}}
+    for invalid in ("foo", "", object):
+        handler_method(
+            MagicMock(data={"new_state": ha.State("domain.test", invalid, {})})
+        )
+        assert not mock_client.gauge.called
+        assert mock_client.incr.called
 
-        config["statsd"][statsd.CONF_RATE] = statsd.DEFAULT_RATE
 
-        self.hass.bus.listen = mock.MagicMock()
-        setup_component(self.hass, statsd.DOMAIN, config)
-        assert self.hass.bus.listen.called
-        handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+async def test_event_listener_attr_details(hass, mock_client):
+    """Test event listener."""
+    config = {"statsd": {"host": "host", "log_attributes": True}}
 
-        valid = {"1": 1, "1.0": 1.0, "custom": 3, STATE_ON: 1, STATE_OFF: 0}
-        for in_, out in valid.items():
-            state = mock.MagicMock(state=in_, attributes={"attribute key": 3.2})
-            handler_method(mock.MagicMock(data={"new_state": state}))
-            mock_client.return_value.gauge.assert_has_calls(
-                [mock.call(state.entity_id, out, statsd.DEFAULT_RATE)]
-            )
+    config["statsd"][statsd.CONF_RATE] = statsd.DEFAULT_RATE
 
-            mock_client.return_value.gauge.reset_mock()
+    hass.bus.listen = MagicMock()
+    await async_setup_component(hass, statsd.DOMAIN, config)
+    assert hass.bus.listen.called
+    handler_method = hass.bus.listen.call_args_list[0][0][1]
 
-            assert mock_client.return_value.incr.call_count == 1
-            assert mock_client.return_value.incr.call_args == mock.call(
-                state.entity_id, rate=statsd.DEFAULT_RATE
-            )
-            mock_client.return_value.incr.reset_mock()
+    valid = {"1": 1, "1.0": 1.0, STATE_ON: 1, STATE_OFF: 0}
+    for in_, out in valid.items():
+        state = MagicMock(state=in_, attributes={"attribute key": 3.2})
+        handler_method(MagicMock(data={"new_state": state}))
+        mock_client.gauge.assert_has_calls(
+            [
+                mock.call("%s.state" % state.entity_id, out, statsd.DEFAULT_RATE),
+                mock.call(
+                    "%s.attribute_key" % state.entity_id, 3.2, statsd.DEFAULT_RATE
+                ),
+            ]
+        )
 
-        for invalid in ("foo", "", object):
-            handler_method(
-                mock.MagicMock(data={"new_state": ha.State("domain.test", invalid, {})})
-            )
-            assert not mock_client.return_value.gauge.called
-            assert mock_client.return_value.incr.called
+        mock_client.gauge.reset_mock()
 
-    @mock.patch("statsd.StatsClient")
-    def test_event_listener_attr_details(self, mock_client):
-        """Test event listener."""
-        config = {"statsd": {"host": "host", "log_attributes": True}}
+        assert mock_client.incr.call_count == 1
+        assert mock_client.incr.call_args == mock.call(
+            state.entity_id, rate=statsd.DEFAULT_RATE
+        )
+        mock_client.incr.reset_mock()
 
-        config["statsd"][statsd.CONF_RATE] = statsd.DEFAULT_RATE
-
-        self.hass.bus.listen = mock.MagicMock()
-        setup_component(self.hass, statsd.DOMAIN, config)
-        assert self.hass.bus.listen.called
-        handler_method = self.hass.bus.listen.call_args_list[0][0][1]
-
-        valid = {"1": 1, "1.0": 1.0, STATE_ON: 1, STATE_OFF: 0}
-        for in_, out in valid.items():
-            state = mock.MagicMock(state=in_, attributes={"attribute key": 3.2})
-            handler_method(mock.MagicMock(data={"new_state": state}))
-            mock_client.return_value.gauge.assert_has_calls(
-                [
-                    mock.call("%s.state" % state.entity_id, out, statsd.DEFAULT_RATE),
-                    mock.call(
-                        "%s.attribute_key" % state.entity_id, 3.2, statsd.DEFAULT_RATE
-                    ),
-                ]
-            )
-
-            mock_client.return_value.gauge.reset_mock()
-
-            assert mock_client.return_value.incr.call_count == 1
-            assert mock_client.return_value.incr.call_args == mock.call(
-                state.entity_id, rate=statsd.DEFAULT_RATE
-            )
-            mock_client.return_value.incr.reset_mock()
-
-        for invalid in ("foo", "", object):
-            handler_method(
-                mock.MagicMock(data={"new_state": ha.State("domain.test", invalid, {})})
-            )
-            assert not mock_client.return_value.gauge.called
-            assert mock_client.return_value.incr.called
+    for invalid in ("foo", "", object):
+        handler_method(
+            MagicMock(data={"new_state": ha.State("domain.test", invalid, {})})
+        )
+        assert not mock_client.gauge.called
+        assert mock_client.incr.called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move statsd tests to pytest flavour.

I don't have that much experience with Python testing, so please tell me if there is something to be improved. Any learning opportunity is appreciated ;)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40897 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
