### PR TITLE
Rewrite zwave init tests to pytest style test function (phase 2)

### DIFF
--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -37,6 +37,15 @@ async def zwave_setup(hass):
     await hass.async_block_till_done()
 
 
+@pytest.fixture
+async def zwave_setup_ready(hass, zwave_setup):
+    """Zwave setup and set network to ready."""
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+
+    await hass.async_start()
+
+
 async def test_valid_device_config(hass, mock_openzwave):
     """Test valid device config."""
     device_config = {"light.kitchen": {"ignored": "true"}}
@@ -1249,12 +1258,9 @@ async def test_device_config_glob_is_ordered():
     assert isinstance(conf["zwave"][CONF_DEVICE_CONFIG_GLOB], OrderedDict)
 
 
-async def test_add_node(hass, mock_openzwave, zwave_setup):
+async def test_add_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave add_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call("zwave", "add_node", {})
     await hass.async_block_till_done()
@@ -1264,12 +1270,9 @@ async def test_add_node(hass, mock_openzwave, zwave_setup):
     assert len(zwave_network.controller.add_node.mock_calls[0][1]) == 0
 
 
-async def test_add_node_secure(hass, mock_openzwave, zwave_setup):
+async def test_add_node_secure(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave add_node_secure service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call("zwave", "add_node_secure", {})
     await hass.async_block_till_done()
@@ -1279,12 +1282,9 @@ async def test_add_node_secure(hass, mock_openzwave, zwave_setup):
     assert zwave_network.controller.add_node.mock_calls[0][1][0] is True
 
 
-async def test_remove_node(hass, mock_openzwave, zwave_setup):
+async def test_remove_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave remove_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call("zwave", "remove_node", {})
     await hass.async_block_till_done()
@@ -1293,12 +1293,9 @@ async def test_remove_node(hass, mock_openzwave, zwave_setup):
     assert len(zwave_network.controller.remove_node.mock_calls) == 1
 
 
-async def test_cancel_command(hass, mock_openzwave, zwave_setup):
+async def test_cancel_command(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave cancel_command service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call("zwave", "cancel_command", {})
     await hass.async_block_till_done()
@@ -1307,12 +1304,9 @@ async def test_cancel_command(hass, mock_openzwave, zwave_setup):
     assert len(zwave_network.controller.cancel_command.mock_calls) == 1
 
 
-async def test_heal_network(hass, mock_openzwave, zwave_setup):
+async def test_heal_network(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave heal_network service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call("zwave", "heal_network", {})
     await hass.async_block_till_done()
@@ -1321,12 +1315,9 @@ async def test_heal_network(hass, mock_openzwave, zwave_setup):
     assert len(zwave_network.heal.mock_calls) == 1
 
 
-async def test_soft_reset(hass, mock_openzwave, zwave_setup):
+async def test_soft_reset(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave soft_reset service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call("zwave", "soft_reset", {})
     await hass.async_block_till_done()
@@ -1335,12 +1326,9 @@ async def test_soft_reset(hass, mock_openzwave, zwave_setup):
     assert len(zwave_network.controller.soft_reset.mock_calls) == 1
 
 
-async def test_test_network(hass, mock_openzwave, zwave_setup):
+async def test_test_network(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave test_network service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call("zwave", "test_network", {})
     await hass.async_block_till_done()
@@ -1349,12 +1337,9 @@ async def test_test_network(hass, mock_openzwave, zwave_setup):
     assert len(zwave_network.test.mock_calls) == 1
 
 
-async def test_stop_network(hass, mock_openzwave, zwave_setup):
+async def test_stop_network(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave stop_network service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     with patch.object(hass.bus, "fire") as mock_fire:
         await hass.services.async_call("zwave", "stop_network", {})
@@ -1367,12 +1352,9 @@ async def test_stop_network(hass, mock_openzwave, zwave_setup):
         assert mock_fire.mock_calls[0][1][0] == const.EVENT_NETWORK_STOP
 
 
-async def test_rename_node(hass, mock_openzwave, zwave_setup):
+async def test_rename_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave rename_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     zwave_network.nodes = {11: MagicMock()}
     await hass.services.async_call(
@@ -1385,12 +1367,9 @@ async def test_rename_node(hass, mock_openzwave, zwave_setup):
     assert zwave_network.nodes[11].name == "test_name"
 
 
-async def test_rename_value(hass, mock_openzwave, zwave_setup):
+async def test_rename_value(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave rename_value service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, label="Old Label")
@@ -1412,12 +1391,9 @@ async def test_rename_value(hass, mock_openzwave, zwave_setup):
     assert value.label == "New Label"
 
 
-async def test_set_poll_intensity_enable(hass, mock_openzwave, zwave_setup):
+async def test_set_poll_intensity_enable(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave set_poll_intensity service, successful set."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=0)
@@ -1442,12 +1418,11 @@ async def test_set_poll_intensity_enable(hass, mock_openzwave, zwave_setup):
     assert enable_poll.mock_calls[0][1][0] == 4
 
 
-async def test_set_poll_intensity_enable_failed(hass, mock_openzwave, zwave_setup):
+async def test_set_poll_intensity_enable_failed(
+    hass, mock_openzwave, zwave_setup_ready
+):
     """Test zwave set_poll_intensity service, failed set."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=0)
@@ -1472,12 +1447,9 @@ async def test_set_poll_intensity_enable_failed(hass, mock_openzwave, zwave_setu
     assert len(enable_poll.mock_calls) == 1
 
 
-async def test_set_poll_intensity_disable(hass, mock_openzwave, zwave_setup):
+async def test_set_poll_intensity_disable(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave set_poll_intensity service, successful disable."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=4)
@@ -1501,12 +1473,11 @@ async def test_set_poll_intensity_disable(hass, mock_openzwave, zwave_setup):
     assert len(disable_poll.mock_calls) == 2
 
 
-async def test_set_poll_intensity_disable_failed(hass, mock_openzwave, zwave_setup):
+async def test_set_poll_intensity_disable_failed(
+    hass, mock_openzwave, zwave_setup_ready
+):
     """Test zwave set_poll_intensity service, failed disable."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=4)
@@ -1531,12 +1502,9 @@ async def test_set_poll_intensity_disable_failed(hass, mock_openzwave, zwave_set
     assert len(disable_poll.mock_calls) == 1
 
 
-async def test_remove_failed_node(hass, mock_openzwave, zwave_setup):
+async def test_remove_failed_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave remove_failed_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call(
         "zwave", "remove_failed_node", {const.ATTR_NODE_ID: 12}
@@ -1549,12 +1517,9 @@ async def test_remove_failed_node(hass, mock_openzwave, zwave_setup):
     assert remove_failed_node.mock_calls[0][1][0] == 12
 
 
-async def test_replace_failed_node(hass, mock_openzwave, zwave_setup):
+async def test_replace_failed_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave replace_failed_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     await hass.services.async_call(
         "zwave", "replace_failed_node", {const.ATTR_NODE_ID: 13}
@@ -1567,12 +1532,9 @@ async def test_replace_failed_node(hass, mock_openzwave, zwave_setup):
     assert replace_failed_node.mock_calls[0][1][0] == 13
 
 
-async def test_set_config_parameter(hass, mock_openzwave, zwave_setup):
+async def test_set_config_parameter(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave set_config_parameter service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     value_byte = MockValue(
         index=12,
@@ -1717,12 +1679,9 @@ async def test_set_config_parameter(hass, mock_openzwave, zwave_setup):
     node.set_config_param.reset_mock()
 
 
-async def test_print_config_parameter(hass, mock_openzwave, zwave_setup, caplog):
+async def test_print_config_parameter(hass, mock_openzwave, zwave_setup_ready, caplog):
     """Test zwave print_config_parameter service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     value1 = MockValue(
         index=12, command_class=const.COMMAND_CLASS_CONFIGURATION, data=1234
@@ -1746,12 +1705,9 @@ async def test_print_config_parameter(hass, mock_openzwave, zwave_setup, caplog)
     assert "Config parameter 13 on Node 14: 2345" in caplog.text
 
 
-async def test_print_node(hass, mock_openzwave, zwave_setup):
+async def test_print_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave print_node_parameter service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=14)
 
@@ -1764,12 +1720,9 @@ async def test_print_node(hass, mock_openzwave, zwave_setup):
         assert "FOUND NODE " in mock_logger.info.mock_calls[0][1][0]
 
 
-async def test_set_wakeup(hass, mock_openzwave, zwave_setup):
+async def test_set_wakeup(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave set_wakeup service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
     node = MockNode(node_id=14)
@@ -1793,12 +1746,9 @@ async def test_set_wakeup(hass, mock_openzwave, zwave_setup):
     assert value.data == 15
 
 
-async def test_reset_node_meters(hass, mock_openzwave, zwave_setup):
+async def test_reset_node_meters(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave reset_node_meters service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     value = MockValue(
         instance=1, index=8, data=99.5, command_class=const.COMMAND_CLASS_METER
@@ -1834,12 +1784,9 @@ async def test_reset_node_meters(hass, mock_openzwave, zwave_setup):
     assert value_id == reset_value.value_id
 
 
-async def test_add_association(hass, mock_openzwave, zwave_setup):
+async def test_add_association(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave change_association service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     ZWaveGroup = mock_openzwave.group.ZWaveGroup
     group = MagicMock()
@@ -1874,12 +1821,9 @@ async def test_add_association(hass, mock_openzwave, zwave_setup):
     assert group.add_association.mock_calls[0][1][1] == 5
 
 
-async def test_remove_association(hass, mock_openzwave, zwave_setup):
+async def test_remove_association(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave change_association service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     ZWaveGroup = mock_openzwave.group.ZWaveGroup
     group = MagicMock()
@@ -1914,13 +1858,8 @@ async def test_remove_association(hass, mock_openzwave, zwave_setup):
     assert group.remove_association.mock_calls[0][1][1] == 5
 
 
-async def test_refresh_entity(hass, mock_openzwave, zwave_setup):
+async def test_refresh_entity(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave refresh_entity service."""
-    zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
-
     node = MockNode()
     value = MockValue(
         data=False, node=node, command_class=const.COMMAND_CLASS_SENSOR_BINARY
@@ -1951,12 +1890,9 @@ async def test_refresh_entity(hass, mock_openzwave, zwave_setup):
     )
 
 
-async def test_refresh_node(hass, mock_openzwave, zwave_setup):
+async def test_refresh_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave refresh_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=14)
     zwave_network.nodes = {14: node}
@@ -1967,12 +1903,9 @@ async def test_refresh_node(hass, mock_openzwave, zwave_setup):
     assert len(node.refresh_info.mock_calls) == 1
 
 
-async def test_set_node_value(hass, mock_openzwave, zwave_setup):
+async def test_set_node_value(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave set_node_value service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     value = MockValue(index=12, command_class=const.COMMAND_CLASS_INDICATOR, data=4)
     node = MockNode(node_id=14, command_classes=[const.COMMAND_CLASS_INDICATOR])
@@ -1995,13 +1928,10 @@ async def test_set_node_value(hass, mock_openzwave, zwave_setup):
 
 
 async def test_set_node_value_with_long_id_and_text_value(
-    hass, mock_openzwave, zwave_setup
+    hass, mock_openzwave, zwave_setup_ready
 ):
     """Test zwave set_node_value service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     value = MockValue(
         index=87512398541236578,
@@ -2027,12 +1957,9 @@ async def test_set_node_value_with_long_id_and_text_value(
     assert zwave_network.nodes[14].values[87512398541236578].data == "#00ff00"
 
 
-async def test_refresh_node_value(hass, mock_openzwave, zwave_setup):
+async def test_refresh_node_value(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave refresh_node_value service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(
         node_id=14,
@@ -2058,12 +1985,9 @@ async def test_refresh_node_value(hass, mock_openzwave, zwave_setup):
     assert value.refresh.called
 
 
-async def test_heal_node(hass, mock_openzwave, zwave_setup):
+async def test_heal_node(hass, mock_openzwave, zwave_setup_ready):
     """Test zwave heal_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=19)
     zwave_network.nodes = {19: node}
@@ -2074,12 +1998,9 @@ async def test_heal_node(hass, mock_openzwave, zwave_setup):
     assert len(node.heal.mock_calls) == 1
 
 
-async def test_test_node(hass, mock_openzwave, zwave_setup):
+async def test_test_node(hass, mock_openzwave, zwave_setup_ready):
     """Test the zwave test_node service."""
     zwave_network = hass.data[DATA_NETWORK]
-    zwave_network.state = MockNetwork.STATE_READY
-
-    await hass.async_start()
 
     node = MockNode(node_id=19)
     zwave_network.nodes = {19: node}

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1933,7 +1933,7 @@ async def test_refresh_entity(hass, mock_openzwave, zwave_setup):
     device = get_device(node=node, values=values, node_config={})
     device.hass = hass
     device.entity_id = "binary_sensor.mock_entity_id"
-    await hass.async_add_job(device.async_added_to_hass())
+    await device.async_added_to_hass()
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.components.zwave import (
     const,
 )
 from homeassistant.components.zwave.binary_sensor import get_device
-from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
 from homeassistant.helpers.entity_registry import async_get_registry
 
@@ -198,8 +198,8 @@ async def test_zwave_ready_wait(hass, mock_openzwave, zwave_setup):
         with patch("asyncio.sleep", new=sleep):
             with patch.object(zwave, "_LOGGER") as mock_logger:
                 hass.data[DATA_NETWORK].state = MockNetwork.STATE_STARTED
-                hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-                await hass.async_block_till_done()
+
+                await hass.async_start()
 
                 assert len(sleeps) == const.NETWORK_READY_WAIT_SECS
                 assert mock_logger.warning.called
@@ -417,8 +417,8 @@ async def test_value_entities(hass, mock_openzwave):
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     assert mock_receivers
 
@@ -1253,8 +1253,8 @@ async def test_add_node(hass, mock_openzwave, zwave_setup):
     """Test zwave add_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call("zwave", "add_node", {})
     await hass.async_block_till_done()
@@ -1268,8 +1268,8 @@ async def test_add_node_secure(hass, mock_openzwave, zwave_setup):
     """Test zwave add_node_secure service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call("zwave", "add_node_secure", {})
     await hass.async_block_till_done()
@@ -1283,8 +1283,8 @@ async def test_remove_node(hass, mock_openzwave, zwave_setup):
     """Test zwave remove_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call("zwave", "remove_node", {})
     await hass.async_block_till_done()
@@ -1297,8 +1297,8 @@ async def test_cancel_command(hass, mock_openzwave, zwave_setup):
     """Test zwave cancel_command service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call("zwave", "cancel_command", {})
     await hass.async_block_till_done()
@@ -1311,8 +1311,8 @@ async def test_heal_network(hass, mock_openzwave, zwave_setup):
     """Test zwave heal_network service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call("zwave", "heal_network", {})
     await hass.async_block_till_done()
@@ -1325,8 +1325,8 @@ async def test_soft_reset(hass, mock_openzwave, zwave_setup):
     """Test zwave soft_reset service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call("zwave", "soft_reset", {})
     await hass.async_block_till_done()
@@ -1339,8 +1339,8 @@ async def test_test_network(hass, mock_openzwave, zwave_setup):
     """Test zwave test_network service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call("zwave", "test_network", {})
     await hass.async_block_till_done()
@@ -1353,8 +1353,8 @@ async def test_stop_network(hass, mock_openzwave, zwave_setup):
     """Test zwave stop_network service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     with patch.object(hass.bus, "fire") as mock_fire:
         await hass.services.async_call("zwave", "stop_network", {})
@@ -1371,8 +1371,8 @@ async def test_rename_node(hass, mock_openzwave, zwave_setup):
     """Test zwave rename_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     zwave_network.nodes = {11: MagicMock()}
     await hass.services.async_call(
@@ -1389,8 +1389,8 @@ async def test_rename_value(hass, mock_openzwave, zwave_setup):
     """Test zwave rename_value service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, label="Old Label")
@@ -1416,8 +1416,8 @@ async def test_set_poll_intensity_enable(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, successful set."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=0)
@@ -1446,8 +1446,8 @@ async def test_set_poll_intensity_enable_failed(hass, mock_openzwave, zwave_setu
     """Test zwave set_poll_intensity service, failed set."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=0)
@@ -1476,8 +1476,8 @@ async def test_set_poll_intensity_disable(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, successful disable."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=4)
@@ -1505,8 +1505,8 @@ async def test_set_poll_intensity_disable_failed(hass, mock_openzwave, zwave_set
     """Test zwave set_poll_intensity service, failed disable."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=14)
     value = MockValue(index=12, value_id=123456, poll_intensity=4)
@@ -1535,8 +1535,8 @@ async def test_remove_failed_node(hass, mock_openzwave, zwave_setup):
     """Test zwave remove_failed_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call(
         "zwave", "remove_failed_node", {const.ATTR_NODE_ID: 12}
@@ -1553,8 +1553,8 @@ async def test_replace_failed_node(hass, mock_openzwave, zwave_setup):
     """Test zwave replace_failed_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     await hass.services.async_call(
         "zwave", "replace_failed_node", {const.ATTR_NODE_ID: 13}
@@ -1571,8 +1571,8 @@ async def test_set_config_parameter(hass, mock_openzwave, zwave_setup):
     """Test zwave set_config_parameter service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     value_byte = MockValue(
         index=12,
@@ -1721,8 +1721,8 @@ async def test_print_config_parameter(hass, mock_openzwave, zwave_setup):
     """Test zwave print_config_parameter service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     value1 = MockValue(
         index=12, command_class=const.COMMAND_CLASS_CONFIGURATION, data=1234
@@ -1753,8 +1753,8 @@ async def test_print_node(hass, mock_openzwave, zwave_setup):
     """Test zwave print_node_parameter service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=14)
 
@@ -1771,8 +1771,8 @@ async def test_set_wakeup(hass, mock_openzwave, zwave_setup):
     """Test zwave set_wakeup service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
     node = MockNode(node_id=14)
@@ -1800,8 +1800,8 @@ async def test_reset_node_meters(hass, mock_openzwave, zwave_setup):
     """Test zwave reset_node_meters service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     value = MockValue(
         instance=1, index=8, data=99.5, command_class=const.COMMAND_CLASS_METER
@@ -1841,8 +1841,8 @@ async def test_add_association(hass, mock_openzwave, zwave_setup):
     """Test zwave change_association service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     ZWaveGroup = mock_openzwave.group.ZWaveGroup
     group = MagicMock()
@@ -1881,8 +1881,8 @@ async def test_remove_association(hass, mock_openzwave, zwave_setup):
     """Test zwave change_association service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     ZWaveGroup = mock_openzwave.group.ZWaveGroup
     group = MagicMock()
@@ -1921,8 +1921,8 @@ async def test_refresh_entity(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_entity service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode()
     value = MockValue(
@@ -1958,8 +1958,8 @@ async def test_refresh_node(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=14)
     zwave_network.nodes = {14: node}
@@ -1974,8 +1974,8 @@ async def test_set_node_value(hass, mock_openzwave, zwave_setup):
     """Test zwave set_node_value service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     value = MockValue(index=12, command_class=const.COMMAND_CLASS_INDICATOR, data=4)
     node = MockNode(node_id=14, command_classes=[const.COMMAND_CLASS_INDICATOR])
@@ -2003,8 +2003,8 @@ async def test_set_node_value_with_long_id_and_text_value(
     """Test zwave set_node_value service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     value = MockValue(
         index=87512398541236578,
@@ -2034,8 +2034,8 @@ async def test_refresh_node_value(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_node_value service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(
         node_id=14,
@@ -2065,8 +2065,8 @@ async def test_heal_node(hass, mock_openzwave, zwave_setup):
     """Test zwave heal_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=19)
     zwave_network.nodes = {19: node}
@@ -2081,8 +2081,8 @@ async def test_test_node(hass, mock_openzwave, zwave_setup):
     """Test the zwave test_node service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
+
+    await hass.async_start()
 
     node = MockNode(node_id=19)
     zwave_network.nodes = {19: node}

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -33,18 +33,8 @@ def mock_storage(hass_storage):
 @pytest.fixture
 async def zwave_setup(hass):
     """Zwave setup."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-
+    await async_setup_component(hass, "zwave", {"zwave": {}})
     await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
 
 async def test_valid_device_config(hass, mock_openzwave):
@@ -190,12 +180,8 @@ async def test_setup_platform(hass, mock_openzwave):
     assert async_add_entities.mock_calls[0][1][0] == [mock_device]
 
 
-async def test_zwave_ready_wait(hass, mock_openzwave):
+async def test_zwave_ready_wait(hass, mock_openzwave, zwave_setup):
     """Test that zwave continues after waiting for network ready."""
-    # Initialize zwave
-    await async_setup_component(hass, "zwave", {"zwave": {}})
-    await hass.async_block_till_done()
-
     sleeps = []
 
     def utcnow():
@@ -841,24 +827,12 @@ async def test_network_complete_some_dead(hass, mock_openzwave):
 
 
 async def test_entity_discovery(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test the creation of a new entity."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -932,24 +906,12 @@ async def test_entity_discovery(
 
 
 async def test_entity_existing_values(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test the loading of already discovered values."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -998,24 +960,12 @@ async def test_entity_existing_values(
 
 
 async def test_node_schema_mismatch(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test node schema mismatch."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -1046,24 +996,12 @@ async def test_node_schema_mismatch(
 
 
 async def test_entity_workaround_component(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test component workaround."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     node.manufacturer_id = "010f"
     node.product_type = "0b00"
@@ -1108,24 +1046,12 @@ async def test_entity_workaround_component(
 
 
 async def test_entity_workaround_ignore(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test ignore workaround."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -1162,24 +1088,12 @@ async def test_entity_workaround_ignore(
 
 
 async def test_entity_config_ignore(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test ignore config."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -1209,7 +1123,7 @@ async def test_entity_config_ignore(
 
 
 async def test_entity_config_ignore_with_registry(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test ignore config.
 
@@ -1218,18 +1132,6 @@ async def test_entity_config_ignore_with_registry(
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -1265,24 +1167,12 @@ async def test_entity_config_ignore_with_registry(
 
 
 async def test_entity_platform_ignore(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test platform ignore device."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -1315,24 +1205,12 @@ async def test_entity_platform_ignore(
 
 
 async def test_config_polling_intensity(
-    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave, zwave_setup
 ):
     """Test polling intensity."""
     (node, value_class, mock_schema) = mock_values
 
     registry = mock_registry(hass)
-
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -849,7 +849,9 @@ async def test_entity_discovery(
     zwave_config = {"zwave": {}}
     device_config = {entity_id: {}}
 
-    with patch.object(zwave, "discovery", mock_discovery):
+    with patch.object(zwave, "discovery", mock_discovery), patch.object(
+        zwave, "import_module", mock_import_module
+    ):
         values = zwave.ZWaveDeviceEntityValues(
             hass=hass,
             schema=mock_schema,
@@ -891,7 +893,9 @@ async def test_entity_discovery(
     )
 
     mock_discovery.async_load_platform.reset_mock()
-    with patch.object(zwave, "discovery", mock_discovery):
+    with patch.object(zwave, "discovery", mock_discovery), patch.object(
+        zwave, "import_module", mock_import_module
+    ):
         values.check_value(value_class.optional)
         values.check_value(value_class.duplicate_secondary)
         values.check_value(value_class.no_match_value)
@@ -929,6 +933,8 @@ async def test_entity_existing_values(
     with patch("pydispatch.dispatcher.connect", new=mock_connect):
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -976,7 +982,9 @@ async def test_entity_existing_values(
     )
 
 
-async def test_node_schema_mismatch(hass, mock_discovery, mock_values, mock_openzwave):
+async def test_node_schema_mismatch(
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+):
     """Test node schema mismatch."""
     (node, value_class, mock_schema) = mock_values
 
@@ -992,6 +1000,8 @@ async def test_node_schema_mismatch(hass, mock_discovery, mock_values, mock_open
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
 
+    assert len(mock_receivers) == 1
+
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
     device_config = {entity_id: {}}
@@ -1003,7 +1013,9 @@ async def test_node_schema_mismatch(hass, mock_discovery, mock_values, mock_open
     }
     mock_schema[const.DISC_GENERIC_DEVICE_CLASS] = ["generic_match"]
 
-    with patch.object(zwave, "discovery", mock_discovery):
+    with patch.object(zwave, "discovery", mock_discovery), patch.object(
+        zwave, "import_module", mock_import_module
+    ):
         values = zwave.ZWaveDeviceEntityValues(
             hass=hass,
             schema=mock_schema,
@@ -1035,6 +1047,8 @@ async def test_entity_workaround_component(
     with patch("pydispatch.dispatcher.connect", new=mock_connect):
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
 
     node.manufacturer_id = "010f"
     node.product_type = "0b00"
@@ -1079,7 +1093,7 @@ async def test_entity_workaround_component(
 
 
 async def test_entity_workaround_ignore(
-    hass, mock_discovery, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
 ):
     """Test ignore workaround."""
     (node, value_class, mock_schema) = mock_values
@@ -1095,6 +1109,8 @@ async def test_entity_workaround_ignore(
     with patch("pydispatch.dispatcher.connect", new=mock_connect):
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -1113,7 +1129,9 @@ async def test_entity_workaround_ignore(
         },
     }
 
-    with patch.object(zwave, "discovery", mock_discovery):
+    with patch.object(zwave, "discovery", mock_discovery), patch.object(
+        zwave, "import_module", mock_import_module
+    ):
         values = zwave.ZWaveDeviceEntityValues(
             hass=hass,
             schema=mock_schema,
@@ -1128,7 +1146,9 @@ async def test_entity_workaround_ignore(
         assert not mock_discovery.async_load_platform.called
 
 
-async def test_entity_config_ignore(hass, mock_discovery, mock_values, mock_openzwave):
+async def test_entity_config_ignore(
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
+):
     """Test ignore config."""
     (node, value_class, mock_schema) = mock_values
 
@@ -1144,6 +1164,8 @@ async def test_entity_config_ignore(hass, mock_discovery, mock_values, mock_open
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
 
+    assert len(mock_receivers) == 1
+
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
     device_config = {entity_id: {}}
@@ -1154,7 +1176,9 @@ async def test_entity_config_ignore(hass, mock_discovery, mock_values, mock_open
     }
     device_config = {entity_id: {zwave.CONF_IGNORED: True}}
 
-    with patch.object(zwave, "discovery", mock_discovery):
+    with patch.object(zwave, "discovery", mock_discovery), patch.object(
+        zwave, "import_module", mock_import_module
+    ):
         values = zwave.ZWaveDeviceEntityValues(
             hass=hass,
             schema=mock_schema,
@@ -1170,7 +1194,7 @@ async def test_entity_config_ignore(hass, mock_discovery, mock_values, mock_open
 
 
 async def test_entity_config_ignore_with_registry(
-    hass, mock_discovery, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
 ):
     """Test ignore config.
 
@@ -1190,6 +1214,8 @@ async def test_entity_config_ignore_with_registry(
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
 
+    assert len(mock_receivers) == 1
+
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
     device_config = {entity_id: {}}
@@ -1207,7 +1233,9 @@ async def test_entity_config_ignore_with_registry(
             suggested_object_id="registry_id",
         )
 
-    with patch.object(zwave, "discovery", mock_discovery):
+    with patch.object(zwave, "discovery", mock_discovery), patch.object(
+        zwave, "import_module", mock_import_module
+    ):
         zwave.ZWaveDeviceEntityValues(
             hass=hass,
             schema=mock_schema,
@@ -1222,7 +1250,7 @@ async def test_entity_config_ignore_with_registry(
 
 
 async def test_entity_platform_ignore(
-    hass, mock_discovery, mock_values, mock_openzwave
+    hass, mock_discovery, mock_import_module, mock_values, mock_openzwave
 ):
     """Test platform ignore device."""
     (node, value_class, mock_schema) = mock_values
@@ -1238,6 +1266,8 @@ async def test_entity_platform_ignore(
     with patch("pydispatch.dispatcher.connect", new=mock_connect):
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}
@@ -1286,6 +1316,8 @@ async def test_config_polling_intensity(
     with patch("pydispatch.dispatcher.connect", new=mock_connect):
         await async_setup_component(hass, "zwave", {"zwave": {}})
         await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
 
     entity_id = "mock_component.mock_node_mock_value"
     zwave_config = {"zwave": {}}

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1717,7 +1717,7 @@ async def test_set_config_parameter(hass, mock_openzwave, zwave_setup):
     node.set_config_param.reset_mock()
 
 
-async def test_print_config_parameter(hass, mock_openzwave, zwave_setup):
+async def test_print_config_parameter(hass, mock_openzwave, zwave_setup, caplog):
     """Test zwave print_config_parameter service."""
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1734,19 +1734,16 @@ async def test_print_config_parameter(hass, mock_openzwave, zwave_setup):
     node.values = {12: value1, 13: value2}
     zwave_network.nodes = {14: node}
 
-    with patch.object(zwave, "_LOGGER") as mock_logger:
-        await hass.services.async_call(
-            "zwave",
-            "print_config_parameter",
-            {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_PARAMETER: 13},
-        )
-        await hass.async_block_till_done()
+    caplog.clear()
 
-        assert mock_logger.info.called
-        assert len(mock_logger.info.mock_calls) == 1
-        assert mock_logger.info.mock_calls[0][1][1] == 13
-        assert mock_logger.info.mock_calls[0][1][2] == 14
-        assert mock_logger.info.mock_calls[0][1][3] == 2345
+    await hass.services.async_call(
+        "zwave",
+        "print_config_parameter",
+        {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_PARAMETER: 13},
+    )
+    await hass.async_block_till_done()
+
+    assert "Config parameter 13 on Node 14: 2345" in caplog.text
 
 
 async def test_print_node(hass, mock_openzwave, zwave_setup):

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -31,20 +31,20 @@ def mock_storage(hass_storage):
 
 
 @pytest.fixture
-def zwave_setup(hass):
+async def zwave_setup(hass):
     """Zwave setup."""
+    mock_receivers = []
 
-    async def _zwave():
-        mock_receivers = []
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
 
-        def mock_connect(receiver, signal, *args, **kwargs):
-            if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-                mock_receivers.append(receiver)
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
 
-        with patch("pydispatch.dispatcher.connect", new=mock_connect):
-            return await async_setup_component(hass, "zwave", {"zwave": {}})
+    await hass.async_block_till_done()
 
-    return _zwave
+    assert len(mock_receivers) == 1
 
 
 async def test_valid_device_config(hass, mock_openzwave):
@@ -1373,9 +1373,6 @@ async def test_device_config_glob_is_ordered():
 
 async def test_add_node(hass, mock_openzwave, zwave_setup):
     """Test zwave add_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1391,9 +1388,6 @@ async def test_add_node(hass, mock_openzwave, zwave_setup):
 
 async def test_add_node_secure(hass, mock_openzwave, zwave_setup):
     """Test zwave add_node_secure service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1409,9 +1403,6 @@ async def test_add_node_secure(hass, mock_openzwave, zwave_setup):
 
 async def test_remove_node(hass, mock_openzwave, zwave_setup):
     """Test zwave remove_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1426,9 +1417,6 @@ async def test_remove_node(hass, mock_openzwave, zwave_setup):
 
 async def test_cancel_command(hass, mock_openzwave, zwave_setup):
     """Test zwave cancel_command service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1443,9 +1431,6 @@ async def test_cancel_command(hass, mock_openzwave, zwave_setup):
 
 async def test_heal_network(hass, mock_openzwave, zwave_setup):
     """Test zwave heal_network service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1460,9 +1445,6 @@ async def test_heal_network(hass, mock_openzwave, zwave_setup):
 
 async def test_soft_reset(hass, mock_openzwave, zwave_setup):
     """Test zwave soft_reset service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1477,9 +1459,6 @@ async def test_soft_reset(hass, mock_openzwave, zwave_setup):
 
 async def test_test_network(hass, mock_openzwave, zwave_setup):
     """Test zwave test_network service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1494,9 +1473,6 @@ async def test_test_network(hass, mock_openzwave, zwave_setup):
 
 async def test_stop_network(hass, mock_openzwave, zwave_setup):
     """Test zwave stop_network service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1515,9 +1491,6 @@ async def test_stop_network(hass, mock_openzwave, zwave_setup):
 
 async def test_rename_node(hass, mock_openzwave, zwave_setup):
     """Test zwave rename_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1536,9 +1509,6 @@ async def test_rename_node(hass, mock_openzwave, zwave_setup):
 
 async def test_rename_value(hass, mock_openzwave, zwave_setup):
     """Test zwave rename_value service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1566,9 +1536,6 @@ async def test_rename_value(hass, mock_openzwave, zwave_setup):
 
 async def test_set_poll_intensity_enable(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, successful set."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1599,9 +1566,6 @@ async def test_set_poll_intensity_enable(hass, mock_openzwave, zwave_setup):
 
 async def test_set_poll_intensity_enable_failed(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, failed set."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1632,9 +1596,6 @@ async def test_set_poll_intensity_enable_failed(hass, mock_openzwave, zwave_setu
 
 async def test_set_poll_intensity_disable(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, successful disable."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1664,9 +1625,6 @@ async def test_set_poll_intensity_disable(hass, mock_openzwave, zwave_setup):
 
 async def test_set_poll_intensity_disable_failed(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, failed disable."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1697,9 +1655,6 @@ async def test_set_poll_intensity_disable_failed(hass, mock_openzwave, zwave_set
 
 async def test_remove_failed_node(hass, mock_openzwave, zwave_setup):
     """Test zwave remove_failed_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1718,9 +1673,6 @@ async def test_remove_failed_node(hass, mock_openzwave, zwave_setup):
 
 async def test_replace_failed_node(hass, mock_openzwave, zwave_setup):
     """Test zwave replace_failed_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1739,9 +1691,6 @@ async def test_replace_failed_node(hass, mock_openzwave, zwave_setup):
 
 async def test_set_config_parameter(hass, mock_openzwave, zwave_setup):
     """Test zwave set_config_parameter service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1892,9 +1841,6 @@ async def test_set_config_parameter(hass, mock_openzwave, zwave_setup):
 
 async def test_print_config_parameter(hass, mock_openzwave, zwave_setup):
     """Test zwave print_config_parameter service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1927,9 +1873,6 @@ async def test_print_config_parameter(hass, mock_openzwave, zwave_setup):
 
 async def test_print_node(hass, mock_openzwave, zwave_setup):
     """Test zwave print_node_parameter service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1948,9 +1891,6 @@ async def test_print_node(hass, mock_openzwave, zwave_setup):
 
 async def test_set_wakeup(hass, mock_openzwave, zwave_setup):
     """Test zwave set_wakeup service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -1980,9 +1920,6 @@ async def test_set_wakeup(hass, mock_openzwave, zwave_setup):
 
 async def test_reset_node_meters(hass, mock_openzwave, zwave_setup):
     """Test zwave reset_node_meters service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2024,9 +1961,6 @@ async def test_reset_node_meters(hass, mock_openzwave, zwave_setup):
 
 async def test_add_association(hass, mock_openzwave, zwave_setup):
     """Test zwave change_association service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2067,9 +2001,6 @@ async def test_add_association(hass, mock_openzwave, zwave_setup):
 
 async def test_remove_association(hass, mock_openzwave, zwave_setup):
     """Test zwave change_association service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2110,9 +2041,6 @@ async def test_remove_association(hass, mock_openzwave, zwave_setup):
 
 async def test_refresh_entity(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_entity service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2150,9 +2078,6 @@ async def test_refresh_entity(hass, mock_openzwave, zwave_setup):
 
 async def test_refresh_node(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2169,9 +2094,6 @@ async def test_refresh_node(hass, mock_openzwave, zwave_setup):
 
 async def test_set_node_value(hass, mock_openzwave, zwave_setup):
     """Test zwave set_node_value service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2201,9 +2123,6 @@ async def test_set_node_value_with_long_id_and_text_value(
     hass, mock_openzwave, zwave_setup
 ):
     """Test zwave set_node_value service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2235,9 +2154,6 @@ async def test_set_node_value_with_long_id_and_text_value(
 
 async def test_refresh_node_value(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_node_value service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2269,9 +2185,6 @@ async def test_refresh_node_value(hass, mock_openzwave, zwave_setup):
 
 async def test_heal_node(hass, mock_openzwave, zwave_setup):
     """Test zwave heal_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -2288,9 +2201,6 @@ async def test_heal_node(hass, mock_openzwave, zwave_setup):
 
 async def test_test_node(hass, mock_openzwave, zwave_setup):
     """Test the zwave test_node service."""
-    assert await zwave_setup()
-    await hass.async_block_till_done()
-
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -2070,35 +2070,34 @@ async def test_print_config_parameter(hass, mock_openzwave):
         assert mock_logger.info.mock_calls[0][1][3] == 2345
 
 
-# @patch("homeassistant.components.zwave._LOGGER")
-# async def test_print_node(hass, mock_openzwave):
-#     """Test zwave print_node_parameter service."""
-#     mock_receivers = []
+async def test_print_node(hass, mock_openzwave):
+    """Test zwave print_node_parameter service."""
+    mock_receivers = []
 
-#     def mock_connect(receiver, signal, *args, **kwargs):
-#         if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-#             mock_receivers.append(receiver)
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
 
-#     with patch("pydispatch.dispatcher.connect", new=mock_connect):
-#         await async_setup_component(hass, "zwave", {"zwave": {}})
-#         await hass.async_block_till_done()
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
 
-#     assert len(mock_receivers) == 1
+    assert len(mock_receivers) == 1
 
-#     zwave_network = hass.data[DATA_NETWORK]
-#     zwave_network.state = MockNetwork.STATE_READY
-#     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-#     await hass.async_block_till_done()
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
 
-#     node = MockNode(node_id=14)
+    node = MockNode(node_id=14)
 
-#     zwave_network.nodes = {14: node}
+    zwave_network.nodes = {14: node}
 
-#     with assertLogs(level="DEBUG") as mock_logger:
-#         await hass.services.async_call("zwave", "print_node", {const.ATTR_NODE_ID: 14})
-#         await hass.async_block_till_done()
+    with patch.object(zwave, "_LOGGER") as mock_logger:
+        await hass.services.async_call("zwave", "print_node", {const.ATTR_NODE_ID: 14})
+        await hass.async_block_till_done()
 
-#         assert "FOUND NODE " in mock_logger.output[1]
+        assert "FOUND NODE " in mock_logger.info.mock_calls[0][1][0]
 
 
 async def test_set_wakeup(hass, mock_openzwave):

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -2,7 +2,6 @@
 import asyncio
 from collections import OrderedDict
 from datetime import datetime
-import unittest
 
 import pytest
 from pytz import utc
@@ -20,10 +19,9 @@ from homeassistant.components.zwave.binary_sensor import get_device
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
 from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
 from homeassistant.helpers.entity_registry import async_get_registry
-from homeassistant.setup import setup_component
 
 from tests.async_mock import MagicMock, patch
-from tests.common import async_fire_time_changed, get_test_home_assistant, mock_registry
+from tests.common import async_fire_time_changed, mock_registry
 from tests.mock.zwave import MockEntityValues, MockNetwork, MockNode, MockValue
 
 
@@ -1350,699 +1348,1210 @@ async def test_config_polling_intensity(
     assert value_class.primary.enable_poll.mock_calls[0][1][0] == 123
 
 
-class TestZwave(unittest.TestCase):
-    """Test zwave init."""
-
-    def test_device_config_glob_is_ordered(self):
-        """Test that device_config_glob preserves order."""
-        conf = CONFIG_SCHEMA({"zwave": {CONF_DEVICE_CONFIG_GLOB: OrderedDict()}})
-        assert isinstance(conf["zwave"][CONF_DEVICE_CONFIG_GLOB], OrderedDict)
+async def test_device_config_glob_is_ordered():
+    """Test that device_config_glob preserves order."""
+    conf = CONFIG_SCHEMA({"zwave": {CONF_DEVICE_CONFIG_GLOB: OrderedDict()}})
+    assert isinstance(conf["zwave"][CONF_DEVICE_CONFIG_GLOB], OrderedDict)
 
 
-class TestZWaveServices(unittest.TestCase):
-    """Tests for zwave services."""
+async def test_add_node(hass, mock_openzwave):
+    """Test zwave add_node service."""
+    mock_receivers = []
 
-    @pytest.fixture(autouse=True)
-    def set_mock_openzwave(self, mock_openzwave):
-        """Use the mock_openzwave fixture for this class."""
-        self.mock_openzwave = mock_openzwave
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        self.hass.start()
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
 
-        # Initialize zwave
-        setup_component(self.hass, "zwave", {"zwave": {}})
-        self.hass.block_till_done()
-        self.zwave_network = self.hass.data[DATA_NETWORK]
-        self.zwave_network.state = MockNetwork.STATE_READY
-        self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
-        self.hass.block_till_done()
-        self.addCleanup(self.tear_down_cleanup)
+    assert len(mock_receivers) == 1
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.services.call("zwave", "stop_network", {})
-        self.hass.block_till_done()
-        self.hass.stop()
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
 
-    def test_add_node(self):
-        """Test zwave add_node service."""
-        self.hass.services.call("zwave", "add_node", {})
-        self.hass.block_till_done()
+    await hass.services.async_call("zwave", "add_node", {})
+    await hass.async_block_till_done()
 
-        assert self.zwave_network.controller.add_node.called
-        assert len(self.zwave_network.controller.add_node.mock_calls) == 1
-        assert len(self.zwave_network.controller.add_node.mock_calls[0][1]) == 0
+    assert zwave_network.controller.add_node.called
+    assert len(zwave_network.controller.add_node.mock_calls) == 1
+    assert len(zwave_network.controller.add_node.mock_calls[0][1]) == 0
 
-    def test_add_node_secure(self):
-        """Test zwave add_node_secure service."""
-        self.hass.services.call("zwave", "add_node_secure", {})
-        self.hass.block_till_done()
 
-        assert self.zwave_network.controller.add_node.called
-        assert len(self.zwave_network.controller.add_node.mock_calls) == 1
-        assert self.zwave_network.controller.add_node.mock_calls[0][1][0] is True
+async def test_add_node_secure(hass, mock_openzwave):
+    """Test zwave add_node_secure service."""
+    mock_receivers = []
 
-    def test_remove_node(self):
-        """Test zwave remove_node service."""
-        self.hass.services.call("zwave", "remove_node", {})
-        self.hass.block_till_done()
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
 
-        assert self.zwave_network.controller.remove_node.called
-        assert len(self.zwave_network.controller.remove_node.mock_calls) == 1
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
 
-    def test_cancel_command(self):
-        """Test zwave cancel_command service."""
-        self.hass.services.call("zwave", "cancel_command", {})
-        self.hass.block_till_done()
+    assert len(mock_receivers) == 1
 
-        assert self.zwave_network.controller.cancel_command.called
-        assert len(self.zwave_network.controller.cancel_command.mock_calls) == 1
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
 
-    def test_heal_network(self):
-        """Test zwave heal_network service."""
-        self.hass.services.call("zwave", "heal_network", {})
-        self.hass.block_till_done()
+    await hass.services.async_call("zwave", "add_node_secure", {})
+    await hass.async_block_till_done()
 
-        assert self.zwave_network.heal.called
-        assert len(self.zwave_network.heal.mock_calls) == 1
+    assert zwave_network.controller.add_node.called
+    assert len(zwave_network.controller.add_node.mock_calls) == 1
+    assert zwave_network.controller.add_node.mock_calls[0][1][0] is True
 
-    def test_soft_reset(self):
-        """Test zwave soft_reset service."""
-        self.hass.services.call("zwave", "soft_reset", {})
-        self.hass.block_till_done()
 
-        assert self.zwave_network.controller.soft_reset.called
-        assert len(self.zwave_network.controller.soft_reset.mock_calls) == 1
+async def test_remove_node(hass, mock_openzwave):
+    """Test zwave remove_node service."""
+    mock_receivers = []
 
-    def test_test_network(self):
-        """Test zwave test_network service."""
-        self.hass.services.call("zwave", "test_network", {})
-        self.hass.block_till_done()
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
 
-        assert self.zwave_network.test.called
-        assert len(self.zwave_network.test.mock_calls) == 1
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
 
-    def test_stop_network(self):
-        """Test zwave stop_network service."""
-        with patch.object(self.hass.bus, "fire") as mock_fire:
-            self.hass.services.call("zwave", "stop_network", {})
-            self.hass.block_till_done()
+    assert len(mock_receivers) == 1
 
-            assert self.zwave_network.stop.called
-            assert len(self.zwave_network.stop.mock_calls) == 1
-            assert mock_fire.called
-            assert len(mock_fire.mock_calls) == 1
-            assert mock_fire.mock_calls[0][1][0] == const.EVENT_NETWORK_STOP
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
 
-    def test_rename_node(self):
-        """Test zwave rename_node service."""
-        self.zwave_network.nodes = {11: MagicMock()}
-        self.hass.services.call(
+    await hass.services.async_call("zwave", "remove_node", {})
+    await hass.async_block_till_done()
+
+    assert zwave_network.controller.remove_node.called
+    assert len(zwave_network.controller.remove_node.mock_calls) == 1
+
+
+async def test_cancel_command(hass, mock_openzwave):
+    """Test zwave cancel_command service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call("zwave", "cancel_command", {})
+    await hass.async_block_till_done()
+
+    assert zwave_network.controller.cancel_command.called
+    assert len(zwave_network.controller.cancel_command.mock_calls) == 1
+
+
+async def test_heal_network(hass, mock_openzwave):
+    """Test zwave heal_network service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call("zwave", "heal_network", {})
+    await hass.async_block_till_done()
+
+    assert zwave_network.heal.called
+    assert len(zwave_network.heal.mock_calls) == 1
+
+
+async def test_soft_reset(hass, mock_openzwave):
+    """Test zwave soft_reset service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call("zwave", "soft_reset", {})
+    await hass.async_block_till_done()
+
+    assert zwave_network.controller.soft_reset.called
+    assert len(zwave_network.controller.soft_reset.mock_calls) == 1
+
+
+async def test_test_network(hass, mock_openzwave):
+    """Test zwave test_network service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call("zwave", "test_network", {})
+    await hass.async_block_till_done()
+
+    assert zwave_network.test.called
+    assert len(zwave_network.test.mock_calls) == 1
+
+
+async def test_stop_network(hass, mock_openzwave):
+    """Test zwave stop_network service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    with patch.object(hass.bus, "fire") as mock_fire:
+        await hass.services.async_call("zwave", "stop_network", {})
+        await hass.async_block_till_done()
+
+        assert zwave_network.stop.called
+        assert len(zwave_network.stop.mock_calls) == 1
+        assert mock_fire.called
+        assert len(mock_fire.mock_calls) == 1
+        assert mock_fire.mock_calls[0][1][0] == const.EVENT_NETWORK_STOP
+
+
+async def test_rename_node(hass, mock_openzwave):
+    """Test zwave rename_node service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    zwave_network.nodes = {11: MagicMock()}
+    await hass.services.async_call(
+        "zwave",
+        "rename_node",
+        {const.ATTR_NODE_ID: 11, const.ATTR_NAME: "test_name"},
+    )
+    await hass.async_block_till_done()
+
+    assert zwave_network.nodes[11].name == "test_name"
+
+
+async def test_rename_value(hass, mock_openzwave):
+    """Test zwave rename_value service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=14)
+    value = MockValue(index=12, value_id=123456, label="Old Label")
+    node.values = {123456: value}
+    zwave_network.nodes = {11: node}
+
+    assert value.label == "Old Label"
+    await hass.services.async_call(
+        "zwave",
+        "rename_value",
+        {
+            const.ATTR_NODE_ID: 11,
+            const.ATTR_VALUE_ID: 123456,
+            const.ATTR_NAME: "New Label",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert value.label == "New Label"
+
+
+async def test_set_poll_intensity_enable(hass, mock_openzwave):
+    """Test zwave set_poll_intensity service, successful set."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=14)
+    value = MockValue(index=12, value_id=123456, poll_intensity=0)
+    node.values = {123456: value}
+    zwave_network.nodes = {11: node}
+
+    assert value.poll_intensity == 0
+    await hass.services.async_call(
+        "zwave",
+        "set_poll_intensity",
+        {
+            const.ATTR_NODE_ID: 11,
+            const.ATTR_VALUE_ID: 123456,
+            const.ATTR_POLL_INTENSITY: 4,
+        },
+    )
+    await hass.async_block_till_done()
+
+    enable_poll = value.enable_poll
+    assert value.enable_poll.called
+    assert len(enable_poll.mock_calls) == 2
+    assert enable_poll.mock_calls[0][1][0] == 4
+
+
+async def test_set_poll_intensity_enable_failed(hass, mock_openzwave):
+    """Test zwave set_poll_intensity service, failed set."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=14)
+    value = MockValue(index=12, value_id=123456, poll_intensity=0)
+    value.enable_poll.return_value = False
+    node.values = {123456: value}
+    zwave_network.nodes = {11: node}
+
+    assert value.poll_intensity == 0
+    await hass.services.async_call(
+        "zwave",
+        "set_poll_intensity",
+        {
+            const.ATTR_NODE_ID: 11,
+            const.ATTR_VALUE_ID: 123456,
+            const.ATTR_POLL_INTENSITY: 4,
+        },
+    )
+    await hass.async_block_till_done()
+
+    enable_poll = value.enable_poll
+    assert value.enable_poll.called
+    assert len(enable_poll.mock_calls) == 1
+
+
+async def test_set_poll_intensity_disable(hass, mock_openzwave):
+    """Test zwave set_poll_intensity service, successful disable."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=14)
+    value = MockValue(index=12, value_id=123456, poll_intensity=4)
+    node.values = {123456: value}
+    zwave_network.nodes = {11: node}
+
+    assert value.poll_intensity == 4
+    await hass.services.async_call(
+        "zwave",
+        "set_poll_intensity",
+        {
+            const.ATTR_NODE_ID: 11,
+            const.ATTR_VALUE_ID: 123456,
+            const.ATTR_POLL_INTENSITY: 0,
+        },
+    )
+    await hass.async_block_till_done()
+
+    disable_poll = value.disable_poll
+    assert value.disable_poll.called
+    assert len(disable_poll.mock_calls) == 2
+
+
+async def test_set_poll_intensity_disable_failed(hass, mock_openzwave):
+    """Test zwave set_poll_intensity service, failed disable."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=14)
+    value = MockValue(index=12, value_id=123456, poll_intensity=4)
+    value.disable_poll.return_value = False
+    node.values = {123456: value}
+    zwave_network.nodes = {11: node}
+
+    assert value.poll_intensity == 4
+    await hass.services.async_call(
+        "zwave",
+        "set_poll_intensity",
+        {
+            const.ATTR_NODE_ID: 11,
+            const.ATTR_VALUE_ID: 123456,
+            const.ATTR_POLL_INTENSITY: 0,
+        },
+    )
+    await hass.async_block_till_done()
+
+    disable_poll = value.disable_poll
+    assert value.disable_poll.called
+    assert len(disable_poll.mock_calls) == 1
+
+
+async def test_remove_failed_node(hass, mock_openzwave):
+    """Test zwave remove_failed_node service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "zwave", "remove_failed_node", {const.ATTR_NODE_ID: 12}
+    )
+    await hass.async_block_till_done()
+
+    remove_failed_node = zwave_network.controller.remove_failed_node
+    assert remove_failed_node.called
+    assert len(remove_failed_node.mock_calls) == 1
+    assert remove_failed_node.mock_calls[0][1][0] == 12
+
+
+async def test_replace_failed_node(hass, mock_openzwave):
+    """Test zwave replace_failed_node service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "zwave", "replace_failed_node", {const.ATTR_NODE_ID: 13}
+    )
+    await hass.async_block_till_done()
+
+    replace_failed_node = zwave_network.controller.replace_failed_node
+    assert replace_failed_node.called
+    assert len(replace_failed_node.mock_calls) == 1
+    assert replace_failed_node.mock_calls[0][1][0] == 13
+
+
+async def test_set_config_parameter(hass, mock_openzwave):
+    """Test zwave set_config_parameter service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    value_byte = MockValue(
+        index=12,
+        command_class=const.COMMAND_CLASS_CONFIGURATION,
+        type=const.TYPE_BYTE,
+    )
+    value_list = MockValue(
+        index=13,
+        command_class=const.COMMAND_CLASS_CONFIGURATION,
+        type=const.TYPE_LIST,
+        data_items=["item1", "item2", "item3"],
+    )
+    value_button = MockValue(
+        index=14,
+        command_class=const.COMMAND_CLASS_CONFIGURATION,
+        type=const.TYPE_BUTTON,
+    )
+    value_list_int = MockValue(
+        index=15,
+        command_class=const.COMMAND_CLASS_CONFIGURATION,
+        type=const.TYPE_LIST,
+        data_items=["1", "2", "3"],
+    )
+    value_bool = MockValue(
+        index=16,
+        command_class=const.COMMAND_CLASS_CONFIGURATION,
+        type=const.TYPE_BOOL,
+    )
+    node = MockNode(node_id=14)
+    node.get_values.return_value = {
+        12: value_byte,
+        13: value_list,
+        14: value_button,
+        15: value_list_int,
+        16: value_bool,
+    }
+    zwave_network.nodes = {14: node}
+
+    # Byte
+    await hass.services.async_call(
+        "zwave",
+        "set_config_parameter",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 12,
+            const.ATTR_CONFIG_VALUE: 7,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert value_byte.data == 7
+
+    # List
+    await hass.services.async_call(
+        "zwave",
+        "set_config_parameter",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 13,
+            const.ATTR_CONFIG_VALUE: "item3",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert value_list.data == "item3"
+
+    # Button
+    await hass.services.async_call(
+        "zwave",
+        "set_config_parameter",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 14,
+            const.ATTR_CONFIG_VALUE: True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert zwave_network.manager.pressButton.called
+    assert zwave_network.manager.releaseButton.called
+
+    # List of Ints
+    await hass.services.async_call(
+        "zwave",
+        "set_config_parameter",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 15,
+            const.ATTR_CONFIG_VALUE: 3,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert value_list_int.data == "3"
+
+    # Boolean Truthy
+    await hass.services.async_call(
+        "zwave",
+        "set_config_parameter",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 16,
+            const.ATTR_CONFIG_VALUE: "True",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert value_bool.data == 1
+
+    # Boolean Falsy
+    await hass.services.async_call(
+        "zwave",
+        "set_config_parameter",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 16,
+            const.ATTR_CONFIG_VALUE: "False",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert value_bool.data == 0
+
+    # Different Parameter Size
+    await hass.services.async_call(
+        "zwave",
+        "set_config_parameter",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 19,
+            const.ATTR_CONFIG_VALUE: 0x01020304,
+            const.ATTR_CONFIG_SIZE: 4,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert node.set_config_param.called
+    assert len(node.set_config_param.mock_calls) == 1
+    assert node.set_config_param.mock_calls[0][1][0] == 19
+    assert node.set_config_param.mock_calls[0][1][1] == 0x01020304
+    assert node.set_config_param.mock_calls[0][1][2] == 4
+    node.set_config_param.reset_mock()
+
+
+async def test_print_config_parameter(hass, mock_openzwave):
+    """Test zwave print_config_parameter service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    value1 = MockValue(
+        index=12, command_class=const.COMMAND_CLASS_CONFIGURATION, data=1234
+    )
+    value2 = MockValue(
+        index=13, command_class=const.COMMAND_CLASS_CONFIGURATION, data=2345
+    )
+    node = MockNode(node_id=14)
+    node.values = {12: value1, 13: value2}
+    zwave_network.nodes = {14: node}
+
+    with patch.object(zwave, "_LOGGER") as mock_logger:
+        await hass.services.async_call(
             "zwave",
-            "rename_node",
-            {const.ATTR_NODE_ID: 11, const.ATTR_NAME: "test_name"},
+            "print_config_parameter",
+            {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_PARAMETER: 13},
         )
-        self.hass.block_till_done()
+        await hass.async_block_till_done()
 
-        assert self.zwave_network.nodes[11].name == "test_name"
+        assert mock_logger.info.called
+        assert len(mock_logger.info.mock_calls) == 1
+        assert mock_logger.info.mock_calls[0][1][1] == 13
+        assert mock_logger.info.mock_calls[0][1][2] == 14
+        assert mock_logger.info.mock_calls[0][1][3] == 2345
 
-    def test_rename_value(self):
-        """Test zwave rename_value service."""
-        node = MockNode(node_id=14)
-        value = MockValue(index=12, value_id=123456, label="Old Label")
-        node.values = {123456: value}
-        self.zwave_network.nodes = {11: node}
 
-        assert value.label == "Old Label"
-        self.hass.services.call(
-            "zwave",
-            "rename_value",
-            {
-                const.ATTR_NODE_ID: 11,
-                const.ATTR_VALUE_ID: 123456,
-                const.ATTR_NAME: "New Label",
-            },
+# @patch("homeassistant.components.zwave._LOGGER")
+# async def test_print_node(hass, mock_openzwave):
+#     """Test zwave print_node_parameter service."""
+#     mock_receivers = []
+
+#     def mock_connect(receiver, signal, *args, **kwargs):
+#         if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+#             mock_receivers.append(receiver)
+
+#     with patch("pydispatch.dispatcher.connect", new=mock_connect):
+#         await async_setup_component(hass, "zwave", {"zwave": {}})
+#         await hass.async_block_till_done()
+
+#     assert len(mock_receivers) == 1
+
+#     zwave_network = hass.data[DATA_NETWORK]
+#     zwave_network.state = MockNetwork.STATE_READY
+#     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+#     await hass.async_block_till_done()
+
+#     node = MockNode(node_id=14)
+
+#     zwave_network.nodes = {14: node}
+
+#     with assertLogs(level="DEBUG") as mock_logger:
+#         await hass.services.async_call("zwave", "print_node", {const.ATTR_NODE_ID: 14})
+#         await hass.async_block_till_done()
+
+#         assert "FOUND NODE " in mock_logger.output[1]
+
+
+async def test_set_wakeup(hass, mock_openzwave):
+    """Test zwave set_wakeup service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
+    node = MockNode(node_id=14)
+    node.values = {12: value}
+    node.get_values.return_value = node.values
+    zwave_network.nodes = {14: node}
+
+    await hass.services.async_call(
+        "zwave", "set_wakeup", {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_VALUE: 15}
+    )
+    await hass.async_block_till_done()
+
+    assert value.data == 15
+
+    node.can_wake_up_value = False
+    await hass.services.async_call(
+        "zwave", "set_wakeup", {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_VALUE: 20}
+    )
+    await hass.async_block_till_done()
+
+    assert value.data == 15
+
+
+async def test_reset_node_meters(hass, mock_openzwave):
+    """Test zwave reset_node_meters service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    value = MockValue(
+        instance=1, index=8, data=99.5, command_class=const.COMMAND_CLASS_METER
+    )
+    reset_value = MockValue(
+        instance=1, index=33, command_class=const.COMMAND_CLASS_METER
+    )
+    node = MockNode(node_id=14)
+    node.values = {8: value, 33: reset_value}
+    node.get_values.return_value = node.values
+    zwave_network.nodes = {14: node}
+
+    await hass.services.async_call(
+        "zwave",
+        "reset_node_meters",
+        {const.ATTR_NODE_ID: 14, const.ATTR_INSTANCE: 2},
+    )
+    await hass.async_block_till_done()
+
+    assert not zwave_network.manager.pressButton.called
+    assert not zwave_network.manager.releaseButton.called
+
+    await hass.services.async_call(
+        "zwave", "reset_node_meters", {const.ATTR_NODE_ID: 14}
+    )
+    await hass.async_block_till_done()
+
+    assert zwave_network.manager.pressButton.called
+    (value_id,) = zwave_network.manager.pressButton.mock_calls.pop(0)[1]
+    assert value_id == reset_value.value_id
+    assert zwave_network.manager.releaseButton.called
+    (value_id,) = zwave_network.manager.releaseButton.mock_calls.pop(0)[1]
+    assert value_id == reset_value.value_id
+
+
+async def test_add_association(hass, mock_openzwave):
+    """Test zwave change_association service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    ZWaveGroup = mock_openzwave.group.ZWaveGroup
+    group = MagicMock()
+    ZWaveGroup.return_value = group
+
+    value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
+    node = MockNode(node_id=14)
+    node.values = {12: value}
+    node.get_values.return_value = node.values
+    zwave_network.nodes = {14: node}
+
+    await hass.services.async_call(
+        "zwave",
+        "change_association",
+        {
+            const.ATTR_ASSOCIATION: "add",
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_TARGET_NODE_ID: 24,
+            const.ATTR_GROUP: 3,
+            const.ATTR_INSTANCE: 5,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert ZWaveGroup.called
+    assert len(ZWaveGroup.mock_calls) == 2
+    assert ZWaveGroup.mock_calls[0][1][0] == 3
+    assert ZWaveGroup.mock_calls[0][1][2] == 14
+    assert group.add_association.called
+    assert len(group.add_association.mock_calls) == 1
+    assert group.add_association.mock_calls[0][1][0] == 24
+    assert group.add_association.mock_calls[0][1][1] == 5
+
+
+async def test_remove_association(hass, mock_openzwave):
+    """Test zwave change_association service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    ZWaveGroup = mock_openzwave.group.ZWaveGroup
+    group = MagicMock()
+    ZWaveGroup.return_value = group
+
+    value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
+    node = MockNode(node_id=14)
+    node.values = {12: value}
+    node.get_values.return_value = node.values
+    zwave_network.nodes = {14: node}
+
+    await hass.services.async_call(
+        "zwave",
+        "change_association",
+        {
+            const.ATTR_ASSOCIATION: "remove",
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_TARGET_NODE_ID: 24,
+            const.ATTR_GROUP: 3,
+            const.ATTR_INSTANCE: 5,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert ZWaveGroup.called
+    assert len(ZWaveGroup.mock_calls) == 2
+    assert ZWaveGroup.mock_calls[0][1][0] == 3
+    assert ZWaveGroup.mock_calls[0][1][2] == 14
+    assert group.remove_association.called
+    assert len(group.remove_association.mock_calls) == 1
+    assert group.remove_association.mock_calls[0][1][0] == 24
+    assert group.remove_association.mock_calls[0][1][1] == 5
+
+
+async def test_refresh_entity(hass, mock_openzwave):
+    """Test zwave refresh_entity service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode()
+    value = MockValue(
+        data=False, node=node, command_class=const.COMMAND_CLASS_SENSOR_BINARY
+    )
+    power_value = MockValue(data=50, node=node, command_class=const.COMMAND_CLASS_METER)
+    values = MockEntityValues(primary=value, power=power_value)
+    device = get_device(node=node, values=values, node_config={})
+    device.hass = hass
+    device.entity_id = "binary_sensor.mock_entity_id"
+    await hass.async_add_job(device.async_added_to_hass())
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "zwave", "refresh_entity", {ATTR_ENTITY_ID: "binary_sensor.mock_entity_id"}
+    )
+    await hass.async_block_till_done()
+
+    assert node.refresh_value.called
+    assert len(node.refresh_value.mock_calls) == 2
+    assert (
+        sorted(
+            [
+                node.refresh_value.mock_calls[0][1][0],
+                node.refresh_value.mock_calls[1][1][0],
+            ]
         )
-        self.hass.block_till_done()
-
-        assert value.label == "New Label"
-
-    def test_set_poll_intensity_enable(self):
-        """Test zwave set_poll_intensity service, successful set."""
-        node = MockNode(node_id=14)
-        value = MockValue(index=12, value_id=123456, poll_intensity=0)
-        node.values = {123456: value}
-        self.zwave_network.nodes = {11: node}
-
-        assert value.poll_intensity == 0
-        self.hass.services.call(
-            "zwave",
-            "set_poll_intensity",
-            {
-                const.ATTR_NODE_ID: 11,
-                const.ATTR_VALUE_ID: 123456,
-                const.ATTR_POLL_INTENSITY: 4,
-            },
-        )
-        self.hass.block_till_done()
-
-        enable_poll = value.enable_poll
-        assert value.enable_poll.called
-        assert len(enable_poll.mock_calls) == 2
-        assert enable_poll.mock_calls[0][1][0] == 4
-
-    def test_set_poll_intensity_enable_failed(self):
-        """Test zwave set_poll_intensity service, failed set."""
-        node = MockNode(node_id=14)
-        value = MockValue(index=12, value_id=123456, poll_intensity=0)
-        value.enable_poll.return_value = False
-        node.values = {123456: value}
-        self.zwave_network.nodes = {11: node}
-
-        assert value.poll_intensity == 0
-        self.hass.services.call(
-            "zwave",
-            "set_poll_intensity",
-            {
-                const.ATTR_NODE_ID: 11,
-                const.ATTR_VALUE_ID: 123456,
-                const.ATTR_POLL_INTENSITY: 4,
-            },
-        )
-        self.hass.block_till_done()
-
-        enable_poll = value.enable_poll
-        assert value.enable_poll.called
-        assert len(enable_poll.mock_calls) == 1
-
-    def test_set_poll_intensity_disable(self):
-        """Test zwave set_poll_intensity service, successful disable."""
-        node = MockNode(node_id=14)
-        value = MockValue(index=12, value_id=123456, poll_intensity=4)
-        node.values = {123456: value}
-        self.zwave_network.nodes = {11: node}
-
-        assert value.poll_intensity == 4
-        self.hass.services.call(
-            "zwave",
-            "set_poll_intensity",
-            {
-                const.ATTR_NODE_ID: 11,
-                const.ATTR_VALUE_ID: 123456,
-                const.ATTR_POLL_INTENSITY: 0,
-            },
-        )
-        self.hass.block_till_done()
-
-        disable_poll = value.disable_poll
-        assert value.disable_poll.called
-        assert len(disable_poll.mock_calls) == 2
-
-    def test_set_poll_intensity_disable_failed(self):
-        """Test zwave set_poll_intensity service, failed disable."""
-        node = MockNode(node_id=14)
-        value = MockValue(index=12, value_id=123456, poll_intensity=4)
-        value.disable_poll.return_value = False
-        node.values = {123456: value}
-        self.zwave_network.nodes = {11: node}
-
-        assert value.poll_intensity == 4
-        self.hass.services.call(
-            "zwave",
-            "set_poll_intensity",
-            {
-                const.ATTR_NODE_ID: 11,
-                const.ATTR_VALUE_ID: 123456,
-                const.ATTR_POLL_INTENSITY: 0,
-            },
-        )
-        self.hass.block_till_done()
-
-        disable_poll = value.disable_poll
-        assert value.disable_poll.called
-        assert len(disable_poll.mock_calls) == 1
-
-    def test_remove_failed_node(self):
-        """Test zwave remove_failed_node service."""
-        self.hass.services.call("zwave", "remove_failed_node", {const.ATTR_NODE_ID: 12})
-        self.hass.block_till_done()
-
-        remove_failed_node = self.zwave_network.controller.remove_failed_node
-        assert remove_failed_node.called
-        assert len(remove_failed_node.mock_calls) == 1
-        assert remove_failed_node.mock_calls[0][1][0] == 12
-
-    def test_replace_failed_node(self):
-        """Test zwave replace_failed_node service."""
-        self.hass.services.call(
-            "zwave", "replace_failed_node", {const.ATTR_NODE_ID: 13}
-        )
-        self.hass.block_till_done()
-
-        replace_failed_node = self.zwave_network.controller.replace_failed_node
-        assert replace_failed_node.called
-        assert len(replace_failed_node.mock_calls) == 1
-        assert replace_failed_node.mock_calls[0][1][0] == 13
-
-    def test_set_config_parameter(self):
-        """Test zwave set_config_parameter service."""
-        value_byte = MockValue(
-            index=12,
-            command_class=const.COMMAND_CLASS_CONFIGURATION,
-            type=const.TYPE_BYTE,
-        )
-        value_list = MockValue(
-            index=13,
-            command_class=const.COMMAND_CLASS_CONFIGURATION,
-            type=const.TYPE_LIST,
-            data_items=["item1", "item2", "item3"],
-        )
-        value_button = MockValue(
-            index=14,
-            command_class=const.COMMAND_CLASS_CONFIGURATION,
-            type=const.TYPE_BUTTON,
-        )
-        value_list_int = MockValue(
-            index=15,
-            command_class=const.COMMAND_CLASS_CONFIGURATION,
-            type=const.TYPE_LIST,
-            data_items=["1", "2", "3"],
-        )
-        value_bool = MockValue(
-            index=16,
-            command_class=const.COMMAND_CLASS_CONFIGURATION,
-            type=const.TYPE_BOOL,
-        )
-        node = MockNode(node_id=14)
-        node.get_values.return_value = {
-            12: value_byte,
-            13: value_list,
-            14: value_button,
-            15: value_list_int,
-            16: value_bool,
-        }
-        self.zwave_network.nodes = {14: node}
-
-        # Byte
-        self.hass.services.call(
-            "zwave",
-            "set_config_parameter",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_CONFIG_PARAMETER: 12,
-                const.ATTR_CONFIG_VALUE: 7,
-            },
-        )
-        self.hass.block_till_done()
-
-        assert value_byte.data == 7
-
-        # List
-        self.hass.services.call(
-            "zwave",
-            "set_config_parameter",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_CONFIG_PARAMETER: 13,
-                const.ATTR_CONFIG_VALUE: "item3",
-            },
-        )
-        self.hass.block_till_done()
-
-        assert value_list.data == "item3"
-
-        # Button
-        self.hass.services.call(
-            "zwave",
-            "set_config_parameter",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_CONFIG_PARAMETER: 14,
-                const.ATTR_CONFIG_VALUE: True,
-            },
-        )
-        self.hass.block_till_done()
-
-        assert self.zwave_network.manager.pressButton.called
-        assert self.zwave_network.manager.releaseButton.called
-
-        # List of Ints
-        self.hass.services.call(
-            "zwave",
-            "set_config_parameter",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_CONFIG_PARAMETER: 15,
-                const.ATTR_CONFIG_VALUE: 3,
-            },
-        )
-        self.hass.block_till_done()
-
-        assert value_list_int.data == "3"
-
-        # Boolean Truthy
-        self.hass.services.call(
-            "zwave",
-            "set_config_parameter",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_CONFIG_PARAMETER: 16,
-                const.ATTR_CONFIG_VALUE: "True",
-            },
-        )
-        self.hass.block_till_done()
-
-        assert value_bool.data == 1
-
-        # Boolean Falsy
-        self.hass.services.call(
-            "zwave",
-            "set_config_parameter",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_CONFIG_PARAMETER: 16,
-                const.ATTR_CONFIG_VALUE: "False",
-            },
-        )
-        self.hass.block_till_done()
-
-        assert value_bool.data == 0
-
-        # Different Parameter Size
-        self.hass.services.call(
-            "zwave",
-            "set_config_parameter",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_CONFIG_PARAMETER: 19,
-                const.ATTR_CONFIG_VALUE: 0x01020304,
-                const.ATTR_CONFIG_SIZE: 4,
-            },
-        )
-        self.hass.block_till_done()
-
-        assert node.set_config_param.called
-        assert len(node.set_config_param.mock_calls) == 1
-        assert node.set_config_param.mock_calls[0][1][0] == 19
-        assert node.set_config_param.mock_calls[0][1][1] == 0x01020304
-        assert node.set_config_param.mock_calls[0][1][2] == 4
-        node.set_config_param.reset_mock()
-
-    def test_print_config_parameter(self):
-        """Test zwave print_config_parameter service."""
-        value1 = MockValue(
-            index=12, command_class=const.COMMAND_CLASS_CONFIGURATION, data=1234
-        )
-        value2 = MockValue(
-            index=13, command_class=const.COMMAND_CLASS_CONFIGURATION, data=2345
-        )
-        node = MockNode(node_id=14)
-        node.values = {12: value1, 13: value2}
-        self.zwave_network.nodes = {14: node}
-
-        with patch.object(zwave, "_LOGGER") as mock_logger:
-            self.hass.services.call(
-                "zwave",
-                "print_config_parameter",
-                {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_PARAMETER: 13},
-            )
-            self.hass.block_till_done()
-
-            assert mock_logger.info.called
-            assert len(mock_logger.info.mock_calls) == 1
-            assert mock_logger.info.mock_calls[0][1][1] == 13
-            assert mock_logger.info.mock_calls[0][1][2] == 14
-            assert mock_logger.info.mock_calls[0][1][3] == 2345
-
-    def test_print_node(self):
-        """Test zwave print_node_parameter service."""
-        node = MockNode(node_id=14)
-
-        self.zwave_network.nodes = {14: node}
-
-        with self.assertLogs(level="DEBUG") as mock_logger:
-            self.hass.services.call("zwave", "print_node", {const.ATTR_NODE_ID: 14})
-            self.hass.block_till_done()
-
-            assert "FOUND NODE " in mock_logger.output[1]
-
-    def test_set_wakeup(self):
-        """Test zwave set_wakeup service."""
-        value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
-        node = MockNode(node_id=14)
-        node.values = {12: value}
-        node.get_values.return_value = node.values
-        self.zwave_network.nodes = {14: node}
-
-        self.hass.services.call(
-            "zwave", "set_wakeup", {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_VALUE: 15}
-        )
-        self.hass.block_till_done()
-
-        assert value.data == 15
-
-        node.can_wake_up_value = False
-        self.hass.services.call(
-            "zwave", "set_wakeup", {const.ATTR_NODE_ID: 14, const.ATTR_CONFIG_VALUE: 20}
-        )
-        self.hass.block_till_done()
-
-        assert value.data == 15
-
-    def test_reset_node_meters(self):
-        """Test zwave reset_node_meters service."""
-        value = MockValue(
-            instance=1, index=8, data=99.5, command_class=const.COMMAND_CLASS_METER
-        )
-        reset_value = MockValue(
-            instance=1, index=33, command_class=const.COMMAND_CLASS_METER
-        )
-        node = MockNode(node_id=14)
-        node.values = {8: value, 33: reset_value}
-        node.get_values.return_value = node.values
-        self.zwave_network.nodes = {14: node}
-
-        self.hass.services.call(
-            "zwave",
-            "reset_node_meters",
-            {const.ATTR_NODE_ID: 14, const.ATTR_INSTANCE: 2},
-        )
-        self.hass.block_till_done()
-
-        assert not self.zwave_network.manager.pressButton.called
-        assert not self.zwave_network.manager.releaseButton.called
-
-        self.hass.services.call("zwave", "reset_node_meters", {const.ATTR_NODE_ID: 14})
-        self.hass.block_till_done()
-
-        assert self.zwave_network.manager.pressButton.called
-        (value_id,) = self.zwave_network.manager.pressButton.mock_calls.pop(0)[1]
-        assert value_id == reset_value.value_id
-        assert self.zwave_network.manager.releaseButton.called
-        (value_id,) = self.zwave_network.manager.releaseButton.mock_calls.pop(0)[1]
-        assert value_id == reset_value.value_id
-
-    def test_add_association(self):
-        """Test zwave change_association service."""
-        ZWaveGroup = self.mock_openzwave.group.ZWaveGroup
-        group = MagicMock()
-        ZWaveGroup.return_value = group
-
-        value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
-        node = MockNode(node_id=14)
-        node.values = {12: value}
-        node.get_values.return_value = node.values
-        self.zwave_network.nodes = {14: node}
-
-        self.hass.services.call(
-            "zwave",
-            "change_association",
-            {
-                const.ATTR_ASSOCIATION: "add",
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_TARGET_NODE_ID: 24,
-                const.ATTR_GROUP: 3,
-                const.ATTR_INSTANCE: 5,
-            },
-        )
-        self.hass.block_till_done()
-
-        assert ZWaveGroup.called
-        assert len(ZWaveGroup.mock_calls) == 2
-        assert ZWaveGroup.mock_calls[0][1][0] == 3
-        assert ZWaveGroup.mock_calls[0][1][2] == 14
-        assert group.add_association.called
-        assert len(group.add_association.mock_calls) == 1
-        assert group.add_association.mock_calls[0][1][0] == 24
-        assert group.add_association.mock_calls[0][1][1] == 5
-
-    def test_remove_association(self):
-        """Test zwave change_association service."""
-        ZWaveGroup = self.mock_openzwave.group.ZWaveGroup
-        group = MagicMock()
-        ZWaveGroup.return_value = group
-
-        value = MockValue(index=12, command_class=const.COMMAND_CLASS_WAKE_UP)
-        node = MockNode(node_id=14)
-        node.values = {12: value}
-        node.get_values.return_value = node.values
-        self.zwave_network.nodes = {14: node}
-
-        self.hass.services.call(
-            "zwave",
-            "change_association",
-            {
-                const.ATTR_ASSOCIATION: "remove",
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_TARGET_NODE_ID: 24,
-                const.ATTR_GROUP: 3,
-                const.ATTR_INSTANCE: 5,
-            },
-        )
-        self.hass.block_till_done()
-
-        assert ZWaveGroup.called
-        assert len(ZWaveGroup.mock_calls) == 2
-        assert ZWaveGroup.mock_calls[0][1][0] == 3
-        assert ZWaveGroup.mock_calls[0][1][2] == 14
-        assert group.remove_association.called
-        assert len(group.remove_association.mock_calls) == 1
-        assert group.remove_association.mock_calls[0][1][0] == 24
-        assert group.remove_association.mock_calls[0][1][1] == 5
-
-    def test_refresh_entity(self):
-        """Test zwave refresh_entity service."""
-        node = MockNode()
-        value = MockValue(
-            data=False, node=node, command_class=const.COMMAND_CLASS_SENSOR_BINARY
-        )
-        power_value = MockValue(
-            data=50, node=node, command_class=const.COMMAND_CLASS_METER
-        )
-        values = MockEntityValues(primary=value, power=power_value)
-        device = get_device(node=node, values=values, node_config={})
-        device.hass = self.hass
-        device.entity_id = "binary_sensor.mock_entity_id"
-        self.hass.add_job(device.async_added_to_hass())
-        self.hass.block_till_done()
-
-        self.hass.services.call(
-            "zwave", "refresh_entity", {ATTR_ENTITY_ID: "binary_sensor.mock_entity_id"}
-        )
-        self.hass.block_till_done()
-
-        assert node.refresh_value.called
-        assert len(node.refresh_value.mock_calls) == 2
-        assert (
-            sorted(
-                [
-                    node.refresh_value.mock_calls[0][1][0],
-                    node.refresh_value.mock_calls[1][1][0],
-                ]
-            )
-            == sorted([value.value_id, power_value.value_id])
-        )
-
-    def test_refresh_node(self):
-        """Test zwave refresh_node service."""
-        node = MockNode(node_id=14)
-        self.zwave_network.nodes = {14: node}
-        self.hass.services.call("zwave", "refresh_node", {const.ATTR_NODE_ID: 14})
-        self.hass.block_till_done()
-
-        assert node.refresh_info.called
-        assert len(node.refresh_info.mock_calls) == 1
-
-    def test_set_node_value(self):
-        """Test zwave set_node_value service."""
-        value = MockValue(index=12, command_class=const.COMMAND_CLASS_INDICATOR, data=4)
-        node = MockNode(node_id=14, command_classes=[const.COMMAND_CLASS_INDICATOR])
-        node.values = {12: value}
-        node.get_values.return_value = node.values
-        self.zwave_network.nodes = {14: node}
-
-        self.hass.services.call(
-            "zwave",
-            "set_node_value",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_VALUE_ID: 12,
-                const.ATTR_CONFIG_VALUE: 2,
-            },
-        )
-        self.hass.block_till_done()
-
-        assert self.zwave_network.nodes[14].values[12].data == 2
-
-    def test_set_node_value_with_long_id_and_text_value(self):
-        """Test zwave set_node_value service."""
-        value = MockValue(
-            index=87512398541236578,
-            command_class=const.COMMAND_CLASS_SWITCH_COLOR,
-            data="#ff0000",
-        )
-        node = MockNode(node_id=14, command_classes=[const.COMMAND_CLASS_SWITCH_COLOR])
-        node.values = {87512398541236578: value}
-        node.get_values.return_value = node.values
-        self.zwave_network.nodes = {14: node}
-
-        self.hass.services.call(
-            "zwave",
-            "set_node_value",
-            {
-                const.ATTR_NODE_ID: 14,
-                const.ATTR_VALUE_ID: "87512398541236578",
-                const.ATTR_CONFIG_VALUE: "#00ff00",
-            },
-        )
-        self.hass.block_till_done()
-
-        assert self.zwave_network.nodes[14].values[87512398541236578].data == "#00ff00"
-
-    def test_refresh_node_value(self):
-        """Test zwave refresh_node_value service."""
-        node = MockNode(
-            node_id=14,
-            command_classes=[const.COMMAND_CLASS_INDICATOR],
-            network=self.zwave_network,
-        )
-        value = MockValue(
-            node=node, index=12, command_class=const.COMMAND_CLASS_INDICATOR, data=2
-        )
-        value.refresh = MagicMock()
-
-        node.values = {12: value}
-        node.get_values.return_value = node.values
-        self.zwave_network.nodes = {14: node}
-
-        self.hass.services.call(
-            "zwave",
-            "refresh_node_value",
-            {const.ATTR_NODE_ID: 14, const.ATTR_VALUE_ID: 12},
-        )
-        self.hass.block_till_done()
-
-        assert value.refresh.called
-
-    def test_heal_node(self):
-        """Test zwave heal_node service."""
-        node = MockNode(node_id=19)
-        self.zwave_network.nodes = {19: node}
-        self.hass.services.call("zwave", "heal_node", {const.ATTR_NODE_ID: 19})
-        self.hass.block_till_done()
-
-        assert node.heal.called
-        assert len(node.heal.mock_calls) == 1
-
-    def test_test_node(self):
-        """Test the zwave test_node service."""
-        node = MockNode(node_id=19)
-        self.zwave_network.nodes = {19: node}
-        self.hass.services.call("zwave", "test_node", {const.ATTR_NODE_ID: 19})
-        self.hass.block_till_done()
-
-        assert node.test.called
-        assert len(node.test.mock_calls) == 1
+        == sorted([value.value_id, power_value.value_id])
+    )
+
+
+async def test_refresh_node(hass, mock_openzwave):
+    """Test zwave refresh_node service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=14)
+    zwave_network.nodes = {14: node}
+    await hass.services.async_call("zwave", "refresh_node", {const.ATTR_NODE_ID: 14})
+    await hass.async_block_till_done()
+
+    assert node.refresh_info.called
+    assert len(node.refresh_info.mock_calls) == 1
+
+
+async def test_set_node_value(hass, mock_openzwave):
+    """Test zwave set_node_value service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    value = MockValue(index=12, command_class=const.COMMAND_CLASS_INDICATOR, data=4)
+    node = MockNode(node_id=14, command_classes=[const.COMMAND_CLASS_INDICATOR])
+    node.values = {12: value}
+    node.get_values.return_value = node.values
+    zwave_network.nodes = {14: node}
+
+    await hass.services.async_call(
+        "zwave",
+        "set_node_value",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_VALUE_ID: 12,
+            const.ATTR_CONFIG_VALUE: 2,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert zwave_network.nodes[14].values[12].data == 2
+
+
+async def test_set_node_value_with_long_id_and_text_value(hass, mock_openzwave):
+    """Test zwave set_node_value service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    value = MockValue(
+        index=87512398541236578,
+        command_class=const.COMMAND_CLASS_SWITCH_COLOR,
+        data="#ff0000",
+    )
+    node = MockNode(node_id=14, command_classes=[const.COMMAND_CLASS_SWITCH_COLOR])
+    node.values = {87512398541236578: value}
+    node.get_values.return_value = node.values
+    zwave_network.nodes = {14: node}
+
+    await hass.services.async_call(
+        "zwave",
+        "set_node_value",
+        {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_VALUE_ID: "87512398541236578",
+            const.ATTR_CONFIG_VALUE: "#00ff00",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert zwave_network.nodes[14].values[87512398541236578].data == "#00ff00"
+
+
+async def test_refresh_node_value(hass, mock_openzwave):
+    """Test zwave refresh_node_value service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(
+        node_id=14,
+        command_classes=[const.COMMAND_CLASS_INDICATOR],
+        network=zwave_network,
+    )
+    value = MockValue(
+        node=node, index=12, command_class=const.COMMAND_CLASS_INDICATOR, data=2
+    )
+    value.refresh = MagicMock()
+
+    node.values = {12: value}
+    node.get_values.return_value = node.values
+    zwave_network.nodes = {14: node}
+
+    await hass.services.async_call(
+        "zwave",
+        "refresh_node_value",
+        {const.ATTR_NODE_ID: 14, const.ATTR_VALUE_ID: 12},
+    )
+    await hass.async_block_till_done()
+
+    assert value.refresh.called
+
+
+async def test_heal_node(hass, mock_openzwave):
+    """Test zwave heal_node service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=19)
+    zwave_network.nodes = {19: node}
+    await hass.services.async_call("zwave", "heal_node", {const.ATTR_NODE_ID: 19})
+    await hass.async_block_till_done()
+
+    assert node.heal.called
+    assert len(node.heal.mock_calls) == 1
+
+
+async def test_test_node(hass, mock_openzwave):
+    """Test the zwave test_node service."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        await async_setup_component(hass, "zwave", {"zwave": {}})
+        await hass.async_block_till_done()
+
+    assert len(mock_receivers) == 1
+
+    zwave_network = hass.data[DATA_NETWORK]
+    zwave_network.state = MockNetwork.STATE_READY
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    node = MockNode(node_id=19)
+    zwave_network.nodes = {19: node}
+    await hass.services.async_call("zwave", "test_node", {const.ATTR_NODE_ID: 19})
+    await hass.async_block_till_done()
+
+    assert node.test.called
+    assert len(node.test.mock_calls) == 1

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -30,6 +30,23 @@ def mock_storage(hass_storage):
     """Autouse hass_storage for the TestCase tests."""
 
 
+@pytest.fixture
+def zwave_setup(hass):
+    """Zwave setup."""
+
+    async def _zwave():
+        mock_receivers = []
+
+        def mock_connect(receiver, signal, *args, **kwargs):
+            if signal == MockNetwork.SIGNAL_VALUE_ADDED:
+                mock_receivers.append(receiver)
+
+        with patch("pydispatch.dispatcher.connect", new=mock_connect):
+            return await async_setup_component(hass, "zwave", {"zwave": {}})
+
+    return _zwave
+
+
 async def test_valid_device_config(hass, mock_openzwave):
     """Test valid device config."""
     device_config = {"light.kitchen": {"ignored": "true"}}
@@ -1354,19 +1371,10 @@ async def test_device_config_glob_is_ordered():
     assert isinstance(conf["zwave"][CONF_DEVICE_CONFIG_GLOB], OrderedDict)
 
 
-async def test_add_node(hass, mock_openzwave):
+async def test_add_node(hass, mock_openzwave, zwave_setup):
     """Test zwave add_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1381,19 +1389,10 @@ async def test_add_node(hass, mock_openzwave):
     assert len(zwave_network.controller.add_node.mock_calls[0][1]) == 0
 
 
-async def test_add_node_secure(hass, mock_openzwave):
+async def test_add_node_secure(hass, mock_openzwave, zwave_setup):
     """Test zwave add_node_secure service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1408,19 +1407,10 @@ async def test_add_node_secure(hass, mock_openzwave):
     assert zwave_network.controller.add_node.mock_calls[0][1][0] is True
 
 
-async def test_remove_node(hass, mock_openzwave):
+async def test_remove_node(hass, mock_openzwave, zwave_setup):
     """Test zwave remove_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1434,19 +1424,10 @@ async def test_remove_node(hass, mock_openzwave):
     assert len(zwave_network.controller.remove_node.mock_calls) == 1
 
 
-async def test_cancel_command(hass, mock_openzwave):
+async def test_cancel_command(hass, mock_openzwave, zwave_setup):
     """Test zwave cancel_command service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1460,19 +1441,10 @@ async def test_cancel_command(hass, mock_openzwave):
     assert len(zwave_network.controller.cancel_command.mock_calls) == 1
 
 
-async def test_heal_network(hass, mock_openzwave):
+async def test_heal_network(hass, mock_openzwave, zwave_setup):
     """Test zwave heal_network service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1486,19 +1458,10 @@ async def test_heal_network(hass, mock_openzwave):
     assert len(zwave_network.heal.mock_calls) == 1
 
 
-async def test_soft_reset(hass, mock_openzwave):
+async def test_soft_reset(hass, mock_openzwave, zwave_setup):
     """Test zwave soft_reset service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1512,19 +1475,10 @@ async def test_soft_reset(hass, mock_openzwave):
     assert len(zwave_network.controller.soft_reset.mock_calls) == 1
 
 
-async def test_test_network(hass, mock_openzwave):
+async def test_test_network(hass, mock_openzwave, zwave_setup):
     """Test zwave test_network service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1538,19 +1492,10 @@ async def test_test_network(hass, mock_openzwave):
     assert len(zwave_network.test.mock_calls) == 1
 
 
-async def test_stop_network(hass, mock_openzwave):
+async def test_stop_network(hass, mock_openzwave, zwave_setup):
     """Test zwave stop_network service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1568,19 +1513,10 @@ async def test_stop_network(hass, mock_openzwave):
         assert mock_fire.mock_calls[0][1][0] == const.EVENT_NETWORK_STOP
 
 
-async def test_rename_node(hass, mock_openzwave):
+async def test_rename_node(hass, mock_openzwave, zwave_setup):
     """Test zwave rename_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1598,19 +1534,10 @@ async def test_rename_node(hass, mock_openzwave):
     assert zwave_network.nodes[11].name == "test_name"
 
 
-async def test_rename_value(hass, mock_openzwave):
+async def test_rename_value(hass, mock_openzwave, zwave_setup):
     """Test zwave rename_value service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1637,19 +1564,10 @@ async def test_rename_value(hass, mock_openzwave):
     assert value.label == "New Label"
 
 
-async def test_set_poll_intensity_enable(hass, mock_openzwave):
+async def test_set_poll_intensity_enable(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, successful set."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1679,19 +1597,10 @@ async def test_set_poll_intensity_enable(hass, mock_openzwave):
     assert enable_poll.mock_calls[0][1][0] == 4
 
 
-async def test_set_poll_intensity_enable_failed(hass, mock_openzwave):
+async def test_set_poll_intensity_enable_failed(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, failed set."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1721,19 +1630,10 @@ async def test_set_poll_intensity_enable_failed(hass, mock_openzwave):
     assert len(enable_poll.mock_calls) == 1
 
 
-async def test_set_poll_intensity_disable(hass, mock_openzwave):
+async def test_set_poll_intensity_disable(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, successful disable."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1762,19 +1662,10 @@ async def test_set_poll_intensity_disable(hass, mock_openzwave):
     assert len(disable_poll.mock_calls) == 2
 
 
-async def test_set_poll_intensity_disable_failed(hass, mock_openzwave):
+async def test_set_poll_intensity_disable_failed(hass, mock_openzwave, zwave_setup):
     """Test zwave set_poll_intensity service, failed disable."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1804,19 +1695,10 @@ async def test_set_poll_intensity_disable_failed(hass, mock_openzwave):
     assert len(disable_poll.mock_calls) == 1
 
 
-async def test_remove_failed_node(hass, mock_openzwave):
+async def test_remove_failed_node(hass, mock_openzwave, zwave_setup):
     """Test zwave remove_failed_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1834,19 +1716,10 @@ async def test_remove_failed_node(hass, mock_openzwave):
     assert remove_failed_node.mock_calls[0][1][0] == 12
 
 
-async def test_replace_failed_node(hass, mock_openzwave):
+async def test_replace_failed_node(hass, mock_openzwave, zwave_setup):
     """Test zwave replace_failed_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -1864,19 +1737,10 @@ async def test_replace_failed_node(hass, mock_openzwave):
     assert replace_failed_node.mock_calls[0][1][0] == 13
 
 
-async def test_set_config_parameter(hass, mock_openzwave):
+async def test_set_config_parameter(hass, mock_openzwave, zwave_setup):
     """Test zwave set_config_parameter service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2026,19 +1890,10 @@ async def test_set_config_parameter(hass, mock_openzwave):
     node.set_config_param.reset_mock()
 
 
-async def test_print_config_parameter(hass, mock_openzwave):
+async def test_print_config_parameter(hass, mock_openzwave, zwave_setup):
     """Test zwave print_config_parameter service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2070,19 +1925,10 @@ async def test_print_config_parameter(hass, mock_openzwave):
         assert mock_logger.info.mock_calls[0][1][3] == 2345
 
 
-async def test_print_node(hass, mock_openzwave):
+async def test_print_node(hass, mock_openzwave, zwave_setup):
     """Test zwave print_node_parameter service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2100,19 +1946,10 @@ async def test_print_node(hass, mock_openzwave):
         assert "FOUND NODE " in mock_logger.info.mock_calls[0][1][0]
 
 
-async def test_set_wakeup(hass, mock_openzwave):
+async def test_set_wakeup(hass, mock_openzwave, zwave_setup):
     """Test zwave set_wakeup service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2141,19 +1978,10 @@ async def test_set_wakeup(hass, mock_openzwave):
     assert value.data == 15
 
 
-async def test_reset_node_meters(hass, mock_openzwave):
+async def test_reset_node_meters(hass, mock_openzwave, zwave_setup):
     """Test zwave reset_node_meters service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2194,19 +2022,10 @@ async def test_reset_node_meters(hass, mock_openzwave):
     assert value_id == reset_value.value_id
 
 
-async def test_add_association(hass, mock_openzwave):
+async def test_add_association(hass, mock_openzwave, zwave_setup):
     """Test zwave change_association service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2246,19 +2065,10 @@ async def test_add_association(hass, mock_openzwave):
     assert group.add_association.mock_calls[0][1][1] == 5
 
 
-async def test_remove_association(hass, mock_openzwave):
+async def test_remove_association(hass, mock_openzwave, zwave_setup):
     """Test zwave change_association service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2298,19 +2108,10 @@ async def test_remove_association(hass, mock_openzwave):
     assert group.remove_association.mock_calls[0][1][1] == 5
 
 
-async def test_refresh_entity(hass, mock_openzwave):
+async def test_refresh_entity(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_entity service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2347,19 +2148,10 @@ async def test_refresh_entity(hass, mock_openzwave):
     )
 
 
-async def test_refresh_node(hass, mock_openzwave):
+async def test_refresh_node(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2375,19 +2167,10 @@ async def test_refresh_node(hass, mock_openzwave):
     assert len(node.refresh_info.mock_calls) == 1
 
 
-async def test_set_node_value(hass, mock_openzwave):
+async def test_set_node_value(hass, mock_openzwave, zwave_setup):
     """Test zwave set_node_value service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2414,19 +2197,12 @@ async def test_set_node_value(hass, mock_openzwave):
     assert zwave_network.nodes[14].values[12].data == 2
 
 
-async def test_set_node_value_with_long_id_and_text_value(hass, mock_openzwave):
+async def test_set_node_value_with_long_id_and_text_value(
+    hass, mock_openzwave, zwave_setup
+):
     """Test zwave set_node_value service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2457,19 +2233,10 @@ async def test_set_node_value_with_long_id_and_text_value(hass, mock_openzwave):
     assert zwave_network.nodes[14].values[87512398541236578].data == "#00ff00"
 
 
-async def test_refresh_node_value(hass, mock_openzwave):
+async def test_refresh_node_value(hass, mock_openzwave, zwave_setup):
     """Test zwave refresh_node_value service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2500,19 +2267,10 @@ async def test_refresh_node_value(hass, mock_openzwave):
     assert value.refresh.called
 
 
-async def test_heal_node(hass, mock_openzwave):
+async def test_heal_node(hass, mock_openzwave, zwave_setup):
     """Test zwave heal_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY
@@ -2528,19 +2286,10 @@ async def test_heal_node(hass, mock_openzwave):
     assert len(node.heal.mock_calls) == 1
 
 
-async def test_test_node(hass, mock_openzwave):
+async def test_test_node(hass, mock_openzwave, zwave_setup):
     """Test the zwave test_node service."""
-    mock_receivers = []
-
-    def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
-
-    with patch("pydispatch.dispatcher.connect", new=mock_connect):
-        await async_setup_component(hass, "zwave", {"zwave": {}})
-        await hass.async_block_till_done()
-
-    assert len(mock_receivers) == 1
+    assert await zwave_setup()
+    await hass.async_block_till_done()
 
     zwave_network = hass.data[DATA_NETWORK]
     zwave_network.state = MockNetwork.STATE_READY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite zwave init tests (#40913), second and last batch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40913
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
