### PR TITLE
Ensure recorder commit can retry after encountering invalid data

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -506,7 +506,8 @@ class Recorder(threading.Thread):
                 for dbstate in self._pending_expunge:
                     # Expunge the state so its not expired
                     # until we use it later for dbstate.old_state
-                    self.event_session.expunge(dbstate)
+                    if dbstate in self.event_session:
+                        self.event_session.expunge(dbstate)
                 self._pending_expunge = []
             self.event_session.commit()
         except Exception as err:

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -506,8 +506,7 @@ class Recorder(threading.Thread):
                 for dbstate in self._pending_expunge:
                     # Expunge the state so its not expired
                     # until we use it later for dbstate.old_state
-                    if dbstate in self.event_session:
-                        self.event_session.expunge(dbstate)
+                    self.event_session.expunge(dbstate)
                 self._pending_expunge = []
             self.event_session.commit()
         except Exception as err:

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -47,7 +47,7 @@ def test_saving_state(hass, hass_recorder):
     assert state == _state_empty_context(hass, entity_id)
 
 
-def test_saving_state_with_exception(hass, hass_recorder):
+def test_saving_state_with_exception(hass, hass_recorder, caplog):
     """Test saving and restoring a state."""
     hass = hass_recorder()
 
@@ -68,12 +68,17 @@ def test_saving_state_with_exception(hass, hass_recorder):
         hass.states.set(entity_id, "fail", attributes)
         wait_recording_done(hass)
 
+    assert "Error saving events" in caplog.text
+    caplog.clear()
+
     hass.states.set(entity_id, state, attributes)
     wait_recording_done(hass)
 
     with session_scope(hass=hass) as session:
         db_states = list(session.query(States))
         assert len(db_states) >= 1
+
+    assert "Error saving events" not in caplog.text
 
 
 def test_saving_event(hass, hass_recorder):

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -2,6 +2,8 @@
 # pylint: disable=protected-access
 from datetime import datetime, timedelta
 
+from sqlalchemy.exc import OperationalError
+
 from homeassistant.components.recorder import (
     CONFIG_SCHEMA,
     DOMAIN,
@@ -43,6 +45,35 @@ def test_saving_state(hass, hass_recorder):
         state = db_states[0].to_native()
 
     assert state == _state_empty_context(hass, entity_id)
+
+
+def test_saving_state_with_exception(hass, hass_recorder):
+    """Test saving and restoring a state."""
+    hass = hass_recorder()
+
+    entity_id = "test.recorder"
+    state = "restoring_from_db"
+    attributes = {"test_attr": 5, "test_attr_10": "nice"}
+
+    def _throw_if_state_in_session(*args, **kwargs):
+        for obj in hass.data[DATA_INSTANCE].event_session:
+            if isinstance(obj, States):
+                raise OperationalError(None, None, None)
+
+    with patch("time.sleep"), patch.object(
+        hass.data[DATA_INSTANCE].event_session,
+        "flush",
+        side_effect=_throw_if_state_in_session,
+    ):
+        hass.states.set(entity_id, "fail", attributes)
+        wait_recording_done(hass)
+
+    hass.states.set(entity_id, state, attributes)
+    wait_recording_done(hass)
+
+    with session_scope(hass=hass) as session:
+        db_states = list(session.query(States))
+        assert len(db_states) >= 1
 
 
 def test_saving_event(hass, hass_recorder):

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -58,7 +58,9 @@ def test_saving_state_with_exception(hass, hass_recorder, caplog):
     def _throw_if_state_in_session(*args, **kwargs):
         for obj in hass.data[DATA_INSTANCE].event_session:
             if isinstance(obj, States):
-                raise OperationalError(None, None, None)
+                raise OperationalError(
+                    "insert the state", "fake params", "forced to fail"
+                )
 
     with patch("time.sleep"), patch.object(
         hass.data[DATA_INSTANCE].event_session,
@@ -68,9 +70,10 @@ def test_saving_state_with_exception(hass, hass_recorder, caplog):
         hass.states.set(entity_id, "fail", attributes)
         wait_recording_done(hass)
 
-    assert "Error saving events" in caplog.text
-    caplog.clear()
+    assert "Error executing query" in caplog.text
+    assert "Error saving events" not in caplog.text
 
+    caplog.clear()
     hass.states.set(entity_id, state, attributes)
     wait_recording_done(hass)
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -81,6 +81,7 @@ def test_saving_state_with_exception(hass, hass_recorder, caplog):
         db_states = list(session.query(States))
         assert len(db_states) >= 1
 
+    assert "Error executing query" not in caplog.text
     assert "Error saving events" not in caplog.text
 
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure recorder commit can retry after encountering invalid data
```
2020-10-07 22:16:04 ERROR (Recorder) [homeassistant.components.recorder] Error executing query: (MySQLdb._exceptions.OperationalError) (1366, "Incorrect string value: '\\xF0\\x9F\\x90\\xBC' for column `homeassistant`.`states`.`state` at row 1")
[SQL: INSERT INTO states (domain, entity_id, state, attributes, event_id, last_changed, last_updated, created, old_state_id) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)]
[parameters: ('sensor', 'sensor.telefon_ionut_sim_1', '🐼', '{"carrier name": "Vodafone RO", "iso country code": "", "friendly_name": "Telefon Ionut SIM_1", "icon": "mdi:sim"}', 11101170, datetime.datetime(2020, 10, 7, 19, 15, 27, 582700, tzinfo=<UTC>), datetime.datetime(2020, 10, 7, 19, 15, 27, 582700, tzinfo=<UTC>), datetime.datetime(2020, 10, 7, 19, 16, 4, 29127, tzinfo=<UTC>), None)]
(Background on this error at: http://sqlalche.me/e/13/e3q8)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41422
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
