### PR TITLE
Multiple Hue activate scene

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -1,4 +1,5 @@
 """Support for the Philips Hue system."""
+import asyncio
 import logging
 
 from aiohue.util import normalize_bridge_id
@@ -7,7 +8,13 @@ from homeassistant import config_entries, core
 from homeassistant.components import persistent_notification
 from homeassistant.helpers import device_registry as dr
 
-from .bridge import HueBridge
+from .bridge import (
+    ATTR_GROUP_NAME,
+    ATTR_SCENE_NAME,
+    SCENE_SCHEMA,
+    SERVICE_HUE_SCENE,
+    HueBridge,
+)
 from .const import (
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
@@ -21,6 +28,39 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass, config):
     """Set up the Hue platform."""
+
+    async def hue_activate_scene(call, skip_reload=True):
+        """Handle activation of Hue scene."""
+        # Get parameters
+        group_name = call.data[ATTR_GROUP_NAME]
+        scene_name = call.data[ATTR_SCENE_NAME]
+
+        # Call the set scene function on each bridge
+        tasks = [
+            bridge.hue_activate_scene(
+                call, updated=skip_reload, hide_warnings=skip_reload
+            )
+            for bridge in hass.data[DOMAIN].values()
+            if isinstance(bridge, HueBridge)
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # Did *any* bridge succeed? If not, refresh / retry
+        # Note that we'll get a "None" value for a successful call
+        if None not in results:
+            if skip_reload:
+                return await hue_activate_scene(call, skip_reload=False)
+            _LOGGER.warning(
+                "No bridge was able to activate " "scene %s in group %s",
+                scene_name,
+                group_name,
+            )
+
+    # Register a local handler for scene activation
+    hass.services.async_register(
+        DOMAIN, SERVICE_HUE_SCENE, hue_activate_scene, schema=SCENE_SCHEMA
+    )
+
     hass.data[DOMAIN] = {}
     return True
 
@@ -131,4 +171,5 @@ async def async_setup_entry(
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     bridge = hass.data[DOMAIN].pop(entry.entry_id)
+    hass.services.async_remove(DOMAIN, SERVICE_HUE_SCENE)
     return await bridge.async_reset()

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -19,7 +19,6 @@ from .const import (
     CONF_ALLOW_UNREACHABLE,
     DEFAULT_ALLOW_HUE_GROUPS,
     DEFAULT_ALLOW_UNREACHABLE,
-    DOMAIN,
     LOGGER,
 )
 from .errors import AuthenticationRequired, CannotConnect
@@ -117,10 +116,6 @@ class HueBridge:
             hass.config_entries.async_forward_entry_setup(self.config_entry, "sensor")
         )
 
-        hass.services.async_register(
-            DOMAIN, SERVICE_HUE_SCENE, self.hue_activate_scene, schema=SCENE_SCHEMA
-        )
-
         self.parallel_updates_semaphore = asyncio.Semaphore(
             3 if self.api.config.modelid == "BSB001" else 10
         )
@@ -179,8 +174,6 @@ class HueBridge:
         if self.api is None:
             return True
 
-        self.hass.services.async_remove(DOMAIN, SERVICE_HUE_SCENE)
-
         while self.reset_jobs:
             self.reset_jobs.pop()()
 
@@ -204,7 +197,7 @@ class HueBridge:
         # None and True are OK
         return False not in results
 
-    async def hue_activate_scene(self, call, updated=False):
+    async def hue_activate_scene(self, call, updated=False, hide_warnings=False):
         """Service to call directly into bridge to set scenes."""
         group_name = call.data[ATTR_GROUP_NAME]
         scene_name = call.data[ATTR_SCENE_NAME]
@@ -230,18 +223,20 @@ class HueBridge:
         if not updated and (group is None or scene is None):
             await self.async_request_call(self.api.groups.update)
             await self.async_request_call(self.api.scenes.update)
-            await self.hue_activate_scene(call, updated=True)
-            return
+            return await self.hue_activate_scene(call, updated=True)
 
         if group is None:
-            LOGGER.warning("Unable to find group %s", group_name)
-            return
+            if not hide_warnings:
+                LOGGER.warning(
+                    "Unable to find group %s" " on bridge %s", group_name, self.host
+                )
+            return False
 
         if scene is None:
             LOGGER.warning("Unable to find scene %s", scene_name)
             return
 
-        await self.async_request_call(partial(group.set_action, scene=scene.id))
+        return await self.async_request_call(partial(group.set_action, scene=scene.id))
 
     async def handle_unauthorized_error(self):
         """Create a new config flow when the authorization is no longer valid."""

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -234,7 +234,7 @@ class HueBridge:
 
         if scene is None:
             LOGGER.warning("Unable to find scene %s", scene_name)
-            return
+            return False
 
         return await self.async_request_call(partial(group.set_action, scene=scene.id))
 

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -3,6 +3,7 @@ from collections import deque
 
 from aiohue.groups import Groups
 from aiohue.lights import Lights
+from aiohue.scenes import Scenes
 from aiohue.sensors import Sensors
 import pytest
 
@@ -10,7 +11,7 @@ from homeassistant import config_entries
 from homeassistant.components import hue
 from homeassistant.components.hue import sensor_base as hue_sensor_base
 
-from tests.async_mock import Mock, patch
+from tests.async_mock import AsyncMock, Mock, patch
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +64,39 @@ def create_mock_bridge(hass):
     bridge.api.groups = Groups({}, mock_request)
     bridge.api.sensors = Sensors({}, mock_request)
     return bridge
+
+
+@pytest.fixture
+def mock_api(hass):
+    """Mock the Hue api."""
+    api = Mock(initialize=AsyncMock())
+    api.mock_requests = []
+    api.mock_light_responses = deque()
+    api.mock_group_responses = deque()
+    api.mock_sensor_responses = deque()
+    api.mock_scene_responses = deque()
+
+    async def mock_request(method, path, **kwargs):
+        kwargs["method"] = method
+        kwargs["path"] = path
+        api.mock_requests.append(kwargs)
+
+        if path == "lights":
+            return api.mock_light_responses.popleft()
+        if path == "groups":
+            return api.mock_group_responses.popleft()
+        if path == "sensors":
+            return api.mock_sensor_responses.popleft()
+        if path == "scenes":
+            return api.mock_scene_responses.popleft()
+        return None
+
+    api.config.apiversion = "9.9.9"
+    api.lights = Lights({}, mock_request)
+    api.groups = Groups({}, mock_request)
+    api.sensors = Sensors({}, mock_request)
+    api.scenes = Scenes({}, mock_request)
+    return api
 
 
 @pytest.fixture

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -88,7 +88,7 @@ async def test_reset_unloads_entry_if_setup(hass):
     ), patch.object(hass.config_entries, "async_forward_entry_setup") as mock_forward:
         assert await hue_bridge.async_setup() is True
 
-    assert len(hass.services.async_services()) == 1
+    assert len(hass.services.async_services()) == 0
     assert len(mock_forward.mock_calls) == 3
 
     with patch.object(

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -1,8 +1,8 @@
 """Test Hue bridge."""
-from components import hue
-import config_entries
 import pytest
 
+from homeassistant import config_entries
+from homeassistant.components import hue
 from homeassistant.components.hue import bridge, errors
 from homeassistant.components.hue.const import (
     CONF_ALLOW_HUE_GROUPS,

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -1,4 +1,6 @@
 """Test Hue bridge."""
+from components import hue
+import config_entries
 import pytest
 
 from homeassistant.components.hue import bridge, errors
@@ -120,3 +122,131 @@ async def test_handle_unauthorized(hass):
     assert hue_bridge.authorized is False
     assert len(mock_create.mock_calls) == 1
     assert mock_create.mock_calls[0][1][1] == "1.2.3.4"
+
+
+GROUP_RESPONSE = {
+    "group_1": {
+        "name": "Group 1",
+        "lights": ["1", "2"],
+        "type": "LightGroup",
+        "action": {
+            "on": True,
+            "bri": 254,
+            "hue": 10000,
+            "sat": 254,
+            "effect": "none",
+            "xy": [0.5, 0.5],
+            "ct": 250,
+            "alert": "select",
+            "colormode": "ct",
+        },
+        "state": {"any_on": True, "all_on": False},
+    }
+}
+SCENE_RESPONSE = {
+    "scene_1": {
+        "name": "Cozy dinner",
+        "lights": ["1", "2"],
+        "owner": "ffffffffe0341b1b376a2389376a2389",
+        "recycle": True,
+        "locked": False,
+        "appdata": {"version": 1, "data": "myAppData"},
+        "picture": "",
+        "lastupdated": "2015-12-03T10:09:22",
+        "version": 2,
+    }
+}
+
+
+async def test_hue_activate_scene(hass, mock_api):
+    """Test successful hue_activate_scene."""
+    config_entry = config_entries.ConfigEntry(
+        1,
+        hue.DOMAIN,
+        "Mock Title",
+        {"host": "mock-host", "username": "mock-username"},
+        "test",
+        config_entries.CONN_CLASS_LOCAL_POLL,
+        system_options={},
+        options={CONF_ALLOW_HUE_GROUPS: True, CONF_ALLOW_UNREACHABLE: False},
+    )
+    hue_bridge = bridge.HueBridge(hass, config_entry)
+
+    mock_api.mock_group_responses.append(GROUP_RESPONSE)
+    mock_api.mock_scene_responses.append(SCENE_RESPONSE)
+
+    with patch("aiohue.Bridge", return_value=mock_api), patch.object(
+        hass.config_entries, "async_forward_entry_setup"
+    ):
+        assert await hue_bridge.async_setup() is True
+
+    assert hue_bridge.api is mock_api
+
+    call = Mock()
+    call.data = {"group_name": "Group 1", "scene_name": "Cozy dinner"}
+    with patch("aiohue.Bridge", return_value=mock_api):
+        assert await hue_bridge.hue_activate_scene(call) is None
+
+    assert len(mock_api.mock_requests) == 3
+    assert mock_api.mock_requests[2]["json"]["scene"] == "scene_1"
+    assert mock_api.mock_requests[2]["path"] == "groups/group_1/action"
+
+
+async def test_hue_activate_scene_group_not_found(hass, mock_api):
+    """Test failed hue_activate_scene due to missing group."""
+    config_entry = config_entries.ConfigEntry(
+        1,
+        hue.DOMAIN,
+        "Mock Title",
+        {"host": "mock-host", "username": "mock-username"},
+        "test",
+        config_entries.CONN_CLASS_LOCAL_POLL,
+        system_options={},
+        options={CONF_ALLOW_HUE_GROUPS: True, CONF_ALLOW_UNREACHABLE: False},
+    )
+    hue_bridge = bridge.HueBridge(hass, config_entry)
+
+    mock_api.mock_group_responses.append({})
+    mock_api.mock_scene_responses.append(SCENE_RESPONSE)
+
+    with patch("aiohue.Bridge", return_value=mock_api), patch.object(
+        hass.config_entries, "async_forward_entry_setup"
+    ):
+        assert await hue_bridge.async_setup() is True
+
+    assert hue_bridge.api is mock_api
+
+    call = Mock()
+    call.data = {"group_name": "Group 1", "scene_name": "Cozy dinner"}
+    with patch("aiohue.Bridge", return_value=mock_api):
+        assert await hue_bridge.hue_activate_scene(call) is False
+
+
+async def test_hue_activate_scene_scene_not_found(hass, mock_api):
+    """Test failed hue_activate_scene due to missing scene."""
+    config_entry = config_entries.ConfigEntry(
+        1,
+        hue.DOMAIN,
+        "Mock Title",
+        {"host": "mock-host", "username": "mock-username"},
+        "test",
+        config_entries.CONN_CLASS_LOCAL_POLL,
+        system_options={},
+        options={CONF_ALLOW_HUE_GROUPS: True, CONF_ALLOW_UNREACHABLE: False},
+    )
+    hue_bridge = bridge.HueBridge(hass, config_entry)
+
+    mock_api.mock_group_responses.append(GROUP_RESPONSE)
+    mock_api.mock_scene_responses.append({})
+
+    with patch("aiohue.Bridge", return_value=mock_api), patch.object(
+        hass.config_entries, "async_forward_entry_setup"
+    ):
+        assert await hue_bridge.async_setup() is True
+
+    assert hue_bridge.api is mock_api
+
+    call = Mock()
+    call.data = {"group_name": "Group 1", "scene_name": "Cozy dinner"}
+    with patch("aiohue.Bridge", return_value=mock_api):
+        assert await hue_bridge.hue_activate_scene(call) is False

--- a/tests/components/hue/test_init_multiple_bridges.py
+++ b/tests/components/hue/test_init_multiple_bridges.py
@@ -1,0 +1,192 @@
+"""Test Hue init with multiple bridges."""
+
+from aiohue.groups import Groups
+from aiohue.lights import Lights
+from aiohue.scenes import Scenes
+from aiohue.sensors import Sensors
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components import hue
+from homeassistant.components.hue import sensor_base as hue_sensor_base
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import Mock, patch
+
+
+async def setup_component(hass):
+    """Hue component with two bridges configured."""
+    with patch.object(hue, "async_setup_entry", return_value=True):
+        assert (
+            await async_setup_component(
+                hass,
+                hue.DOMAIN,
+                {
+                    hue.DOMAIN: {
+                        hue.CONF_BRIDGES: [
+                            {hue.CONF_HOST: "0.0.0.0"},
+                            {hue.CONF_HOST: "1.1.1.1"},
+                        ]
+                    }
+                },
+            )
+            is True
+        )
+
+
+async def test_hue_activate_scene_both_responds(
+    hass, mock_bridge1, mock_bridge2, mock_config_entry1, mock_config_entry2
+):
+    """Test that makes both bridges successfully activate a scene."""
+
+    await setup_component(hass)
+
+    await setup_bridge(hass, mock_bridge1, mock_config_entry1)
+    await setup_bridge(hass, mock_bridge2, mock_config_entry2)
+
+    with patch.object(
+        mock_bridge1, "hue_activate_scene", return_value=None
+    ) as mock_hue_activate_scene1, patch.object(
+        mock_bridge2, "hue_activate_scene", return_value=None
+    ) as mock_hue_activate_scene2:
+        await hass.services.async_call(
+            "hue",
+            "hue_activate_scene",
+            {"group_name": "group_2", "scene_name": "my_scene"},
+            blocking=True,
+        )
+
+    mock_hue_activate_scene1.assert_called_once()
+    mock_hue_activate_scene2.assert_called_once()
+
+
+async def test_hue_activate_scene_one_responds(
+    hass, mock_bridge1, mock_bridge2, mock_config_entry1, mock_config_entry2
+):
+    """Test that makes only one bridge successfully activate a scene."""
+
+    await setup_component(hass)
+
+    await setup_bridge(hass, mock_bridge1, mock_config_entry1)
+    await setup_bridge(hass, mock_bridge2, mock_config_entry2)
+
+    with patch.object(
+        mock_bridge1, "hue_activate_scene", return_value=None
+    ) as mock_hue_activate_scene1, patch.object(
+        mock_bridge2, "hue_activate_scene", return_value=False
+    ) as mock_hue_activate_scene2:
+        await hass.services.async_call(
+            "hue",
+            "hue_activate_scene",
+            {"group_name": "group_2", "scene_name": "my_scene"},
+            blocking=True,
+        )
+
+    mock_hue_activate_scene1.assert_called_once()
+    mock_hue_activate_scene2.assert_called_once()
+
+
+async def test_hue_activate_scene_zero_responds(
+    hass, mock_bridge1, mock_bridge2, mock_config_entry1, mock_config_entry2
+):
+    """Test that makes no bridge successfully activate a scene."""
+
+    await setup_component(hass)
+
+    await setup_bridge(hass, mock_bridge1, mock_config_entry1)
+    await setup_bridge(hass, mock_bridge2, mock_config_entry2)
+
+    with patch.object(
+        mock_bridge1, "hue_activate_scene", return_value=False
+    ) as mock_hue_activate_scene1, patch.object(
+        mock_bridge2, "hue_activate_scene", return_value=False
+    ) as mock_hue_activate_scene2:
+        await hass.services.async_call(
+            "hue",
+            "hue_activate_scene",
+            {"group_name": "group_2", "scene_name": "my_scene"},
+            blocking=True,
+        )
+
+    # both were retried
+    assert mock_hue_activate_scene1.call_count == 2
+    assert mock_hue_activate_scene2.call_count == 2
+
+
+async def setup_bridge(hass, mock_bridge, config_entry):
+    """Load the Hue light platform with the provided bridge."""
+    mock_bridge.config_entry = config_entry
+    hass.data[hue.DOMAIN][config_entry.entry_id] = mock_bridge
+    await hass.config_entries.async_forward_entry_setup(config_entry, "light")
+    # To flush out the service call to update the group
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+def mock_config_entry1(hass):
+    """Mock a config entry."""
+    return create_config_entry()
+
+
+@pytest.fixture
+def mock_config_entry2(hass):
+    """Mock a config entry."""
+    return create_config_entry()
+
+
+def create_config_entry():
+    """Mock a config entry."""
+    return config_entries.ConfigEntry(
+        1,
+        hue.DOMAIN,
+        "Mock Title",
+        {"host": "mock-host"},
+        "test",
+        config_entries.CONN_CLASS_LOCAL_POLL,
+        system_options={},
+    )
+
+
+@pytest.fixture
+def mock_bridge1(hass):
+    """Mock a Hue bridge."""
+    return create_mock_bridge(hass)
+
+
+@pytest.fixture
+def mock_bridge2(hass):
+    """Mock a Hue bridge."""
+    return create_mock_bridge(hass)
+
+
+def create_mock_bridge(hass):
+    """Create a mock Hue bridge."""
+    bridge = Mock(
+        hass=hass,
+        available=True,
+        authorized=True,
+        allow_unreachable=False,
+        allow_groups=False,
+        api=Mock(),
+        reset_jobs=[],
+        spec=hue.HueBridge,
+    )
+    bridge.sensor_manager = hue_sensor_base.SensorManager(bridge)
+    bridge.mock_requests = []
+
+    async def mock_request(method, path, **kwargs):
+        kwargs["method"] = method
+        kwargs["path"] = path
+        bridge.mock_requests.append(kwargs)
+        return {}
+
+    async def async_request_call(task):
+        await task()
+
+    bridge.async_request_call = async_request_call
+    bridge.api.config.apiversion = "9.9.9"
+    bridge.api.lights = Lights({}, mock_request)
+    bridge.api.groups = Groups({}, mock_request)
+    bridge.api.sensors = Sensors({}, mock_request)
+    bridge.api.scenes = Scenes({}, mock_request)
+    return bridge

--- a/tests/components/hue/test_init_multiple_bridges.py
+++ b/tests/components/hue/test_init_multiple_bridges.py
@@ -15,7 +15,7 @@ from tests.async_mock import Mock, patch
 
 
 async def setup_component(hass):
-    """Hue component with two bridges configured."""
+    """Hue component."""
     with patch.object(hue, "async_setup_entry", return_value=True):
         assert (
             await async_setup_component(

--- a/tests/components/hue/test_init_multiple_bridges.py
+++ b/tests/components/hue/test_init_multiple_bridges.py
@@ -21,14 +21,7 @@ async def setup_component(hass):
             await async_setup_component(
                 hass,
                 hue.DOMAIN,
-                {
-                    hue.DOMAIN: {
-                        hue.CONF_BRIDGES: [
-                            {hue.CONF_HOST: "0.0.0.0"},
-                            {hue.CONF_HOST: "1.1.1.1"},
-                        ]
-                    }
-                },
+                {},
             )
             is True
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is #19997 but applied to current dev and with tests. The description in that PR is 100% what this is and is @alistairg's work.
I'm running the code with two hue bridges at home.
Mocking with Python is completely new to me, so I apologize in advance if the tests are whack, but they verify that it at least does something.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16452.
- This PR is related to issue: #19997
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
