### PR TITLE
Adjust dts warning messages in stream

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -89,7 +89,7 @@ def _stream_worker_internal(hass, stream, quit_event):
     # Keep track of consecutive packets without a dts to detect end of stream.
     last_packet_was_without_dts = False
     # Keep track of consecutive packets with a large dts gap to detect an overflow.
-    last_packet_had_large_dts_gap = False
+    last_packet_had_large_negative_dts_gap = False
     # Holds the buffers for each stream provider
     outputs = None
     # Keep track of the number of segments we've processed
@@ -239,7 +239,7 @@ def _stream_worker_internal(hass, stream, quit_event):
             if (last_dts[packet.stream] - packet.dts) > (
                 packet.time_base * MAX_TIMESTAMP_GAP
             ):
-                if last_packet_had_large_dts_gap:
+                if last_packet_had_large_negative_dts_gap:
                     _LOGGER.warning(
                         "Timestamp overflow detected: last dts %s, dts = %s, resetting stream",
                         last_dts[packet.stream],
@@ -247,7 +247,7 @@ def _stream_worker_internal(hass, stream, quit_event):
                     )
                     finalize_stream()
                     break
-                last_packet_had_large_dts_gap = True
+                last_packet_had_large_negative_dts_gap = True
             if packet.dts < last_dts[packet.stream]:
                 _LOGGER.warning(
                     "Dropping out of order packet: %s < %s",
@@ -255,7 +255,7 @@ def _stream_worker_internal(hass, stream, quit_event):
                     last_dts[packet.stream],
                 )
             continue
-        last_packet_had_large_dts_gap = False
+        last_packet_had_large_negative_dts_gap = False
 
         # Check for end of segment
         if packet.stream == video_stream and packet.is_keyframe:

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -238,16 +238,18 @@ def _stream_worker_internal(hass, stream, quit_event):
                 packet.time_base * MAX_TIMESTAMP_GAP
             ):
                 _LOGGER.warning(
-                    "Timestamp overflow detected: dts = %s, resetting stream",
+                    "Timestamp overflow detected: last dts %s, dts = %s, resetting stream",
+                    last_dts[packet.stream],
                     packet.dts,
                 )
                 finalize_stream()
                 break
-            _LOGGER.warning(
-                "Dropping out of order packet: %s <= %s",
-                packet.dts,
-                last_dts[packet.stream],
-            )
+            if packet.dts < last_dts[packet.stream]:
+                _LOGGER.warning(
+                    "Dropping out of order packet: %s < %s",
+                    packet.dts,
+                    last_dts[packet.stream],
+                )
             continue
 
         # Check for end of segment

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -88,6 +88,8 @@ def _stream_worker_internal(hass, stream, quit_event):
     last_dts = None
     # Keep track of consecutive packets without a dts to detect end of stream.
     last_packet_was_without_dts = False
+    # Keep track of consecutive packets with a large dts gap to detect an overflow.
+    last_packet_had_large_dts_gap = False
     # Holds the buffers for each stream provider
     outputs = None
     # Keep track of the number of segments we've processed
@@ -237,13 +239,15 @@ def _stream_worker_internal(hass, stream, quit_event):
             if (last_dts[packet.stream] - packet.dts) > (
                 packet.time_base * MAX_TIMESTAMP_GAP
             ):
-                _LOGGER.warning(
-                    "Timestamp overflow detected: last dts %s, dts = %s, resetting stream",
-                    last_dts[packet.stream],
-                    packet.dts,
-                )
-                finalize_stream()
-                break
+                if last_packet_had_large_dts_gap:
+                    _LOGGER.warning(
+                        "Timestamp overflow detected: last dts %s, dts = %s, resetting stream",
+                        last_dts[packet.stream],
+                        packet.dts,
+                    )
+                    finalize_stream()
+                    break
+                last_packet_had_large_dts_gap = True
             if packet.dts < last_dts[packet.stream]:
                 _LOGGER.warning(
                     "Dropping out of order packet: %s < %s",
@@ -251,6 +255,7 @@ def _stream_worker_internal(hass, stream, quit_event):
                     last_dts[packet.stream],
                 )
             continue
+        last_packet_had_large_dts_gap = False
 
         # Check for end of segment
         if packet.stream == video_stream and packet.is_keyframe:

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -248,12 +248,6 @@ def _stream_worker_internal(hass, stream, quit_event):
                     finalize_stream()
                     break
                 last_packet_had_large_negative_dts_gap = True
-            if packet.dts < last_dts[packet.stream]:
-                _LOGGER.warning(
-                    "Dropping out of order packet: %s < %s",
-                    packet.dts,
-                    last_dts[packet.stream],
-                )
             continue
         last_packet_had_large_negative_dts_gap = False
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We added some warning messages when encountering out of order packets in https://github.com/home-assistant/core/pull/39844 . It seems like the pyav rtsp demuxer automatically drops out of order packets, but it allows packets with the same DTS through.
For out of order packets, this PR skips printing the warning if consecutive packets with the same DTS are encountered. With this change, we do not expect the out of order packet warning to ever be printed as the demuxer should drop the strictly out of order packets, and this warning should only print for these strictly out of order packets.
This PR also adjusts the overflow warning to include the last dts value for help with troubleshooting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #41747 #41891 #41899 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
