### PR TITLE
Rewrite uptime unittest tests to pytest style

### DIFF
--- a/tests/components/uptime/test_sensor.py
+++ b/tests/components/uptime/test_sensor.py
@@ -1,90 +1,73 @@
 """The tests for the uptime sensor platform."""
-import asyncio
 from datetime import timedelta
-import unittest
 
 from homeassistant.components.uptime.sensor import UptimeSensor
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
-from tests.common import get_test_home_assistant
 
 
-class TestUptimeSensor(unittest.TestCase):
-    """Test the uptime sensor."""
+async def test_uptime_min_config(hass):
+    """Test minimum uptime configuration."""
+    config = {"sensor": {"platform": "uptime"}}
+    assert await async_setup_component(hass, "sensor", config)
 
-    def setUp(self):
-        """Set up things to run when tests begin."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
 
-    def test_uptime_min_config(self):
-        """Test minimum uptime configuration."""
-        config = {"sensor": {"platform": "uptime"}}
-        assert setup_component(self.hass, "sensor", config)
+async def test_uptime_sensor_name_change(hass):
+    """Test uptime sensor with different name."""
+    config = {"sensor": {"platform": "uptime", "name": "foobar"}}
+    assert await async_setup_component(hass, "sensor", config)
 
-    def test_uptime_sensor_name_change(self):
-        """Test uptime sensor with different name."""
-        config = {"sensor": {"platform": "uptime", "name": "foobar"}}
-        assert setup_component(self.hass, "sensor", config)
 
-    def test_uptime_sensor_config_hours(self):
-        """Test uptime sensor with hours defined in config."""
-        config = {"sensor": {"platform": "uptime", "unit_of_measurement": "hours"}}
-        assert setup_component(self.hass, "sensor", config)
+async def test_uptime_sensor_config_hours(hass):
+    """Test uptime sensor with hours async defined in config."""
+    config = {"sensor": {"platform": "uptime", "unit_of_measurement": "hours"}}
+    assert await async_setup_component(hass, "sensor", config)
 
-    def test_uptime_sensor_config_minutes(self):
-        """Test uptime sensor with minutes defined in config."""
-        config = {"sensor": {"platform": "uptime", "unit_of_measurement": "minutes"}}
-        assert setup_component(self.hass, "sensor", config)
 
-    def test_uptime_sensor_days_output(self):
-        """Test uptime sensor output data."""
-        sensor = UptimeSensor("test", "days")
-        assert sensor.unit_of_measurement == "days"
-        new_time = sensor.initial + timedelta(days=1)
-        with patch("homeassistant.util.dt.now", return_value=new_time):
-            asyncio.run_coroutine_threadsafe(
-                sensor.async_update(), self.hass.loop
-            ).result()
-            assert sensor.state == 1.00
-        new_time = sensor.initial + timedelta(days=111.499)
-        with patch("homeassistant.util.dt.now", return_value=new_time):
-            asyncio.run_coroutine_threadsafe(
-                sensor.async_update(), self.hass.loop
-            ).result()
-            assert sensor.state == 111.50
+async def test_uptime_sensor_config_minutes(hass):
+    """Test uptime sensor with minutes async defined in config."""
+    config = {"sensor": {"platform": "uptime", "unit_of_measurement": "minutes"}}
+    assert await async_setup_component(hass, "sensor", config)
 
-    def test_uptime_sensor_hours_output(self):
-        """Test uptime sensor output data."""
-        sensor = UptimeSensor("test", "hours")
-        assert sensor.unit_of_measurement == "hours"
-        new_time = sensor.initial + timedelta(hours=16)
-        with patch("homeassistant.util.dt.now", return_value=new_time):
-            asyncio.run_coroutine_threadsafe(
-                sensor.async_update(), self.hass.loop
-            ).result()
-            assert sensor.state == 16.00
-        new_time = sensor.initial + timedelta(hours=72.499)
-        with patch("homeassistant.util.dt.now", return_value=new_time):
-            asyncio.run_coroutine_threadsafe(
-                sensor.async_update(), self.hass.loop
-            ).result()
-            assert sensor.state == 72.50
 
-    def test_uptime_sensor_minutes_output(self):
-        """Test uptime sensor output data."""
-        sensor = UptimeSensor("test", "minutes")
-        assert sensor.unit_of_measurement == "minutes"
-        new_time = sensor.initial + timedelta(minutes=16)
-        with patch("homeassistant.util.dt.now", return_value=new_time):
-            asyncio.run_coroutine_threadsafe(
-                sensor.async_update(), self.hass.loop
-            ).result()
-            assert sensor.state == 16.00
-        new_time = sensor.initial + timedelta(minutes=12.499)
-        with patch("homeassistant.util.dt.now", return_value=new_time):
-            asyncio.run_coroutine_threadsafe(
-                sensor.async_update(), self.hass.loop
-            ).result()
-            assert sensor.state == 12.50
+async def test_uptime_sensor_days_output():
+    """Test uptime sensor output data."""
+    sensor = UptimeSensor("test", "days")
+    assert sensor.unit_of_measurement == "days"
+    new_time = sensor.initial + timedelta(days=1)
+    with patch("homeassistant.util.dt.now", return_value=new_time):
+        await sensor.async_update()
+        assert sensor.state == 1.00
+    new_time = sensor.initial + timedelta(days=111.499)
+    with patch("homeassistant.util.dt.now", return_value=new_time):
+        await sensor.async_update()
+        assert sensor.state == 111.50
+
+
+async def test_uptime_sensor_hours_output():
+    """Test uptime sensor output data."""
+    sensor = UptimeSensor("test", "hours")
+    assert sensor.unit_of_measurement == "hours"
+    new_time = sensor.initial + timedelta(hours=16)
+    with patch("homeassistant.util.dt.now", return_value=new_time):
+        await sensor.async_update()
+        assert sensor.state == 16.00
+    new_time = sensor.initial + timedelta(hours=72.499)
+    with patch("homeassistant.util.dt.now", return_value=new_time):
+        await sensor.async_update()
+        assert sensor.state == 72.50
+
+
+async def test_uptime_sensor_minutes_output():
+    """Test uptime sensor output data."""
+    sensor = UptimeSensor("test", "minutes")
+    assert sensor.unit_of_measurement == "minutes"
+    new_time = sensor.initial + timedelta(minutes=16)
+    with patch("homeassistant.util.dt.now", return_value=new_time):
+        await sensor.async_update()
+        assert sensor.state == 16.00
+    new_time = sensor.initial + timedelta(minutes=12.499)
+    with patch("homeassistant.util.dt.now", return_value=new_time):
+        await sensor.async_update()
+        assert sensor.state == 12.50


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Improves the test for the uptime sensor by rewriting tests to async pytest functions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40905
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
