### PR TITLE
Add script for bypassing onboarding

### DIFF
--- a/homeassistant/scripts/onboarding.py
+++ b/homeassistant/scripts/onboarding.py
@@ -1,0 +1,74 @@
+"""Script to programmatically perform onboarding."""
+import argparse
+import asyncio
+import os
+from typing import Dict, List
+
+from homeassistant import runner
+from homeassistant.auth import auth_manager_from_config
+from homeassistant.auth.providers.homeassistant import HassAuthProvider
+from homeassistant.components.onboarding import (
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    OnboadingStorage,
+)
+from homeassistant.components.onboarding.const import STEP_USER, STEPS
+from homeassistant.config import get_default_config_dir
+from homeassistant.core import HomeAssistant
+
+
+def run(args: List) -> int:
+    """Handle Home Assistant onboarding script."""
+    parser = argparse.ArgumentParser(description="Perform Home Assistant onboarding")
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=get_default_config_dir(),
+        help="Directory that contains the Home Assistant configuration",
+    )
+    parser.add_argument("--script", choices=["onboarding"])
+
+    asyncio.set_event_loop_policy(runner.HassEventLoopPolicy(False))
+    asyncio.run(run_command(parser.parse_args(args)))
+
+    return 0
+
+
+async def run_command(args: argparse.Namespace) -> None:
+    """Run the command."""
+    hass = HomeAssistant()
+    hass.config.config_dir = os.path.join(os.getcwd(), args.config)
+    store = OnboadingStorage(hass, STORAGE_VERSION, STORAGE_KEY, private=True)
+    data = await store.async_load()
+
+    if data is None or not isinstance(data, Dict):
+        data = {"done": []}
+
+    if not await check_has_owner(hass, data):
+        print("No user found.")
+        print("Onboarding aborted!")
+    else:
+        for step in STEPS:
+            if step not in data["done"]:
+                data["done"].append(step)
+        await store.async_save(data)
+        print("Onboarding complete.")
+
+    await hass.async_stop()
+
+
+async def check_has_owner(hass: HomeAssistant, data: Dict) -> bool:
+    """Check if there a user account is registered."""
+    if STEP_USER in data["done"]:
+        return True
+
+    hass.auth = await auth_manager_from_config(hass, [{"type": "homeassistant"}], [])
+    provider = hass.auth.auth_providers[0]
+    if not isinstance(provider, HassAuthProvider):
+        return False
+    await provider.async_initialize()
+
+    if provider.data and provider.data.users and len(provider.data.users):
+        return True
+    return False

--- a/homeassistant/scripts/onboarding.py
+++ b/homeassistant/scripts/onboarding.py
@@ -42,7 +42,7 @@ async def run_command(args: argparse.Namespace) -> None:
     store = OnboadingStorage(hass, STORAGE_VERSION, STORAGE_KEY, private=True)
     data = await store.async_load()
 
-    if data is None or not isinstance(data, Dict):
+    if data is None or not isinstance(data, dict):
         data = {"done": []}
 
     if not await check_has_owner(hass, data):
@@ -69,6 +69,6 @@ async def check_has_owner(hass: HomeAssistant, data: Dict) -> bool:
         return False
     await provider.async_initialize()
 
-    if provider.data and provider.data.users and len(provider.data.users):
+    if provider.data and provider.data.users and len(provider.data.users) > 0:
         return True
     return False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This allows an advanced user to bypass the onboarding process in the web interface by running 
`> homeassistant --script onboarding`

Use cases:
 - (Semi-)Automated testing and/or deployment
 - Accessibility (no clicking a map to continue)
 - People who just don't care if their geographical position is correct and just want to get on with it


I would appreciate help with how to test this correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
