### PR TITLE
Add common strings in ps4 config flow

### DIFF
--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -139,7 +139,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
                 # If list is empty then all devices are configured.
                 if not self.device_list:
-                    return self.async_abort(reason="devices_configured")
+                    return self.async_abort(reason="already_configured_device")
 
         # Login to PS4 with user data.
         if user_input is not None:
@@ -154,7 +154,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             )
 
             if is_ready is False:
-                errors["base"] = "not_ready"
+                errors["base"] = "cannot_connect"
             elif is_login is False:
                 errors["base"] = "login_failed"
             else:

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -139,7 +139,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
                 # If list is empty then all devices are configured.
                 if not self.device_list:
-                    return self.async_abort(reason="already_configured_device")
+                    return self.async_abort(reason="already_configured")
 
         # Login to PS4 with user data.
         if user_input is not None:

--- a/homeassistant/components/ps4/strings.json
+++ b/homeassistant/components/ps4/strings.json
@@ -7,7 +7,7 @@
       },
       "mode": {
         "title": "PlayStation 4",
-        "description": "Select mode for configuration. The IP Address field can be left blank if selecting Auto Discovery, as devices will be automatically discovered.",
+        "description": "Select mode for configuration. The [%key:common::config_flow::data::ip%] field can be left blank if selecting Auto Discovery, as devices will be automatically discovered.",
         "data": {
           "mode": "Config Mode",
           "ip_address": "[%key:common::config_flow::data::ip%] (Leave empty if using Auto Discovery)."
@@ -27,8 +27,8 @@
     "error": {
       "credential_timeout": "Credential service timed out. Press submit to restart.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "login_failed": "Failed to pair to PlayStation 4. Verify PIN is correct.",
-      "no_ipaddress": "Enter the IP Address of the PlayStation 4 you would like to configure."
+      "login_failed": "Failed to pair to PlayStation 4. Verify [%key:common::config_flow::data::pin%] is correct.",
+      "no_ipaddress": "Enter the [%key:common::config_flow::data::ip%] of the PlayStation 4 you would like to configure."
     },
     "abort": {
       "credential_error": "Error fetching credentials.",

--- a/homeassistant/components/ps4/strings.json
+++ b/homeassistant/components/ps4/strings.json
@@ -15,7 +15,7 @@
       },
       "link": {
         "title": "PlayStation 4",
-        "description": "[%key:common::config_flow::data::pin%]",
+        "description": "Enter your PlayStation 4 information. For [%key:common::config_flow::data::pin%], navigate to 'Settings' on your PlayStation 4 console. Then navigate to 'Mobile App Connection Settings' and select 'Add Device'. Enter the [%key:common::config_flow::data::pin%] that is displayed. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
         "data": {
           "region": "Region",
           "name": "[%key:common::config_flow::data::name%]",

--- a/homeassistant/components/ps4/strings.json
+++ b/homeassistant/components/ps4/strings.json
@@ -26,14 +26,14 @@
     },
     "error": {
       "credential_timeout": "Credential service timed out. Press submit to restart.",
-      "not_ready": "PlayStation 4 is not on or connected to network.",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "login_failed": "Failed to pair to PlayStation 4. Verify PIN is correct.",
       "no_ipaddress": "Enter the IP Address of the PlayStation 4 you would like to configure."
     },
     "abort": {
       "credential_error": "Error fetching credentials.",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-      "devices_configured": "All devices found are already configured.",
+      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",
       "port_987_bind_error": "Could not bind to port 987. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
       "port_997_bind_error": "Could not bind to port 997. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info."
     }

--- a/homeassistant/components/ps4/strings.json
+++ b/homeassistant/components/ps4/strings.json
@@ -15,7 +15,7 @@
       },
       "link": {
         "title": "PlayStation 4",
-        "description": "Enter your PlayStation 4 information. For 'PIN', navigate to 'Settings' on your PlayStation 4 console. Then navigate to 'Mobile App Connection Settings' and select 'Add Device'. Enter the PIN that is displayed. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
+        "description": "[%key:common::config_flow::data::pin%]",
         "data": {
           "region": "Region",
           "name": "[%key:common::config_flow::data::name%]",
@@ -33,7 +33,7 @@
     "abort": {
       "credential_error": "Error fetching credentials.",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "port_987_bind_error": "Could not bind to port 987. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
       "port_997_bind_error": "Could not bind to port 997. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info."
     }

--- a/homeassistant/components/ps4/strings.json
+++ b/homeassistant/components/ps4/strings.json
@@ -10,7 +10,7 @@
         "description": "Select mode for configuration. The IP Address field can be left blank if selecting Auto Discovery, as devices will be automatically discovered.",
         "data": {
           "mode": "Config Mode",
-          "ip_address": "IP Address (Leave empty if using Auto Discovery)."
+          "ip_address": "[%key:common::config_flow::data::ip%] (Leave empty if using Auto Discovery)."
         }
       },
       "link": {
@@ -19,7 +19,7 @@
         "data": {
           "region": "Region",
           "name": "[%key:common::config_flow::data::name%]",
-          "code": "PIN",
+          "code": "[%key:common::config_flow::data::pin%]",
           "ip_address": "[%key:common::config_flow::data::ip%]"
         }
       }
@@ -32,7 +32,7 @@
     },
     "abort": {
       "credential_error": "Error fetching credentials.",
-      "no_devices_found": "No PlayStation 4 devices found on the network.",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "devices_configured": "All devices found are already configured.",
       "port_987_bind_error": "Could not bind to port 987. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
       "port_997_bind_error": "Could not bind to port 997. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info."

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -284,7 +284,7 @@ async def test_duplicate_abort(hass):
             result["flow_id"], user_input=MOCK_AUTO
         )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured_device"
+    assert result["reason"] == "already_configured"
 
 
 async def test_additional_device(hass):

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -284,7 +284,7 @@ async def test_duplicate_abort(hass):
             result["flow_id"], user_input=MOCK_AUTO
         )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "devices_configured"
+    assert result["reason"] == "already_configured_device"
 
 
 async def test_additional_device(hass):
@@ -515,7 +515,7 @@ async def test_device_connection_error(hass):
         )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"
-    assert result["errors"] == {"base": "not_ready"}
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_manual_mode_no_ip_error(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add missing common string in ps4 config flow as described in #40578.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40578 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
