### PR TITLE
Return empty dictionary at first for attributes

### DIFF
--- a/homeassistant/components/directv/media_player.py
+++ b/homeassistant/components/directv/media_player.py
@@ -126,14 +126,14 @@ class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        if not self._is_standby:
-            return {
-                ATTR_MEDIA_CURRENTLY_RECORDING: self.media_currently_recording,
-                ATTR_MEDIA_RATING: self.media_rating,
-                ATTR_MEDIA_RECORDED: self.media_recorded,
-                ATTR_MEDIA_START_TIME: self.media_start_time,
-            }
-        return {}
+        if self._is_standby:
+            return {}
+        return {
+            ATTR_MEDIA_CURRENTLY_RECORDING: self.media_currently_recording,
+            ATTR_MEDIA_RATING: self.media_rating,
+            ATTR_MEDIA_RECORDED: self.media_recorded,
+            ATTR_MEDIA_START_TIME: self.media_start_time,
+        }
 
     @property
     def name(self):

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -235,6 +235,6 @@ class EpsonProjector(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        if self._cmode is not None:
-            return {ATTR_CMODE: self._cmode}
-        return {}
+        if self._cmode is None:
+            return {}
+        return {ATTR_CMODE: self._cmode}

--- a/homeassistant/components/flo/binary_sensor.py
+++ b/homeassistant/components/flo/binary_sensor.py
@@ -36,13 +36,13 @@ class FloPendingAlertsBinarySensor(FloEntity, BinarySensorEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        if self._device.has_alerts:
-            return {
-                "info": self._device.pending_info_alerts_count,
-                "warning": self._device.pending_warning_alerts_count,
-                "critical": self._device.pending_critical_alerts_count,
-            }
-        return {}
+        if not self._device.has_alerts:
+            return {}
+        return {
+            "info": self._device.pending_info_alerts_count,
+            "warning": self._device.pending_warning_alerts_count,
+            "critical": self._device.pending_critical_alerts_count,
+        }
 
     @property
     def device_class(self):

--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -121,13 +121,13 @@ class GarminConnectSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return attributes for sensor."""
-        if self._data.data:
-            return {
-                "source": self._data.data["source"],
-                "last_synced": self._data.data["lastSyncTimestampGMT"],
-                ATTR_ATTRIBUTION: ATTRIBUTION,
-            }
-        return {}
+        if not self._data.data:
+            return {}
+        return {
+            "source": self._data.data["source"],
+            "last_synced": self._data.data["lastSyncTimestampGMT"],
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+        }
 
     @property
     def device_info(self) -> Dict[str, Any]:

--- a/homeassistant/components/geo_json_events/geo_location.py
+++ b/homeassistant/components/geo_json_events/geo_location.py
@@ -203,6 +203,6 @@ class GeoJsonLocationEvent(GeolocationEvent):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        if self._external_id:
-            return {ATTR_EXTERNAL_ID: self._external_id}
-        return {}
+        if not self._external_id:
+            return {}
+        return {ATTR_EXTERNAL_ID: self._external_id}

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -112,6 +112,6 @@ class HomeKitAlarmControlPanelEntity(HomeKitEntity, AlarmControlPanelEntity):
         """Return the optional state attributes."""
         battery_level = self.service.value(CharacteristicsTypes.BATTERY_LEVEL)
 
-        if battery_level:
-            return {ATTR_BATTERY_LEVEL: battery_level}
-        return {}
+        if not battery_level:
+            return {}
+        return {ATTR_BATTERY_LEVEL: battery_level}

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -120,10 +120,9 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
         obstruction_detected = self.service.value(
             CharacteristicsTypes.OBSTRUCTION_DETECTED
         )
-        if obstruction_detected:
-            return {"obstruction-detected": obstruction_detected}
-
-        return {}
+        if not obstruction_detected:
+            return {}
+        return {"obstruction-detected": obstruction_detected}
 
 
 class HomeKitWindowCover(HomeKitEntity, CoverEntity):
@@ -250,6 +249,6 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         obstruction_detected = self.service.value(
             CharacteristicsTypes.OBSTRUCTION_DETECTED
         )
-        if obstruction_detected:
-            return {"obstruction-detected": obstruction_detected}
-        return {}
+        if not obstruction_detected:
+            return {}
+        return {"obstruction-detected": obstruction_detected}

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -458,6 +458,6 @@ class HueLight(CoordinatorEntity, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        if self.is_group:
-            return {ATTR_IS_HUE_GROUP: self.is_group}
-        return {}
+        if not self.is_group:
+            return {}
+        return {ATTR_IS_HUE_GROUP: self.is_group}

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -113,10 +113,9 @@ class JewishCalendarSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        if self._type == "holiday":
-            return self._holiday_attrs
-
-        return {}
+        if self._type != "holiday":
+            return {}
+        return self._holiday_attrs
 
     def get_state(self, daytime_date, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -415,12 +415,12 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        if self.state == STATE_ALARM_PENDING:
-            return {
-                ATTR_PRE_PENDING_STATE: self._previous_state,
-                ATTR_POST_PENDING_STATE: self._state,
-            }
-        return {}
+        if self.state != STATE_ALARM_PENDING:
+            return {}
+        return {
+            ATTR_PRE_PENDING_STATE: self._previous_state,
+            ATTR_POST_PENDING_STATE: self._state,
+        }
 
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -287,9 +287,9 @@ class MaxCubeClimate(ClimateEntity):
         cube = self._cubehandle.cube
         device = cube.device_by_rf(self._rf_address)
 
-        if cube.is_thermostat(device):
-            return {ATTR_VALVE_POSITION: device.valve_position}
-        return {}
+        if not cube.is_thermostat(device):
+            return {}
+        return {ATTR_VALVE_POSITION: device.valve_position}
 
     def update(self):
         """Get latest data from MAX! Cube."""

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -61,6 +61,6 @@ class OPNSenseDeviceScanner(DeviceScanner):
         if device not in self.last_results:
             return None
         mfg = self.last_results[device].get("manufacturer")
-        if mfg:
-            return {"manufacturer": mfg}
-        return {}
+        if not mfg:
+            return {}
+        return {"manufacturer": mfg}

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -197,9 +197,9 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        if self._brightness is not None:
-            return {ATTR_BRIGHTNESS: self._brightness}
-        return {}
+        if self._brightness is None:
+            return {}
+        return {ATTR_BRIGHTNESS: self._brightness}
 
     @property
     def supported_features(self):
@@ -259,9 +259,9 @@ class HybridRflinkLight(SwitchableRflinkDevice, LightEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        if self._brightness is not None:
-            return {ATTR_BRIGHTNESS: self._brightness}
-        return {}
+        if self._brightness is None:
+            return {}
+        return {ATTR_BRIGHTNESS: self._brightness}
 
     @property
     def supported_features(self):

--- a/homeassistant/components/sighthound/image_processing.py
+++ b/homeassistant/components/sighthound/image_processing.py
@@ -172,6 +172,6 @@ class SighthoundEntity(ImageProcessingEntity):
     @property
     def device_state_attributes(self):
         """Return the attributes."""
-        if self._last_detection:
-            return {"last_person": self._last_detection}
-        return {}
+        if not self._last_detection:
+            return {}
+        return {"last_person": self._last_detection}

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -74,14 +74,14 @@ class VeSyncSwitchHA(VeSyncBaseSwitch, SwitchEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        if hasattr(self.smartplug, "weekly_energy_total"):
-            return {
-                "voltage": self.smartplug.voltage,
-                "weekly_energy_total": self.smartplug.weekly_energy_total,
-                "monthly_energy_total": self.smartplug.monthly_energy_total,
-                "yearly_energy_total": self.smartplug.yearly_energy_total,
-            }
-        return {}
+        if not hasattr(self.smartplug, "weekly_energy_total"):
+            return {}
+        return {
+            "voltage": self.smartplug.voltage,
+            "weekly_energy_total": self.smartplug.weekly_energy_total,
+            "monthly_energy_total": self.smartplug.monthly_energy_total,
+            "yearly_energy_total": self.smartplug.yearly_energy_total,
+        }
 
     @property
     def current_power_w(self):

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -320,9 +320,9 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        if self._client.sound_output is not None and self.state != STATE_OFF:
-            return {ATTR_SOUND_OUTPUT: self._client.sound_output}
-        return {}
+        if self._client.sound_output is None and self.state == STATE_OFF:
+            return {}
+        return {ATTR_SOUND_OUTPUT: self._client.sound_output}
 
     @cmd
     async def async_turn_off(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Return empty dictionary at first for attribute properties. This makes the code easier to read because edge cases are handled first and foremost. After that the "default" behaviour is handled and then returned.

```python
# Before
def attributes(self):
    if self._devices:
        return {"key": "value"}
    return {}

# After
def attributes(self):
    if not self._devices:
        return {}
    return {"key": "value"}
```
cc @balloob from https://github.com/home-assistant/core/pull/41271#discussion_r500223769

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to PRs: #41206 and #41271
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
