### PR TITLE
Add the Feature of Reordering Shopping List by Moving Up or Down an Item

### DIFF
--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -311,3 +311,386 @@ async def test_ws_add_item_fail(hass, hass_ws_client, sl_setup):
     msg = await client.receive_json()
     assert msg["success"] is False
     assert len(hass.data["shopping_list"].items) == 0
+
+
+async def test_api_move_up_down_item_basic(hass, hass_client, sl_setup):
+    """Test moving up and down shopping_list item API."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+
+    client = await hass_client()
+
+    resp = await client.post(f"/api/shopping_list/item/{wine_id}/move_up")
+    assert resp.status == 200
+    assert hass.data["shopping_list"].items[0] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+
+    resp = await client.post(f"/api/shopping_list/item/{wine_id}/move_down")
+    assert resp.status == 200
+    assert hass.data["shopping_list"].items[0] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+
+
+async def test_api_move_up_item_complex_case(hass, hass_client, sl_setup):
+    """Test moving up shopping_list item API."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "apple"}}
+    )
+
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+    apple_id = hass.data["shopping_list"].items[2]["id"]
+
+    client = await hass_client()
+
+    # Mark wine as completed.
+    resp = await client.post(
+        f"/api/shopping_list/item/{wine_id}", json={"complete": True}
+    )
+
+    # The item apple should be moved from index 2 all the way up to index 0.
+    resp = await client.post(f"/api/shopping_list/item/{apple_id}/move_up")
+    assert resp.status == 200
+    assert hass.data["shopping_list"].items[0] == {
+        "id": apple_id,
+        "name": "apple",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[2] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": True,
+    }
+
+
+async def test_api_move_down_item_complex_case(hass, hass_client, sl_setup):
+    """Test moving down shopping_list item API."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "apple"}}
+    )
+
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+    apple_id = hass.data["shopping_list"].items[2]["id"]
+
+    client = await hass_client()
+
+    # Mark wine as completed.
+    resp = await client.post(
+        f"/api/shopping_list/item/{wine_id}", json={"complete": True}
+    )
+
+    # The item beer should be moved from index 0 all the way down to index 2.
+    resp = await client.post(f"/api/shopping_list/item/{beer_id}/move_down")
+    assert resp.status == 200
+    assert hass.data["shopping_list"].items[0] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": True,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": apple_id,
+        "name": "apple",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[2] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+
+
+async def test_api_move_up_down_item_fail(hass, hass_client, sl_setup):
+    """Test moving up and down shopping_list item API."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+
+    client = await hass_client()
+
+    resp = await client.post("/api/shopping_list/item/BAD_ID/move_up")
+    assert resp.status == 404
+
+    resp = await client.post(f"/api/shopping_list/item/{beer_id}/move_up")
+    # The item 'beer' is already at the top, api should return 400 and the list order shouldn't change.
+    assert resp.status == 400
+    assert hass.data["shopping_list"].items[0] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+
+    resp = await client.post(f"/api/shopping_list/item/{wine_id}/move_down")
+    # The item 'wine' is already at the top, api should return 400 and the list order shouldn't change.
+    assert resp.status == 400
+    assert hass.data["shopping_list"].items[0] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+
+
+async def test_ws_move_up_down_item_basic(hass, hass_ws_client, sl_setup):
+    """Test moving up and down shopping_list item websocket command."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 7, "type": "shopping_list/items/move_up", "item_id": wine_id}
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is True
+    assert hass.data["shopping_list"].items[0] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+
+    await client.send_json(
+        {"id": 8, "type": "shopping_list/items/move_down", "item_id": wine_id}
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is True
+    assert hass.data["shopping_list"].items[0] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+
+
+async def test_ws_move_up_item_complex_case(hass, hass_ws_client, sl_setup):
+    """Test moving up and down shopping_list item websocket command."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "apple"}}
+    )
+
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+    apple_id = hass.data["shopping_list"].items[2]["id"]
+
+    client = await hass_ws_client(hass)
+
+    # Mark wine as completed.
+    await client.send_json(
+        {
+            "id": 9,
+            "type": "shopping_list/items/update",
+            "item_id": wine_id,
+            "complete": True,
+        }
+    )
+    _ = await client.receive_json()
+
+    # The item apple should be moved from index 2 all the way up to index 0.
+    await client.send_json(
+        {"id": 10, "type": "shopping_list/items/move_up", "item_id": apple_id}
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is True
+    assert hass.data["shopping_list"].items[0] == {
+        "id": apple_id,
+        "name": "apple",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[2] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": True,
+    }
+
+
+async def test_ws_move_down_item_complex_case(hass, hass_ws_client, sl_setup):
+    """Test the API."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "apple"}}
+    )
+
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+    apple_id = hass.data["shopping_list"].items[2]["id"]
+
+    client = await hass_ws_client(hass)
+
+    # Mark wine as completed.
+    await client.send_json(
+        {
+            "id": 11,
+            "type": "shopping_list/items/update",
+            "item_id": wine_id,
+            "complete": True,
+        }
+    )
+    _ = await client.receive_json()
+
+    # The item beer should be moved from index 0 all the way down to index 2.
+    await client.send_json(
+        {"id": 12, "type": "shopping_list/items/move_down", "item_id": beer_id}
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is True
+    assert hass.data["shopping_list"].items[0] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": True,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": apple_id,
+        "name": "apple",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[2] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+
+
+async def test_ws_move_up_down_item_fail(hass, hass_ws_client, sl_setup):
+    """Test moving up and down shopping_list item websocket command."""
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 13, "type": "shopping_list/items/move_up", "item_id": "BAD_ID"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is False
+
+    await client.send_json(
+        {"id": 14, "type": "shopping_list/items/move_up", "item_id": beer_id}
+    )
+    msg = await client.receive_json()
+    # The item 'beer' is already at the top, the ws message should be failure and the list order should be the same.
+    assert msg["success"] is False
+    assert hass.data["shopping_list"].items[0] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+
+    await client.send_json(
+        {"id": 15, "type": "shopping_list/items/move_down", "item_id": wine_id}
+    )
+    msg = await client.receive_json()
+    # The item 'beer' is already at the top, the ws message should be failure and the list order should be the same.
+    assert msg["success"] is False
+    assert hass.data["shopping_list"].items[0] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding the feature of recording shopping list (the shopping list component) by adding the api and ws endpoints to move up or move down a shopping list item. 

The Frontend PR: https://github.com/home-assistant/frontend/pull/7281

![Kapture 2020-10-09 at 12 04 17](https://user-images.githubusercontent.com/7324708/95611563-9aad8f00-0a27-11eb-8ef0-ae466d27e663.gif)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [N/A] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [N/A] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [N/A] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [N/A] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
