### PR TITLE
Rewrite pytest node_entity tests for pytest

### DIFF
--- a/tests/components/zwave/conftest.py
+++ b/tests/components/zwave/conftest.py
@@ -30,7 +30,7 @@ def mock_openzwave():
 
 @pytest.fixture
 def mock_node():
-    """Provides a mock ZWave node."""
+    """Provide mock z-wave node."""
     node = MockNode(
         query_stage="Dynamic",
         is_awake=True,
@@ -48,5 +48,5 @@ def mock_node():
 
 @pytest.fixture
 def mock_entity(mock_node):
-    """Provides a mock ZWaveNodeEntity."""
+    """Provide mock z-wave node entity."""
     yield node_entity.ZWaveNodeEntity(mock_node, MagicMock())

--- a/tests/components/zwave/conftest.py
+++ b/tests/components/zwave/conftest.py
@@ -1,8 +1,10 @@
 """Fixtures for Z-Wave tests."""
 import pytest
 
+from homeassistant.components.zwave import node_entity
+
 from tests.async_mock import MagicMock, patch
-from tests.mock.zwave import MockNetwork, MockOption
+from tests.mock.zwave import MockNetwork, MockNode, MockOption
 
 
 @pytest.fixture
@@ -24,3 +26,27 @@ def mock_openzwave():
         },
     ):
         yield base_mock
+
+
+@pytest.fixture
+def mock_node():
+    """Provides a mock ZWave node."""
+    node = MockNode(
+        query_stage="Dynamic",
+        is_awake=True,
+        is_ready=False,
+        is_failed=False,
+        is_info_received=True,
+        max_baud_rate=40000,
+        is_zwave_plus=False,
+        capabilities=[],
+        neighbors=[],
+        location=None,
+    )
+    yield node
+
+
+@pytest.fixture
+def mock_entity(mock_node):
+    """Provides a mock ZWaveNodeEntity."""
+    yield node_entity.ZWaveNodeEntity(mock_node, MagicMock())


### PR DESCRIPTION
Adds mock_node and mock_entity fixtures.
Removes dependency on unittest.TestCase for TestZWaveNodeEntity class.

See: #40913

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Uses `pytest.fixture` instead of the setup and teardown method in order to remove dependency on `unittest.TestCase` per #40913.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40913
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
