### PR TITLE
Support HomeKit accessory mode

### DIFF
--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -20,11 +20,15 @@ from .const import (
     CONF_AUTO_START,
     CONF_ENTITY_CONFIG,
     CONF_FILTER,
+    CONF_HOMEKIT_MODE,
     CONF_SAFE_MODE,
     CONF_VIDEO_CODEC,
     DEFAULT_AUTO_START,
     DEFAULT_CONFIG_FLOW_PORT,
+    DEFAULT_HOMEKIT_MODE,
     DEFAULT_SAFE_MODE,
+    HOMEKIT_MODE_ACCESSORY,
+    HOMEKIT_MODES,
     SHORT_BRIDGE_NAME,
     VIDEO_CODEC_COPY,
 )
@@ -292,14 +296,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_INCLUDE_ENTITIES: [],
                 CONF_EXCLUDE_ENTITIES: [],
             }
+            if isinstance(user_input[CONF_ENTITIES], list):
+                entities = user_input[CONF_ENTITIES]
+            else:
+                entities = [user_input[CONF_ENTITIES]]
 
-            if user_input[CONF_INCLUDE_EXCLUDE_MODE] == MODE_INCLUDE:
-                entity_filter[CONF_INCLUDE_ENTITIES] = user_input[CONF_ENTITIES]
+            if (
+                self.homekit_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_ACCESSORY
+                or user_input[CONF_INCLUDE_EXCLUDE_MODE] == MODE_INCLUDE
+            ):
+                entity_filter[CONF_INCLUDE_ENTITIES] = entities
                 # Include all of the domain if there are no entities
                 # explicitly included as the user selected the domain
-                domains_with_entities_selected = _domains_set_from_entities(
-                    user_input[CONF_ENTITIES]
-                )
+                domains_with_entities_selected = _domains_set_from_entities(entities)
                 entity_filter[CONF_INCLUDE_DOMAINS] = [
                     domain
                     for domain in self.homekit_options[CONF_DOMAINS]
@@ -307,12 +316,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ]
 
                 for entity_id in list(self.included_cameras):
-                    if entity_id not in user_input[CONF_ENTITIES]:
+                    if entity_id not in entities:
                         self.included_cameras.remove(entity_id)
             else:
                 entity_filter[CONF_INCLUDE_DOMAINS] = self.homekit_options[CONF_DOMAINS]
-                entity_filter[CONF_EXCLUDE_ENTITIES] = user_input[CONF_ENTITIES]
-                for entity_id in user_input[CONF_ENTITIES]:
+                entity_filter[CONF_EXCLUDE_ENTITIES] = entities
+                for entity_id in entities:
                     if entity_id in self.included_cameras:
                         self.included_cameras.remove(entity_id)
 
@@ -335,26 +344,28 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             if entity_id.startswith("camera.")
         }
 
+        data_schema = {}
         entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
-        if entities:
-            include_exclude_mode = MODE_INCLUDE
+        if self.homekit_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_ACCESSORY:
+            entity_schema = vol.In
         else:
-            include_exclude_mode = MODE_EXCLUDE
-            entities = entity_filter.get(CONF_EXCLUDE_ENTITIES, [])
+            if entities:
+                include_exclude_mode = MODE_INCLUDE
+            else:
+                include_exclude_mode = MODE_EXCLUDE
+                entities = entity_filter.get(CONF_EXCLUDE_ENTITIES, [])
+            data_schema[
+                vol.Required(CONF_INCLUDE_EXCLUDE_MODE, default=include_exclude_mode)
+            ] = vol.In(INCLUDE_EXCLUDE_MODES)
+            entity_schema = cv.multi_select
 
-        data_schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_INCLUDE_EXCLUDE_MODE,
-                    default=include_exclude_mode,
-                ): vol.In(INCLUDE_EXCLUDE_MODES),
-                vol.Optional(
-                    CONF_ENTITIES,
-                    default=entities,
-                ): cv.multi_select(all_supported_entities),
-            }
+        data_schema[vol.Optional(CONF_ENTITIES, default=entities)] = entity_schema(
+            all_supported_entities
         )
-        return self.async_show_form(step_id="include_exclude", data_schema=data_schema)
+
+        return self.async_show_form(
+            step_id="include_exclude", data_schema=vol.Schema(data_schema)
+        )
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
@@ -368,6 +379,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.homekit_options = dict(self.config_entry.options)
         entity_filter = self.homekit_options.get(CONF_FILTER, {})
 
+        homekit_mode = self.homekit_options.get(CONF_HOMEKIT_MODE, DEFAULT_HOMEKIT_MODE)
         domains = entity_filter.get(CONF_INCLUDE_DOMAINS, [])
         include_entities = entity_filter.get(CONF_INCLUDE_ENTITIES)
         if include_entities:
@@ -375,10 +387,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         data_schema = vol.Schema(
             {
+                vol.Optional(CONF_HOMEKIT_MODE, default=homekit_mode): vol.In(
+                    HOMEKIT_MODES
+                ),
                 vol.Optional(
                     CONF_DOMAINS,
                     default=domains,
-                ): cv.multi_select(SUPPORTED_DOMAINS)
+                ): cv.multi_select(SUPPORTED_DOMAINS),
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -30,6 +30,7 @@ ATTR_SOFTWARE_VERSION = "sw_version"
 ATTR_KEY_NAME = "key_name"
 
 # #### Config ####
+CONF_HOMEKIT_MODE = "mode"
 CONF_ADVERTISE_IP = "advertise_ip"
 CONF_AUDIO_CODEC = "audio_codec"
 CONF_AUDIO_MAP = "audio_map"
@@ -85,6 +86,12 @@ FEATURE_TOGGLE_MUTE = "toggle_mute"
 # #### HomeKit Component Event ####
 EVENT_HOMEKIT_CHANGED = "homekit_state_change"
 EVENT_HOMEKIT_TV_REMOTE_KEY_PRESSED = "homekit_tv_remote_key_pressed"
+
+# #### HomeKit Modes ####
+HOMEKIT_MODE_ACCESSORY = "accessory"
+HOMEKIT_MODE_BRIDGE = "bridge"
+DEFAULT_HOMEKIT_MODE = HOMEKIT_MODE_BRIDGE
+HOMEKIT_MODES = [HOMEKIT_MODE_BRIDGE, HOMEKIT_MODE_ACCESSORY]
 
 # #### HomeKit Component Services ####
 SERVICE_HOMEKIT_START = "start"
@@ -283,4 +290,5 @@ CONFIG_OPTIONS = [
     CONF_AUTO_START,
     CONF_SAFE_MODE,
     CONF_ENTITY_CONFIG,
+    CONF_HOMEKIT_MODE,
 ]

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -1,5 +1,4 @@
 {
-    "title": "HomeKit",
     "options": {
         "step": {
             "yaml": {

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -1,25 +1,26 @@
 {
-    "title": "HomeKit Bridge",
+    "title": "HomeKit",
     "options": {
         "step": {
             "yaml": {
-                "title": "Adjust HomeKit Bridge Options",
+                "title": "Adjust HomeKit Options",
                 "description": "This entry is controlled via YAML"
             },
             "init": {
                 "data": {
+                    "mode": "Mode",
                     "include_domains": "[%key:component::homekit::config::step::user::data::include_domains%]"
                 },
-                "description": "Entities in the \u201cDomains to include\u201d will be bridged to HomeKit. You will be able to select which entities to include or exclude from this list on the next screen.",
-                "title": "Select domains to bridge."
+                "description": "HomeKit can be configured expose a bridge or a single accessory. In accessory mode, only a single entity can be used. Accessory mode is required for media players with the TV device class to function properly. Entities in the \u201cDomains to include\u201d will be exposed to HomeKit. You will be able to select which entities to include or exclude from this list on the next screen.",
+                "title": "Select domains to expose."
             },
             "include_exclude": {
                 "data": {
                     "mode": "Mode",
                     "entities": "Entities"
                 },
-                "description": "Choose the entities to be bridged. In include mode, all entities in the domain will be bridged unless specific entities are selected. In exclude mode, all entities in the domain will be bridged except for the excluded entities.",
-                "title": "Select entities to be bridged"
+                "description": "Choose the entities to be exposed. In accessory mode, only a single entity is exposed. In bridge include mode, all entities in the domain will be exposed unless specific entities are selected. In bridge exclude mode, all entities in the domain will be exposed except for the excluded entities.",
+                "title": "Select entities to be exposed"
             },
             "cameras": {
                 "data": {
@@ -33,7 +34,7 @@
                     "auto_start": "[%key:component::homekit::config::step::user::data::auto_start%]",
                     "safe_mode": "Safe Mode (enable only if pairing fails)"
                 },
-                "description": "These settings only need to be adjusted if the HomeKit bridge is not functional.",
+                "description": "These settings only need to be adjusted if HomeKit is not functional.",
                 "title": "Advanced Configuration"
             }
         }
@@ -45,16 +46,16 @@
                     "auto_start": "Autostart (disable if using Z-Wave or other delayed start system)",
                     "include_domains": "Domains to include"
                 },
-                "description": "A HomeKit Bridge will allow you to access your Home Assistant entities in HomeKit. HomeKit Bridges are limited to 150 accessories per instance including the bridge itself. If you wish to bridge more than the maximum number of accessories, it is recommended that you use multiple HomeKit bridges for different domains. Detailed entity configuration is only available via YAML for the primary bridge.",
-                "title": "Activate HomeKit Bridge"
+                "description": "The HomeKit integration will allow you to access your Home Assistant entities in HomeKit. In bridge mode, HomeKit Bridges are limited to 150 accessories per instance including the bridge itself. If you wish to bridge more than the maximum number of accessories, it is recommended that you use multiple HomeKit bridges for different domains. Detailed entity configuration is only available via YAML for the primary bridge.",
+                "title": "Activate HomeKit"
             },
             "pairing": {
-                "title": "Pair HomeKit Bridge",
-                "description": "As soon as the {name} bridge is ready, pairing will be available in \u201cNotifications\u201d as \u201cHomeKit Bridge Setup\u201d."
+                "title": "Pair HomeKit",
+                "description": "As soon as the {name} is ready, pairing will be available in \u201cNotifications\u201d as \u201cHomeKit Bridge Setup\u201d."
             }
         },
         "abort": {
-            "port_name_in_use": "A bridge with the same name or port is already configured."
+            "port_name_in_use": "An accessory or bridge with the same name or port is already configured."
         }
     }
 }

--- a/homeassistant/components/homekit/translations/en.json
+++ b/homeassistant/components/homekit/translations/en.json
@@ -1,25 +1,26 @@
 {
-    "title": "HomeKit Bridge",
+    "title": "HomeKit",
     "options": {
         "step": {
             "yaml": {
-                "title": "Adjust HomeKit Bridge Options",
+                "title": "Adjust HomeKit Options",
                 "description": "This entry is controlled via YAML"
             },
             "init": {
                 "data": {
+                    "mode": "Mode",
                     "include_domains": "[%key:component::homekit::config::step::user::data::include_domains%]"
                 },
-                "description": "Entities in the \u201cDomains to include\u201d will be bridged to HomeKit. You will be able to select which entities to include or exclude from this list on the next screen.",
-                "title": "Select domains to bridge."
+                "description": "HomeKit can be configured expose a bridge or a single accessory. In accessory mode, only a single entity can be used. Accessory mode is required for media players with the TV device class to function properly. Entities in the \u201cDomains to include\u201d will be exposed to HomeKit. You will be able to select which entities to include or exclude from this list on the next screen.",
+                "title": "Select domains to expose."
             },
             "include_exclude": {
                 "data": {
                     "mode": "Mode",
                     "entities": "Entities"
                 },
-                "description": "Choose the entities to be bridged. In include mode, all entities in the domain will be bridged unless specific entities are selected. In exclude mode, all entities in the domain will be bridged except for the excluded entities.",
-                "title": "Select entities to be bridged"
+                "description": "Choose the entities to be exposed. In accessory mode, only a single entity is exposed. In bridge include mode, all entities in the domain will be exposed unless specific entities are selected. In bridge exclude mode, all entities in the domain will be exposed except for the excluded entities.",
+                "title": "Select entities to be exposed"
             },
             "cameras": {
                 "data": {
@@ -33,7 +34,7 @@
                     "auto_start": "[%key:component::homekit::config::step::user::data::auto_start%]",
                     "safe_mode": "Safe Mode (enable only if pairing fails)"
                 },
-                "description": "These settings only need to be adjusted if the HomeKit bridge is not functional.",
+                "description": "These settings only need to be adjusted if HomeKit is not functional.",
                 "title": "Advanced Configuration"
             }
         }
@@ -45,16 +46,16 @@
                     "auto_start": "Autostart (disable if using Z-Wave or other delayed start system)",
                     "include_domains": "Domains to include"
                 },
-                "description": "A HomeKit Bridge will allow you to access your Home Assistant entities in HomeKit. HomeKit Bridges are limited to 150 accessories per instance including the bridge itself. If you wish to bridge more than the maximum number of accessories, it is recommended that you use multiple HomeKit bridges for different domains. Detailed entity configuration is only available via YAML for the primary bridge.",
-                "title": "Activate HomeKit Bridge"
+                "description": "The HomeKit integration will allow you to access your Home Assistant entities in HomeKit. In bridge mode, HomeKit Bridges are limited to 150 accessories per instance including the bridge itself. If you wish to bridge more than the maximum number of accessories, it is recommended that you use multiple HomeKit bridges for different domains. Detailed entity configuration is only available via YAML for the primary bridge.",
+                "title": "Activate HomeKit"
             },
             "pairing": {
-                "title": "Pair HomeKit Bridge",
-                "description": "As soon as the {name} bridge is ready, pairing will be available in \u201cNotifications\u201d as \u201cHomeKit Bridge Setup\u201d."
+                "title": "Pair HomeKit",
+                "description": "As soon as the {name} is ready, pairing will be available in \u201cNotifications\u201d as \u201cHomeKit Bridge Setup\u201d."
             }
         },
         "abort": {
-            "port_name_in_use": "A bridge with the same name or port is already configured."
+            "port_name_in_use": "An accessory or bridge with the same name or port is already configured."
         }
     }
 }

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -280,6 +280,7 @@ class TelevisionMediaPlayer(HomeAccessory):
 
         serv_tv = self.add_preload_service(SERV_TELEVISION, self.chars_tv)
         self.set_primary_service(serv_tv)
+        serv_tv.configure_char(CHAR_CONFIGURED_NAME, value=self.display_name)
         serv_tv.configure_char(CHAR_SLEEP_DISCOVER_MODE, value=True)
         self.char_active = serv_tv.configure_char(
             CHAR_ACTIVE, setter_callback=self.set_on_off


### PR DESCRIPTION
Requires #41662

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support HomeKit accessory mode
    
The homekit spec does not allow TVs to be bridged, which results in
unexpected behavior. Single entity mode resolves this problem.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40245 and fixes #39903
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15249

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
