### PR TITLE
Add daily_schedule integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -214,6 +214,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/cups/ @fabaff
 /homeassistant/components/daikin/ @fredrike
 /tests/components/daikin/ @fredrike
+/homeassistant/components/daily_schedule/ @amitfin
+/tests/components/daily_schedule/ @amitfin
 /homeassistant/components/darksky/ @fabaff
 /tests/components/darksky/ @fabaff
 /homeassistant/components/debugpy/ @frenck

--- a/homeassistant/components/daily_schedule/__init__.py
+++ b/homeassistant/components/daily_schedule/__init__.py
@@ -1,0 +1,27 @@
+"""Daily schedule integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up entity from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(
+        entry, (Platform.BINARY_SENSOR,)
+    )
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+    return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener, called when the config entry options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(
+        entry, (Platform.BINARY_SENSOR,)
+    )

--- a/homeassistant/components/daily_schedule/binary_sensor.py
+++ b/homeassistant/components/daily_schedule/binary_sensor.py
@@ -1,0 +1,99 @@
+"""Support for representing daily schedule as binary sensors."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import event as event_helper
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import homeassistant.util.dt as dt_util
+
+from .const import ATTR_SCHEDULE
+from .schedule import Schedule
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize config entry."""
+    async_add_entities(
+        [
+            DailyScheduleSenosr(
+                config_entry.title,
+                config_entry.entry_id,
+                config_entry.options.get(ATTR_SCHEDULE, []),
+            )
+        ]
+    )
+
+
+class DailyScheduleSenosr(BinarySensorEntity):
+    """Representation of a daily schedule sensor."""
+
+    _attr_icon = "mdi:timetable"
+
+    def __init__(
+        self, name: str, unique_id: str, schedule: list[dict[str, str]]
+    ) -> None:
+        """Initialize object with defaults."""
+        self._name = name
+        self._attr_unique_id = unique_id
+        self._schedule: Schedule = Schedule(schedule)
+        self._unsub_update: CALLBACK_TYPE | None = None
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def is_on(self) -> bool:
+        """Return True is sensor is on."""
+        return self._schedule.containing(dt_util.now().time())
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes of the sensor."""
+        return {
+            ATTR_SCHEDULE: self._schedule.to_list(),
+        }
+
+    @callback
+    def _clean_up_listener(self):
+        """Remove the update timer."""
+        if self._unsub_update is not None:
+            self._unsub_update()
+            self._unsub_update = None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(self._clean_up_listener)
+        self._update_state()
+
+    def _schedule_update(self) -> None:
+        """Schedule a timer for the point when the state should be changed."""
+        self._clean_up_listener()
+
+        next_update = self._schedule.next_update(dt_util.now())
+        if not next_update:
+            return
+
+        self._unsub_update = event_helper.async_track_point_in_time(
+            self.hass, self._update_state, next_update
+        )
+
+    @callback
+    def _update_state(self, *_):
+        """Update the state to reflect the current time."""
+        self._schedule_update()
+        self.async_write_ha_state()

--- a/homeassistant/components/daily_schedule/config_flow.py
+++ b/homeassistant/components/daily_schedule/config_flow.py
@@ -1,0 +1,165 @@
+"""Config flow for daily schedule integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
+import homeassistant.helpers.config_validation as cv
+
+from .const import ATTR_END, ATTR_SCHEDULE, ATTR_START, DOMAIN
+from .schedule import Schedule
+
+ADD_PERIOD = "add_period"
+PERIOD_DELIMITER = " - "
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): selector.TextSelector(),
+        vol.Required(ADD_PERIOD, default=True): selector.BooleanSelector(),
+    }
+)
+CONFIG_PERIOD = vol.Schema(
+    {
+        vol.Required(ATTR_START, default="00:00:00"): selector.TimeSelector(),
+        vol.Required(ATTR_END, default="00:00:00"): selector.TimeSelector(),
+        vol.Required(ADD_PERIOD, default=False): selector.BooleanSelector(),
+    }
+)
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_START, default="00:00:00"): selector.TimeSelector(),
+        vol.Optional(ATTR_END, default="00:00:00"): selector.TimeSelector(),
+    }
+)
+
+
+class DailyScheduleConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow."""
+
+    def __init__(self):
+        """Initialize a new flow."""
+        self.options: dict[str, Any] = {ATTR_SCHEDULE: []}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=CONFIG_SCHEMA)
+
+        if user_input.get(ADD_PERIOD, False):
+            self.options[CONF_NAME] = user_input[CONF_NAME]
+            return await self.async_step_period()
+
+        return self.async_create_entry(
+            title=user_input[CONF_NAME],
+            data={},
+            options={ATTR_SCHEDULE: []},
+        )
+
+    async def async_step_period(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle adding a time period."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+
+            # Validate the new schedule.
+            time_periods = self.options[ATTR_SCHEDULE].copy()
+            time_periods.append(
+                {ATTR_START: user_input[ATTR_START], ATTR_END: user_input[ATTR_END]}
+            )
+            try:
+                schedule = Schedule(time_periods)
+            except vol.Invalid:
+                errors["base"] = "invalid_schedule"
+
+            if not errors:
+                self.options[ATTR_SCHEDULE] = schedule.to_list()
+
+                if user_input.get(ADD_PERIOD, False):
+                    return await self.async_step_period()
+
+                return self.async_create_entry(
+                    title=self.options[CONF_NAME],
+                    data={},
+                    options={ATTR_SCHEDULE: self.options[ATTR_SCHEDULE]},
+                )
+
+        return self.async_show_form(
+            step_id="period", data_schema=CONFIG_PERIOD, errors=errors
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(OptionsFlow):
+    """Handles options flow for the component."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any]) -> FlowResult:
+        """Handle an options flow."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+
+            # Get all periods except for the ones which were unchecked by the user.
+            time_periods = [
+                {
+                    ATTR_START: period.split(PERIOD_DELIMITER)[0],
+                    ATTR_END: period.split(PERIOD_DELIMITER)[1],
+                }
+                for period in user_input.get(ATTR_SCHEDULE, [])
+            ]
+
+            # Add the additional period.
+            if user_input.get(ADD_PERIOD, True):
+                time_periods.append(
+                    {
+                        ATTR_START: user_input.get(ATTR_START, "00:00:00"),
+                        ATTR_END: user_input.get(ATTR_END, "00:00:00"),
+                    }
+                )
+
+            try:
+                schedule = Schedule(time_periods)
+            except vol.Invalid:
+                errors["base"] = "invalid_schedule"
+
+            if not errors:
+                return self.async_create_entry(
+                    title="",
+                    data={ATTR_SCHEDULE: schedule.to_list()},
+                )
+
+        periods = [
+            f"{period[ATTR_START]}{PERIOD_DELIMITER}{period[ATTR_END]}"
+            for period in self.config_entry.options.get(ATTR_SCHEDULE, [])
+        ]
+        if periods:
+            schema = vol.Schema(
+                {
+                    vol.Required(ATTR_SCHEDULE, default=periods): cv.multi_select(
+                        periods
+                    ),
+                    vol.Required(ADD_PERIOD, default=False): cv.boolean,
+                }
+            ).extend(OPTIONS_SCHEMA.schema)
+        else:
+            schema = OPTIONS_SCHEMA
+
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/homeassistant/components/daily_schedule/const.py
+++ b/homeassistant/components/daily_schedule/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Daily Schedule integration."""
+DOMAIN = "daily_schedule"
+
+ATTR_START = "start"
+ATTR_END = "end"
+ATTR_SCHEDULE = "schedule"

--- a/homeassistant/components/daily_schedule/manifest.json
+++ b/homeassistant/components/daily_schedule/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "daily_schedule",
+  "integration_type": "helper",
+  "name": "Daily Schedule",
+  "documentation": "https://www.home-assistant.io/integrations/daily_schedule",
+  "codeowners": ["@amitfin"],
+  "quality_scale": "internal",
+  "iot_class": "calculated",
+  "config_flow": true
+}

--- a/homeassistant/components/daily_schedule/schedule.py
+++ b/homeassistant/components/daily_schedule/schedule.py
@@ -1,0 +1,109 @@
+"""Schedule and time period logic."""
+from __future__ import annotations
+
+import datetime
+
+import voluptuous as vol
+
+from .const import ATTR_END, ATTR_START
+
+
+class TimePeriod:
+    """Time period with start and end."""
+
+    def __init__(self, start: str, end: str) -> None:
+        """Initialize the object."""
+        self.start: datetime.time = datetime.time.fromisoformat(start)
+        self.end: datetime.time = datetime.time.fromisoformat(end)
+
+    def containing(self, time: datetime.time) -> bool:
+        """Check if the time is inside the period."""
+        # If the period crosses the day boundary.
+        if self.end <= self.start:
+            return self.start <= time or time < self.end
+
+        return self.start <= time < self.end
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the object as a dict."""
+        return {
+            ATTR_START: self.start.isoformat(),
+            ATTR_END: self.end.isoformat(),
+        }
+
+
+class Schedule:
+    """List of TimePeriod."""
+
+    def __init__(self, schedule: list[dict[str, str]]) -> None:
+        """Create a list of TimePeriods representing the schedule."""
+        self._schedule = [
+            TimePeriod(period[ATTR_START], period[ATTR_END]) for period in schedule
+        ]
+        self._schedule.sort(key=lambda period: period.start)
+        self._validate()
+
+    def _validate(self) -> None:
+        """Validate the schedule."""
+        # Any schedule with zero or a single entry is valid.
+        if len(self._schedule) <= 1:
+            return
+
+        # Check all except the last period of the schedule.
+        for i in range(len(self._schedule) - 1):
+            # The end should be between starts of current and next periods.
+            # Note that adjusted periods are allowed.
+            if (
+                not self._schedule[i].start
+                < self._schedule[i].end
+                <= self._schedule[i + 1].start
+            ):
+                raise vol.Invalid("Invalid input schedule")
+
+        # Check the last period.
+        if self._schedule[-1].end <= self._schedule[-1].start:
+            # If it crosses the day boundary, check overlap with 1st period.
+            if self._schedule[-1].end > self._schedule[0].start:
+                raise vol.Invalid("Invalid input schedule")
+
+    def containing(self, time: datetime.time) -> bool:
+        """Check if the time is inside the period."""
+        for period in self._schedule:
+            if period.containing(time):
+                return True
+        return False
+
+    def to_list(self) -> list[dict[str, str]]:
+        """Serialize the object as a list."""
+        return [period.to_dict() for period in self._schedule]
+
+    def next_update(self, date: datetime.datetime) -> datetime.datetime | None:
+        """Schedule a timer for the point when the state should be changed."""
+        if not self._schedule:
+            return None
+
+        time = date.time()
+        today = date.date()
+        prev = datetime.time()  # Midnight.
+
+        # Get all timestamps (de-duped and sorted).
+        timestamps = [period.start for period in self._schedule] + [
+            period.end for period in self._schedule
+        ]
+        timestamps = list(set(timestamps))
+        timestamps.sort()
+
+        # Find the smallest timestamp which is bigger than time.
+        for current in timestamps:
+            if prev <= time < current:
+                return datetime.datetime.combine(
+                    today,
+                    current,
+                )
+            prev = current
+
+        # Time is bigger than all timestamps. Use tomorrow's 1st timestamp.
+        return datetime.datetime.combine(
+            today + datetime.timedelta(days=1),
+            timestamps[0],
+        )

--- a/homeassistant/components/daily_schedule/strings.json
+++ b/homeassistant/components/daily_schedule/strings.json
@@ -1,0 +1,43 @@
+{
+  "title": "Daily Schedule",
+  "config": {
+    "error": {
+      "invalid_schedule": "Invalid time periods in schedule. Enter the last period again."
+    },
+    "step": {
+      "user": {
+        "title": "Add Daily Schedule Sensor",
+        "description": "Create a binary sensor which turns on according to a daily schedule.",
+        "data": {
+          "name": "Name",
+          "add_period": "Add a time period"
+        }
+      },
+      "period": {
+        "title": "Add Time Period",
+        "description": "Set a time period when the sensor will be on.",
+        "data": {
+          "start": "Start time",
+          "end": "End time",
+          "add_period": "Add an additional time period"
+        }
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "invalid_schedule": "Invalid time periods in schedule. Enter the new period again."
+    },
+    "step": {
+      "init": {
+        "title": "Edit Daily Schedule Sensor",
+        "description": "Modify the time periods in the daily schedule.",
+        "data": {
+          "add_period": "Add a time period",
+          "start": "Start time",
+          "end": "End time"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/daily_schedule/translations/en.json
+++ b/homeassistant/components/daily_schedule/translations/en.json
@@ -1,0 +1,43 @@
+{
+    "title": "Daily Schedule",
+    "config": {
+        "error": {
+            "invalid_schedule": "Invalid time periods in schedule. Enter the last period again."
+        },
+        "step": {
+            "user": {
+                "title": "Add Daily Schedule Sensor",
+                "description": "Create a binary sensor which turns on according to a daily schedule.",
+                "data": {
+                    "name": "Name",
+                    "add_period": "Add a time period"
+                }
+            },
+            "period": {
+                "title": "Add Time Period",
+                "description": "Set a time period when the sensor will be on.",
+                "data": {
+                    "start": "Start time",
+                    "end": "End time",
+                    "add_period": "Add an additional time period"
+                }
+            }
+        }
+    },
+    "options": {
+        "error": {
+            "invalid_schedule": "Invalid time periods in schedule. Enter the new period again."
+        },
+        "step": {
+            "init": {
+                "title": "Edit Daily Schedule Sensor",
+                "description": "Modify the time periods in the daily schedule.",
+                "data": {
+                    "add_period": "Add a time period",
+                    "start": "Start time",
+                    "end": "End time"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -440,6 +440,7 @@ FLOWS = {
         "zwave_me"
     ],
     "helper": [
+        "daily_schedule",
         "derivative",
         "group",
         "integration",

--- a/tests/components/daily_schedule/__init__.py
+++ b/tests/components/daily_schedule/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the daily_schedule component."""

--- a/tests/components/daily_schedule/test_binary_sensor.py
+++ b/tests/components/daily_schedule/test_binary_sensor.py
@@ -1,0 +1,224 @@
+"""The tests for the daily schedule sensor component."""
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.daily_schedule.const import (
+    ATTR_END,
+    ATTR_SCHEDULE,
+    ATTR_START,
+    DOMAIN,
+)
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def setup_entity(
+    hass: HomeAssistant, name: str, schedule: list[dict[str, str]]
+) -> None:
+    """Create a new entity by adding a config entry."""
+    config_entry = MockConfigEntry(
+        options={ATTR_SCHEDULE: schedule},
+        domain=DOMAIN,
+        title=name,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ["schedule"],
+    [
+        ([],),
+        (
+            [
+                {
+                    ATTR_START: "01:02:03",
+                    ATTR_END: "04:05:06",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "04:05:06",
+                    ATTR_END: "01:02:03",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "00:00:00",
+                    ATTR_END: "00:00:00",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "07:08:09",
+                    ATTR_END: "10:11:12",
+                },
+                {
+                    ATTR_START: "01:02:03",
+                    ATTR_END: "04:05:06",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "10:11:12",
+                    ATTR_END: "01:02:03",
+                },
+                {
+                    ATTR_START: "01:02:03",
+                    ATTR_END: "04:05:06",
+                },
+            ],
+        ),
+    ],
+    ids=[
+        "empty",
+        "single",
+        "overnight",
+        "entire_day",
+        "multiple",
+        "adjusted",
+    ],
+)
+async def test_new_sensor(hass, schedule):
+    """Test new sensor."""
+    entity_id = f"{Platform.BINARY_SENSOR}.my_test"
+    await setup_entity(hass, "My Test", schedule)
+    schedule.sort(key=lambda period: period[ATTR_START])
+    assert hass.states.get(entity_id).attributes[ATTR_SCHEDULE] == schedule
+
+
+@patch("homeassistant.util.dt.now")
+async def test_state(mock_now, hass):
+    """Test state attribute."""
+    mock_now.return_value = datetime.datetime.fromisoformat("2000-01-01 23:50:00")
+
+    entity_id = f"{Platform.BINARY_SENSOR}.my_test"
+    await setup_entity(
+        hass,
+        "My Test",
+        [
+            {ATTR_START: "23:50:00", ATTR_END: "23:55:00"},
+            {ATTR_START: "00:00:00", ATTR_END: "00:05:00"},
+        ],
+    )
+
+    assert hass.states.get(entity_id).state == STATE_ON
+
+    state = STATE_OFF
+    for _ in range(3):
+        mock_now.return_value += datetime.timedelta(minutes=5)
+        async_fire_time_changed(hass, mock_now.return_value)
+        await hass.async_block_till_done()
+        assert hass.states.get(entity_id).state == state
+        state = STATE_ON if state == STATE_OFF else STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ["schedule"],
+    [
+        (
+            [
+                {
+                    ATTR_START: "00:00:00",
+                    ATTR_END: "00:00:00",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "07:00:00",
+                    ATTR_END: "07:00:00",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "17:00:00",
+                    ATTR_END: "07:00:00",
+                },
+                {
+                    ATTR_START: "07:00:00",
+                    ATTR_END: "17:00:00",
+                },
+            ],
+        ),
+    ],
+    ids=["midnight", "one", "two"],
+)
+async def test_entire_day(hass, schedule):
+    """Test entire day schedule."""
+    entity_id = f"{Platform.BINARY_SENSOR}.my_test"
+    await setup_entity(hass, "My Test", schedule)
+    assert hass.states.get(entity_id).state == STATE_ON
+
+
+@patch("homeassistant.util.dt.now")
+@patch("homeassistant.helpers.event.async_track_point_in_time")
+async def test_next_update(async_track_point_in_time, mock_now, hass):
+    """Test next update time."""
+    mock_now.return_value = datetime.datetime.fromisoformat("2000-01-01")
+
+    in_5_minutes = mock_now.return_value + datetime.timedelta(minutes=5)
+    in_10_minutes = mock_now.return_value + datetime.timedelta(minutes=10)
+    previous_5_minutes = mock_now.return_value + datetime.timedelta(minutes=-5)
+    previous_10_minutes = mock_now.return_value + datetime.timedelta(minutes=-10)
+
+    # No schedule => no updates.
+    assert async_track_point_in_time.call_count == 0
+
+    # Inside a time period.
+    await setup_entity(
+        hass,
+        "Test",
+        [
+            {
+                ATTR_START: previous_5_minutes.time().isoformat(),
+                ATTR_END: in_5_minutes.time().isoformat(),
+            }
+        ],
+    )
+    next_update = async_track_point_in_time.call_args[0][2]
+    assert next_update == in_5_minutes
+
+    # After all periods.
+    await setup_entity(
+        hass,
+        "Test",
+        [
+            {
+                ATTR_START: previous_10_minutes.time().isoformat(),
+                ATTR_END: previous_5_minutes.time().isoformat(),
+            }
+        ],
+    )
+    next_update = async_track_point_in_time.call_args[0][2]
+    assert next_update == previous_10_minutes + datetime.timedelta(days=1)
+
+    # Before any period.
+    await setup_entity(
+        hass,
+        "Test",
+        [
+            {
+                ATTR_START: in_5_minutes.time().isoformat(),
+                ATTR_END: in_10_minutes.time().isoformat(),
+            }
+        ],
+    )
+    next_update = async_track_point_in_time.call_args[0][2]
+    assert next_update == in_5_minutes

--- a/tests/components/daily_schedule/test_config_flow.py
+++ b/tests/components/daily_schedule/test_config_flow.py
@@ -1,0 +1,150 @@
+"""Tests for the Daily Schedule config flow."""
+from homeassistant.components.daily_schedule.config_flow import (
+    ADD_PERIOD,
+    PERIOD_DELIMITER,
+)
+from homeassistant.components.daily_schedule.const import (
+    ATTR_END,
+    ATTR_SCHEDULE,
+    ATTR_START,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_config_flow_no_schedule(hass: HomeAssistant) -> None:
+    """Test the user flow without a schedule."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_NAME: "test", ADD_PERIOD: False},
+    )
+
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2.get("title") == "test"
+    assert result2.get("options") == {ATTR_SCHEDULE: []}
+
+
+async def test_config_flow_with_schedule(hass: HomeAssistant) -> None:
+    """Test the user flow with a schedule."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_NAME: "test"},  # Default is to add a time period
+    )
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "period"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={ATTR_START: "15:00:00", ATTR_END: "20:00:00", ADD_PERIOD: True},
+    )
+    assert result3.get("type") == FlowResultType.FORM
+    assert result3.get("step_id") == "period"
+
+    result4 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={ATTR_START: "05:00:00", ATTR_END: "10:00:00"},
+    )
+    assert result4.get("type") == FlowResultType.CREATE_ENTRY
+    assert result4.get("title") == "test"
+    assert result4.get("options") == {
+        ATTR_SCHEDULE: [
+            {ATTR_START: "05:00:00", ATTR_END: "10:00:00"},
+            {ATTR_START: "15:00:00", ATTR_END: "20:00:00"},
+        ]
+    }
+
+
+async def test_config_flow_invalid_schedule(hass: HomeAssistant) -> None:
+    """Test the user flow with an invalid schedule."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_NAME: "test"},
+    )
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={ATTR_START: "05:00:00", ATTR_END: "10:00:00", ADD_PERIOD: True},
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={ATTR_START: "03:00:00", ATTR_END: "06:00:00"},
+    )
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "period"
+    assert result2.get("errors")["base"] == "invalid_schedule"
+
+
+async def test_options_flow(hass: HomeAssistant) -> None:
+    """Test the options flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My Test",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "init"
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            ATTR_START: "01:00:00",
+            ATTR_END: "04:00:00",
+        },
+    )
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2.get("data") == {
+        ATTR_SCHEDULE: [
+            {ATTR_START: "01:00:00", ATTR_END: "04:00:00"},
+        ]
+    }
+
+
+async def test_invalid_options_flow(hass: HomeAssistant) -> None:
+    """Test invalid options flow."""
+    config_entry = MockConfigEntry(
+        options={ATTR_SCHEDULE: [{ATTR_START: "05:00:00", ATTR_END: "10:00:00"}]},
+        domain=DOMAIN,
+        title="My Test",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            ATTR_SCHEDULE: [f"05:00:00{PERIOD_DELIMITER}10:00:00"],
+            ADD_PERIOD: True,
+            ATTR_START: "01:00:00",
+            ATTR_END: "06:00:00",
+        },
+    )
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("errors")["base"] == "invalid_schedule"

--- a/tests/components/daily_schedule/test_init.py
+++ b/tests/components/daily_schedule/test_init.py
@@ -1,0 +1,52 @@
+"""The tests for the daily schedule integration."""
+from homeassistant.components.daily_schedule.const import (
+    ATTR_END,
+    ATTR_SCHEDULE,
+    ATTR_START,
+    DOMAIN,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_change_remove_config_entry(hass: HomeAssistant) -> None:
+    """Test setting up and removing a config entry."""
+    entity_id = f"{Platform.BINARY_SENSOR}.my_test"
+    config_entry = MockConfigEntry(domain=DOMAIN, title="My Test", unique_id="1234")
+
+    # Add the config entry.
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry.
+    registry = er.async_get(hass)
+    assert registry.async_get(entity_id) is not None
+    state = hass.states.get(entity_id)
+    assert state.state == "off"
+    assert state.attributes[ATTR_SCHEDULE] == []
+
+    # Update the config entry.
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={ATTR_SCHEDULE: [{ATTR_START: "00:00:00", ATTR_END: "00:00:00"}]},
+    )
+    await hass.async_block_till_done()
+
+    # Check the updated entity.
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    assert state.attributes[ATTR_SCHEDULE] == [
+        {ATTR_START: "00:00:00", ATTR_END: "00:00:00"},
+    ]
+
+    # Remove the config entry.
+    assert await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are removed.
+    assert hass.states.get(entity_id) is None
+    assert registry.async_get(entity_id) is None

--- a/tests/components/daily_schedule/test_schedule.py
+++ b/tests/components/daily_schedule/test_schedule.py
@@ -1,0 +1,180 @@
+"""The tests for the schedule class."""
+import datetime
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.daily_schedule.const import ATTR_END, ATTR_START
+from homeassistant.components.daily_schedule.schedule import Schedule, TimePeriod
+
+
+@pytest.mark.parametrize(
+    ["start", "end", "time", "result"],
+    [
+        ("05:00", "10:00", "05:00", True),
+        ("05:00", "10:00", "10:00", False),
+        ("22:00", "05:00", "23:00", True),
+        ("22:00", "05:00", "04:00", True),
+        ("22:00", "05:00", "12:00", False),
+        ("00:00", "00:00", "00:00", True),
+    ],
+    ids=[
+        "contained",
+        "not contained",
+        "cross day night",
+        "cross day morning",
+        "cross day not contained",
+        "entire day",
+    ],
+)
+def test_time_period(start: str, end: str, time: str, result: bool):
+    """Test for TimePeriod class."""
+    period = TimePeriod(start, end)
+    assert period.containing(datetime.time.fromisoformat(time)) is result
+
+
+@pytest.mark.parametrize(
+    [
+        "param",
+    ],
+    [
+        ({ATTR_START: "05:00:00", ATTR_END: "10:00:00"},),
+        ({ATTR_START: "10:00:00", ATTR_END: "05:00:00"},),
+        ({ATTR_START: "05:00:00", ATTR_END: "05:00:00"},),
+    ],
+    ids=[
+        "regular",
+        "cross day",
+        "entire day",
+    ],
+)
+def test_time_period_to_dict(param: dict[str, str]):
+    """Test TimePeriod to_dict."""
+    assert TimePeriod(param[ATTR_START], param[ATTR_END]).to_dict() == param
+
+
+@pytest.mark.parametrize(
+    ["schedule", "time", "result"],
+    [
+        ([], "05:00", False),
+        ([{ATTR_START: "05:00", ATTR_END: "10:00"}], "05:00", True),
+        ([{ATTR_START: "05:00", ATTR_END: "10:00"}], "10:00", False),
+        (
+            [
+                {ATTR_START: "22:00", ATTR_END: "00:00"},
+                {ATTR_START: "05:00", ATTR_END: "10:00"},
+            ],
+            "23:00",
+            True,
+        ),
+    ],
+    ids=[
+        "empty",
+        "contained",
+        "not contained",
+        "2 periods contained",
+    ],
+)
+def test_schedule_containing(schedule: list[dict[str, str]], time: str, result: bool):
+    """Test containing method of Schedule."""
+    assert Schedule(schedule).containing(datetime.time.fromisoformat(time)) is result
+
+
+@pytest.mark.parametrize(
+    ["schedule"],
+    [
+        (
+            [
+                {
+                    ATTR_START: "04:05:05",
+                    ATTR_END: "07:08:09",
+                },
+                {
+                    ATTR_START: "01:02:03",
+                    ATTR_END: "04:05:06",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "07:08:09",
+                    ATTR_END: "01:02:04",
+                },
+                {
+                    ATTR_START: "01:02:03",
+                    ATTR_END: "04:05:06",
+                },
+            ],
+        ),
+    ],
+    ids=["overlap", "overnight_overlap"],
+)
+def test_invalid(schedule: list[dict[str, str]]):
+    """Test invalid schedule."""
+    with pytest.raises(vol.Invalid) as excinfo:
+        Schedule(schedule)
+    assert "Invalid input schedule" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ["schedule"],
+    [
+        (
+            [
+                {
+                    ATTR_START: "01:00:00",
+                    ATTR_END: "02:00:00",
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    ATTR_START: "03:00:00",
+                    ATTR_END: "04:00:00",
+                },
+                {
+                    ATTR_START: "01:00:00",
+                    ATTR_END: "02:00:00",
+                },
+            ],
+        ),
+    ],
+    ids=["one", "two"],
+)
+def test_to_list(schedule: list[dict[str, str]]) -> None:
+    """Test schedule to string list function."""
+    str_list = Schedule(schedule).to_list()
+    schedule.sort(key=lambda period: period[ATTR_START])
+    assert str_list == schedule
+
+
+@pytest.mark.parametrize(
+    ["start_sec_offset", "end_sec_offset", "next_update_sec_offset"],
+    [
+        (-5, 5, 5),
+        (-10, -5, datetime.timedelta(days=1).total_seconds() - 10),
+        (5, 10, 5),
+    ],
+    ids=["inside period", "after all periods", "before all periods"],
+)
+def test_next_update(
+    start_sec_offset: int,
+    end_sec_offset: int,
+    next_update_sec_offset: int,
+) -> None:
+    """Test next update logic."""
+    now = datetime.datetime.fromisoformat("2000-01-01")
+    assert Schedule(
+        [
+            {
+                ATTR_START: (now + datetime.timedelta(seconds=start_sec_offset))
+                .time()
+                .isoformat(),
+                ATTR_END: (now + datetime.timedelta(seconds=end_sec_offset))
+                .time()
+                .isoformat(),
+            }
+        ]
+    ).next_update(now) == now + datetime.timedelta(seconds=next_update_sec_offset)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a new integration which should help using fixed automation rules, while controlling their behavior through this new entity type.
The "daily_schedule" entity has an on/off state based on the time periods provided as input by the user. It preserves the time periods during reboots.
A typical usage will be to create a static automation rule, which will behave according to changes in the time periods of the schedule, without the need to change the rule itself.
A demo clip can be found [here](https://www.youtube.com/watch?v=TluMAZpORwk).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
daily_schedule:
  lights:
    name: Lights
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15023

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
