### PR TITLE
Improve performance of generating non-cryptographically secure uuids

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -139,7 +139,7 @@ class ConfigEntry:
     ) -> None:
         """Initialize a config entry."""
         # Unique id of the config entry
-        self.entry_id = entry_id or uuid_util.uuid_v1mc_hex()
+        self.entry_id = entry_id or uuid_util.random_uuid_hex()
 
         # Version of the configuration.
         self.version = version

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -511,7 +511,7 @@ class Context:
 
     user_id: str = attr.ib(default=None)
     parent_id: Optional[str] = attr.ib(default=None)
-    id: str = attr.ib(factory=uuid_util.uuid_v1mc_hex)
+    id: str = attr.ib(factory=uuid_util.random_uuid_hex)
 
     def as_dict(self) -> dict:
         """Return a dictionary representation of the context."""

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -26,7 +26,7 @@ class AreaEntry:
     """Area Registry Entry."""
 
     name: Optional[str] = attr.ib(default=None)
-    id: str = attr.ib(factory=uuid_util.uuid_v1mc_hex)
+    id: str = attr.ib(factory=uuid_util.random_uuid_hex)
 
 
 class AreaRegistry:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -73,7 +73,7 @@ class DeviceEntry:
     area_id: str = attr.ib(default=None)
     name_by_user: str = attr.ib(default=None)
     entry_type: str = attr.ib(default=None)
-    id: str = attr.ib(factory=uuid_util.uuid_v1mc_hex)
+    id: str = attr.ib(factory=uuid_util.random_uuid_hex)
     # This value is not stored, just used to keep track of events to fire.
     is_new: bool = attr.ib(default=False)
 

--- a/homeassistant/util/uuid.py
+++ b/homeassistant/util/uuid.py
@@ -1,15 +1,12 @@
 """Helpers to generate uuids."""
 
-import random
-import uuid
+from random import getrandbits
 
 
-def uuid_v1mc_hex() -> str:
-    """Generate a uuid1 with a random multicast MAC address.
+def random_uuid_hex() -> str:
+    """Generate a random UUID hex.
 
-    The uuid1 uses a random multicast MAC address instead of the real MAC address
-    of the machine without the overhead of calling the getrandom() system call.
-
-    This is effectively equivalent to PostgreSQL's uuid_generate_v1mc() function
+    This uuid should not be used for cryptographically secure
+    operations.
     """
-    return uuid.uuid1(node=random.getrandbits(48) | (1 << 40)).hex
+    return "%032x" % getrandbits(32 * 4)

--- a/tests/util/test_uuid.py
+++ b/tests/util/test_uuid.py
@@ -5,7 +5,7 @@ import uuid
 import homeassistant.util.uuid as uuid_util
 
 
-async def test_uuid_v1mc_hex():
-    """Verify we can generate a uuid_v1mc and return hex."""
-    assert len(uuid_util.uuid_v1mc_hex()) == 32
-    assert uuid.UUID(uuid_util.uuid_v1mc_hex())
+async def test_uuid_util_random_uuid_hex():
+    """Verify we can generate a random uuid."""
+    assert len(uuid_util.random_uuid_hex()) == 32
+    assert uuid.UUID(uuid_util.random_uuid_hex())


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Resolves performance bottleneck firing events. The overhead of the uuid class isn't needed since all consumers of this function only need a non-repeating 32 hex string. 

After https://github.com/home-assistant/core/pull/41304 and this PR, the measurable overhead of firing event is reduced to a combination of calling `utcnow`, creating the event object, and the event loop & python implementation overhead. Previously generating the `uuid` and checking the callable type were the top performance bottlenecks.

Timings:
```
import timeit
print (timeit.Timer("uuid.uuid4()", "import uuid").timeit())
print (timeit.Timer("uuid.uuid1()", "import uuid").timeit())
print (timeit.Timer("secrets.token_hex(32)", "import secrets").timeit())
print (timeit.Timer("'%032x' % random.randrange(16**32)", "import random").timeit())
print (timeit.Timer("'%032x' % getrandbits(32 * 4)", "from random import getrandbits").timeit())
```
```
12.235297594685107
2.0886352149999996
2.617477936
1.480198939
0.31510891299999955
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
