### PR TITLE
Update translate develop to substitute references

### DIFF
--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 from pathlib import Path
+import re
 from shutil import rmtree
 import sys
 
@@ -29,6 +30,59 @@ def get_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def flatten_translations(translations):
+    """Flatten all translations"""
+    stack = [iter(translations.items())]
+    key_stack = []
+    flattened_translations = {}
+    while stack:
+        for k, v in stack[-1]:
+            key_stack.append(k)
+            if isinstance(v, dict):
+                stack.append(iter(v.items()))
+                break
+            elif isinstance(v, str):
+                common_key = "::".join(key_stack)
+                flattened_translations[common_key] = v
+                key_stack.pop()
+        else:
+            stack.pop()
+            if len(key_stack) > 0:
+                key_stack.pop()
+
+    return flattened_translations
+
+
+def substitute_translation_references(integration_strings, flattened_translations):
+    """Recursively processes all translation strings for the integration"""
+    result = {}
+    for key, value in integration_strings.items():
+        if isinstance(value, dict):
+            sub_dict = substitute_translation_references(value, flattened_translations)
+            result[key] = sub_dict
+        elif isinstance(value, str):
+            result[key] = substitute_reference(value, flattened_translations)
+
+    return result
+
+
+def substitute_reference(value, flattened_translations):
+    """Substitute localization key references in a translation string"""
+    matches = re.findall(r"\[\%key:((?:[\w]+|[:]{2})*)\%\]", value)
+    if not matches:
+        return value
+
+    new = value
+    for key in matches:
+        if key in flattened_translations:
+            new = new.replace(f"[%key:{key}%]", flattened_translations[key])
+        else:
+            print(f"Invalid substitution key '{key}' found in string '{value}'")
+            sys.exit(1)
+
+    return new
+
+
 def run():
     """Run the script."""
     args = get_arguments()
@@ -50,6 +104,13 @@ def run():
     if integration not in translations["component"]:
         print("Integration has no strings.json")
         sys.exit(1)
+
+    flattened_translations = flatten_translations(translations)
+    integration_strings = translations["component"][integration]
+
+    translations["component"][integration] = substitute_translation_references(
+        integration_strings, flattened_translations
+    )
 
     if download.DOWNLOAD_DIR.is_dir():
         rmtree(str(download.DOWNLOAD_DIR))

--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -31,7 +31,7 @@ def get_arguments() -> argparse.Namespace:
 
 
 def flatten_translations(translations):
-    """Flatten all translations"""
+    """Flatten all translations."""
     stack = [iter(translations.items())]
     key_stack = []
     flattened_translations = {}
@@ -54,7 +54,7 @@ def flatten_translations(translations):
 
 
 def substitute_translation_references(integration_strings, flattened_translations):
-    """Recursively processes all translation strings for the integration"""
+    """Recursively processes all translation strings for the integration."""
     result = {}
     for key, value in integration_strings.items():
         if isinstance(value, dict):
@@ -67,7 +67,7 @@ def substitute_translation_references(integration_strings, flattened_translation
 
 
 def substitute_reference(value, flattened_translations):
-    """Substitute localization key references in a translation string"""
+    """Substitute localization key references in a translation string."""
     matches = re.findall(r"\[\%key:((?:[\w]+|[:]{2})*)\%\]", value)
     if not matches:
         return value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When building functionality that requires new translations, the development script does not support references and so we can't test with the actual values that will be shown.

When the development script encounters a reference, it looks it up and substitutes with the actual value. It fail if the reference doesn't exist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37261
- This PR is related to issue: #37261
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
