### PR TITLE
Fix bool registers in modbus integration

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -122,5 +122,5 @@ class ModbusBinarySensor(BinarySensorEntity):
             self._available = False
             return
 
-        self._value = result.bits[0]
+        self._value = result.bits[0] & 1
         self._available = True

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -228,7 +228,7 @@ class ModbusCover(CoverEntity, RestoreEntity):
             self._available = False
             return
 
-        value = bool(result.bits[0])
+        value = bool(result.bits[0] & 1)
         self._available = True
 
         return value

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -174,7 +174,7 @@ class ModbusCoilSwitch(ToggleEntity, RestoreEntity):
         # bits[0] select the lowest bit in result,
         # is_on for a binary_sensor is true if the bit are 1
         # The other bits are not considered.
-        return bool(result.bits[0])
+        return bool(result.bits[0] & 1)
 
     def _write_coil(self, coil, value):
         """Write coil using the Modbus hub slave."""

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -33,7 +33,28 @@ _LOGGER = logging.getLogger(__name__)
             {
                 CONF_INPUT_TYPE: CALL_TYPE_COIL,
             },
+            [0x01],
+            STATE_ON,
+        ),
+        (
+            {
+                CONF_INPUT_TYPE: CALL_TYPE_COIL,
+            },
             [0x00],
+            STATE_OFF,
+        ),
+        (
+            {
+                CONF_INPUT_TYPE: CALL_TYPE_COIL,
+            },
+            [0x80],
+            STATE_OFF,
+        ),
+        (
+            {
+                CONF_INPUT_TYPE: CALL_TYPE_COIL,
+            },
+            [0xFE],
             STATE_OFF,
         ),
         (

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -13,39 +13,19 @@ from .conftest import run_base_read_test, setup_base_test
 _LOGGER = logging.getLogger(__name__)
 
 
-async def run_sensor_test(hass, use_mock_hub, value, expected):
-    """Run test for given config."""
-    switch_name = "modbus_test_switch"
-    scan_interval = 5
-    entity_id, now, device = await setup_base_test(
-        switch_name,
-        hass,
-        use_mock_hub,
-        {
-            CONF_COILS: [
-                {CONF_NAME: switch_name, CALL_TYPE_COIL: 1234, CONF_SLAVE: 1},
-            ]
-        },
-        SWITCH_DOMAIN,
-        scan_interval,
-    )
-
-    await run_base_read_test(
-        entity_id,
-        hass,
-        use_mock_hub,
-        CALL_TYPE_COIL,
-        value,
-        expected,
-        now + timedelta(seconds=scan_interval + 1),
-    )
-
-
 @pytest.mark.parametrize(
     "regs,expected",
     [
         (
             [0x00],
+            STATE_OFF,
+        ),
+        (
+            [0x80],
+            STATE_OFF,
+        ),
+        (
+            [0xFE],
             STATE_OFF,
         ),
         (
@@ -59,10 +39,28 @@ async def run_sensor_test(hass, use_mock_hub, value, expected):
     ],
 )
 async def test_coil_switch(hass, mock_hub, regs, expected):
-    """Test reading of switch coil."""
-    await run_sensor_test(
+    """Run test for given config."""
+    switch_name = "modbus_test_switch"
+    scan_interval = 5
+    entity_id, now, device = await setup_base_test(
+        switch_name,
         hass,
         mock_hub,
+        {
+            CONF_COILS: [
+                {CONF_NAME: switch_name, CALL_TYPE_COIL: 1234, CONF_SLAVE: 1},
+            ]
+        },
+        SWITCH_DOMAIN,
+        scan_interval,
+    )
+
+    await run_base_read_test(
+        entity_id,
+        hass,
+        mock_hub,
+        CALL_TYPE_COIL,
         regs,
         expected,
+        now + timedelta(seconds=scan_interval + 1),
     )


### PR DESCRIPTION
When a register is of type bool modbus returns a whole byte, but ONLY the
lowest bit determine true/false.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When reading a bool from modbus a byte is returned, however ONLY the lowest bit are to be considered.

Corrected read routines and added test cases.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
fixes Not filed since I detected the issue.
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [x ] I have followed the [development checklist][dev-checklist]
- [x ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
