### PR TITLE
Only log xiaomi_miio update exceptions once

### DIFF
--- a/homeassistant/components/xiaomi_miio/air_quality.py
+++ b/homeassistant/components/xiaomi_miio/air_quality.py
@@ -195,8 +195,9 @@ class AirMonitorS1(AirMonitorB1):
             self._humidity = state.humidity
             self._available = True
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
 
 class AirMonitorV1(AirMonitorB1):
@@ -210,8 +211,9 @@ class AirMonitorV1(AirMonitorB1):
             self._air_quality_index = state.aqi
             self._available = True
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/xiaomi_miio/alarm_control_panel.py
+++ b/homeassistant/components/xiaomi_miio/alarm_control_panel.py
@@ -3,7 +3,7 @@
 from functools import partial
 import logging
 
-from miio.gateway import GatewayException
+from miio import DeviceException
 
 from homeassistant.components.alarm_control_panel import (
     SUPPORT_ALARM_ARM_AWAY,
@@ -103,7 +103,7 @@ class XiaomiGatewayAlarm(AlarmControlPanelEntity):
                 partial(func, *args, **kwargs)
             )
             _LOGGER.debug("Response received from miio device: %s", result)
-        except GatewayException as exc:
+        except DeviceException as exc:
             _LOGGER.error(mask_error, exc)
 
     async def async_alarm_arm_away(self, code=None):
@@ -128,7 +128,6 @@ class XiaomiGatewayAlarm(AlarmControlPanelEntity):
                 _LOGGER.error("Got exception while fetching the state: %s", ex)
 
             return
-
 
         _LOGGER.debug("Got new state: %s", state)
 

--- a/homeassistant/components/xiaomi_miio/alarm_control_panel.py
+++ b/homeassistant/components/xiaomi_miio/alarm_control_panel.py
@@ -122,10 +122,12 @@ class XiaomiGatewayAlarm(AlarmControlPanelEntity):
         """Fetch state from the device."""
         try:
             state = await self.hass.async_add_executor_job(self._gateway.alarm.status)
-        except GatewayException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
-            return
+        except DeviceException as ex:
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+                return
+
 
         _LOGGER.debug("Got new state: %s", state)
 

--- a/homeassistant/components/xiaomi_miio/alarm_control_panel.py
+++ b/homeassistant/components/xiaomi_miio/alarm_control_panel.py
@@ -126,7 +126,8 @@ class XiaomiGatewayAlarm(AlarmControlPanelEntity):
             if self._available:
                 self._available = False
                 _LOGGER.error("Got exception while fetching the state: %s", ex)
-                return
+
+            return
 
 
         _LOGGER.debug("Got new state: %s", state)

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -655,8 +655,10 @@ class XiaomiGenericDevice(FanEntity):
 
             return result == SUCCESS
         except DeviceException as exc:
-            _LOGGER.error(mask_error, exc)
-            self._available = False
+            if self._available:
+                _LOGGER.error(mask_error, exc)
+                self._available = False
+
             return False
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -785,8 +785,9 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
             )
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @property
     def speed_list(self) -> list:
@@ -1029,8 +1030,9 @@ class XiaomiAirHumidifier(XiaomiGenericDevice):
             )
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @property
     def speed_list(self) -> list:
@@ -1138,8 +1140,9 @@ class XiaomiAirFresh(XiaomiGenericDevice):
             )
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     @property
     def speed_list(self) -> list:

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -65,7 +65,7 @@ class XiaomiGatewayDevice(Entity):
         self._entry = entry
         self._unique_id = sub_device.sid
         self._name = f"{sub_device.name} ({sub_device.sid})"
-        self._available = None
+        self._available = False
 
     @property
     def unique_id(self):

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -100,5 +100,6 @@ class XiaomiGatewayDevice(Entity):
             await self.hass.async_add_executor_job(self._sub_device.update)
             self._available = True
         except gateway.GatewayException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -361,9 +361,10 @@ class XiaomiPhilipsAbstractLight(LightEntity):
         try:
             state = await self.hass.async_add_executor_job(self._light.status)
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
-            return
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+                return
 
         _LOGGER.debug("Got new state: %s", state)
         self._available = True

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -329,8 +329,10 @@ class XiaomiPhilipsAbstractLight(LightEntity):
 
             return result == SUCCESS
         except DeviceException as exc:
-            _LOGGER.error(mask_error, exc)
-            self._available = False
+            if self._available:
+                _LOGGER.error(mask_error, exc)
+                self._available = False
+
             return False
 
     async def async_turn_on(self, **kwargs):
@@ -364,7 +366,8 @@ class XiaomiPhilipsAbstractLight(LightEntity):
             if self._available:
                 self._available = False
                 _LOGGER.error("Got exception while fetching the state: %s", ex)
-                return
+
+            return
 
         _LOGGER.debug("Got new state: %s", state)
         self._available = True
@@ -386,8 +389,10 @@ class XiaomiPhilipsGenericLight(XiaomiPhilipsAbstractLight):
         try:
             state = await self.hass.async_add_executor_job(self._light.status)
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+
             return
 
         _LOGGER.debug("Got new state: %s", state)
@@ -542,8 +547,10 @@ class XiaomiPhilipsBulb(XiaomiPhilipsGenericLight):
         try:
             state = await self.hass.async_add_executor_job(self._light.status)
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+
             return
 
         _LOGGER.debug("Got new state: %s", state)
@@ -599,8 +606,10 @@ class XiaomiPhilipsCeilingLamp(XiaomiPhilipsBulb):
         try:
             state = await self.hass.async_add_executor_job(self._light.status)
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+
             return
 
         _LOGGER.debug("Got new state: %s", state)
@@ -643,8 +652,10 @@ class XiaomiPhilipsEyecareLamp(XiaomiPhilipsGenericLight):
         try:
             state = await self.hass.async_add_executor_job(self._light.status)
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+
             return
 
         _LOGGER.debug("Got new state: %s", state)
@@ -784,8 +795,10 @@ class XiaomiPhilipsEyecareLampAmbientLight(XiaomiPhilipsAbstractLight):
         try:
             state = await self.hass.async_add_executor_job(self._light.status)
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+
             return
 
         _LOGGER.debug("Got new state: %s", state)
@@ -938,8 +951,10 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
         try:
             state = await self.hass.async_add_executor_job(self._light.status)
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+
             return
 
         _LOGGER.debug("Got new state: %s", state)

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -236,8 +236,9 @@ class XiaomiAirQualityMonitor(Entity):
             )
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
 
 class XiaomiGatewaySensor(XiaomiGatewayDevice):

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -285,9 +285,10 @@ class XiaomiPlugGenericSwitch(SwitchEntity):
 
             return result == SUCCESS
         except DeviceException as exc:
-            _LOGGER.error(mask_error, exc)
-            self._available = False
-            return False
+            if self._available:
+                _LOGGER.error(mask_error, exc)
+                self._available = False
+                return False
 
     async def async_turn_on(self, **kwargs):
         """Turn the plug on."""
@@ -321,8 +322,9 @@ class XiaomiPlugGenericSwitch(SwitchEntity):
             self._state_attrs[ATTR_TEMPERATURE] = state.temperature
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     async def async_set_wifi_led_on(self):
         """Turn the wifi led on."""
@@ -407,8 +409,9 @@ class XiaomiPowerStripSwitch(XiaomiPlugGenericSwitch):
                 self._state_attrs[ATTR_POWER_PRICE] = state.power_price
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
     async def async_set_power_mode(self, mode: str):
         """Set the power mode."""
@@ -497,8 +500,9 @@ class ChuangMiPlugSwitch(XiaomiPlugGenericSwitch):
                 self._state_attrs[ATTR_LOAD_POWER] = state.load_power
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
 
 
 class XiaomiAirConditioningCompanionSwitch(XiaomiPlugGenericSwitch):
@@ -546,5 +550,6 @@ class XiaomiAirConditioningCompanionSwitch(XiaomiPlugGenericSwitch):
             self._state_attrs[ATTR_LOAD_POWER] = state.load_power
 
         except DeviceException as ex:
-            self._available = False
-            _LOGGER.error("Got exception while fetching the state: %s", ex)
+            if self._available:
+                self._available = False
+                _LOGGER.error("Got exception while fetching the state: %s", ex)

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -288,7 +288,8 @@ class XiaomiPlugGenericSwitch(SwitchEntity):
             if self._available:
                 _LOGGER.error(mask_error, exc)
                 self._available = False
-                return False
+
+            return False
 
     async def async_turn_on(self, **kwargs):
         """Turn the plug on."""

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -487,10 +487,10 @@ class MiroboVacuum(StateVacuumEntity):
             self._timers = self._vacuum.timer()
 
             self._available = True
-        except OSError as exc:
-            _LOGGER.error("Got OSError while fetching the state: %s", exc)
-        except DeviceException as exc:
-            _LOGGER.warning("Got exception while fetching the state: %s", exc)
+        except (OSError, DeviceException) as exc:
+            if self._available:
+                self._available = False
+                _LOGGER.warning("Got exception while fetching the state: %s", exc)
 
     async def async_clean_zone(self, zone, repeats=1):
         """Clean selected area for the number of repeats indicated."""

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -55,6 +55,8 @@ from homeassistant.const import (
 )
 from homeassistant.setup import async_setup_component
 
+from tests.async_mock import MagicMock, patch
+
 PLATFORM = "xiaomi_miio"
 
 # calls made when device status is requested
@@ -70,7 +72,7 @@ STATUS_CALLS = [
 @pytest.fixture(name="mock_mirobo_is_got_error")
 def mirobo_is_got_error_fixture():
     """Mock mock_mirobo."""
-    mock_vacuum = mock.MagicMock()
+    mock_vacuum = MagicMock()
     mock_vacuum.status().data = {"test": "raw"}
     mock_vacuum.status().is_on = False
     mock_vacuum.status().fanspeed = 38
@@ -98,21 +100,19 @@ def mirobo_is_got_error_fixture():
     mock_vacuum.dnd_status().start = time(hour=22, minute=0)
     mock_vacuum.dnd_status().end = time(hour=6, minute=0)
 
-    mock_timer_1 = mock.MagicMock()
+    mock_timer_1 = MagicMock()
     mock_timer_1.enabled = True
     mock_timer_1.cron = "5 5 1 8 1"
     mock_timer_1.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
-    mock_timer_2 = mock.MagicMock()
+    mock_timer_2 = MagicMock()
     mock_timer_2.enabled = False
     mock_timer_2.cron = "5 5 1 8 2"
     mock_timer_2.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
-    with mock.patch(
-        "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls:
+    with patch("homeassistant.components.xiaomi_miio.vacuum.Vacuum") as mock_vaccum_cls:
         mock_vaccum_cls.return_value = mock_vacuum
         yield mock_vacuum
 
@@ -135,14 +135,12 @@ new_fanspeeds = {
 @pytest.fixture(name="mock_mirobo_fanspeeds", params=[old_fanspeeds, new_fanspeeds])
 def mirobo_old_speeds_fixture(request):
     """Fixture for testing both types of fanspeeds."""
-    mock_vacuum = mock.MagicMock()
+    mock_vacuum = MagicMock()
     mock_vacuum.status().battery = 32
     mock_vacuum.fan_speed_presets.return_value = request.param
     mock_vacuum.status().fanspeed = list(request.param.values())[0]
 
-    with mock.patch(
-        "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls:
+    with patch("homeassistant.components.xiaomi_miio.vacuum.Vacuum") as mock_vaccum_cls:
         mock_vaccum_cls.return_value = mock_vacuum
         yield mock_vacuum
 
@@ -150,7 +148,7 @@ def mirobo_old_speeds_fixture(request):
 @pytest.fixture(name="mock_mirobo_is_on")
 def mirobo_is_on_fixture():
     """Mock mock_mirobo."""
-    mock_vacuum = mock.MagicMock()
+    mock_vacuum = MagicMock()
     mock_vacuum.status().data = {"test": "raw"}
     mock_vacuum.status().is_on = True
     mock_vacuum.status().fanspeed = 99
@@ -176,21 +174,19 @@ def mirobo_is_on_fixture():
     mock_vacuum.status().state_code = 5
     mock_vacuum.dnd_status().enabled = False
 
-    mock_timer_1 = mock.MagicMock()
+    mock_timer_1 = MagicMock()
     mock_timer_1.enabled = True
     mock_timer_1.cron = "5 5 1 8 1"
     mock_timer_1.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
-    mock_timer_2 = mock.MagicMock()
+    mock_timer_2 = MagicMock()
     mock_timer_2.enabled = False
     mock_timer_2.cron = "5 5 1 8 2"
     mock_timer_2.next_schedule = datetime(2020, 5, 23, 13, 21, 10, tzinfo=utc)
 
     mock_vacuum.timer.return_value = [mock_timer_1, mock_timer_2]
 
-    with mock.patch(
-        "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls:
+    with patch("homeassistant.components.xiaomi_miio.vacuum.Vacuum") as mock_vaccum_cls:
         mock_vaccum_cls.return_value = mock_vacuum
         yield mock_vacuum
 
@@ -198,11 +194,9 @@ def mirobo_is_on_fixture():
 @pytest.fixture(name="mock_mirobo_errors")
 def mirobo_errors_fixture():
     """Mock mock_mirobo_errors to simulate a bad vacuum status request."""
-    mock_vacuum = mock.MagicMock()
+    mock_vacuum = MagicMock()
     mock_vacuum.status.side_effect = OSError()
-    with mock.patch(
-        "homeassistant.components.xiaomi_miio.vacuum.Vacuum"
-    ) as mock_vaccum_cls:
+    with patch("homeassistant.components.xiaomi_miio.vacuum.Vacuum") as mock_vaccum_cls:
         mock_vaccum_cls.return_value = mock_vacuum
         yield mock_vacuum
 
@@ -463,7 +457,7 @@ async def test_xiaomi_vacuum_fanspeeds(hass, caplog, mock_mirobo_fanspeeds):
         {"entity_id": entity_id, "fan_speed": "invent"},
         blocking=True,
     )
-    assert "ERROR" in caplog.text
+    assert "Fan speed step not recognized" in caplog.text
 
 
 async def test_xiaomi_vacuum_goto_service(hass, caplog, mock_mirobo_is_on):


### PR DESCRIPTION
(Revival of #37696 which I couldn't reopen anymore after force pushing to the branch)

Extends #37695 and replaces it:
* All platforms will now only log the update errors one time
* The vacuum will now also be correctly marked as unavailable when the update fails
* Related to #21899


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io