### PR TITLE
Add cancel_command service for OpenZWave

### DIFF
--- a/homeassistant/components/ozw/const.py
+++ b/homeassistant/components/ozw/const.py
@@ -40,6 +40,7 @@ ATTR_SCENE_VALUE_LABEL = "scene_value_label"
 # Service specific
 SERVICE_ADD_NODE = "add_node"
 SERVICE_REMOVE_NODE = "remove_node"
+SERVICE_CANCEL_COMMAND = "cancel_command"
 SERVICE_SET_CONFIG_PARAMETER = "set_config_parameter"
 
 # Home Assistant Events

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -42,6 +42,14 @@ class ZWaveServices:
                 {vol.Optional(const.ATTR_INSTANCE_ID, default=1): vol.Coerce(int)}
             ),
         )
+        self._hass.services.async_register(
+            const.DOMAIN,
+            const.SERVICE_CANCEL_COMMAND,
+            self.async_cancel_command,
+            schema=vol.Schema(
+                {vol.Optional(const.ATTR_INSTANCE_ID, default=1): vol.Coerce(int)}
+            ),
+        )
 
         self._hass.services.async_register(
             const.DOMAIN,
@@ -138,3 +146,10 @@ class ZWaveServices:
         instance_id = service.data[const.ATTR_INSTANCE_ID]
         instance = self._manager.get_instance(instance_id)
         instance.remove_node()
+
+    @callback
+    def async_cancel_command(self, service):
+        """Tell the controller to cancel an add or remove command."""
+        instance_id = service.data[const.ATTR_INSTANCE_ID]
+        instance = self._manager.get_instance(instance_id)
+        instance.cancel_controller_command()

--- a/homeassistant/components/ozw/services.py
+++ b/homeassistant/components/ozw/services.py
@@ -152,4 +152,6 @@ class ZWaveServices:
         """Tell the controller to cancel an add or remove command."""
         instance_id = service.data[const.ATTR_INSTANCE_ID]
         instance = self._manager.get_instance(instance_id)
+        if instance is None:
+            raise ValueError(f"No OpenZWave Instance with ID {instance_id}")
         instance.cancel_controller_command()

--- a/homeassistant/components/ozw/services.yaml
+++ b/homeassistant/components/ozw/services.yaml
@@ -13,6 +13,12 @@ remove_node:
     instance_id:
       description: (Optional) The OZW Instance/Controller to use, defaults to 1.
 
+cancel_command:
+  description: Cancel a pending add or remove node command.
+  fields:
+    instance_id:
+      description: (Optional) The OZW Instance/Controller to use, defaults to 1.
+
 set_config_parameter:
   description: Set a config parameter to a node on the Z-Wave network.
   fields:


### PR DESCRIPTION
## Proposed change
If you call the add node or remove node service to put OpenZWave into add or exclusion mode, it will queue all other commands until a node is added or removed (there is no built-in timeout). This allows you to cancel a pending add or remove node command.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14955

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
