### PR TITLE
Add extended validation for script repeat/choose

### DIFF
--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -10,7 +10,7 @@ from homeassistant.config import async_log_exception, config_without_domain
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform
 from homeassistant.helpers.condition import async_validate_condition_config
-from homeassistant.helpers.script import async_validate_action_config
+from homeassistant.helpers.script import async_validate_actions_config
 from homeassistant.helpers.trigger import async_validate_trigger_config
 from homeassistant.loader import IntegrationNotFound
 
@@ -36,9 +36,7 @@ async def async_validate_config_item(hass, config, full_config=None):
             ]
         )
 
-    config[CONF_ACTION] = await asyncio.gather(
-        *[async_validate_action_config(hass, action) for action in config[CONF_ACTION]]
-    )
+    config[CONF_ACTION] = await async_validate_actions_config(hass, config[CONF_ACTION])
 
     return config
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -123,29 +123,70 @@ def make_script_schema(schema, default_script_mode, extra=vol.PREVENT_EXTRA):
     )
 
 
+STATIC_VALIDATION_ACTION_TYPES = (
+    cv.SCRIPT_ACTION_CALL_SERVICE,
+    cv.SCRIPT_ACTION_DELAY,
+    cv.SCRIPT_ACTION_WAIT_TEMPLATE,
+    cv.SCRIPT_ACTION_FIRE_EVENT,
+    cv.SCRIPT_ACTION_ACTIVATE_SCENE,
+    cv.SCRIPT_ACTION_VARIABLES,
+)
+
+
+async def async_validate_actions_config(
+    hass: HomeAssistant, actions: List[ConfigType]
+) -> List[ConfigType]:
+    """Validate a list of actions."""
+    return await asyncio.gather(
+        *[async_validate_action_config(hass, action) for action in actions]
+    )
+
+
 async def async_validate_action_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType:
     """Validate config."""
     action_type = cv.determine_script_action(config)
 
-    if action_type == cv.SCRIPT_ACTION_DEVICE_AUTOMATION:
+    if action_type in STATIC_VALIDATION_ACTION_TYPES:
+        pass
+
+    elif action_type == cv.SCRIPT_ACTION_DEVICE_AUTOMATION:
         platform = await device_automation.async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], "action"
         )
         config = platform.ACTION_SCHEMA(config)  # type: ignore
-    elif (
-        action_type == cv.SCRIPT_ACTION_CHECK_CONDITION
-        and config[CONF_CONDITION] == "device"
-    ):
-        platform = await device_automation.async_get_device_automation_platform(
-            hass, config[CONF_DOMAIN], "condition"
-        )
-        config = platform.CONDITION_SCHEMA(config)  # type: ignore
+
+    elif action_type == cv.SCRIPT_ACTION_CHECK_CONDITION:
+        if config[CONF_CONDITION] == "device":
+            platform = await device_automation.async_get_device_automation_platform(
+                hass, config[CONF_DOMAIN], "condition"
+            )
+            config = platform.CONDITION_SCHEMA(config)  # type: ignore
+
     elif action_type == cv.SCRIPT_ACTION_WAIT_FOR_TRIGGER:
         config[CONF_WAIT_FOR_TRIGGER] = await async_validate_trigger_config(
             hass, config[CONF_WAIT_FOR_TRIGGER]
         )
+
+    elif action_type == cv.SCRIPT_ACTION_REPEAT:
+        config[CONF_SEQUENCE] = await async_validate_actions_config(
+            hass, config[CONF_REPEAT][CONF_SEQUENCE]
+        )
+
+    elif action_type == cv.SCRIPT_ACTION_CHOOSE:
+        if CONF_DEFAULT in config:
+            config[CONF_DEFAULT] = await async_validate_actions_config(
+                hass, config[CONF_DEFAULT]
+            )
+
+        for choose_conf in config[CONF_CHOOSE]:
+            choose_conf[CONF_SEQUENCE] = await async_validate_actions_config(
+                hass, choose_conf[CONF_SEQUENCE]
+            )
+
+    else:
+        raise ValueError(f"No validation for {action_type}")
 
     return config
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1873,6 +1873,13 @@ async def test_validate_action_config(hass):
     for key in cv.ACTION_TYPE_SCHEMAS:
         assert key in configs, f"No validate config test found for {key}"
 
+    # Verify we raise if we don't know the action type
+    with patch(
+        "homeassistant.helpers.config_validation.determine_script_action",
+        return_value="non-existing",
+    ), pytest.raises(ValueError):
+        await script.async_validate_action_config(hass, {})
+
     for action_type, config in configs.items():
         assert cv.determine_script_action(config) == action_type
         try:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -16,6 +16,7 @@ import homeassistant.components.scene as scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import Context, CoreState, callback
 from homeassistant.helpers import config_validation as cv, script
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.async_mock import patch
@@ -1828,3 +1829,107 @@ async def test_set_redefines_variable(hass, caplog):
 
     assert mock_calls[0].data["value"] == "1"
     assert mock_calls[1].data["value"] == "2"
+
+
+async def test_validate_action_config(hass):
+    """Validate action config."""
+    configs = {
+        cv.SCRIPT_ACTION_CALL_SERVICE: {"service": "light.turn_on"},
+        cv.SCRIPT_ACTION_DELAY: {"delay": 5},
+        cv.SCRIPT_ACTION_WAIT_TEMPLATE: {
+            "wait_template": "{{ states.light.kitchen.state == 'on' }}"
+        },
+        cv.SCRIPT_ACTION_FIRE_EVENT: {"event": "my_event"},
+        cv.SCRIPT_ACTION_CHECK_CONDITION: {
+            "condition": "{{ states.light.kitchen.state == 'on' }}"
+        },
+        cv.SCRIPT_ACTION_DEVICE_AUTOMATION: {
+            "domain": "light",
+            "entity_id": "light.kitchen",
+            "device_id": "abcd",
+            "type": "turn_on",
+        },
+        cv.SCRIPT_ACTION_ACTIVATE_SCENE: {"scene": "scene.relax"},
+        cv.SCRIPT_ACTION_REPEAT: {
+            "repeat": {"count": 3, "sequence": [{"event": "repeat_event"}]}
+        },
+        cv.SCRIPT_ACTION_CHOOSE: {
+            "choose": [
+                {
+                    "condition": "{{ states.light.kitchen.state == 'on' }}",
+                    "sequence": [{"event": "choose_event"}],
+                }
+            ],
+            "default": [{"event": "choose_default_event"}],
+        },
+        cv.SCRIPT_ACTION_WAIT_FOR_TRIGGER: {
+            "wait_for_trigger": [
+                {"platform": "event", "event_type": "wait_for_trigger_event"}
+            ]
+        },
+        cv.SCRIPT_ACTION_VARIABLES: {"variables": {"hello": "world"}},
+    }
+
+    for key in cv.ACTION_TYPE_SCHEMAS:
+        assert key in configs, f"No validate config test found for {key}"
+
+    for action_type, config in configs.items():
+        assert cv.determine_script_action(config) == action_type
+        try:
+            await script.async_validate_action_config(hass, config)
+        except vol.Invalid as err:
+            assert False, f"{action_type} config invalid: {err}"
+
+
+async def test_embedded_wait_for_trigger_in_automation(hass):
+    """Test an embedded wait for trigger."""
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "action": {
+                    "repeat": {
+                        "while": [
+                            {
+                                "condition": "template",
+                                "value_template": '{{ is_state("test.value1", "trigger-while") }}',
+                            }
+                        ],
+                        "sequence": [
+                            {"event": "trigger_wait_event"},
+                            {
+                                "wait_for_trigger": [
+                                    {
+                                        "platform": "template",
+                                        "value_template": '{{ is_state("test.value2", "trigger-wait") }}',
+                                    }
+                                ]
+                            },
+                            {"service": "test.script"},
+                        ],
+                    }
+                },
+            }
+        },
+    )
+
+    hass.states.async_set("test.value1", "trigger-while")
+    hass.states.async_set("test.value2", "not-trigger-wait")
+    mock_calls = async_mock_service(hass, "test", "script")
+
+    async def trigger_wait_event(_):
+        # give script the time to attach the trigger.
+        await asyncio.sleep(0)
+        hass.states.async_set("test.value1", "not-trigger-while")
+        hass.states.async_set("test.value2", "trigger-wait")
+
+    hass.bus.async_listen("trigger_wait_event", trigger_wait_event)
+
+    # Start automation
+    hass.bus.async_fire("test_event")
+
+    await hass.async_block_till_done()
+
+    assert len(mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We need to use async config validation to make sure that we process all embedded trigger configs correctly. We skipped this for `choose` and `repeat` actions, causing us to pass unprocessed configs to attach trigger.

This fixes it, and adds a test to make sure that future script extensions are added to the config validator.

Fixes #40613

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
