### PR TITLE
Not everyone uses the same date and time format

### DIFF
--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -27,7 +27,7 @@ OPTION_TYPES = {
     "time_utc": "Time (UTC)",
     "time_12h": "Time (12hr)",
     "date_dmy": "Date (dmy)",
-    "date_mdy": "Date (mdy)"
+    "date_mdy": "Date (mdy)",
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -110,10 +110,10 @@ class TimeDateSensor(Entity):
         return now + timedelta(seconds=delta)
 
     def _update_internal_state(self, time_date):
-        lt = dt_util.as_local(time_date)
-        time = lt.strftime(TIME_STR_FORMAT)
+        local_time = dt_util.as_local(time_date)
+        time = local_time.strftime(TIME_STR_FORMAT)
         time_utc = time_date.strftime(TIME_STR_FORMAT)
-        date = lt.date().isoformat()
+        date = local_time.date().isoformat()
         date_utc = time_date.date().isoformat()
 
         # Calculate Swatch Internet Time.
@@ -129,13 +129,13 @@ class TimeDateSensor(Entity):
         if self.type == "time":
             self._state = time
         elif self.type == "time_12h":
-            self._state = lt.strftime("%I:%M %p")
+            self._state = local_time.strftime("%I:%M %p")
         elif self.type == "date":
             self._state = date
         elif self.type == "date_dmy":
-            self._state = lt.strftime("%d-%m-%Y")
+            self._state = local_time.strftime("%d-%m-%Y")
         elif self.type == "date_mdy":
-            self._state = lt.strftime("%m-%d-%Y")
+            self._state = local_time.strftime("%m-%d-%Y")
         elif self.type == "date_time":
             self._state = f"{date}, {time}"
         elif self.type == "date_time_utc":


### PR DESCRIPTION
Not everyone uses the same date and time format, so add
- 12 hour time
- dates in dmy and mdy formats
These are only provided for local time.  I assume that if you are sophisticated enough to use UTC or isoformats, then you are happy with using the standardized time format (24hr, ymd).

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There's a strange (Euro centric) selection of date and time formats offered by this sensor.  This change rounds out that selection to offer the major missing formats, consisting of 12hr clock time, and dates in day/month/year and month/day/year order.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

sensor:
  - platform: time_date
    display_options:
      - 'time'
      - 'date'
      - 'date_time'
      - 'date_time_utc'
      - 'date_time_iso'
      - 'time_date'
      - 'time_utc'
      - 'beat'
      - 'time_12h'
      - 'date_dmy'
      - 'date_mdy'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
