### PR TITLE
Add configurable reconnect interval to esphome

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -7,7 +7,13 @@ import voluptuous as vol
 
 from homeassistant.components import zeroconf
 from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, ConfigFlow
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -26,6 +32,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         """Initialize flow."""
         self._host: Optional[str] = None
         self._port: Optional[int] = None
+        self._interval: Optional[int] = None
         self._password: Optional[str] = None
 
     async def async_step_user(
@@ -38,6 +45,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         fields = OrderedDict()
         fields[vol.Required(CONF_HOST, default=self._host or vol.UNDEFINED)] = str
         fields[vol.Optional(CONF_PORT, default=self._port or 6053)] = int
+        fields[vol.Optional(CONF_SCAN_INTERVAL, default=self._interval or 0)] = int
 
         errors = {}
         if error is not None:
@@ -63,6 +71,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return
         self._host = user_input[CONF_HOST]
         self._port = user_input[CONF_PORT]
+        self._interval = user_input[CONF_SCAN_INTERVAL]
 
     async def _async_authenticate_or_add(self, user_input):
         self._set_user_input(user_input)
@@ -128,6 +137,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self._host = discovery_info[CONF_HOST]
         self._port = discovery_info[CONF_PORT]
+        self._interval = 0
         self._name = node_name
 
         return await self.async_step_discovery_confirm()
@@ -139,6 +149,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             data={
                 CONF_HOST: self._host,
                 CONF_PORT: self._port,
+                CONF_SCAN_INTERVAL: self._interval,
                 # The API uses protobuf, so empty string denotes absence
                 CONF_PASSWORD: self._password or "",
             },

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -13,7 +13,8 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "port": "[%key:common::config_flow::data::port%]",
+          "scan_interval": "Maximum reconnect interval in seconds, 0 for random"
         },
         "description": "Please enter connection settings of your [ESPHome](https://esphomelib.com/) node."
       },

--- a/homeassistant/components/esphome/translations/en.json
+++ b/homeassistant/components/esphome/translations/en.json
@@ -7,7 +7,6 @@
         "error": {
             "connection_error": "Can't connect to ESP. Please make sure your YAML file contains an 'api:' line.",
             "invalid_auth": "Invalid authentication",
-            "invalid_password": "Invalid password!",
             "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address: https://esphomelib.com/esphomeyaml/components/wifi.html#manual-ips"
         },
         "flow_title": "ESPHome: {name}",
@@ -25,7 +24,8 @@
             "user": {
                 "data": {
                     "host": "Host",
-                    "port": "Port"
+                    "port": "Port",
+                    "scan_interval": "Reconnect interval in seconds, 0 for random"
                 },
                 "description": "Please enter connection settings of your [ESPHome](https://esphomelib.com/) node."
             }

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import pytest
 
 from homeassistant.components.esphome import DATA_KEY
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_CREATE_ENTRY,
@@ -63,11 +63,16 @@ async def test_user_connection_works(hass, mock_client):
     result = await hass.config_entries.flow.async_init(
         "esphome",
         context={"source": "user"},
-        data={CONF_HOST: "127.0.0.1", CONF_PORT: 80},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 80, CONF_SCAN_INTERVAL: 0},
     )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["data"] == {CONF_HOST: "127.0.0.1", CONF_PORT: 80, CONF_PASSWORD: ""}
+    assert result["data"] == {
+        CONF_HOST: "127.0.0.1",
+        CONF_PORT: 80,
+        CONF_PASSWORD: "",
+        CONF_SCAN_INTERVAL: 0,
+    }
     assert result["title"] == "test"
 
     assert len(mock_client.connect.mock_calls) == 1
@@ -96,7 +101,7 @@ async def test_user_resolve_error(hass, mock_api_connection_error, mock_client):
         result = await hass.config_entries.flow.async_init(
             "esphome",
             context={"source": "user"},
-            data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+            data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053, CONF_SCAN_INTERVAL: 0},
         )
 
     assert result["type"] == RESULT_TYPE_FORM
@@ -115,7 +120,7 @@ async def test_user_connection_error(hass, mock_api_connection_error, mock_clien
     result = await hass.config_entries.flow.async_init(
         "esphome",
         context={"source": "user"},
-        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053, CONF_SCAN_INTERVAL: 0},
     )
 
     assert result["type"] == RESULT_TYPE_FORM
@@ -134,7 +139,7 @@ async def test_user_with_password(hass, mock_client):
     result = await hass.config_entries.flow.async_init(
         "esphome",
         context={"source": "user"},
-        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053, CONF_SCAN_INTERVAL: 0},
     )
 
     assert result["type"] == RESULT_TYPE_FORM
@@ -149,6 +154,7 @@ async def test_user_with_password(hass, mock_client):
         CONF_HOST: "127.0.0.1",
         CONF_PORT: 6053,
         CONF_PASSWORD: "password1",
+        CONF_SCAN_INTERVAL: 0,
     }
     assert mock_client.password == "password1"
 
@@ -160,7 +166,7 @@ async def test_user_invalid_password(hass, mock_api_connection_error, mock_clien
     result = await hass.config_entries.flow.async_init(
         "esphome",
         context={"source": "user"},
-        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053, CONF_SCAN_INTERVAL: 0},
     )
 
     assert result["type"] == RESULT_TYPE_FORM


### PR DESCRIPTION
## Proposed change
This PR adds the ability to configure the maximum reconnect interval for homeassistant devices.
This is useful, when esphome nodes are periodically reconnected (e.g. on a switchable power source or while debugging), and the default waiting time until the device becomes available is to long.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
