### PR TITLE
Improve uvc test camera

### DIFF
--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -12,6 +12,7 @@ from homeassistant.components.camera import PLATFORM_SCHEMA, SUPPORT_STREAM, Cam
 from homeassistant.const import CONF_PASSWORD, CONF_PORT, CONF_SSL
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.dt import utc_from_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -258,5 +259,5 @@ class UnifiVideoCamera(Camera):
 def timestamp_ms_to_date(epoch_ms: int) -> Optional[datetime]:
     """Convert millisecond timestamp to datetime."""
     if epoch_ms:
-        return datetime.fromtimestamp(epoch_ms / 1000)
+        return utc_from_timestamp(epoch_ms / 1000)
     return None

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -8,6 +8,8 @@ from uvcclient import camera as camera, nvr
 
 from homeassistant.components.camera import (
     DEFAULT_CONTENT_TYPE,
+    SERVICE_DISABLE_MOTION,
+    SERVICE_ENABLE_MOTION,
     STATE_RECORDING,
     SUPPORT_STREAM,
     async_get_image,
@@ -523,3 +525,78 @@ async def test_camera_image_error(
         await async_get_image(hass, "camera.front")
 
     assert camera_v320.return_value.get_snapshot.call_count == snapshot_calls
+
+
+async def test_enable_disable_motion_detection(hass, mock_remote, camera_info):
+    """Test enable and disable motion detection."""
+
+    def set_recordmode(uuid, mode):
+        """Set record mode."""
+        motion_record_enabled = mode == "motion"
+        camera_info["recordingSettings"]["motionRecordEnabled"] = motion_record_enabled
+
+    mock_remote.return_value.set_recordmode.side_effect = set_recordmode
+    config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
+    assert await async_setup_component(hass, "camera", {"camera": config})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("camera.front")
+
+    assert state
+    assert "motion_detection" not in state.attributes
+
+    await hass.services.async_call(
+        "camera", SERVICE_ENABLE_MOTION, {"entity_id": "camera.front"}, True
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("camera.front")
+
+    assert state
+    assert state.attributes["motion_detection"]
+
+    await hass.services.async_call(
+        "camera", SERVICE_DISABLE_MOTION, {"entity_id": "camera.front"}, True
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("camera.front")
+
+    assert state
+    assert "motion_detection" not in state.attributes
+
+    mock_remote.return_value.set_recordmode.side_effect = nvr.NvrError
+
+    await hass.services.async_call(
+        "camera", SERVICE_ENABLE_MOTION, {"entity_id": "camera.front"}, True
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("camera.front")
+
+    assert state
+    assert "motion_detection" not in state.attributes
+
+    mock_remote.return_value.set_recordmode.side_effect = set_recordmode
+
+    await hass.services.async_call(
+        "camera", SERVICE_ENABLE_MOTION, {"entity_id": "camera.front"}, True
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("camera.front")
+
+    assert state
+    assert state.attributes["motion_detection"]
+
+    mock_remote.return_value.set_recordmode.side_effect = nvr.NvrError
+
+    await hass.services.async_call(
+        "camera", SERVICE_DISABLE_MOTION, {"entity_id": "camera.front"}, True
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("camera.front")
+
+    assert state
+    assert state.attributes["motion_detection"]

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -552,21 +552,6 @@ async def test_login_fails_both_properly(hass, mock_remote, camera_v320):
     assert camera_v320.return_value.get_snapshot.call_count == 0
 
 
-async def test_camera_image_tries_login_bails_on_failure(uvc_fixture):
-    """Test retrieving failure."""
-    with patch.object(uvc_fixture, "_login") as mock_login:
-        mock_login.return_value = False
-        assert uvc_fixture.camera_image() is None
-        assert mock_login.call_count == 1
-        assert mock_login.call_args == call()
-
-
-async def test_camera_image_logged_in(uvc_fixture):
-    """Test the login state."""
-    uvc_fixture._camera = MagicMock()
-    assert uvc_fixture._camera.get_snapshot.return_value == uvc_fixture.camera_image()
-
-
 async def test_camera_image_error(uvc_fixture):
     """Test the camera image error."""
     uvc_fixture._camera = MagicMock()

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -1,381 +1,371 @@
 """The tests for UVC camera module."""
 from datetime import datetime
 import socket
-import unittest
-from unittest import mock
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 import requests
-from uvcclient import camera, nvr
+from uvcclient import camera as camera, nvr
 
 from homeassistant.components.camera import SUPPORT_STREAM
 from homeassistant.components.uvc import camera as uvc
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.setup import setup_component
-
-from tests.common import get_test_home_assistant
+from homeassistant.setup import async_setup_component
 
 
-class TestUVCSetup(unittest.TestCase):
-    """Test the UVC camera platform."""
+@patch("uvcclient.nvr.UVCRemote")
+@patch.object(uvc, "UnifiVideoCamera")
+async def test_setup_full_config(mock_uvc, mock_remote, hass):
+    """Test the setup with full configuration."""
+    config = {
+        "platform": "uvc",
+        "nvr": "foo",
+        "password": "bar",
+        "port": 123,
+        "key": "secret",
+    }
+    mock_cameras = [
+        {"uuid": "one", "name": "Front", "id": "id1"},
+        {"uuid": "two", "name": "Back", "id": "id2"},
+        {"uuid": "three", "name": "Old AirCam", "id": "id3"},
+    ]
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
+    def mock_get_camera(uuid):
+        """Create a mock camera."""
+        if uuid == "id3":
+            return {"model": "airCam"}
+        return {"model": "UVC"}
 
-    @mock.patch("uvcclient.nvr.UVCRemote")
-    @mock.patch.object(uvc, "UnifiVideoCamera")
-    def test_setup_full_config(self, mock_uvc, mock_remote):
-        """Test the setup with full configuration."""
-        config = {
-            "platform": "uvc",
-            "nvr": "foo",
-            "password": "bar",
-            "port": 123,
-            "key": "secret",
-        }
-        mock_cameras = [
-            {"uuid": "one", "name": "Front", "id": "id1"},
-            {"uuid": "two", "name": "Back", "id": "id2"},
-            {"uuid": "three", "name": "Old AirCam", "id": "id3"},
+    mock_remote.return_value.index.return_value = mock_cameras
+    mock_remote.return_value.get_camera.side_effect = mock_get_camera
+    mock_remote.return_value.server_version = (3, 2, 0)
+
+    assert await async_setup_component(hass, "camera", {"camera": config})
+    await hass.async_block_till_done()
+
+    assert mock_remote.call_count == 1
+    assert mock_remote.call_args == call("foo", 123, "secret", ssl=False)
+    mock_uvc.assert_has_calls(
+        [
+            call(mock_remote.return_value, "id1", "Front", "bar"),
+            call(mock_remote.return_value, "id2", "Back", "bar"),
+        ],
+    )
+
+
+@patch("uvcclient.nvr.UVCRemote")
+@patch.object(uvc, "UnifiVideoCamera")
+async def test_setup_partial_config(mock_uvc, mock_remote, hass):
+    """Test the setup with partial configuration."""
+    config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
+    mock_cameras = [
+        {"uuid": "one", "name": "Front", "id": "id1"},
+        {"uuid": "two", "name": "Back", "id": "id2"},
+    ]
+    mock_remote.return_value.index.return_value = mock_cameras
+    mock_remote.return_value.get_camera.return_value = {"model": "UVC"}
+    mock_remote.return_value.server_version = (3, 2, 0)
+
+    assert await async_setup_component(hass, "camera", {"camera": config})
+    await hass.async_block_till_done()
+
+    assert mock_remote.call_count == 1
+    assert mock_remote.call_args == call("foo", 7080, "secret", ssl=False)
+    mock_uvc.assert_has_calls(
+        [
+            call(mock_remote.return_value, "id1", "Front", "ubnt"),
+            call(mock_remote.return_value, "id2", "Back", "ubnt"),
         ]
+    )
 
-        def mock_get_camera(uuid):
-            """Create a mock camera."""
-            if uuid == "id3":
-                return {"model": "airCam"}
-            return {"model": "UVC"}
 
-        mock_remote.return_value.index.return_value = mock_cameras
-        mock_remote.return_value.get_camera.side_effect = mock_get_camera
-        mock_remote.return_value.server_version = (3, 2, 0)
+@patch("uvcclient.nvr.UVCRemote")
+@patch.object(uvc, "UnifiVideoCamera")
+async def test_setup_partial_config_v31x(mock_uvc, mock_remote, hass):
+    """Test the setup with a v3.1.x server."""
+    config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
+    mock_cameras = [
+        {"uuid": "one", "name": "Front", "id": "id1"},
+        {"uuid": "two", "name": "Back", "id": "id2"},
+    ]
+    mock_remote.return_value.index.return_value = mock_cameras
+    mock_remote.return_value.get_camera.return_value = {"model": "UVC"}
+    mock_remote.return_value.server_version = (3, 1, 3)
 
-        assert setup_component(self.hass, "camera", {"camera": config})
-        self.hass.block_till_done()
+    assert await async_setup_component(hass, "camera", {"camera": config})
+    await hass.async_block_till_done()
 
-        assert mock_remote.call_count == 1
-        assert mock_remote.call_args == mock.call("foo", 123, "secret", ssl=False)
-        mock_uvc.assert_has_calls(
-            [
-                mock.call(mock_remote.return_value, "id1", "Front", "bar"),
-                mock.call(mock_remote.return_value, "id2", "Back", "bar"),
-            ]
-        )
-
-    @mock.patch("uvcclient.nvr.UVCRemote")
-    @mock.patch.object(uvc, "UnifiVideoCamera")
-    def test_setup_partial_config(self, mock_uvc, mock_remote):
-        """Test the setup with partial configuration."""
-        config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
-        mock_cameras = [
-            {"uuid": "one", "name": "Front", "id": "id1"},
-            {"uuid": "two", "name": "Back", "id": "id2"},
+    assert mock_remote.call_count == 1
+    assert mock_remote.call_args == call("foo", 7080, "secret", ssl=False)
+    mock_uvc.assert_has_calls(
+        [
+            call(mock_remote.return_value, "one", "Front", "ubnt"),
+            call(mock_remote.return_value, "two", "Back", "ubnt"),
         ]
-        mock_remote.return_value.index.return_value = mock_cameras
-        mock_remote.return_value.get_camera.return_value = {"model": "UVC"}
-        mock_remote.return_value.server_version = (3, 2, 0)
+    )
 
-        assert setup_component(self.hass, "camera", {"camera": config})
-        self.hass.block_till_done()
 
-        assert mock_remote.call_count == 1
-        assert mock_remote.call_args == mock.call("foo", 7080, "secret", ssl=False)
-        mock_uvc.assert_has_calls(
-            [
-                mock.call(mock_remote.return_value, "id1", "Front", "ubnt"),
-                mock.call(mock_remote.return_value, "id2", "Back", "ubnt"),
-            ]
-        )
+@patch.object(uvc, "UnifiVideoCamera")
+async def test_setup_incomplete_config(mock_uvc, hass):
+    """Test the setup with incomplete configuration."""
+    assert await async_setup_component(
+        hass, "camera", {"platform": "uvc", "nvr": "foo"}
+    )
+    await hass.async_block_till_done()
 
-    @mock.patch("uvcclient.nvr.UVCRemote")
-    @mock.patch.object(uvc, "UnifiVideoCamera")
-    def test_setup_partial_config_v31x(self, mock_uvc, mock_remote):
-        """Test the setup with a v3.1.x server."""
-        config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
-        mock_cameras = [
-            {"uuid": "one", "name": "Front", "id": "id1"},
-            {"uuid": "two", "name": "Back", "id": "id2"},
-        ]
-        mock_remote.return_value.index.return_value = mock_cameras
-        mock_remote.return_value.get_camera.return_value = {"model": "UVC"}
-        mock_remote.return_value.server_version = (3, 1, 3)
+    assert not mock_uvc.called
+    assert await async_setup_component(
+        hass, "camera", {"platform": "uvc", "key": "secret"}
+    )
+    await hass.async_block_till_done()
 
-        assert setup_component(self.hass, "camera", {"camera": config})
-        self.hass.block_till_done()
+    assert not mock_uvc.called
+    assert await async_setup_component(
+        hass, "camera", {"platform": "uvc", "port": "invalid"}
+    )
+    await hass.async_block_till_done()
 
-        assert mock_remote.call_count == 1
-        assert mock_remote.call_args == mock.call("foo", 7080, "secret", ssl=False)
-        mock_uvc.assert_has_calls(
-            [
-                mock.call(mock_remote.return_value, "one", "Front", "ubnt"),
-                mock.call(mock_remote.return_value, "two", "Back", "ubnt"),
-            ]
-        )
+    assert not mock_uvc.called
 
-    @mock.patch.object(uvc, "UnifiVideoCamera")
-    def test_setup_incomplete_config(self, mock_uvc):
-        """Test the setup with incomplete configuration."""
-        assert setup_component(self.hass, "camera", {"platform": "uvc", "nvr": "foo"})
-        self.hass.block_till_done()
 
-        assert not mock_uvc.called
-        assert setup_component(
-            self.hass, "camera", {"platform": "uvc", "key": "secret"}
-        )
-        self.hass.block_till_done()
+@patch.object(uvc, "UnifiVideoCamera")
+@patch("uvcclient.nvr.UVCRemote")
+@pytest.mark.parametrize(
+    "error", [nvr.NotAuthorized, nvr.NvrError, requests.exceptions.ConnectionError]
+)
+async def test_setup_nvr_errors_during_indexing(mock_remote, mock_uvc, hass, error):
+    """Set up test for NVR errors during indexing."""
+    config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
+    mock_remote.return_value.index.side_effect = error
+    assert await async_setup_component(hass, "camera", {"camera": config})
+    await hass.async_block_till_done()
 
-        assert not mock_uvc.called
-        assert setup_component(
-            self.hass, "camera", {"platform": "uvc", "port": "invalid"}
-        )
-        self.hass.block_till_done()
-
-        assert not mock_uvc.called
-
-    @mock.patch.object(uvc, "UnifiVideoCamera")
-    @mock.patch("uvcclient.nvr.UVCRemote")
-    def setup_nvr_errors_during_indexing(self, error, mock_remote, mock_uvc):
-        """Set up test for NVR errors during indexing."""
-        config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
-        mock_remote.return_value.index.side_effect = error
-        assert setup_component(self.hass, "camera", {"camera": config})
-        self.hass.block_till_done()
-
-        assert not mock_uvc.called
-
-    def test_setup_nvr_error_during_indexing_notauthorized(self):
-        """Test for error: nvr.NotAuthorized."""
-        self.setup_nvr_errors_during_indexing(nvr.NotAuthorized)
-
-    def test_setup_nvr_error_during_indexing_nvrerror(self):
-        """Test for error: nvr.NvrError."""
-        self.setup_nvr_errors_during_indexing(nvr.NvrError)
-        pytest.raises(PlatformNotReady)
-
-    def test_setup_nvr_error_during_indexing_connectionerror(self):
-        """Test for error: requests.exceptions.ConnectionError."""
-        self.setup_nvr_errors_during_indexing(requests.exceptions.ConnectionError)
-        pytest.raises(PlatformNotReady)
-
-    @mock.patch.object(uvc, "UnifiVideoCamera")
-    @mock.patch("uvcclient.nvr.UVCRemote.__init__")
-    def setup_nvr_errors_during_initialization(self, error, mock_remote, mock_uvc):
-        """Set up test for NVR errors during initialization."""
-        config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
-        mock_remote.return_value = None
-        mock_remote.side_effect = error
-        assert setup_component(self.hass, "camera", {"camera": config})
-        self.hass.block_till_done()
-
-        assert not mock_remote.index.called
-        assert not mock_uvc.called
-
-    def test_setup_nvr_error_during_initialization_notauthorized(self):
-        """Test for error: nvr.NotAuthorized."""
-        self.setup_nvr_errors_during_initialization(nvr.NotAuthorized)
-
-    def test_setup_nvr_error_during_initialization_nvrerror(self):
-        """Test for error: nvr.NvrError."""
-        self.setup_nvr_errors_during_initialization(nvr.NvrError)
-        pytest.raises(PlatformNotReady)
-
-    def test_setup_nvr_error_during_initialization_connectionerror(self):
-        """Test for error: requests.exceptions.ConnectionError."""
-        self.setup_nvr_errors_during_initialization(requests.exceptions.ConnectionError)
+    assert not mock_uvc.called
+    if error in [nvr.NvrError, requests.exceptions.ConnectionError]:
         pytest.raises(PlatformNotReady)
 
 
-class TestUVC(unittest.TestCase):
-    """Test class for UVC."""
+@patch.object(uvc, "UnifiVideoCamera")
+@patch("uvcclient.nvr.UVCRemote.__init__")
+@pytest.mark.parametrize(
+    "error", [nvr.NotAuthorized, nvr.NvrError, requests.exceptions.ConnectionError]
+)
+async def test_setup_nvr_errors_during_initialization(
+    mock_remote, mock_uvc, hass, error
+):
+    """Set up test for NVR errors during initialization."""
+    config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
+    mock_remote.return_value = None
+    mock_remote.side_effect = error
+    assert await async_setup_component(hass, "camera", {"camera": config})
+    await hass.async_block_till_done()
 
-    def setup_method(self, method):
-        """Set up the mock camera."""
-        self.nvr = mock.MagicMock()
-        self.uuid = "uuid"
-        self.name = "name"
-        self.password = "seekret"
-        self.uvc = uvc.UnifiVideoCamera(self.nvr, self.uuid, self.name, self.password)
-        self.nvr.get_camera.return_value = {
-            "model": "UVC Fake",
-            "uuid": "06e3ff29-8048-31c2-8574-0852d1bd0e03",
-            "recordingSettings": {
-                "fullTimeRecordEnabled": True,
-                "motionRecordEnabled": False,
+    assert not mock_remote.index.called
+    assert not mock_uvc.called
+
+    if error in [nvr.NvrError, requests.exceptions.ConnectionError]:
+        pytest.raises(PlatformNotReady)
+
+
+@pytest.fixture
+def uvc_fixture():
+    """Set up the mock camera."""
+    nvr = MagicMock()
+    uuid = "uuid"
+    name = "name"
+    password = "seekret"
+    _uvc = uvc.UnifiVideoCamera(nvr, uuid, name, password)
+    nvr.get_camera.return_value = {
+        "model": "UVC Fake",
+        "recordingSettings": {"fullTimeRecordEnabled": True},
+        "host": "host-a",
+        "internalHost": "host-b",
+        "username": "admin",
+        "channels": [
+            {
+                "id": "0",
+                "width": 1920,
+                "height": 1080,
+                "fps": 25,
+                "bitrate": 6000000,
+                "isRtspEnabled": True,
+                "rtspUris": [
+                    "rtsp://host-a:7447/uuid_rtspchannel_0",
+                    "rtsp://foo:7447/uuid_rtspchannel_0",
+                ],
             },
-            "host": "host-a",
-            "internalHost": "host-b",
-            "username": "admin",
-            "lastRecordingStartTime": 1610070992367,
-            "channels": [
-                {
-                    "id": "0",
-                    "width": 1920,
-                    "height": 1080,
-                    "fps": 25,
-                    "bitrate": 6000000,
-                    "isRtspEnabled": True,
-                    "rtspUris": [
-                        "rtsp://host-a:7447/uuid_rtspchannel_0",
-                        "rtsp://foo:7447/uuid_rtspchannel_0",
-                    ],
-                },
-                {
-                    "id": "1",
-                    "width": 1024,
-                    "height": 576,
-                    "fps": 15,
-                    "bitrate": 1200000,
-                    "isRtspEnabled": False,
-                    "rtspUris": [
-                        "rtsp://host-a:7447/uuid_rtspchannel_1",
-                        "rtsp://foo:7447/uuid_rtspchannel_1",
-                    ],
-                },
-            ],
-        }
-        self.nvr.server_version = (3, 2, 0)
-        self.uvc.update()
+            {
+                "id": "1",
+                "width": 1024,
+                "height": 576,
+                "fps": 15,
+                "bitrate": 1200000,
+                "isRtspEnabled": False,
+                "rtspUris": [
+                    "rtsp://host-a:7447/uuid_rtspchannel_1",
+                    "rtsp://foo:7447/uuid_rtspchannel_1",
+                ],
+            },
+        ],
+    }
+    nvr.server_version = (3, 2, 0)
+    nvr._host = "foo"
 
-    def test_properties(self):
-        """Test the properties."""
-        assert self.name == self.uvc.name
-        assert self.uvc.is_recording
-        assert "Ubiquiti" == self.uvc.brand
-        assert "UVC Fake" == self.uvc.model
-        assert SUPPORT_STREAM == self.uvc.supported_features
-        assert "uuid" == self.uvc.unique_id
+    _uvc.update()
+    return _uvc
 
-    def test_motion_recording_mode_properties(self):
-        """Test the properties."""
-        self.nvr.get_camera.return_value["recordingSettings"][
-            "fullTimeRecordEnabled"
-        ] = False
-        self.nvr.get_camera.return_value["recordingSettings"][
-            "motionRecordEnabled"
-        ] = True
-        assert not self.uvc.is_recording
-        assert (
-            datetime(2021, 1, 8, 1, 56, 32, 367000)
-            == self.uvc.extra_state_attributes["last_recording_start_time"]
-        )
 
-        self.nvr.get_camera.return_value["recordingIndicator"] = "DISABLED"
-        assert not self.uvc.is_recording
+async def test_properties(uvc_fixture):
+    """Test the properties."""
+    assert "name" == uvc_fixture.name
+    assert uvc_fixture.is_recording
+    assert "Ubiquiti" == uvc_fixture.brand
+    assert "UVC Fake" == uvc_fixture.model
+    assert SUPPORT_STREAM == uvc_fixture.supported_features
 
-        self.nvr.get_camera.return_value["recordingIndicator"] = "MOTION_INPROGRESS"
-        assert self.uvc.is_recording
 
-        self.nvr.get_camera.return_value["recordingIndicator"] = "MOTION_FINISHED"
-        assert self.uvc.is_recording
+@patch("uvcclient.camera.UVCCameraClientV320")
+async def test_motion_recording_mode_properties(mock_camera, uvc_fixture):
+    """Test the properties."""
+    mock_camera.get_camera.return_value["recordingSettings"][
+        "fullTimeRecordEnabled"
+    ] = False
+    mock_camera.get_camera.return_value["recordingSettings"][
+        "motionRecordEnabled"
+    ] = True
+    assert not uvc_fixture.is_recording
+    assert (
+        datetime(2021, 1, 8, 1, 56, 32, 367000)
+        == uvc_fixture.extra_state_attributes["last_recording_start_time"]
+    )
 
-    def test_stream(self):
-        """Test the RTSP stream URI."""
-        stream_source = yield from self.uvc.stream_source()
-        assert stream_source == "rtsp://foo:7447/uuid_rtspchannel_0"
+    mock_camera.get_camera.return_value["recordingIndicator"] = "DISABLED"
+    assert not uvc_fixture.is_recording
 
-    @mock.patch("uvcclient.store.get_info_store")
-    @mock.patch("uvcclient.camera.UVCCameraClientV320")
-    def test_login(self, mock_camera, mock_store):
-        """Test the login."""
-        self.uvc._login()
-        assert mock_camera.call_count == 1
-        assert mock_camera.call_args == mock.call("host-a", "admin", "seekret")
-        assert mock_camera.return_value.login.call_count == 1
-        assert mock_camera.return_value.login.call_args == mock.call()
+    mock_camera.get_camera.return_value["recordingIndicator"] = "MOTION_INPROGRESS"
+    assert uvc_fixture.is_recording
 
-    @mock.patch("uvcclient.store.get_info_store")
-    @mock.patch("uvcclient.camera.UVCCameraClient")
-    def test_login_v31x(self, mock_camera, mock_store):
-        """Test login with v3.1.x server."""
-        self.nvr.server_version = (3, 1, 3)
-        self.uvc._login()
-        assert mock_camera.call_count == 1
-        assert mock_camera.call_args == mock.call("host-a", "admin", "seekret")
-        assert mock_camera.return_value.login.call_count == 1
-        assert mock_camera.return_value.login.call_args == mock.call()
+    mock_camera.get_camera.return_value["recordingIndicator"] = "MOTION_FINISHED"
+    assert uvc_fixture.is_recording
 
-    @mock.patch("uvcclient.store.get_info_store")
-    @mock.patch("uvcclient.camera.UVCCameraClientV320")
-    def test_login_tries_both_addrs_and_caches(self, mock_camera, mock_store):
-        """Test the login tries."""
-        responses = [0]
 
-        def mock_login(*a):
-            """Mock login."""
-            try:
-                responses.pop(0)
-                raise OSError
-            except IndexError:
-                pass
+async def test_stream(uvc_fixture):
+    """Test the RTSP stream URI."""
+    stream_source = await uvc_fixture.stream_source()
 
-        mock_store.return_value.get_camera_password.return_value = None
-        mock_camera.return_value.login.side_effect = mock_login
-        self.uvc._login()
-        assert 2 == mock_camera.call_count
-        assert "host-b" == self.uvc._connect_addr
+    assert stream_source == "rtsp://foo:7447/uuid_rtspchannel_0"
 
-        mock_camera.reset_mock()
-        self.uvc._login()
-        assert mock_camera.call_count == 1
-        assert mock_camera.call_args == mock.call("host-b", "admin", "seekret")
-        assert mock_camera.return_value.login.call_count == 1
-        assert mock_camera.return_value.login.call_args == mock.call()
 
-    @mock.patch("uvcclient.store.get_info_store")
-    @mock.patch("uvcclient.camera.UVCCameraClientV320")
-    def test_login_fails_both_properly(self, mock_camera, mock_store):
-        """Test if login fails properly."""
-        mock_camera.return_value.login.side_effect = socket.error
-        assert self.uvc._login() is None
-        assert self.uvc._connect_addr is None
+@patch("uvcclient.store.get_info_store")
+@patch("uvcclient.camera.UVCCameraClientV320")
+async def test_login(mock_camera, mock_store, uvc_fixture):
+    """Test the login."""
+    uvc_fixture._login()
+    assert mock_camera.call_count == 1
+    assert mock_camera.call_args == call("host-a", "admin", "seekret")
+    assert mock_camera.return_value.login.call_count == 1
+    assert mock_camera.return_value.login.call_args == call()
 
-    def test_camera_image_tries_login_bails_on_failure(self):
-        """Test retrieving failure."""
-        with mock.patch.object(self.uvc, "_login") as mock_login:
-            mock_login.return_value = False
-            assert self.uvc.camera_image() is None
-            assert mock_login.call_count == 1
-            assert mock_login.call_args == mock.call()
 
-    def test_camera_image_logged_in(self):
-        """Test the login state."""
-        self.uvc._camera = mock.MagicMock()
-        assert self.uvc._camera.get_snapshot.return_value == self.uvc.camera_image()
+@patch("uvcclient.store.get_info_store")
+@patch("uvcclient.camera.UVCCameraClient")
+async def test_login_v31x(mock_camera, mock_store, uvc_fixture):
+    """Test login with v3.1.x server."""
+    uvc_fixture._nvr.server_version = (3, 1, 3)
+    uvc_fixture._login()
+    assert mock_camera.call_count == 1
+    assert mock_camera.call_args == call("host-a", "admin", "seekret")
+    assert mock_camera.return_value.login.call_count == 1
+    assert mock_camera.return_value.login.call_args == call()
 
-    def test_camera_image_error(self):
-        """Test the camera image error."""
-        self.uvc._camera = mock.MagicMock()
-        self.uvc._camera.get_snapshot.side_effect = camera.CameraConnectError
-        assert self.uvc.camera_image() is None
 
-    def test_camera_image_reauths(self):
-        """Test the re-authentication."""
-        responses = [0]
+@patch("uvcclient.store.get_info_store")
+@patch("uvcclient.camera.UVCCameraClientV320")
+async def test_login_tries_both_addrs_and_caches(mock_camera, mock_store, uvc_fixture):
+    """Test the login tries."""
+    responses = [0]
 
-        def mock_snapshot():
-            """Mock snapshot."""
-            try:
-                responses.pop()
-                raise camera.CameraAuthError()
-            except IndexError:
-                pass
-            return "image"
+    def mock_login(*a):
+        """Mock login."""
+        try:
+            responses.pop(0)
+            raise OSError
+        except IndexError:
+            pass
 
-        self.uvc._camera = mock.MagicMock()
-        self.uvc._camera.get_snapshot.side_effect = mock_snapshot
-        with mock.patch.object(self.uvc, "_login") as mock_login:
-            assert "image" == self.uvc.camera_image()
-            assert mock_login.call_count == 1
-            assert mock_login.call_args == mock.call()
-            assert [] == responses
+    mock_store.return_value.get_camera_password.return_value = None
+    mock_camera.return_value.login.side_effect = mock_login
+    uvc_fixture._login()
+    assert 2 == mock_camera.call_count
+    assert "host-b" == uvc_fixture._connect_addr
 
-    def test_camera_image_reauths_only_once(self):
-        """Test if the re-authentication only happens once."""
-        self.uvc._camera = mock.MagicMock()
-        self.uvc._camera.get_snapshot.side_effect = camera.CameraAuthError
-        with mock.patch.object(self.uvc, "_login") as mock_login:
-            with pytest.raises(camera.CameraAuthError):
-                self.uvc.camera_image()
-            assert mock_login.call_count == 1
-            assert mock_login.call_args == mock.call()
+    mock_camera.reset_mock()
+    uvc_fixture._login()
+    assert mock_camera.call_count == 1
+    assert mock_camera.call_args == call("host-b", "admin", "seekret")
+    assert mock_camera.return_value.login.call_count == 1
+    assert mock_camera.return_value.login.call_args == call()
+
+
+@patch("uvcclient.store.get_info_store")
+@patch("uvcclient.camera.UVCCameraClientV320")
+async def test_login_fails_both_properly(mock_camera, mock_store, uvc_fixture):
+    """Test if login fails properly."""
+    mock_camera.return_value.login.side_effect = socket.error
+    assert uvc_fixture._login() is None
+    assert uvc_fixture._connect_addr is None
+
+
+async def test_camera_image_tries_login_bails_on_failure(uvc_fixture):
+    """Test retrieving failure."""
+    with patch.object(uvc_fixture, "_login") as mock_login:
+        mock_login.return_value = False
+        assert uvc_fixture.camera_image() is None
+        assert mock_login.call_count == 1
+        assert mock_login.call_args == call()
+
+
+async def test_camera_image_logged_in(uvc_fixture):
+    """Test the login state."""
+    uvc_fixture._camera = MagicMock()
+    assert uvc_fixture._camera.get_snapshot.return_value == uvc_fixture.camera_image()
+
+
+async def test_camera_image_error(uvc_fixture):
+    """Test the camera image error."""
+    uvc_fixture._camera = MagicMock()
+    uvc_fixture._camera.get_snapshot.side_effect = camera.CameraConnectError
+    assert uvc_fixture.camera_image() is None
+
+
+async def test_camera_image_reauths(uvc_fixture):
+    """Test the re-authentication."""
+    responses = [0]
+
+    def mock_snapshot():
+        """Mock snapshot."""
+        try:
+            responses.pop()
+            raise camera.CameraAuthError()
+        except IndexError:
+            pass
+        return "image"
+
+    uvc_fixture._camera = MagicMock()
+    uvc_fixture._camera.get_snapshot.side_effect = mock_snapshot
+    with patch.object(uvc_fixture, "_login") as mock_login:
+        assert "image" == uvc_fixture.camera_image()
+        assert mock_login.call_count == 1
+        assert mock_login.call_args == call()
+        assert [] == responses
+
+
+async def test_camera_image_reauths_only_once(uvc_fixture):
+    """Test if the re-authentication only happens once."""
+    uvc_fixture._camera = MagicMock()
+    uvc_fixture._camera.get_snapshot.side_effect = camera.CameraAuthError
+    with patch.object(uvc_fixture, "_login") as mock_login:
+        with pytest.raises(camera.CameraAuthError):
+            uvc_fixture.camera_image()
+        assert mock_login.call_count == 1
+        assert mock_login.call_args == call()

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -1,5 +1,5 @@
 """The tests for UVC camera module."""
-from datetime import datetime
+from datetime import datetime, timedelta
 import socket
 from unittest.mock import MagicMock, call, patch
 
@@ -12,6 +12,9 @@ from homeassistant.components.uvc import camera as uvc
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
 
 
 @pytest.fixture(name="mock_remote")
@@ -208,21 +211,35 @@ async def test_setup_incomplete_config(hass, mock_remote, config):
     assert not camera_states
 
 
-@patch.object(uvc, "UnifiVideoCamera")
-@patch("uvcclient.nvr.UVCRemote")
 @pytest.mark.parametrize(
-    "error", [nvr.NotAuthorized, nvr.NvrError, requests.exceptions.ConnectionError]
+    "error, ready_states",
+    [
+        (nvr.NotAuthorized, 0),
+        (nvr.NvrError, 2),
+        (requests.exceptions.ConnectionError, 2),
+    ],
 )
-async def test_setup_nvr_errors_during_indexing(mock_remote, mock_uvc, hass, error):
+async def test_setup_nvr_errors_during_indexing(hass, mock_remote, error, ready_states):
     """Set up test for NVR errors during indexing."""
     config = {"platform": "uvc", "nvr": "foo", "key": "secret"}
+    now = utcnow()
     mock_remote.return_value.index.side_effect = error
     assert await async_setup_component(hass, "camera", {"camera": config})
     await hass.async_block_till_done()
 
-    assert not mock_uvc.called
-    if error in [nvr.NvrError, requests.exceptions.ConnectionError]:
-        pytest.raises(PlatformNotReady)
+    camera_states = hass.states.async_all("camera")
+
+    assert not camera_states
+
+    # resolve the error
+    mock_remote.return_value.index.side_effect = None
+
+    async_fire_time_changed(hass, now + timedelta(seconds=31))
+    await hass.async_block_till_done()
+
+    camera_states = hass.states.async_all("camera")
+
+    assert len(camera_states) == ready_states
 
 
 @patch.object(uvc, "UnifiVideoCamera")

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -190,27 +190,22 @@ async def test_setup_partial_config_v31x(hass, mock_remote):
     assert entity_entry.unique_id == "two"
 
 
-@patch.object(uvc, "UnifiVideoCamera")
-async def test_setup_incomplete_config(mock_uvc, hass):
-    """Test the setup with incomplete configuration."""
-    assert await async_setup_component(
-        hass, "camera", {"platform": "uvc", "nvr": "foo"}
-    )
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"platform": "uvc", "nvr": "foo"},
+        {"platform": "uvc", "key": "secret"},
+        {"platform": "uvc", "nvr": "foo", "key": "secret", "port": "invalid"},
+    ],
+)
+async def test_setup_incomplete_config(hass, mock_remote, config):
+    """Test the setup with incomplete or invalid configuration."""
+    assert await async_setup_component(hass, "camera", config)
     await hass.async_block_till_done()
 
-    assert not mock_uvc.called
-    assert await async_setup_component(
-        hass, "camera", {"platform": "uvc", "key": "secret"}
-    )
-    await hass.async_block_till_done()
+    camera_states = hass.states.async_all("camera")
 
-    assert not mock_uvc.called
-    assert await async_setup_component(
-        hass, "camera", {"platform": "uvc", "port": "invalid"}
-    )
-    await hass.async_block_till_done()
-
-    assert not mock_uvc.called
+    assert not camera_states
 
 
 @patch.object(uvc, "UnifiVideoCamera")

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -1,6 +1,6 @@
 """The tests for UVC camera module."""
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 
 import pytest
 import requests
@@ -13,7 +13,6 @@ from homeassistant.components.camera import (
     async_get_image,
     async_get_stream_source,
 )
-from homeassistant.components.uvc import camera as uvc
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.setup import async_setup_component
@@ -311,54 +310,6 @@ async def test_setup_nvr_errors_during_initialization(
     camera_states = hass.states.async_all("camera")
 
     assert len(camera_states) == ready_states
-
-
-@pytest.fixture
-def uvc_fixture():
-    """Set up the mock camera."""
-    nvr = MagicMock()
-    uuid = "uuid"
-    name = "name"
-    password = "seekret"
-    _uvc = uvc.UnifiVideoCamera(nvr, uuid, name, password)
-    nvr.get_camera.return_value = {
-        "model": "UVC Fake",
-        "recordingSettings": {"fullTimeRecordEnabled": True},
-        "host": "host-a",
-        "internalHost": "host-b",
-        "username": "admin",
-        "channels": [
-            {
-                "id": "0",
-                "width": 1920,
-                "height": 1080,
-                "fps": 25,
-                "bitrate": 6000000,
-                "isRtspEnabled": True,
-                "rtspUris": [
-                    "rtsp://host-a:7447/uuid_rtspchannel_0",
-                    "rtsp://foo:7447/uuid_rtspchannel_0",
-                ],
-            },
-            {
-                "id": "1",
-                "width": 1024,
-                "height": 576,
-                "fps": 15,
-                "bitrate": 1200000,
-                "isRtspEnabled": False,
-                "rtspUris": [
-                    "rtsp://host-a:7447/uuid_rtspchannel_1",
-                    "rtsp://foo:7447/uuid_rtspchannel_1",
-                ],
-            },
-        ],
-    }
-    nvr.server_version = (3, 2, 0)
-    nvr._host = "foo"
-
-    _uvc.update()
-    return _uvc
 
 
 async def test_properties(hass, mock_remote):

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -1,5 +1,5 @@
 """The tests for UVC camera module."""
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import call, patch
 
 import pytest
@@ -361,7 +361,7 @@ async def test_motion_recording_mode_properties(hass, mock_remote):
     assert state
     assert state.state != STATE_RECORDING
     assert state.attributes["last_recording_start_time"] == datetime(
-        2021, 1, 8, 2, 56, 32, 367000
+        2021, 1, 8, 1, 56, 32, 367000, tzinfo=timezone.utc
     )
 
     mock_remote.return_value.get_camera.return_value["recordingIndicator"] = "DISABLED"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- The datetime returned in the `last_recording_start_time` state attribute of the uvc camera entity was changed from local time to be UTC time. All times in state attributes must be UTC time. Users should update any automations or scripts that depend on this state attribute.

## Proposed change
Improves the tests for the uvc camera by rewriting tests to async pytest functions.
I changed a lot in this test so it may need some review.
Also I got a logical understanding problem which you can find in the mentioned issue or at this link:
https://github.com/home-assistant/core/issues/40906#issuecomment-704985626

All tests are passing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40906
- This PR is related to issue: #40906
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
