### PR TITLE
Return attribute dict directly without temporary variable v2

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -209,10 +209,7 @@ class DeconzBaseLight(DeconzDevice, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        attributes = {}
-        attributes["is_deconz_group"] = self._device.type == "LightGroup"
-
-        return attributes
+        return {"is_deconz_group": self._device.type == "LightGroup"}
 
 
 class DeconzLight(DeconzBaseLight):

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -308,14 +308,13 @@ class DenonDevice(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        attributes = {}
         if (
             self._sound_mode_raw is not None
             and self._sound_mode_support
             and self._power == "ON"
         ):
-            attributes[ATTR_SOUND_MODE_RAW] = self._sound_mode_raw
-        return attributes
+            return {ATTR_SOUND_MODE_RAW: self._sound_mode_raw}
+        return {}
 
     def media_play_pause(self):
         """Play or pause the media player."""

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -213,8 +213,7 @@ class DerivativeSensor(RestoreEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        state_attr = {ATTR_SOURCE_ID: self._sensor_source_id}
-        return state_attr
+        return {ATTR_SOURCE_ID: self._sensor_source_id}
 
     @property
     def icon(self):

--- a/homeassistant/components/directv/media_player.py
+++ b/homeassistant/components/directv/media_player.py
@@ -126,14 +126,14 @@ class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        attributes = {}
         if not self._is_standby:
-            attributes[ATTR_MEDIA_CURRENTLY_RECORDING] = self.media_currently_recording
-            attributes[ATTR_MEDIA_RATING] = self.media_rating
-            attributes[ATTR_MEDIA_RECORDED] = self.media_recorded
-            attributes[ATTR_MEDIA_START_TIME] = self.media_start_time
-
-        return attributes
+            return {
+                ATTR_MEDIA_CURRENTLY_RECORDING: self.media_currently_recording,
+                ATTR_MEDIA_RATING: self.media_rating,
+                ATTR_MEDIA_RECORDED: self.media_recorded,
+                ATTR_MEDIA_START_TIME: self.media_start_time,
+            }
+        return {}
 
     @property
     def name(self):

--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -112,11 +112,11 @@ class EightHeatSensor(EightSleepHeatEntity):
     @property
     def device_state_attributes(self):
         """Return device state attributes."""
-        state_attr = {ATTR_TARGET_HEAT: self._usrobj.target_heating_level}
-        state_attr[ATTR_ACTIVE_HEAT] = self._usrobj.now_heating
-        state_attr[ATTR_DURATION_HEAT] = self._usrobj.heating_remaining
-
-        return state_attr
+        return {
+            ATTR_TARGET_HEAT: self._usrobj.target_heating_level,
+            ATTR_ACTIVE_HEAT: self._usrobj.now_heating,
+            ATTR_DURATION_HEAT: self._usrobj.heating_remaining,
+        }
 
 
 class EightUserSensor(EightSleepUserEntity):

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -253,13 +253,13 @@ class Enigma2Device(MediaPlayerEntity):
         currservice_begin:  is in the format '21:00'.
         currservice_end:    is in the format '21:00'.
         """
-        if not self.e2_box.in_standby:
-            return {
-                ATTR_MEDIA_CURRENTLY_RECORDING: self.e2_box.status_info["isRecording"],
-                ATTR_MEDIA_DESCRIPTION: self.e2_box.status_info[
-                    "currservice_fulldescription"
-                ],
-                ATTR_MEDIA_START_TIME: self.e2_box.status_info["currservice_begin"],
-                ATTR_MEDIA_END_TIME: self.e2_box.status_info["currservice_end"],
-            }
-        return {}
+        if self.e2_box.in_standby:
+            return {}
+        return {
+            ATTR_MEDIA_CURRENTLY_RECORDING: self.e2_box.status_info["isRecording"],
+            ATTR_MEDIA_DESCRIPTION: self.e2_box.status_info[
+                "currservice_fulldescription"
+            ],
+            ATTR_MEDIA_START_TIME: self.e2_box.status_info["currservice_begin"],
+            ATTR_MEDIA_END_TIME: self.e2_box.status_info["currservice_end"],
+        }

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -253,17 +253,13 @@ class Enigma2Device(MediaPlayerEntity):
         currservice_begin:  is in the format '21:00'.
         currservice_end:    is in the format '21:00'.
         """
-        attributes = {}
         if not self.e2_box.in_standby:
-            attributes[ATTR_MEDIA_CURRENTLY_RECORDING] = self.e2_box.status_info[
-                "isRecording"
-            ]
-            attributes[ATTR_MEDIA_DESCRIPTION] = self.e2_box.status_info[
-                "currservice_fulldescription"
-            ]
-            attributes[ATTR_MEDIA_START_TIME] = self.e2_box.status_info[
-                "currservice_begin"
-            ]
-            attributes[ATTR_MEDIA_END_TIME] = self.e2_box.status_info["currservice_end"]
-
-        return attributes
+            return {
+                ATTR_MEDIA_CURRENTLY_RECORDING: self.e2_box.status_info["isRecording"],
+                ATTR_MEDIA_DESCRIPTION: self.e2_box.status_info[
+                    "currservice_fulldescription"
+                ],
+                ATTR_MEDIA_START_TIME: self.e2_box.status_info["currservice_begin"],
+                ATTR_MEDIA_END_TIME: self.e2_box.status_info["currservice_end"],
+            }
+        return {}

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -235,7 +235,6 @@ class EpsonProjector(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        attributes = {}
         if self._cmode is not None:
-            attributes[ATTR_CMODE] = self._cmode
-        return attributes
+            return {ATTR_CMODE: self._cmode}
+        return {}

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -319,8 +319,7 @@ class SensorFilter(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        state_attr = {ATTR_ENTITY_ID: self._entity}
-        return state_attr
+        return {ATTR_ENTITY_ID: self._entity}
 
 
 class FilterState:

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -36,12 +36,13 @@ class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attr = {}
         if self._device.has_alerts:
-            attr["info"] = self._device.pending_info_alerts_count
-            attr["warning"] = self._device.pending_warning_alerts_count
-            attr["critical"] = self._device.pending_critical_alerts_count
-        return attr
+            return {
+                "info": self._device.pending_info_alerts_count,
+                "warning": self._device.pending_warning_alerts_count,
+                "critical": self._device.pending_critical_alerts_count,
+            }
+        return {}
 
     @property
     def device_class(self):

--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -121,14 +121,13 @@ class GarminConnectSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return attributes for sensor."""
-        attributes = {}
         if self._data.data:
-            attributes = {
+            return {
                 "source": self._data.data["source"],
                 "last_synced": self._data.data["lastSyncTimestampGMT"],
                 ATTR_ATTRIBUTION: ATTRIBUTION,
             }
-        return attributes
+        return {}
 
     @property
     def device_info(self) -> Dict[str, Any]:

--- a/homeassistant/components/geo_json_events/geo_location.py
+++ b/homeassistant/components/geo_json_events/geo_location.py
@@ -203,7 +203,6 @@ class GeoJsonLocationEvent(GeolocationEvent):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        attributes = {}
         if self._external_id:
-            attributes[ATTR_EXTERNAL_ID] = self._external_id
-        return attributes
+            return {ATTR_EXTERNAL_ID: self._external_id}
+        return {}

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -110,10 +110,8 @@ class HomeKitAlarmControlPanelEntity(HomeKitEntity, AlarmControlPanelEntity):
     @property
     def device_state_attributes(self):
         """Return the optional state attributes."""
-        attributes = {}
-
         battery_level = self.service.value(CharacteristicsTypes.BATTERY_LEVEL)
-        if battery_level:
-            attributes[ATTR_BATTERY_LEVEL] = battery_level
 
-        return attributes
+        if battery_level:
+            return {ATTR_BATTERY_LEVEL: battery_level}
+        return {}

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -117,15 +117,13 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
     @property
     def device_state_attributes(self):
         """Return the optional state attributes."""
-        attributes = {}
-
         obstruction_detected = self.service.value(
             CharacteristicsTypes.OBSTRUCTION_DETECTED
         )
         if obstruction_detected:
-            attributes["obstruction-detected"] = obstruction_detected
+            return {"obstruction-detected": obstruction_detected}
 
-        return attributes
+        return {}
 
 
 class HomeKitWindowCover(HomeKitEntity, CoverEntity):
@@ -249,12 +247,9 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
     @property
     def device_state_attributes(self):
         """Return the optional state attributes."""
-        attributes = {}
-
         obstruction_detected = self.service.value(
             CharacteristicsTypes.OBSTRUCTION_DETECTED
         )
         if obstruction_detected:
-            attributes["obstruction-detected"] = obstruction_detected
-
-        return attributes
+            return {"obstruction-detected": obstruction_detected}
+        return {}

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -458,7 +458,6 @@ class HueLight(CoordinatorEntity, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        attributes = {}
         if self.is_group:
-            attributes[ATTR_IS_HUE_GROUP] = self.is_group
-        return attributes
+            return {ATTR_IS_HUE_GROUP: self.is_group}
+        return {}

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -203,8 +203,7 @@ class IntegrationSensor(RestoreEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        state_attr = {ATTR_SOURCE_ID: self._sensor_source_id}
-        return state_attr
+        return {ATTR_SOURCE_ID: self._sensor_source_id}
 
     @property
     def icon(self):

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -394,13 +394,12 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        state_attr = {}
-
         if self.state == STATE_ALARM_PENDING or self.state == STATE_ALARM_ARMING:
-            state_attr[ATTR_PREVIOUS_STATE] = self._previous_state
-            state_attr[ATTR_NEXT_STATE] = self._state
-
-        return state_attr
+            return {
+                ATTR_PREVIOUS_STATE: self._previous_state,
+                ATTR_NEXT_STATE: self._state,
+            }
+        return {}
 
     @callback
     def async_scheduled_update(self, now):

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -415,13 +415,12 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        state_attr = {}
-
         if self.state == STATE_ALARM_PENDING:
-            state_attr[ATTR_PRE_PENDING_STATE] = self._previous_state
-            state_attr[ATTR_POST_PENDING_STATE] = self._state
-
-        return state_attr
+            return {
+                ATTR_PRE_PENDING_STATE: self._previous_state,
+                ATTR_POST_PENDING_STATE: self._state,
+            }
+        return {}
 
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -273,12 +273,10 @@ class MaxCubeClimate(ClimateEntity):
         """Return the optional state attributes."""
         cube = self._cubehandle.cube
         device = cube.device_by_rf(self._rf_address)
-        attributes = {}
 
         if cube.is_thermostat(device):
-            attributes[ATTR_VALVE_POSITION] = device.valve_position
-
-        return attributes
+            return {ATTR_VALVE_POSITION: device.valve_position}
+        return {}
 
     def update(self):
         """Get latest data from MAX! Cube."""

--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -228,12 +228,11 @@ class MinMaxSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
-        state_attr = {
+        return {
             attr: getattr(self, attr)
             for attr in ATTR_TO_PROPERTY
             if getattr(self, attr) is not None
         }
-        return state_attr
 
     @property
     def icon(self):

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -197,10 +197,9 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        attr = {}
         if self._brightness is not None:
-            attr[ATTR_BRIGHTNESS] = self._brightness
-        return attr
+            return {ATTR_BRIGHTNESS: self._brightness}
+        return {}
 
     @property
     def supported_features(self):
@@ -260,10 +259,9 @@ class HybridRflinkLight(SwitchableRflinkDevice, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        attr = {}
         if self._brightness is not None:
-            attr[ATTR_BRIGHTNESS] = self._brightness
-        return attr
+            return {ATTR_BRIGHTNESS: self._brightness}
+        return {}
 
     @property
     def supported_features(self):

--- a/homeassistant/components/sesame/lock.py
+++ b/homeassistant/components/sesame/lock.py
@@ -88,8 +88,8 @@ class SesameDevice(LockEntity):
     @property
     def device_state_attributes(self) -> dict:
         """Return the state attributes."""
-        attributes = {}
-        attributes[ATTR_DEVICE_ID] = self._device_id
-        attributes[ATTR_SERIAL_NO] = self._serial
-        attributes[ATTR_BATTERY_LEVEL] = self._battery
-        return attributes
+        return {
+            ATTR_DEVICE_ID: self._device_id,
+            ATTR_SERIAL_NO: self._serial,
+            ATTR_BATTERY_LEVEL: self._battery,
+        }

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -172,7 +172,6 @@ class SighthoundEntity(ImageProcessingEntity):
     @property
     def device_state_attributes(self):
         """Return the attributes."""
-        attr = {}
         if self._last_detection:
-            attr["last_person"] = self._last_detection
-        return attr
+            return {"last_person": self._last_detection}
+        return {}

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -262,14 +262,13 @@ class TodoistProjectDevice(CalendarEventDevice):
             # No tasks, we don't REALLY need to show anything.
             return None
 
-        attributes = {}
-        attributes[DUE_TODAY] = self.data.event[DUE_TODAY]
-        attributes[OVERDUE] = self.data.event[OVERDUE]
-        attributes[ALL_TASKS] = self._cal_data[ALL_TASKS]
-        attributes[PRIORITY] = self.data.event[PRIORITY]
-        attributes[LABELS] = self.data.event[LABELS]
-
-        return attributes
+        return {
+            DUE_TODAY: self.data.event[DUE_TODAY],
+            OVERDUE: self.data.event[OVERDUE],
+            ALL_TASKS: self._cal_data[ALL_TASKS],
+            PRIORITY: self.data.event[PRIORITY],
+            LABELS: self.data.event[LABELS],
+        }
 
 
 class TodoistProjectData:

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -233,9 +233,7 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
     @property
     def device_state_attributes(self):
         """Return the client state attributes."""
-        attributes = {}
-
-        attributes["is_wired"] = self.is_wired
+        attributes = {"is_wired": self.is_wired}
 
         if self.is_connected:
             for variable in CLIENT_CONNECTED_ATTRIBUTES:

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -74,13 +74,14 @@ class VeSyncSwitchHA(VeSyncBaseSwitch, SwitchEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {}
         if hasattr(self.smartplug, "weekly_energy_total"):
-            attr["voltage"] = self.smartplug.voltage
-            attr["weekly_energy_total"] = self.smartplug.weekly_energy_total
-            attr["monthly_energy_total"] = self.smartplug.monthly_energy_total
-            attr["yearly_energy_total"] = self.smartplug.yearly_energy_total
-        return attr
+            return {
+                "voltage": self.smartplug.voltage,
+                "weekly_energy_total": self.smartplug.weekly_energy_total,
+                "monthly_energy_total": self.smartplug.monthly_energy_total,
+                "yearly_energy_total": self.smartplug.yearly_energy_total,
+            }
+        return {}
 
     @property
     def current_power_w(self):

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -320,10 +320,9 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        attributes = {}
         if self._client.sound_output is not None and self.state != STATE_OFF:
-            attributes[ATTR_SOUND_OUTPUT] = self._client.sound_output
-        return attributes
+            return {ATTR_SOUND_OUTPUT: self._client.sound_output}
+        return {}
 
     @cmd
     async def async_turn_off(self):

--- a/homeassistant/components/xbox_live/sensor.py
+++ b/homeassistant/components/xbox_live/sensor.py
@@ -106,9 +106,7 @@ class XboxSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attributes = {}
-        attributes["gamerscore"] = self._gamerscore
-        attributes["tier"] = self._tier
+        attributes = {"gamerscore": self._gamerscore, "tier": self._tier}
 
         for device in self._presence:
             for title in device["titles"]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Just some quick clean up to remove using unnecessary attribute dictionary and then immediately returning them.
Continuation of  #41206
```python
# Before
def attributes(self):
    attr = {"key": "value"}
    return attr

# After
def attributes(self):
    return {"key": "value"}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
