### PR TITLE
Add default strings to Atag integration

### DIFF
--- a/homeassistant/components/atag/strings.json
+++ b/homeassistant/components/atag/strings.json
@@ -12,11 +12,11 @@
       }
     },
     "error": {
-      "unauthorized": "Pairing denied, check device for auth request",
+      "unauthorized": "[%key:common::config_flow::error::invalid_auth%]",
       "connection_error": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "already_configured": "This device has already been added to HomeAssistant"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }


### PR DESCRIPTION
## Proposed change
Update to use default strings as per https://github.com/home-assistant/core/issues/40578
## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/40578
- Link to documentation pull request: 

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum