### PR TITLE
0.116.2

### DIFF
--- a/homeassistant/components/arris_tg2492lg/manifest.json
+++ b/homeassistant/components/arris_tg2492lg/manifest.json
@@ -3,7 +3,7 @@
   "name": "Arris TG2492LG",
   "documentation": "https://www.home-assistant.io/integrations/arris_tg2492lg",
   "requirements": [
-    "arris-tg2492lg==1.0.0"
+    "arris-tg2492lg==1.1.0"
   ],
   "codeowners": [
     "@vanbalken"

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -136,7 +136,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             conditions = [
                 c.lower()
                 for c in data_class.get_monitored_conditions(module_id=module["_id"])
-                if c in SENSOR_TYPES
+                if c.lower() in SENSOR_TYPES
             ]
             for condition in conditions:
                 if f"{condition}_value" in SENSOR_TYPES:

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -136,6 +136,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             conditions = [
                 c.lower()
                 for c in data_class.get_monitored_conditions(module_id=module["_id"])
+                if c in SENSOR_TYPES
             ]
             for condition in conditions:
                 if f"{condition}_value" in SENSOR_TYPES:

--- a/homeassistant/components/omnilogic/sensor.py
+++ b/homeassistant/components/omnilogic/sensor.py
@@ -119,7 +119,7 @@ class OmniLogicTemperatureSensor(OmnilogicSensor):
         state = sensor_data
 
         if self._unit_type == "Metric":
-            hayward_state = round((hayward_state - 32) * 5 / 9, 1)
+            hayward_state = round((int(hayward_state) - 32) * 5 / 9, 1)
             hayward_unit_of_measure = TEMP_CELSIUS
 
         if int(sensor_data) == -1:

--- a/homeassistant/components/plant/group.py
+++ b/homeassistant/components/plant/group.py
@@ -1,0 +1,15 @@
+"""Describe group states."""
+
+
+from homeassistant.components.group import GroupIntegrationRegistry
+from homeassistant.const import STATE_OK, STATE_PROBLEM
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_describe_on_off_states(
+    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+) -> None:
+    """Describe group on off states."""
+    registry.on_off_states({STATE_PROBLEM}, STATE_OK)

--- a/homeassistant/components/poolsense/strings.json
+++ b/homeassistant/components/poolsense/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "PoolSense",
-        "description": "[%key:common::config_flow::description%]",
+        "description": "[%key:common::config_flow::description::confirm_setup%]",
         "data": {
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -137,7 +137,7 @@ EFFECTS_MAP = {
     EFFECT_POLICE2: yee_transitions.police2,
     EFFECT_CHRISTMAS: yee_transitions.christmas,
     EFFECT_RGB: yee_transitions.rgb,
-    EFFECT_RANDOM_LOOP: yee_transitions.randomloop,
+    EFFECT_RANDOM_LOOP: yee_transitions.random_loop,
     EFFECT_LSD: yee_transitions.lsd,
     EFFECT_SLOWDOWN: yee_transitions.slowdown,
 }
@@ -661,7 +661,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         elif effect in EFFECTS_MAP:
             flow = Flow(count=0, transitions=EFFECTS_MAP[effect]())
         elif effect == EFFECT_FAST_RANDOM_LOOP:
-            flow = Flow(count=0, transitions=yee_transitions.randomloop(duration=250))
+            flow = Flow(count=0, transitions=yee_transitions.random_loop(duration=250))
         elif effect == EFFECT_WHATSAPP:
             flow = Flow(count=2, transitions=yee_transitions.pulse(37, 211, 102))
         elif effect == EFFECT_FACEBOOK:

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
   "requirements": [
-    "yeelight==0.5.3"
+    "yeelight==0.5.4"
   ],
   "codeowners": [
     "@rytilahti",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 116
-PATCH_VERSION = "1"
+PATCH_VERSION = "2"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -275,7 +275,7 @@ aqualogic==1.0
 arcam-fmj==0.5.3
 
 # homeassistant.components.arris_tg2492lg
-arris-tg2492lg==1.0.0
+arris-tg2492lg==1.1.0
 
 # homeassistant.components.ampio
 asmog==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2295,7 +2295,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.yeelight
-yeelight==0.5.3
+yeelight==0.5.4
 
 # homeassistant.components.yeelightsunflower
 yeelightsunflower==0.0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1064,7 +1064,7 @@ wolf_smartset==0.1.6
 xmltodict==0.12.0
 
 # homeassistant.components.yeelight
-yeelight==0.5.3
+yeelight==0.5.4
 
 # homeassistant.components.zeroconf
 zeroconf==0.28.5

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1213,3 +1213,66 @@ async def test_group_that_references_two_types_of_groups(hass):
     assert hass.states.get("group.covers").state == "closed"
     assert hass.states.get("group.device_trackers").state == "home"
     assert hass.states.get("group.grouped_group").state == "on"
+
+
+async def test_plant_group(hass):
+    """Test plant states can be grouped."""
+
+    entity_ids = [
+        "plant.upstairs",
+        "plant.downstairs",
+    ]
+
+    assert await async_setup_component(
+        hass,
+        "plant",
+        {
+            "plant": {
+                "plantname": {
+                    "sensors": {
+                        "moisture": "sensor.mqtt_plant_moisture",
+                        "battery": "sensor.mqtt_plant_battery",
+                        "temperature": "sensor.mqtt_plant_temperature",
+                        "conductivity": "sensor.mqtt_plant_conductivity",
+                        "brightness": "sensor.mqtt_plant_brightness",
+                    },
+                    "min_moisture": 20,
+                    "max_moisture": 60,
+                    "min_battery": 17,
+                    "min_conductivity": 500,
+                    "min_temperature": 15,
+                    "min_brightness": 500,
+                }
+            }
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "plants": {"entities": entity_ids},
+                "plant_with_binary_sensors": {
+                    "entities": [*entity_ids, "binary_sensor.planter"]
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("binary_sensor.planter", "off")
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "ok")
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("group.plants").state == "ok"
+    assert hass.states.get("group.plant_with_binary_sensors").state == "off"
+
+    hass.states.async_set("binary_sensor.planter", "on")
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "problem")
+
+    await hass.async_block_till_done()
+    assert hass.states.get("group.plants").state == "problem"
+    assert hass.states.get("group.plant_with_binary_sensors").state == "on"


### PR DESCRIPTION
- Fix Netatmo non specified sensor types ([@cgtobi] - [#41517]) ([netatmo docs])
- Update Arris TG2492LG dependency version ([@vanbalken] - [#41465]) ([arris_tg2492lg docs])
- Fix omnilogic temperature sensor with metric setting ([@djtimca] - [#41509]) ([omnilogic docs])
- Restore group support to plant entities ([@bdraco] - [#41519]) ([group docs]) ([plant docs])
- Bump yeelight to 0.5.4 ([@shenxn] - [#41524]) ([yeelight docs])
- Fix description reference in PoolSense config flow ([@bieniu] - [#41535]) ([poolsense docs])
- Fix missing weather sensors ([@cgtobi] - [#41540]) ([netatmo docs])

[#41465]: https://github.com/home-assistant/core/pull/41465
[#41509]: https://github.com/home-assistant/core/pull/41509
[#41517]: https://github.com/home-assistant/core/pull/41517
[#41519]: https://github.com/home-assistant/core/pull/41519
[#41524]: https://github.com/home-assistant/core/pull/41524
[#41535]: https://github.com/home-assistant/core/pull/41535
[#41540]: https://github.com/home-assistant/core/pull/41540
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@cgtobi]: https://github.com/cgtobi
[@djtimca]: https://github.com/djtimca
[@shenxn]: https://github.com/shenxn
[@vanbalken]: https://github.com/vanbalken
[arris_tg2492lg docs]: https://www.home-assistant.io/integrations/arris_tg2492lg/
[group docs]: https://www.home-assistant.io/integrations/group/
[netatmo docs]: https://www.home-assistant.io/integrations/netatmo/
[omnilogic docs]: https://www.home-assistant.io/integrations/omnilogic/
[plant docs]: https://www.home-assistant.io/integrations/plant/
[poolsense docs]: https://www.home-assistant.io/integrations/poolsense/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/