### PR TITLE
Allow any value when triggering on state attribute

### DIFF
--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -25,17 +25,39 @@ CONF_ENTITY_ID = "entity_id"
 CONF_FROM = "from"
 CONF_TO = "to"
 
-TRIGGER_SCHEMA = vol.Schema(
+BASE_SCHEMA = {
+    vol.Required(CONF_PLATFORM): "state",
+    vol.Required(CONF_ENTITY_ID): cv.entity_ids,
+    vol.Optional(CONF_FOR): cv.positive_time_period_template,
+    vol.Optional(CONF_ATTRIBUTE): cv.match_all,
+}
+
+TRIGGER_STATE_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_PLATFORM): "state",
-        vol.Required(CONF_ENTITY_ID): cv.entity_ids,
+        **BASE_SCHEMA,
         # These are str on purpose. Want to catch YAML conversions
         vol.Optional(CONF_FROM): vol.Any(str, [str]),
         vol.Optional(CONF_TO): vol.Any(str, [str]),
-        vol.Optional(CONF_FOR): cv.positive_time_period_template,
-        vol.Optional(CONF_ATTRIBUTE): cv.match_all,
     }
 )
+
+TRIGGER_ATTRIBUTE_SCHEMA = vol.Schema(
+    {
+        **BASE_SCHEMA,
+        vol.Optional(CONF_FROM): cv.match_all,
+        vol.Optional(CONF_TO): cv.match_all,
+    }
+)
+
+
+def TRIGGER_SCHEMA(value):  # pylint: disable=invalid-name
+    """Validate trigger."""
+    # We use this approach instead of vol.Any because
+    # this gives better error messages.
+    if CONF_ATTRIBUTE in value:
+        return TRIGGER_ATTRIBUTE_SCHEMA(value)
+
+    return TRIGGER_STATE_SCHEMA(value)
 
 
 async def async_attach_trigger(

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -1,7 +1,7 @@
 """Offer state listening automation rules."""
 from datetime import timedelta
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import voluptuous as vol
 
@@ -50,8 +50,11 @@ TRIGGER_ATTRIBUTE_SCHEMA = vol.Schema(
 )
 
 
-def TRIGGER_SCHEMA(value):  # pylint: disable=invalid-name
+def TRIGGER_SCHEMA(value: Any) -> dict:  # pylint: disable=invalid-name
     """Validate trigger."""
+    if not isinstance(value, dict):
+        raise vol.Invalid("Expected a dictionary")
+
     # We use this approach instead of vol.Any because
     # this gives better error messages.
     if CONF_ATTRIBUTE in value:

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -297,7 +297,7 @@ def async_numeric_state_from_config(
 def state(
     hass: HomeAssistant,
     entity: Union[None, str, State],
-    req_state: Union[str, List[str]],
+    req_state: Any,
     for_period: Optional[timedelta] = None,
     attribute: Optional[str] = None,
 ) -> bool:
@@ -314,17 +314,20 @@ def state(
     assert isinstance(entity, State)
 
     if attribute is None:
-        value = entity.state
+        value: Any = entity.state
     else:
-        value = str(entity.attributes.get(attribute))
+        value = entity.attributes.get(attribute)
 
-    if isinstance(req_state, str):
+    if not isinstance(req_state, list):
         req_state = [req_state]
 
     is_state = False
     for req_state_value in req_state:
         state_value = req_state_value
-        if INPUT_ENTITY_ID.match(req_state_value) is not None:
+        if (
+            isinstance(req_state_value, str)
+            and INPUT_ENTITY_ID.match(req_state_value) is not None
+        ):
             state_entity = hass.states.get(req_state_value)
             if not state_entity:
                 continue

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -1240,3 +1240,32 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
     assert len(calls) == 1
+
+
+async def test_attribute_if_fires_on_entity_change_with_both_filters_boolean(
+    hass, calls
+):
+    """Test for firing if both filters are match attribute."""
+    hass.states.async_set("test.entity", "bla", {"happening": False})
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "state",
+                    "entity_id": "test.entity",
+                    "from": False,
+                    "to": True,
+                    "attribute": "happening",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("test.entity", "bla", {"happening": True})
+    await hass.async_block_till_done()
+    assert len(calls) == 1

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -422,7 +422,7 @@ async def test_state_attribute(hass):
                     "condition": "state",
                     "entity_id": "sensor.temperature",
                     "attribute": "attribute1",
-                    "state": "200",
+                    "state": 200,
                 },
             ],
         },
@@ -435,13 +435,38 @@ async def test_state_attribute(hass):
     assert test(hass)
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": "200"})
-    assert test(hass)
+    assert not test(hass)
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": 201})
     assert not test(hass)
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": None})
     assert not test(hass)
+
+
+async def test_state_attribute_boolean(hass):
+    """Test with boolean state attribute in condition."""
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "state",
+            "entity_id": "sensor.temperature",
+            "attribute": "happening",
+            "state": False,
+        },
+    )
+
+    hass.states.async_set("sensor.temperature", 100, {"happening": 200})
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature", 100, {"happening": True})
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature", 100, {"no_happening": 201})
+    assert not test(hass)
+
+    hass.states.async_set("sensor.temperature", 100, {"happening": False})
+    assert test(hass)
 
 
 async def test_state_using_input_entities(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
State conditions with attribute specified: When testing against a non-string attribute value, you now need to specify the value in your config in the same type as it is in the attribute instead of as a string.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
State triggers used to force `to` and `from` to be strings because `state` is a string, and we didn't want people to be caught off-guard by YAML conversions (ie `"on"` -> `True`).

This PR allows any `to` and `from` value when we match on an attribute so we can match on non-string values.

Also does the same for conditions. State conditions would always convert the attribute to a string, which made it work for some values, but not all. This is fixed in this release but it means that existing config with string values testing against non-string attributes now need to make sure you define the test value in the same type as that the attribute is.

Fixes #40407

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
