### PR TITLE
Use common strings for Panasonic Viera

### DIFF
--- a/homeassistant/components/panasonic_viera/config_flow.py
+++ b/homeassistant/components/panasonic_viera/config_flow.py
@@ -52,7 +52,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except (TimeoutError, URLError, SOAPError, OSError) as err:
                 _LOGGER.error("Could not establish remote connection: %s", err)
-                errors["base"] = ERROR_NOT_CONNECTED
+                errors["base"] = "cannot_connect"
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("An unknown error occurred: %s", err)
                 return self.async_abort(reason="unknown")

--- a/homeassistant/components/panasonic_viera/config_flow.py
+++ b/homeassistant/components/panasonic_viera/config_flow.py
@@ -57,7 +57,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = ERROR_NOT_CONNECTED
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("An unknown error occurred: %s", err)
-                return self.async_abort(reason=REASON_UNKNOWN)
+                return self.async_abort(reason="unknown")
 
             if "base" not in errors:
                 if self._remote.type == TV_TYPE_ENCRYPTED:
@@ -104,10 +104,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = ERROR_INVALID_PIN_CODE
             except (TimeoutError, URLError, OSError) as err:
                 _LOGGER.error("The remote connection was lost: %s", err)
-                return self.async_abort(reason=REASON_NOT_CONNECTED)
+                return self.async_abort(reason="cannot_connect")
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("Unknown error: %s", err)
-                return self.async_abort(reason=REASON_UNKNOWN)
+                return self.async_abort(reason="unknown")
 
             if "base" not in errors:
                 encryption_data = {
@@ -128,10 +128,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         except (TimeoutError, URLError, SOAPError, OSError) as err:
             _LOGGER.error("The remote connection was lost: %s", err)
-            return self.async_abort(reason=REASON_NOT_CONNECTED)
+            return self.async_abort(reason="cannot_connect")
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.exception("Unknown error: %s", err)
-            return self.async_abort(reason=REASON_UNKNOWN)
+            return self.async_abort(reason="unknown")
 
         return self.async_show_form(
             step_id="pairing",

--- a/homeassistant/components/panasonic_viera/config_flow.py
+++ b/homeassistant/components/panasonic_viera/config_flow.py
@@ -18,8 +18,6 @@ from .const import (  # pylint: disable=unused-import
     DOMAIN,
     ERROR_INVALID_PIN_CODE,
     ERROR_NOT_CONNECTED,
-    REASON_NOT_CONNECTED,
-    REASON_UNKNOWN,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/panasonic_viera/config_flow.py
+++ b/homeassistant/components/panasonic_viera/config_flow.py
@@ -17,7 +17,6 @@ from .const import (  # pylint: disable=unused-import
     DEFAULT_PORT,
     DOMAIN,
     ERROR_INVALID_PIN_CODE,
-    ERROR_NOT_CONNECTED,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/panasonic_viera/const.py
+++ b/homeassistant/components/panasonic_viera/const.py
@@ -12,8 +12,4 @@ DEFAULT_PORT = 55000
 
 ATTR_REMOTE = "remote"
 
-ERROR_NOT_CONNECTED = "not_connected"
 ERROR_INVALID_PIN_CODE = "invalid_pin_code"
-
-REASON_NOT_CONNECTED = "not_connected"
-REASON_UNKNOWN = "unknown"

--- a/homeassistant/components/panasonic_viera/strings.json
+++ b/homeassistant/components/panasonic_viera/strings.json
@@ -24,7 +24,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "not_connected": "[%key:common::config_flow::error::cannot_connect%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }

--- a/homeassistant/components/panasonic_viera/strings.json
+++ b/homeassistant/components/panasonic_viera/strings.json
@@ -19,13 +19,13 @@
       }
     },
     "error": {
-      "not_connected": "Could not establish a remote connection with your Panasonic Viera TV",
+      "not_connected": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_pin_code": "The PIN code you entered was invalid"
     },
     "abort": {
-      "already_configured": "This Panasonic Viera TV is already configured.",
-      "not_connected": "The remote connection with your Panasonic Viera TV was lost. Check the logs for more information.",
-      "unknown": "An unknown error occured. Check the logs for more information."
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "not_connected": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }
 }

--- a/homeassistant/components/panasonic_viera/strings.json
+++ b/homeassistant/components/panasonic_viera/strings.json
@@ -19,7 +19,7 @@
       }
     },
     "error": {
-      "not_connected": "[%key:common::config_flow::error::cannot_connect%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_pin_code": "The PIN code you entered was invalid"
     },
     "abort": {

--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -113,7 +113,7 @@ async def test_flow_not_connected_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == "cannot_connect"
 
 
 async def test_flow_unknown_abort(hass):
@@ -527,7 +527,7 @@ async def test_imported_flow_not_connected_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == "cannot_connect"
 
 
 async def test_imported_flow_unknown_abort(hass):

--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -11,9 +11,6 @@ from homeassistant.components.panasonic_viera.const import (
     DEFAULT_PORT,
     DOMAIN,
     ERROR_INVALID_PIN_CODE,
-    ERROR_NOT_CONNECTED,
-    REASON_NOT_CONNECTED,
-    REASON_UNKNOWN,
 )
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PIN, CONF_PORT
 
@@ -139,7 +136,7 @@ async def test_flow_unknown_abort(hass):
         )
 
     assert result["type"] == "abort"
-    assert result["reason"] == REASON_UNKNOWN
+    assert result["reason"] == "unknown"
 
 
 async def test_flow_encrypted_valid_pin_code(hass):

--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -527,7 +527,7 @@ async def test_imported_flow_not_connected_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == "cannot_connect"
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_imported_flow_unknown_abort(hass):

--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -113,7 +113,7 @@ async def test_flow_not_connected_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == "cannot_connect"
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_flow_unknown_abort(hass):

--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -116,7 +116,7 @@ async def test_flow_not_connected_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": ERROR_NOT_CONNECTED}
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_flow_unknown_abort(hass):
@@ -255,7 +255,7 @@ async def test_flow_encrypted_not_connected_abort(hass):
     )
 
     assert result["type"] == "abort"
-    assert result["reason"] == REASON_NOT_CONNECTED
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_flow_encrypted_unknown_abort(hass):
@@ -288,7 +288,7 @@ async def test_flow_encrypted_unknown_abort(hass):
     )
 
     assert result["type"] == "abort"
-    assert result["reason"] == REASON_UNKNOWN
+    assert result["reason"] == "unknown"
 
 
 async def test_flow_non_encrypted_already_configured_abort(hass):
@@ -475,7 +475,7 @@ async def test_imported_flow_encrypted_not_connected_abort(hass):
     )
 
     assert result["type"] == "abort"
-    assert result["reason"] == REASON_NOT_CONNECTED
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_imported_flow_encrypted_unknown_abort(hass):
@@ -507,7 +507,7 @@ async def test_imported_flow_encrypted_unknown_abort(hass):
     )
 
     assert result["type"] == "abort"
-    assert result["reason"] == REASON_UNKNOWN
+    assert result["reason"] == "unknown"
 
 
 async def test_imported_flow_not_connected_error(hass):
@@ -530,7 +530,7 @@ async def test_imported_flow_not_connected_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": ERROR_NOT_CONNECTED}
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_imported_flow_unknown_abort(hass):
@@ -552,7 +552,7 @@ async def test_imported_flow_unknown_abort(hass):
         )
 
     assert result["type"] == "abort"
-    assert result["reason"] == REASON_UNKNOWN
+    assert result["reason"] == "unknown"
 
 
 async def test_imported_flow_non_encrypted_already_configured_abort(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use common strings for Panasonic Viera #40578

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
