### PR TITLE
Use common strings in logi_circle config flow

### DIFF
--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -81,7 +81,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
             return self.async_abort(reason="already_configured")
 
         if not flows:
-            return self.async_abort(reason="oauth2_missing_configuration")
+            return self.async_abort(reason="missing_configuration")
 
         if len(flows) == 1:
             self.flow_impl = list(flows)[0]
@@ -172,7 +172,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
         except asyncio.TimeoutError:
             (
                 self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]
-            ) = "oauth2_authorize_url_timeout"
+            ) = "authorize_url_timeout"
             return self.async_abort(reason="external_error")
 
         account_id = (await logi_session.account)["accountId"]

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -81,7 +81,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
             return self.async_abort(reason="already_configured")
 
         if not flows:
-            return self.async_abort(reason="no_flows")
+            return self.async_abort(reason="oauth2_missing_configuration")
 
         if len(flows) == 1:
             self.flow_impl = list(flows)[0]

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -170,7 +170,9 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
             (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "invalid_auth"
             return self.async_abort(reason="external_error")
         except asyncio.TimeoutError:
-            (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "oauth2_authorize_url_timeout"
+            (
+                self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]
+            ) = "oauth2_authorize_url_timeout"
             return self.async_abort(reason="external_error")
 
         account_id = (await logi_session.account)["accountId"]

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -67,7 +67,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
     async def async_step_import(self, user_input=None):
         """Handle external yaml configuration."""
         if self.hass.config_entries.async_entries(DOMAIN):
-            return self.async_abort(reason="already_setup")
+            return self.async_abort(reason="already_configured")
 
         self.flow_impl = DOMAIN
 
@@ -78,7 +78,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
         flows = self.hass.data.get(DATA_FLOW_IMPL, {})
 
         if self.hass.config_entries.async_entries(DOMAIN):
-            return self.async_abort(reason="already_setup")
+            return self.async_abort(reason="already_configured")
 
         if not flows:
             return self.async_abort(reason="no_flows")
@@ -141,7 +141,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
     async def async_step_code(self, code=None):
         """Received code for authentication."""
         if self.hass.config_entries.async_entries(DOMAIN):
-            return self.async_abort(reason="already_setup")
+            return self.async_abort(reason="already_configured")
 
         return await self._async_create_session(code)
 

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -167,7 +167,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
             with async_timeout.timeout(_TIMEOUT):
                 await logi_session.authorize(code)
         except AuthorizationFailed:
-            (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "auth_error"
+            (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "invalid_auth"
             return self.async_abort(reason="external_error")
         except asyncio.TimeoutError:
             (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "auth_timeout"

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -170,7 +170,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
             (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "invalid_auth"
             return self.async_abort(reason="external_error")
         except asyncio.TimeoutError:
-            (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "auth_timeout"
+            (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "oauth2_authorize_url_timeout"
             return self.async_abort(reason="external_error")
 
         account_id = (await logi_session.account)["accountId"]

--- a/homeassistant/components/logi_circle/strings.json
+++ b/homeassistant/components/logi_circle/strings.json
@@ -13,14 +13,14 @@
     },
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "oauth2_authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "follow_link": "Please follow the link and authenticate before pressing Submit."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "external_error": "Exception occurred from another flow.",
       "external_setup": "Logi Circle successfully configured from another flow.",
-      "oauth2_missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]"
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]"
     }
   }
 }

--- a/homeassistant/components/logi_circle/strings.json
+++ b/homeassistant/components/logi_circle/strings.json
@@ -20,7 +20,7 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "external_error": "Exception occurred from another flow.",
       "external_setup": "Logi Circle successfully configured from another flow.",
-      "no_flows": "You need to configure Logi Circle before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/logi_circle/)."
+      "oauth2_missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]"
     }
   }
 }

--- a/homeassistant/components/logi_circle/strings.json
+++ b/homeassistant/components/logi_circle/strings.json
@@ -15,7 +15,7 @@
       "default": "Successfully authenticated with Logi Circle."
     },
     "error": {
-      "auth_error": "API authorization failed.",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "auth_timeout": "Authorization timed out when requesting access token.",
       "follow_link": "Please follow the link and authenticate before pressing Submit."
     },

--- a/homeassistant/components/logi_circle/strings.json
+++ b/homeassistant/components/logi_circle/strings.json
@@ -20,7 +20,7 @@
       "follow_link": "Please follow the link and authenticate before pressing Submit."
     },
     "abort": {
-      "already_setup": "You can only configure a single Logi Circle account.",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "external_error": "Exception occurred from another flow.",
       "external_setup": "Logi Circle successfully configured from another flow.",
       "no_flows": "You need to configure Logi Circle before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/logi_circle/)."

--- a/homeassistant/components/logi_circle/strings.json
+++ b/homeassistant/components/logi_circle/strings.json
@@ -13,7 +13,7 @@
     },
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "auth_timeout": "Authorization timed out when requesting access token.",
+      "oauth2_authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "follow_link": "Please follow the link and authenticate before pressing Submit."
     },
     "abort": {

--- a/homeassistant/components/logi_circle/strings.json
+++ b/homeassistant/components/logi_circle/strings.json
@@ -11,9 +11,6 @@
         "description": "Please follow the link below and **Accept** access to your Logi Circle account, then come back and press **Submit** below.\n\n[Link]({authorization_url})"
       }
     },
-    "create_entry": {
-      "default": "Successfully authenticated with Logi Circle."
-    },
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "auth_timeout": "Authorization timed out when requesting access token.",

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -116,7 +116,7 @@ async def test_abort_if_no_implementation_registered(hass):
 
     result = await flow.async_step_user()
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "oauth2_missing_configuration"
+    assert result["reason"] == "missing_configuration"
 
 
 async def test_abort_if_already_setup(hass):
@@ -147,7 +147,7 @@ async def test_abort_if_already_setup(hass):
 @pytest.mark.parametrize(
     "side_effect,error",
     [
-        (asyncio.TimeoutError, "oauth2_authorize_url_timeout"),
+        (asyncio.TimeoutError, "authorize_url_timeout"),
         (AuthorizationFailed, "invalid_auth"),
     ],
 )

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -116,7 +116,7 @@ async def test_abort_if_no_implementation_registered(hass):
 
     result = await flow.async_step_user()
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "no_flows"
+    assert result["reason"] == "oauth2_missing_configuration"
 
 
 async def test_abort_if_already_setup(hass):

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -146,7 +146,7 @@ async def test_abort_if_already_setup(hass):
 
 @pytest.mark.parametrize(
     "side_effect,error",
-    [(asyncio.TimeoutError, "auth_timeout"), (AuthorizationFailed, "auth_error")],
+    [(asyncio.TimeoutError, "auth_timeout"), (AuthorizationFailed, "invalid_auth")],
 )
 async def test_abort_if_authorize_fails(
     hass, mock_logi_circle, side_effect, error

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -146,7 +146,7 @@ async def test_abort_if_already_setup(hass):
 
 @pytest.mark.parametrize(
     "side_effect,error",
-    [(asyncio.TimeoutError, "auth_timeout"), (AuthorizationFailed, "invalid_auth")],
+    [(asyncio.TimeoutError, "oauth2_authorize_url_timeout"), (AuthorizationFailed, "invalid_auth")],
 )
 async def test_abort_if_authorize_fails(
     hass, mock_logi_circle, side_effect, error

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -146,7 +146,10 @@ async def test_abort_if_already_setup(hass):
 
 @pytest.mark.parametrize(
     "side_effect,error",
-    [(asyncio.TimeoutError, "oauth2_authorize_url_timeout"), (AuthorizationFailed, "invalid_auth")],
+    [
+        (asyncio.TimeoutError, "oauth2_authorize_url_timeout"),
+        (AuthorizationFailed, "invalid_auth"),
+    ],
 )
 async def test_abort_if_authorize_fails(
     hass, mock_logi_circle, side_effect, error

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -126,17 +126,17 @@ async def test_abort_if_already_setup(hass):
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_user()
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_setup"
+    assert result["reason"] == "already_configured"
 
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_import()
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_setup"
+    assert result["reason"] == "already_configured"
 
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_code()
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_setup"
+    assert result["reason"] == "already_configured"
 
     with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
         result = await flow.async_step_auth()


### PR DESCRIPTION

## Proposed change
Use common strings in logi_circle config flow as described in #40578

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io