### PR TITLE
Make Jewish Calendar use DEVICE_CLASS_TIMSTAMP and remove timestamp attribute

### DIFF
--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -3,7 +3,7 @@ import logging
 
 import hdate
 
-from homeassistant.const import SUN_EVENT_SUNSET
+from homeassistant.const import DEVICE_CLASS_TIMESTAMP, SUN_EVENT_SUNSET
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
@@ -150,7 +150,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
     @property
     def device_class(self):
         """Return the class of this sensor."""
-        return "timestamp"
+        return DEVICE_CLASS_TIMESTAMP
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -152,18 +152,6 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
         """Return the class of this sensor."""
         return DEVICE_CLASS_TIMESTAMP
 
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attrs = {}
-
-        if self._state is None:
-            return attrs
-
-        attrs["timestamp"] = self._state.timestamp()
-
-        return attrs
-
     def get_state(self, daytime_date, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         if self._type == "upcoming_shabbat_candle_lighting":

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -152,6 +152,16 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
         """Return the class of this sensor."""
         return DEVICE_CLASS_TIMESTAMP
 
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {}
+
+        if self._state is None:
+            return attrs
+
+        return attrs
+
     def get_state(self, daytime_date, after_shkia_date, after_tzais_date):
         """For a given type of sensor, return the state."""
         if self._type == "upcoming_shabbat_candle_lighting":

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -3,7 +3,7 @@ import logging
 
 import hdate
 
-from homeassistant.const import SUN_EVENT_SUNSET
+from homeassistant.const import DEVICE_CLASS_TIMESTAMP, SUN_EVENT_SUNSET
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
@@ -150,7 +150,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
     @property
     def device_class(self):
         """Return the class of this sensor."""
-        return "timestamp"
+        return DEVICE_CLASS_TIMESTAMP
 
     @property
     def device_state_attributes(self):
@@ -161,6 +161,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
             return attrs
 
         attrs["timestamp"] = self._state.timestamp()
+        attrs["time"] = self._state.strftime("%H:%M")
 
         return attrs
 

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -3,7 +3,7 @@ import logging
 
 import hdate
 
-from homeassistant.const import DEVICE_CLASS_TIMESTAMP, SUN_EVENT_SUNSET
+from homeassistant.const import SUN_EVENT_SUNSET
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
@@ -150,7 +150,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
     @property
     def device_class(self):
         """Return the class of this sensor."""
-        return DEVICE_CLASS_TIMESTAMP
+        return "timestamp"
 
     @property
     def device_state_attributes(self):
@@ -161,7 +161,6 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
             return attrs
 
         attrs["timestamp"] = self._state.timestamp()
-        attrs["time"] = self._state.strftime("%H:%M")
 
         return attrs
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

This pull request removes the unix timestamp attribute from the sensors.

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request changes the device class "timestamp" to use the global variable, and as stated above, removes the timestamp attribute from timestamp sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

https://github.com/home-assistant/home-assistant.io/pull/15132

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
