### PR TITLE
Support of Z-Wave 4-speed fan controllers

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -41,6 +41,7 @@ SPEED_OFF = "off"
 SPEED_LOW = "low"
 SPEED_MEDIUM = "medium"
 SPEED_HIGH = "high"
+SPEED_VERY_HIGH = "very high"
 
 DIRECTION_FORWARD = "forward"
 DIRECTION_REVERSE = "reverse"

--- a/homeassistant/components/zwave/workaround.py
+++ b/homeassistant/components/zwave/workaround.py
@@ -121,6 +121,10 @@ DEVICE_COMPONENT_MAPPING_MTI = {
     LEVITON_FAN_CONTROLLER_ZW4SF_MULTILEVEL: "fan",
 }
 
+DEVICE_SPEEDS_MAPPING = {
+    LEVITON_FAN_CONTROLLER_ZW4SF_MULTILEVEL: 4,
+}
+
 
 def get_device_component_mapping(value):
     """Get mapping of value to another component."""
@@ -168,3 +172,23 @@ def get_device_mapping(value):
         return DEVICE_MAPPINGS_MT.get((manufacturer_id, product_type))
 
     return None
+
+
+def get_device_speeds(value):
+    """Get number of speeds."""
+    if (
+        value.node.manufacturer_id.strip()
+        and value.node.product_id.strip()
+        and value.node.product_type.strip()
+    ):
+        manufacturer_id = int(value.node.manufacturer_id, 16)
+        product_type = int(value.node.product_type, 16)
+        product_id = int(value.node.product_id, 16)
+        result = DEVICE_SPEEDS_MAPPING.get(
+            (manufacturer_id, product_type, product_id, value.command_class)
+        )
+        if result:
+            return result
+
+    # Default is 3 speeds
+    return 3

--- a/tests/components/zwave/test_fan.py
+++ b/tests/components/zwave/test_fan.py
@@ -4,9 +4,10 @@ from homeassistant.components.fan import (
     SPEED_LOW,
     SPEED_MEDIUM,
     SPEED_OFF,
+    SPEED_VERY_HIGH,
     SUPPORT_SET_SPEED,
 )
-from homeassistant.components.zwave import fan
+from homeassistant.components.zwave import const, fan
 
 from tests.mock.zwave import MockEntityValues, MockNode, MockValue, value_changed
 
@@ -21,6 +22,26 @@ def test_get_device_detects_fan(mock_openzwave):
     assert isinstance(device, fan.ZwaveFan)
     assert device.supported_features == SUPPORT_SET_SPEED
     assert device.speed_list == [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+
+def test_get_device_detects_4speed_fan(mock_openzwave):
+    """Test get_device returns instance of ZwaveFan4 in case of 4-speed fan."""
+    # Leviton ZW4SF-1BZ
+    node = MockNode(manufacturer_id="001d", product_type="0038", product_id="0002")
+    value = MockValue(
+        data=0, node=node, command_class=const.COMMAND_CLASS_SWITCH_MULTILEVEL
+    )
+    values = MockEntityValues(primary=value)
+
+    device = fan.get_device(node=node, values=values, node_config={})
+    assert isinstance(device, fan.ZwaveFan4)
+    assert device.speed_list == [
+        SPEED_OFF,
+        SPEED_LOW,
+        SPEED_MEDIUM,
+        SPEED_HIGH,
+        SPEED_VERY_HIGH,
+    ]
 
 
 def test_fan_turn_on(mock_openzwave):

--- a/tests/components/zwave/test_workaround.py
+++ b/tests/components/zwave/test_workaround.py
@@ -64,3 +64,21 @@ def test_get_device_mapping_mti_instance():
 
     value = MockValue(data=0, node=node, instance=2)
     assert workaround.get_device_mapping(value) is None
+
+
+def test_get_device_speeds():
+    """Test that device speeds is returned."""
+
+    # Leviton ZW4SF-1BZ
+    node = MockNode(manufacturer_id="001d", product_type="0038", product_id="0002")
+    value = MockValue(
+        data=0, node=node, command_class=const.COMMAND_CLASS_SWITCH_MULTILEVEL
+    )
+    assert workaround.get_device_speeds(value) == 4
+
+    # Other device
+    node = MockNode(manufacturer_id="013c", product_type="0001", product_id="0005")
+    value = MockValue(
+        data=0, node=node, command_class=const.COMMAND_CLASS_SWITCH_MULTILEVEL
+    )
+    assert workaround.get_device_speeds(value) == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some of manufactures produces Z-Wave fan speed controllers with 4 speeds,
ex. Leviton ZW4SF-1BW (https://www.leviton.com/en/products/zw4sf-1bz).
However current Home Assistant supports only 3 speeds (low, medium, high).
This PR adds 4th speed ("very high") for ZW4SF-1BW. Also proposed changes
can be used for easy support of more 4-speed fan controllers if needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
