### PR TITLE
Rewrite mhz19 unittest tests to pytest style tests

### DIFF
--- a/tests/components/mhz19/test_sensor.py
+++ b/tests/components/mhz19/test_sensor.py
@@ -1,4 +1,7 @@
 """Tests for MH-Z19 sensor."""
+from pmsensor import co2sensor
+from pmsensor.co2sensor import read_mh_z19_with_temperature
+
 import homeassistant.components.mhz19.sensor as mhz19
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import (
@@ -37,8 +40,6 @@ async def test_setup_connected(hass):
         read_mh_z19=DEFAULT,
         read_mh_z19_with_temperature=DEFAULT,
     ):
-        from pmsensor.co2sensor import read_mh_z19_with_temperature
-
         read_mh_z19_with_temperature.return_value = None
         mock_add = Mock()
         assert mhz19.setup_platform(
@@ -59,8 +60,6 @@ async def test_setup_connected(hass):
 )
 async def aiohttp_client_update_oserror(mock_function):
     """Test MHZClient when library throws OSError."""
-    from pmsensor import co2sensor
-
     client = mhz19.MHZClient(co2sensor, "test.serial")
     client.update()
     assert {} == client.data
@@ -69,8 +68,6 @@ async def aiohttp_client_update_oserror(mock_function):
 @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(5001, 24))
 async def aiohttp_client_update_ppm_overflow(mock_function):
     """Test MHZClient when ppm is too high."""
-    from pmsensor import co2sensor
-
     client = mhz19.MHZClient(co2sensor, "test.serial")
     client.update()
     assert client.data.get("co2") is None
@@ -79,8 +76,6 @@ async def aiohttp_client_update_ppm_overflow(mock_function):
 @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
 async def aiohttp_client_update_good_read(mock_function):
     """Test MHZClient when ppm is too high."""
-    from pmsensor import co2sensor
-
     client = mhz19.MHZClient(co2sensor, "test.serial")
     client.update()
     assert {"temperature": 24, "co2": 1000} == client.data
@@ -89,8 +84,6 @@ async def aiohttp_client_update_good_read(mock_function):
 @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
 async def test_co2_sensor(mock_function):
     """Test CO2 sensor."""
-    from pmsensor import co2sensor
-
     client = mhz19.MHZClient(co2sensor, "test.serial")
     sensor = mhz19.MHZ19Sensor(client, mhz19.SENSOR_CO2, None, "name")
     sensor.update()
@@ -105,8 +98,6 @@ async def test_co2_sensor(mock_function):
 @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
 async def test_temperature_sensor(mock_function):
     """Test temperature sensor."""
-    from pmsensor import co2sensor
-
     client = mhz19.MHZClient(co2sensor, "test.serial")
     sensor = mhz19.MHZ19Sensor(client, mhz19.SENSOR_TEMPERATURE, None, "name")
     sensor.update()
@@ -121,8 +112,6 @@ async def test_temperature_sensor(mock_function):
 @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
 async def test_temperature_sensor_f(mock_function):
     """Test temperature sensor."""
-    from pmsensor import co2sensor
-
     client = mhz19.MHZClient(co2sensor, "test.serial")
     sensor = mhz19.MHZ19Sensor(
         client, mhz19.SENSOR_TEMPERATURE, TEMP_FAHRENHEIT, "name"

--- a/tests/components/mhz19/test_sensor.py
+++ b/tests/components/mhz19/test_sensor.py
@@ -1,6 +1,4 @@
 """Tests for MH-Z19 sensor."""
-import unittest
-
 import homeassistant.components.mhz19.sensor as mhz19
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import (
@@ -8,130 +6,127 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import DEFAULT, Mock, patch
-from tests.common import assert_setup_component, get_test_home_assistant
+from tests.common import assert_setup_component
 
 
-class TestMHZ19Sensor(unittest.TestCase):
-    """Test the MH-Z19 sensor."""
-
-    hass = None
-
-    def setup_method(self, method):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_setup_missing_config(self):
-        """Test setup with configuration missing required entries."""
-        with assert_setup_component(0):
-            assert setup_component(self.hass, DOMAIN, {"sensor": {"platform": "mhz19"}})
-
-    @patch("pmsensor.co2sensor.read_mh_z19", side_effect=OSError("test error"))
-    def test_setup_failed_connect(self, mock_co2):
-        """Test setup when connection error occurs."""
-        assert not mhz19.setup_platform(
-            self.hass,
-            {"platform": "mhz19", mhz19.CONF_SERIAL_DEVICE: "test.serial"},
-            None,
+async def test_setup_missing_config(hass):
+    """Test setup with configuration missing required entries."""
+    with assert_setup_component(0):
+        assert await async_setup_component(
+            hass, DOMAIN, {"sensor": {"platform": "mhz19"}}
         )
 
-    def test_setup_connected(self):
-        """Test setup when connection succeeds."""
-        with patch.multiple(
-            "pmsensor.co2sensor",
-            read_mh_z19=DEFAULT,
-            read_mh_z19_with_temperature=DEFAULT,
-        ):
-            from pmsensor.co2sensor import read_mh_z19_with_temperature
 
-            read_mh_z19_with_temperature.return_value = None
-            mock_add = Mock()
-            assert mhz19.setup_platform(
-                self.hass,
-                {
-                    "platform": "mhz19",
-                    "monitored_conditions": ["co2", "temperature"],
-                    mhz19.CONF_SERIAL_DEVICE: "test.serial",
-                },
-                mock_add,
-            )
-        assert mock_add.call_count == 1
-
-    @patch(
-        "pmsensor.co2sensor.read_mh_z19_with_temperature",
-        side_effect=OSError("test error"),
+@patch("pmsensor.co2sensor.read_mh_z19", side_effect=OSError("test error"))
+async def test_setup_failed_connect(mock_co2, hass):
+    """Test setup when connection error occurs."""
+    assert not mhz19.setup_platform(
+        hass,
+        {"platform": "mhz19", mhz19.CONF_SERIAL_DEVICE: "test.serial"},
+        None,
     )
-    def aiohttp_client_update_oserror(self, mock_function):
-        """Test MHZClient when library throws OSError."""
-        from pmsensor import co2sensor
 
-        client = mhz19.MHZClient(co2sensor, "test.serial")
-        client.update()
-        assert {} == client.data
 
-    @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(5001, 24))
-    def aiohttp_client_update_ppm_overflow(self, mock_function):
-        """Test MHZClient when ppm is too high."""
-        from pmsensor import co2sensor
+async def test_setup_connected(hass):
+    """Test setup when connection succeeds."""
+    with patch.multiple(
+        "pmsensor.co2sensor",
+        read_mh_z19=DEFAULT,
+        read_mh_z19_with_temperature=DEFAULT,
+    ):
+        from pmsensor.co2sensor import read_mh_z19_with_temperature
 
-        client = mhz19.MHZClient(co2sensor, "test.serial")
-        client.update()
-        assert client.data.get("co2") is None
-
-    @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
-    def aiohttp_client_update_good_read(self, mock_function):
-        """Test MHZClient when ppm is too high."""
-        from pmsensor import co2sensor
-
-        client = mhz19.MHZClient(co2sensor, "test.serial")
-        client.update()
-        assert {"temperature": 24, "co2": 1000} == client.data
-
-    @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
-    def test_co2_sensor(self, mock_function):
-        """Test CO2 sensor."""
-        from pmsensor import co2sensor
-
-        client = mhz19.MHZClient(co2sensor, "test.serial")
-        sensor = mhz19.MHZ19Sensor(client, mhz19.SENSOR_CO2, None, "name")
-        sensor.update()
-
-        assert sensor.name == "name: CO2"
-        assert sensor.state == 1000
-        assert sensor.unit_of_measurement == CONCENTRATION_PARTS_PER_MILLION
-        assert sensor.should_poll
-        assert sensor.device_state_attributes == {"temperature": 24}
-
-    @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
-    def test_temperature_sensor(self, mock_function):
-        """Test temperature sensor."""
-        from pmsensor import co2sensor
-
-        client = mhz19.MHZClient(co2sensor, "test.serial")
-        sensor = mhz19.MHZ19Sensor(client, mhz19.SENSOR_TEMPERATURE, None, "name")
-        sensor.update()
-
-        assert sensor.name == "name: Temperature"
-        assert sensor.state == 24
-        assert sensor.unit_of_measurement == TEMP_CELSIUS
-        assert sensor.should_poll
-        assert sensor.device_state_attributes == {"co2_concentration": 1000}
-
-    @patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
-    def test_temperature_sensor_f(self, mock_function):
-        """Test temperature sensor."""
-        from pmsensor import co2sensor
-
-        client = mhz19.MHZClient(co2sensor, "test.serial")
-        sensor = mhz19.MHZ19Sensor(
-            client, mhz19.SENSOR_TEMPERATURE, TEMP_FAHRENHEIT, "name"
+        read_mh_z19_with_temperature.return_value = None
+        mock_add = Mock()
+        assert mhz19.setup_platform(
+            hass,
+            {
+                "platform": "mhz19",
+                "monitored_conditions": ["co2", "temperature"],
+                mhz19.CONF_SERIAL_DEVICE: "test.serial",
+            },
+            mock_add,
         )
-        sensor.update()
+    assert mock_add.call_count == 1
 
-        assert sensor.state == 75.2
+
+@patch(
+    "pmsensor.co2sensor.read_mh_z19_with_temperature",
+    side_effect=OSError("test error"),
+)
+async def aiohttp_client_update_oserror(mock_function):
+    """Test MHZClient when library throws OSError."""
+    from pmsensor import co2sensor
+
+    client = mhz19.MHZClient(co2sensor, "test.serial")
+    client.update()
+    assert {} == client.data
+
+
+@patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(5001, 24))
+async def aiohttp_client_update_ppm_overflow(mock_function):
+    """Test MHZClient when ppm is too high."""
+    from pmsensor import co2sensor
+
+    client = mhz19.MHZClient(co2sensor, "test.serial")
+    client.update()
+    assert client.data.get("co2") is None
+
+
+@patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
+async def aiohttp_client_update_good_read(mock_function):
+    """Test MHZClient when ppm is too high."""
+    from pmsensor import co2sensor
+
+    client = mhz19.MHZClient(co2sensor, "test.serial")
+    client.update()
+    assert {"temperature": 24, "co2": 1000} == client.data
+
+
+@patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
+async def test_co2_sensor(mock_function):
+    """Test CO2 sensor."""
+    from pmsensor import co2sensor
+
+    client = mhz19.MHZClient(co2sensor, "test.serial")
+    sensor = mhz19.MHZ19Sensor(client, mhz19.SENSOR_CO2, None, "name")
+    sensor.update()
+
+    assert sensor.name == "name: CO2"
+    assert sensor.state == 1000
+    assert sensor.unit_of_measurement == CONCENTRATION_PARTS_PER_MILLION
+    assert sensor.should_poll
+    assert sensor.device_state_attributes == {"temperature": 24}
+
+
+@patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
+async def test_temperature_sensor(mock_function):
+    """Test temperature sensor."""
+    from pmsensor import co2sensor
+
+    client = mhz19.MHZClient(co2sensor, "test.serial")
+    sensor = mhz19.MHZ19Sensor(client, mhz19.SENSOR_TEMPERATURE, None, "name")
+    sensor.update()
+
+    assert sensor.name == "name: Temperature"
+    assert sensor.state == 24
+    assert sensor.unit_of_measurement == TEMP_CELSIUS
+    assert sensor.should_poll
+    assert sensor.device_state_attributes == {"co2_concentration": 1000}
+
+
+@patch("pmsensor.co2sensor.read_mh_z19_with_temperature", return_value=(1000, 24))
+async def test_temperature_sensor_f(mock_function):
+    """Test temperature sensor."""
+    from pmsensor import co2sensor
+
+    client = mhz19.MHZClient(co2sensor, "test.serial")
+    sensor = mhz19.MHZ19Sensor(
+        client, mhz19.SENSOR_TEMPERATURE, TEMP_FAHRENHEIT, "name"
+    )
+    sensor.update()
+
+    assert sensor.state == 75.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40865
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
