### PR TITLE
Add support for reordering Shopping List Items via Drag and Drop

### DIFF
--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -203,7 +203,7 @@ class ShoppingData:
                 )
             new_items.append(all_items_mapping[key])
         self.items = new_items
-        self.hass.async_add_job(self.save)
+        self.hass.async_add_executor_job(self.save)
 
     async def async_load(self):
         """Load items."""

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -331,5 +331,7 @@ def websocket_handle_reorder(hass, connection, msg):
         )
     except vol.Invalid as err:
         connection.send_message(
-            websocket_api.error_message(msg_id, "bad_request", f"{err}")
+            websocket_api.error_message(
+                msg_id, websocket_api.const.ERR_INVALID_FORMAT, f"{err}"
+            )
         )

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -31,7 +31,6 @@ WS_TYPE_SHOPPING_LIST_ITEMS = "shopping_list/items"
 WS_TYPE_SHOPPING_LIST_ADD_ITEM = "shopping_list/items/add"
 WS_TYPE_SHOPPING_LIST_UPDATE_ITEM = "shopping_list/items/update"
 WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS = "shopping_list/items/clear"
-WS_TYPE_SHOPPING_LIST_REORDER_ITEMS = "shopping_list/items/reorder"
 
 SCHEMA_WEBSOCKET_ITEMS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
     {vol.Required("type"): WS_TYPE_SHOPPING_LIST_ITEMS}
@@ -52,13 +51,6 @@ SCHEMA_WEBSOCKET_UPDATE_ITEM = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
 
 SCHEMA_WEBSOCKET_CLEAR_ITEMS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
     {vol.Required("type"): WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS}
-)
-
-SCHEMA_WEBSOCKET_REORDER_ITEMS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
-    {
-        vol.Required("type"): WS_TYPE_SHOPPING_LIST_REORDER_ITEMS,
-        vol.Required("item_ids"): [str],
-    }
 )
 
 
@@ -136,11 +128,7 @@ async def async_setup_entry(hass, config_entry):
         SCHEMA_WEBSOCKET_CLEAR_ITEMS,
     )
 
-    hass.components.websocket_api.async_register_command(
-        WS_TYPE_SHOPPING_LIST_REORDER_ITEMS,
-        websocket_handle_reorder,
-        SCHEMA_WEBSOCKET_REORDER_ITEMS,
-    )
+    websocket_api.async_register_command(hass, websocket_handle_reorder)
 
     return True
 
@@ -322,7 +310,12 @@ def websocket_handle_clear(hass, connection, msg):
     connection.send_message(websocket_api.result_message(msg["id"]))
 
 
-@callback
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "shopping_list/items/reorder",
+        vol.Required("item_ids"): [str],
+    }
+)
 def websocket_handle_reorder(hass, connection, msg):
     """Handle reordering shopping_list items."""
     msg_id = msg.pop("id")

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -325,11 +325,9 @@ def websocket_handle_reorder(hass, connection, msg):
         connection.send_result(msg_id)
     except KeyError:
         connection.send_error(
-            msg_id, websocket_api.ERR_NOT_FOUND, "One or more item id(s) not found."
+            msg_id,
+            websocket_api.const.ERR_NOT_FOUND,
+            "One or more item id(s) not found.",
         )
     except vol.Invalid as err:
-        connection.send_message(
-            websocket_api.error_message(
-                msg_id, websocket_api.const.ERR_INVALID_FORMAT, f"{err}"
-            )
-        )
+        connection.send_error(msg_id, websocket_api.const.ERR_INVALID_FORMAT, f"{err}")

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -185,10 +185,10 @@ class ShoppingData:
         """Reorder items."""
         # The array for sorted items.
         new_items = []
-        all_items_mapping = dict((item["id"], item) for item in self.items)
+        all_items_mapping = {item["id"]: item for item in self.items}
         # Append items by the order of passed in array.
         for item_id in item_ids:
-            if not item_id in all_items_mapping:
+            if item_id not in all_items_mapping:
                 raise KeyError
             new_items.append(all_items_mapping[item_id])
             # Remove the item from mapping after it's appended in the result array.

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -322,12 +322,10 @@ def websocket_handle_reorder(hass, connection, msg):
     try:
         hass.data[DOMAIN].async_reorder(msg.pop("item_ids"))
         hass.bus.async_fire(EVENT, {"action": "reorder"})
-        connection.send_message(websocket_api.result_message(msg_id))
+        connection.send_result(msg_id)
     except KeyError:
-        connection.send_message(
-            websocket_api.error_message(
-                msg_id, "item_not_found", "One or more item id(s) not found."
-            )
+        connection.send_error(
+            msg_id, websocket_api.ERR_NOT_FOUND, "One or more item id(s) not found."
         )
     except vol.Invalid as err:
         connection.send_message(

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -1,6 +1,6 @@
 """Test shopping list component."""
 
-from homeassistant.components.websocket_api.const import TYPE_RESULT, ERR_INVALID_FORMAT
+from homeassistant.components.websocket_api.const import ERR_INVALID_FORMAT, TYPE_RESULT
 from homeassistant.const import HTTP_NOT_FOUND
 from homeassistant.helpers import intent
 

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -311,3 +311,125 @@ async def test_ws_add_item_fail(hass, hass_ws_client, sl_setup):
     msg = await client.receive_json()
     assert msg["success"] is False
     assert len(hass.data["shopping_list"].items) == 0
+
+
+async def test_ws_reorder_items(hass, hass_ws_client, sl_setup):
+    """Test reordering shopping_list items websocket command."""
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "apple"}}
+    )
+
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+    apple_id = hass.data["shopping_list"].items[2]["id"]
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 6,
+            "type": "shopping_list/items/reorder",
+            "item_ids": [wine_id, apple_id, beer_id],
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is True
+    assert hass.data["shopping_list"].items[0] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": apple_id,
+        "name": "apple",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[2] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+
+    # Mark wine as completed.
+    await client.send_json(
+        {
+            "id": 7,
+            "type": "shopping_list/items/update",
+            "item_id": wine_id,
+            "complete": True,
+        }
+    )
+    _ = await client.receive_json()
+
+    await client.send_json(
+        {
+            "id": 8,
+            "type": "shopping_list/items/reorder",
+            "item_ids": [apple_id, beer_id],
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is True
+    assert hass.data["shopping_list"].items[0] == {
+        "id": apple_id,
+        "name": "apple",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[1] == {
+        "id": beer_id,
+        "name": "beer",
+        "complete": False,
+    }
+    assert hass.data["shopping_list"].items[2] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": True,
+    }
+
+
+async def test_ws_reorder_items_failure(hass, hass_ws_client, sl_setup):
+    """Test reordering shopping_list items websocket command."""
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "wine"}}
+    )
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "apple"}}
+    )
+
+    beer_id = hass.data["shopping_list"].items[0]["id"]
+    wine_id = hass.data["shopping_list"].items[1]["id"]
+    apple_id = hass.data["shopping_list"].items[2]["id"]
+
+    client = await hass_ws_client(hass)
+
+    # Testing sending bad item id.
+    await client.send_json(
+        {
+            "id": 8,
+            "type": "shopping_list/items/reorder",
+            "item_ids": [wine_id, apple_id, beer_id, "BAD_ID"],
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is False
+    assert msg["error"]["code"] == "item_not_found"
+
+    # Testing not sending all unchecked item ids.
+    await client.send_json(
+        {
+            "id": 9,
+            "type": "shopping_list/items/reorder",
+            "item_ids": [wine_id, apple_id],
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"] is False
+    assert msg["error"]["code"] == "bad_request"

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -1,6 +1,10 @@
 """Test shopping list component."""
 
-from homeassistant.components.websocket_api.const import ERR_INVALID_FORMAT, TYPE_RESULT
+from homeassistant.components.websocket_api.const import (
+    ERR_INVALID_FORMAT,
+    ERR_NOT_FOUND,
+    TYPE_RESULT,
+)
 from homeassistant.const import HTTP_NOT_FOUND
 from homeassistant.helpers import intent
 
@@ -420,7 +424,7 @@ async def test_ws_reorder_items_failure(hass, hass_ws_client, sl_setup):
     )
     msg = await client.receive_json()
     assert msg["success"] is False
-    assert msg["error"]["code"] == "item_not_found"
+    assert msg["error"]["code"] == ERR_NOT_FOUND
 
     # Testing not sending all unchecked item ids.
     await client.send_json(

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -1,6 +1,6 @@
 """Test shopping list component."""
 
-from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.components.websocket_api.const import TYPE_RESULT, ERR_INVALID_FORMAT
 from homeassistant.const import HTTP_NOT_FOUND
 from homeassistant.helpers import intent
 
@@ -432,4 +432,4 @@ async def test_ws_reorder_items_failure(hass, hass_ws_client, sl_setup):
     )
     msg = await client.receive_json()
     assert msg["success"] is False
-    assert msg["error"]["code"] == "bad_request"
+    assert msg["error"]["code"] == ERR_INVALID_FORMAT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding reordering shopping list items web socket  to support drag and drop in shopping list card.

The drag and drop front end pr: https://github.com/home-assistant/frontend/pull/7296

![Kapture 2020-10-10 at 01 25 26](https://user-images.githubusercontent.com/7324708/95647752-84d7b280-0a97-11eb-81b8-b5db05d7ab87.gif)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [N/A] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [N/A] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [N/A] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [N/A] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
