### PR TITLE
Fix Plugwise hvac action and mode

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -114,10 +114,9 @@ class PwThermostat(SmileGateway, ClimateEntity):
             if self._cooling_state:
                 return CURRENT_HVAC_COOL
             return CURRENT_HVAC_IDLE
-        if self._heating_state is not None:
-            if self._setpoint > self._temperature:
-                return CURRENT_HVAC_HEAT
-            return CURRENT_HVAC_IDLE
+        if self._setpoint > self._temperature:
+            return CURRENT_HVAC_HEAT
+        return CURRENT_HVAC_IDLE
 
     @property
     def supported_features(self):
@@ -142,10 +141,9 @@ class PwThermostat(SmileGateway, ClimateEntity):
     @property
     def hvac_modes(self):
         """Return the available hvac modes list."""
-        if self._heating_state is not None:
-            if self._compressor_state is not None:
-                return HVAC_MODES_HEAT_COOL
-            return HVAC_MODES_HEAT_ONLY
+        if self._compressor_state is not None:
+            return HVAC_MODES_HEAT_COOL
+        return HVAC_MODES_HEAT_ONLY
 
     @property
     def hvac_mode(self):
@@ -263,11 +261,11 @@ class PwThermostat(SmileGateway, ClimateEntity):
         if heater_central_data.get("compressor_state") is not None:
             self._compressor_state = heater_central_data["compressor_state"]
 
+        self._hvac_mode = HVAC_MODE_HEAT
+        if self._compressor_state is not None:
+            self._hvac_mode = HVAC_MODE_HEAT_COOL
+
         if self._schema_status:
             self._hvac_mode = HVAC_MODE_AUTO
-        elif self._heating_state is not None:
-            self._hvac_mode = HVAC_MODE_HEAT
-            if self._compressor_state is not None:
-                self._hvac_mode = HVAC_MODE_HEAT_COOL
 
         self.async_write_ha_state()

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["Plugwise_Smile==1.5.1"],
+  "requirements": ["Plugwise_Smile==1.6.0"],
   "codeowners": ["@CoMPaTech", "@bouwew"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -26,7 +26,7 @@ Mastodon.py==1.5.1
 OPi.GPIO==0.4.0
 
 # homeassistant.components.plugwise
-Plugwise_Smile==1.5.1
+Plugwise_Smile==1.6.0
 
 # homeassistant.components.essent
 PyEssent==0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 HAP-python==3.0.0
 
 # homeassistant.components.plugwise
-Plugwise_Smile==1.5.1
+Plugwise_Smile==1.6.0
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -80,49 +80,6 @@ def mock_smile_adam():
             return_value=True
         )
         smile_mock.return_value.single_master_thermostat.side_effect = Mock(
-            return_value=True
-        )
-        smile_mock.return_value.set_schedule_state.side_effect = AsyncMock(
-            return_value=True
-        )
-        smile_mock.return_value.set_preset.side_effect = AsyncMock(return_value=True)
-        smile_mock.return_value.set_temperature.side_effect = AsyncMock(
-            return_value=True
-        )
-        smile_mock.return_value.set_relay_state.side_effect = AsyncMock(
-            return_value=True
-        )
-
-        smile_mock.return_value.get_all_devices.return_value = _read_json(
-            chosen_env, "get_all_devices"
-        )
-        smile_mock.return_value.get_device_data.side_effect = partial(
-            _get_device_data, chosen_env
-        )
-
-        yield smile_mock.return_value
-
-
-@pytest.fixture(name="mock_smile_adam_non_smt")
-def mock_smile_adam_non_smt():
-    """Create a Mock Adam environment for testing exceptions."""
-    chosen_env = "adam_multiple_devices_per_zone"
-    with patch("homeassistant.components.plugwise.gateway.Smile") as smile_mock:
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
-        smile_mock.XMLDataMissingError = Smile.XMLDataMissingError
-
-        smile_mock.return_value.gateway_id = "fe799307f1624099878210aa0b9f1475"
-        smile_mock.return_value.heater_id = "90986d591dcd426cae3ec3e8111ff730"
-        smile_mock.return_value.smile_version = "3.0.15"
-        smile_mock.return_value.smile_type = "thermostat"
-        smile_mock.return_value.smile_hostname = "smile98765"
-
-        smile_mock.return_value.connect.side_effect = AsyncMock(return_value=True)
-        smile_mock.return_value.full_update_device.side_effect = AsyncMock(
-            return_value=True
-        )
-        smile_mock.return_value.single_master_thermostat.side_effect = Mock(
             return_value=False
         )
         smile_mock.return_value.set_schedule_state.side_effect = AsyncMock(

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -103,6 +103,49 @@ def mock_smile_adam():
         yield smile_mock.return_value
 
 
+@pytest.fixture(name="mock_smile_adam_non_smt")
+def mock_smile_adam_non_smt():
+    """Create a Mock Adam environment for testing exceptions."""
+    chosen_env = "adam_multiple_devices_per_zone"
+    with patch("homeassistant.components.plugwise.gateway.Smile") as smile_mock:
+        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
+        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
+        smile_mock.XMLDataMissingError = Smile.XMLDataMissingError
+
+        smile_mock.return_value.gateway_id = "fe799307f1624099878210aa0b9f1475"
+        smile_mock.return_value.heater_id = "90986d591dcd426cae3ec3e8111ff730"
+        smile_mock.return_value.smile_version = "3.0.15"
+        smile_mock.return_value.smile_type = "thermostat"
+        smile_mock.return_value.smile_hostname = "smile98765"
+
+        smile_mock.return_value.connect.side_effect = AsyncMock(return_value=True)
+        smile_mock.return_value.full_update_device.side_effect = AsyncMock(
+            return_value=True
+        )
+        smile_mock.return_value.single_master_thermostat.side_effect = Mock(
+            return_value=False
+        )
+        smile_mock.return_value.set_schedule_state.side_effect = AsyncMock(
+            return_value=True
+        )
+        smile_mock.return_value.set_preset.side_effect = AsyncMock(return_value=True)
+        smile_mock.return_value.set_temperature.side_effect = AsyncMock(
+            return_value=True
+        )
+        smile_mock.return_value.set_relay_state.side_effect = AsyncMock(
+            return_value=True
+        )
+
+        smile_mock.return_value.get_all_devices.return_value = _read_json(
+            chosen_env, "get_all_devices"
+        )
+        smile_mock.return_value.get_device_data.side_effect = partial(
+            _get_device_data, chosen_env
+        )
+
+        yield smile_mock.return_value
+
+
 @pytest.fixture(name="mock_smile_anna")
 def mock_smile_anna():
     """Create a Mock Anna environment for testing exceptions."""

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -13,7 +13,7 @@ async def test_adam_climate_entity_attributes(hass, mock_smile_adam):
     state = hass.states.get("climate.zone_lisa_wk")
     attrs = state.attributes
 
-    assert attrs["hvac_modes"] is None
+    assert attrs["hvac_modes"] == ["heat", "auto"]
 
     assert "preset_modes" in attrs
     assert "no_frost" in attrs["preset_modes"]
@@ -29,7 +29,7 @@ async def test_adam_climate_entity_attributes(hass, mock_smile_adam):
     state = hass.states.get("climate.zone_thermostat_jessie")
     attrs = state.attributes
 
-    assert attrs["hvac_modes"] is None
+    assert attrs["hvac_modes"] == ["heat", "auto"]
 
     assert "preset_modes" in attrs
     assert "no_frost" in attrs["preset_modes"]

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -41,6 +41,22 @@ async def test_adam_climate_entity_attributes(hass, mock_smile_adam):
     assert attrs["preset_mode"] == "asleep"
 
 
+async def test_adam_non_smt_climate_entity_attributes(hass, mock_smile_adam_non_smt):
+    """Test creation of adam climate device environment."""
+    entry = await async_init_integration(hass, mock_smile_adam_non_smt)
+    assert entry.state == ENTRY_STATE_LOADED
+
+    state = hass.states.get("climate.zone_lisa_wk")
+    attrs = state.attributes
+
+    assert attrs["hvac_modes"] == ["heat", "auto"]
+
+    state = hass.states.get("climate.zone_thermostat_jessie")
+    attrs = state.attributes
+
+    assert attrs["hvac_modes"] == ["heat", "auto"]
+
+
 async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
     """Test handling of user requests in adam climate device environment."""
     entry = await async_init_integration(hass, mock_smile_adam)

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -41,22 +41,6 @@ async def test_adam_climate_entity_attributes(hass, mock_smile_adam):
     assert attrs["preset_mode"] == "asleep"
 
 
-async def test_adam_non_smt_climate_entity_attributes(hass, mock_smile_adam_non_smt):
-    """Test creation of adam climate device environment."""
-    entry = await async_init_integration(hass, mock_smile_adam_non_smt)
-    assert entry.state == ENTRY_STATE_LOADED
-
-    state = hass.states.get("climate.zone_lisa_wk")
-    attrs = state.attributes
-
-    assert attrs["hvac_modes"] == ["heat", "auto"]
-
-    state = hass.states.get("climate.zone_thermostat_jessie")
-    attrs = state.attributes
-
-    assert attrs["hvac_modes"] == ["heat", "auto"]
-
-
 async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
     """Test handling of user requests in adam climate device environment."""
     entry = await async_init_integration(hass, mock_smile_adam)


### PR DESCRIPTION
## Proposed change
Small fixes from testers feedback applied including climate handling and state. With autumn and winter seasons coming climate systems are started again as such we incorporated forthcoming codefixes :) 

Version bump changes for module are accordingly and in the [changelog](https://github.com/plugwise/Plugwise-Smile/blob/master/CHANGELOG.md) of our module.

https://github.com/plugwise/Plugwise-Smile/releases/tag/1.6.0

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone
