### PR TITLE
Fix reported temperatures in Maxcube

### DIFF
--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -40,6 +40,11 @@ OFF_TEMPERATURE = 4.5
 # On (valve fully open)
 ON_TEMPERATURE = 30.5
 
+# Lowest Value without turning off
+MIN_TEMPERATURE = 5.0
+# Largest Value without fully opening
+MAX_TEMPERATURE = 30.0
+
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
 HASS_PRESET_TO_MAX_MODE = {
@@ -101,7 +106,7 @@ class MaxCubeClimate(ClimateEntity):
         """Return the minimum temperature."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
         if device.min_temperature is None:
-            return 5.0
+            return MIN_TEMPERATURE
         return device.min_temperature
 
     @property
@@ -109,7 +114,7 @@ class MaxCubeClimate(ClimateEntity):
         """Return the maximum temperature."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
         if device.max_temperature is None:
-            return 30.0
+            return MAX_TEMPERATURE
         return device.max_temperature
 
     @property
@@ -121,6 +126,12 @@ class MaxCubeClimate(ClimateEntity):
     def current_temperature(self):
         """Return the current temperature."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
+        if (
+            device.actual_temperature is None
+            or device.actual_temperature < self.min_temp
+            or device.actual_temperature > self.max_temp
+        ):
+            return None
         return device.actual_temperature
 
     @property
@@ -197,6 +208,12 @@ class MaxCubeClimate(ClimateEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
+        if (
+            device.target_temperature is None
+            or device.target_temperature < self.min_temp
+            or device.target_temperature > self.max_temp
+        ):
+            return None
         return device.target_temperature
 
     def set_temperature(self, **kwargs):

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -100,13 +100,17 @@ class MaxCubeClimate(ClimateEntity):
     def min_temp(self):
         """Return the minimum temperature."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
-        return self.map_temperature_max_hass(device.min_temperature)
+        if device.min_temperature is None:
+            return 5.0
+        return device.min_temperature
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
-        return self.map_temperature_max_hass(device.max_temperature)
+        if device.max_temperature is None:
+            return 30.0
+        return device.max_temperature
 
     @property
     def temperature_unit(self):
@@ -117,9 +121,7 @@ class MaxCubeClimate(ClimateEntity):
     def current_temperature(self):
         """Return the current temperature."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
-
-        # Map and return current temperature
-        return self.map_temperature_max_hass(device.actual_temperature)
+        return device.actual_temperature
 
     @property
     def hvac_mode(self):
@@ -195,7 +197,7 @@ class MaxCubeClimate(ClimateEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
-        return self.map_temperature_max_hass(device.target_temperature)
+        return device.target_temperature
 
     def set_temperature(self, **kwargs):
         """Set new target temperatures."""
@@ -283,11 +285,3 @@ class MaxCubeClimate(ClimateEntity):
     def update(self):
         """Get latest data from MAX! Cube."""
         self._cubehandle.update()
-
-    @staticmethod
-    def map_temperature_max_hass(temperature):
-        """Map Temperature from MAX! to Home Assistant."""
-        if temperature is None:
-            return 0.0
-
-        return temperature

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -126,12 +126,6 @@ class MaxCubeClimate(ClimateEntity):
     def current_temperature(self):
         """Return the current temperature."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)
-        if (
-            device.actual_temperature is None
-            or device.actual_temperature < self.min_temp
-            or device.actual_temperature > self.max_temp
-        ):
-            return None
         return device.actual_temperature
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the device doesn't report its minimum or maximum values, the values from the documentation at https://github.com/Bouni/max-cube-protocol/blob/master/C-Message.md will be returned. Also if no target temp is returned, it instead returns None rather than 0.0, and also wont return one of the magical temps (4.5 = off, 30.5 = full heat).

Fixes #41258


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```
maxcube:
  gateways:
    - host: 192.168.1.124
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41258

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
