### PR TITLE
Add explicit optimistic mode for mqtt climate

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -692,10 +692,7 @@ class MqttClimate(
 
     def _set_temperature(self, temp, cmnd_topic, state_topic, attr):
         if temp is not None:
-            if (
-                self._topic[state_topic] is None
-                or self._optimistic
-            ):
+            if self._topic[state_topic] is None or self._optimistic:
                 # optimistic mode
                 setattr(self, attr, temp)
 
@@ -762,10 +759,7 @@ class MqttClimate(
 
         self._publish(CONF_MODE_COMMAND_TOPIC, hvac_mode)
 
-        if (
-            self._topic[CONF_MODE_STATE_TOPIC] is None
-            or self._optimistic
-        ):
+        if self._topic[CONF_MODE_STATE_TOPIC] is None or self._optimistic:
             self._current_operation = hvac_mode
             self.async_write_ha_state()
 

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -737,7 +737,7 @@ class MqttClimate(
         if self._config[CONF_SEND_IF_OFF] or self._current_operation != HVAC_MODE_OFF:
             self._publish(CONF_SWING_MODE_COMMAND_TOPIC, swing_mode)
 
-        if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
+        if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None or self._optimistic:
             self._current_swing_mode = swing_mode
             self.async_write_ha_state()
 
@@ -746,7 +746,7 @@ class MqttClimate(
         if self._config[CONF_SEND_IF_OFF] or self._current_operation != HVAC_MODE_OFF:
             self._publish(CONF_FAN_MODE_COMMAND_TOPIC, fan_mode)
 
-        if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
+        if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None or self._optimistic:
             self._current_fan_mode = fan_mode
             self.async_write_ha_state()
 
@@ -831,7 +831,7 @@ class MqttClimate(
             self._config[CONF_PAYLOAD_ON] if state else self._config[CONF_PAYLOAD_OFF],
         )
 
-        if self._topic[CONF_AUX_STATE_TOPIC] is None:
+        if self._topic[CONF_AUX_STATE_TOPIC] is None or self._optimistic:
             self._aux = state
             self.async_write_ha_state()
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -350,7 +350,7 @@ async def test_set_target_temperature_with_state_and_optimistic_flag(hass, mqtt_
     config["climate"]["temperature_low_state_topic"] = "temperature-low-state"
     config["climate"]["temperature_high_state_topic"] = "temperature-high-state"'''
     """..but also set the optimistic flag"""
-    '''config["climate"]["optimistic"] = True'''
+    """config["climate"]["optimistic"] = True"""
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -340,9 +340,17 @@ async def test_set_target_temperature(hass, mqtt_mock):
 
 async def test_set_target_temperature_with_state_and_optimistic_flag(hass, mqtt_mock):
     """Test setting the target temperature."""
-    """Set the temperature state topic so that by default it would operate in pessimistic mode"""
+    """Set all the state topics so that by default they would operate in pessimistic mode"""
     config = copy.deepcopy(DEFAULT_CONFIG)
-    config["climate"]["temperature_state_topic"] = "temperature-state"
+    '''config["climate"]["temperature_state_topic"] = "temperature-state"'''
+    config["climate"]["mode_state_topic"] = "mode-state"
+    '''config["climate"]["swing_mode_state_topic"] = "swing-mode-state"
+    config["climate"]["fan_mode_state_topic"] = "fan-mode-state"
+    config["climate"]["aux_state_topic"] = "aux-state"
+    config["climate"]["temperature_low_state_topic"] = "temperature-low-state"
+    config["climate"]["temperature_high_state_topic"] = "temperature-high-state"'''
+    """..but also set the optimistic flag"""
+    '''config["climate"]["optimistic"] = True'''
 
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add optional explicit optimistic mode to mqtt climate support.   Currently this is only implicitly enabled if there is no state topic. Background for my explicit usecase: The fibaro FGT-001 does not publish it's state upon set, but does have a state topic (which is populated on node-refresh in ZWave2Mqtt bridge)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
This is a resulting configuration snippet - though it should be provided via discovery from mqtt rather than in configuration.yaml
```yaml
# Example configuration.yaml snippet
    "temperature_command_topic": "zwave/DrawingRoomRadiator/67/1/1/set",
    "temperature_state_topic": "zwave/DrawingRoomRadiator/67/1/1",
    "optimistic": true,
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
