### PR TITLE
Rewrite APNS tests to use pytest

### DIFF
--- a/tests/components/apns/test_notify.py
+++ b/tests/components/apns/test_notify.py
@@ -1,14 +1,14 @@
 """The tests for the APNS component."""
 import io
-import unittest
 
 from apns2.errors import Unregistered
+import pytest
 import yaml
 
 import homeassistant.components.apns.notify as apns
 import homeassistant.components.notify as notify
 from homeassistant.core import State
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import Mock, mock_open, patch
 from tests.common import assert_setup_component, get_test_home_assistant
@@ -23,356 +23,366 @@ CONFIG = {
 }
 
 
-@patch("homeassistant.components.apns.notify.open", mock_open(), create=True)
-class TestApns(unittest.TestCase):
-    """Test the APNS component."""
+@pytest.fixture(scope="module", autouse=True)
+def mock_apns_notify_open():
+    """Mock builtins.open for apns.notfiy."""
+    with patch("homeassistant.components.apns.notify.open", mock_open(), create=True):
+        yield
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.tear_down_cleanup)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+@patch("os.path.isfile", Mock(return_value=True))
+@patch("os.access", Mock(return_value=True))
+async def _setup_notify(hass_):
+    assert isinstance(apns.load_yaml_config_file, Mock), "Found unmocked load_yaml"
 
-    @patch("os.path.isfile", Mock(return_value=True))
-    @patch("os.access", Mock(return_value=True))
-    def _setup_notify(self):
-        assert isinstance(apns.load_yaml_config_file, Mock), "Found unmocked load_yaml"
+    with assert_setup_component(1) as handle_config:
+        assert await async_setup_component(hass_, notify.DOMAIN, CONFIG)
+    assert handle_config[notify.DOMAIN]
 
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, CONFIG)
-        assert handle_config[notify.DOMAIN]
 
-    @patch("os.path.isfile", return_value=True)
-    @patch("os.access", return_value=True)
-    def test_apns_setup_full(self, mock_access, mock_isfile):
-        """Test setup with all data."""
-        config = {
-            "notify": {
-                "platform": "apns",
-                "name": "test_app",
-                "sandbox": "True",
-                "topic": "testapp.appname",
-                "cert_file": "test_app.pem",
-            }
+@patch("os.path.isfile", return_value=True)
+@patch("os.access", return_value=True)
+async def test_apns_setup_full(mock_access, mock_isfile, hass):
+    """Test setup with all data."""
+    config = {
+        "notify": {
+            "platform": "apns",
+            "name": "test_app",
+            "sandbox": "True",
+            "topic": "testapp.appname",
+            "cert_file": "test_app.pem",
         }
+    }
 
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert handle_config[notify.DOMAIN]
+    with assert_setup_component(1) as handle_config:
+        assert await async_setup_component(hass, notify.DOMAIN, config)
+    assert handle_config[notify.DOMAIN]
 
-    def test_apns_setup_missing_name(self):
-        """Test setup with missing name."""
-        config = {
-            "notify": {
-                "platform": "apns",
-                "topic": "testapp.appname",
-                "cert_file": "test_app.pem",
-            }
+
+async def test_apns_setup_missing_name(hass):
+    """Test setup with missing name."""
+    config = {
+        "notify": {
+            "platform": "apns",
+            "topic": "testapp.appname",
+            "cert_file": "test_app.pem",
         }
-        with assert_setup_component(0) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert not handle_config[notify.DOMAIN]
+    }
+    with assert_setup_component(0) as handle_config:
+        assert await async_setup_component(hass, notify.DOMAIN, config)
+    assert not handle_config[notify.DOMAIN]
 
-    def test_apns_setup_missing_certificate(self):
-        """Test setup with missing certificate."""
-        config = {
-            "notify": {
-                "platform": "apns",
-                "name": "test_app",
-                "topic": "testapp.appname",
-            }
+
+async def test_apns_setup_missing_certificate(hass):
+    """Test setup with missing certificate."""
+    config = {
+        "notify": {
+            "platform": "apns",
+            "name": "test_app",
+            "topic": "testapp.appname",
         }
-        with assert_setup_component(0) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert not handle_config[notify.DOMAIN]
+    }
+    with assert_setup_component(0) as handle_config:
+        assert await async_setup_component(hass, notify.DOMAIN, config)
+    assert not handle_config[notify.DOMAIN]
 
-    def test_apns_setup_missing_topic(self):
-        """Test setup with missing topic."""
-        config = {
-            "notify": {
-                "platform": "apns",
-                "name": "test_app",
-                "cert_file": "test_app.pem",
-            }
+
+async def test_apns_setup_missing_topic(hass):
+    """Test setup with missing topic."""
+    config = {
+        "notify": {
+            "platform": "apns",
+            "name": "test_app",
+            "cert_file": "test_app.pem",
         }
-        with assert_setup_component(0) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert not handle_config[notify.DOMAIN]
+    }
+    with assert_setup_component(0) as handle_config:
+        assert await async_setup_component(hass, notify.DOMAIN, config)
+    assert not handle_config[notify.DOMAIN]
 
-    @patch("homeassistant.components.apns.notify._write_device")
-    def test_register_new_device(self, mock_write):
-        """Test registering a new device with a name."""
-        yaml_file = {5678: {"name": "test device 2"}}
 
-        written_devices = []
+@patch("homeassistant.components.apns.notify._write_device")
+async def test_register_new_device(mock_write, hass):
+    """Test registering a new device with a name."""
+    yaml_file = {5678: {"name": "test device 2"}}
 
-        def fake_write(_out, device):
-            """Fake write_device."""
-            written_devices.append(device)
+    written_devices = []
 
-        mock_write.side_effect = fake_write
+    def fake_write(_out, device):
+        """Fake write_device."""
+        written_devices.append(device)
 
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ):
-            self._setup_notify()
+    mock_write.side_effect = fake_write
 
-        assert self.hass.services.call(
-            apns.DOMAIN,
-            "apns_test_app",
-            {"push_id": "1234", "name": "test device"},
-            blocking=True,
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ):
+        await _setup_notify(hass)
+
+    assert await hass.services.async_call(
+        apns.DOMAIN,
+        "apns_test_app",
+        {"push_id": "1234", "name": "test device"},
+        blocking=True,
+    )
+
+    assert len(written_devices) == 1
+    assert written_devices[0].name == "test device"
+
+
+@patch("homeassistant.components.apns.notify._write_device")
+async def test_register_device_without_name(mock_write, hass):
+    """Test registering a without a name."""
+    yaml_file = {
+        1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
+        5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
+    }
+
+    written_devices = []
+
+    def fake_write(_out, device):
+        """Fake write_device."""
+        written_devices.append(device)
+
+    mock_write.side_effect = fake_write
+
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ):
+        await _setup_notify(hass)
+
+    assert await hass.services.async_call(
+        apns.DOMAIN, "apns_test_app", {"push_id": "1234"}, blocking=True
+    )
+
+    devices = {dev.push_id: dev for dev in written_devices}
+
+    test_device = devices.get("1234")
+
+    assert test_device is not None
+    assert test_device.name is None
+
+
+@patch("homeassistant.components.apns.notify._write_device")
+async def test_update_existing_device(mock_write, hass):
+    """Test updating an existing device."""
+    yaml_file = {1234: {"name": "test device 1"}, 5678: {"name": "test device 2"}}
+
+    written_devices = []
+
+    def fake_write(_out, device):
+        """Fake write_device."""
+        written_devices.append(device)
+
+    mock_write.side_effect = fake_write
+
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ):
+        await _setup_notify(hass)
+
+    assert await hass.services.async_call(
+        apns.DOMAIN,
+        "apns_test_app",
+        {"push_id": "1234", "name": "updated device 1"},
+        blocking=True,
+    )
+
+    devices = {dev.push_id: dev for dev in written_devices}
+
+    test_device_1 = devices.get("1234")
+    test_device_2 = devices.get("5678")
+
+    assert test_device_1 is not None
+    assert test_device_2 is not None
+
+    assert "updated device 1" == test_device_1.name
+
+
+@patch("homeassistant.components.apns.notify._write_device")
+async def test_update_existing_device_with_tracking_id(mock_write, hass):
+    """Test updating an existing device that has a tracking id."""
+    yaml_file = {
+        1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
+        5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
+    }
+
+    written_devices = []
+
+    def fake_write(_out, device):
+        """Fake write_device."""
+        written_devices.append(device)
+
+    mock_write.side_effect = fake_write
+
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ):
+        await _setup_notify(hass)
+
+    assert await hass.services.async_call(
+        apns.DOMAIN,
+        "apns_test_app",
+        {"push_id": "1234", "name": "updated device 1"},
+        blocking=True,
+    )
+
+    devices = {dev.push_id: dev for dev in written_devices}
+
+    test_device_1 = devices.get("1234")
+    test_device_2 = devices.get("5678")
+
+    assert test_device_1 is not None
+    assert test_device_2 is not None
+
+    assert "tracking123" == test_device_1.tracking_device_id
+    assert "tracking456" == test_device_2.tracking_device_id
+
+
+@patch("homeassistant.components.apns.notify.APNsClient")
+async def test_send(mock_client, hass):
+    """Test updating an existing device."""
+    send = mock_client.return_value.send_notification
+
+    yaml_file = {1234: {"name": "test device 1"}}
+
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ):
+        await _setup_notify(hass)
+
+    assert await hass.services.async_call(
+        "notify",
+        "test_app",
+        {
+            "message": "Hello",
+            "data": {"badge": 1, "sound": "test.mp3", "category": "testing"},
+        },
+        blocking=True,
+    )
+
+    assert send.called
+    assert 1 == len(send.mock_calls)
+
+    target = send.mock_calls[0][1][0]
+    payload = send.mock_calls[0][1][1]
+
+    assert "1234" == target
+    assert "Hello" == payload.alert
+    assert 1 == payload.badge
+    assert "test.mp3" == payload.sound
+    assert "testing" == payload.category
+
+
+@patch("homeassistant.components.apns.notify.APNsClient")
+async def test_send_when_disabled(mock_client, hass):
+    """Test updating an existing device."""
+    send = mock_client.return_value.send_notification
+
+    yaml_file = {1234: {"name": "test device 1", "disabled": True}}
+
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ):
+        await _setup_notify(hass)
+
+    assert await hass.services.async_call(
+        "notify",
+        "test_app",
+        {
+            "message": "Hello",
+            "data": {"badge": 1, "sound": "test.mp3", "category": "testing"},
+        },
+        blocking=True,
+    )
+
+    assert not send.called
+
+
+# todo: I had a deadlock issue when making this an async function using the hass fixture
+@patch("homeassistant.components.apns.notify.APNsClient")
+def test_send_with_state(mock_client):
+    """Test updating an existing device."""
+    hass = get_test_home_assistant()
+    send = mock_client.return_value.send_notification
+
+    yaml_file = {
+        1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
+        5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
+    }
+
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ), patch("os.path.isfile", Mock(return_value=True)):
+        notify_service = apns.ApnsNotificationService(
+            hass, "test_app", "testapp.appname", False, "test_app.pem"
         )
 
-        assert len(written_devices) == 1
-        assert written_devices[0].name == "test device"
+    notify_service.device_state_changed_listener(
+        "device_tracker.tracking456",
+        State("device_tracker.tracking456", None),
+        State("device_tracker.tracking456", "home"),
+    )
 
-    @patch("homeassistant.components.apns.notify._write_device")
-    def test_register_device_without_name(self, mock_write):
-        """Test registering a without a name."""
-        yaml_file = {
-            1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
-            5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
-        }
+    notify_service.send_message(message="Hello", target="home")
 
-        written_devices = []
+    assert send.called
+    assert 1 == len(send.mock_calls)
 
-        def fake_write(_out, device):
-            """Fake write_device."""
-            written_devices.append(device)
+    target = send.mock_calls[0][1][0]
+    payload = send.mock_calls[0][1][1]
 
-        mock_write.side_effect = fake_write
+    assert "5678" == target
+    assert "Hello" == payload.alert
 
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ):
-            self._setup_notify()
-
-        assert self.hass.services.call(
-            apns.DOMAIN, "apns_test_app", {"push_id": "1234"}, blocking=True
-        )
-
-        devices = {dev.push_id: dev for dev in written_devices}
-
-        test_device = devices.get("1234")
-
-        assert test_device is not None
-        assert test_device.name is None
-
-    @patch("homeassistant.components.apns.notify._write_device")
-    def test_update_existing_device(self, mock_write):
-        """Test updating an existing device."""
-        yaml_file = {1234: {"name": "test device 1"}, 5678: {"name": "test device 2"}}
-
-        written_devices = []
-
-        def fake_write(_out, device):
-            """Fake write_device."""
-            written_devices.append(device)
-
-        mock_write.side_effect = fake_write
-
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ):
-            self._setup_notify()
-
-        assert self.hass.services.call(
-            apns.DOMAIN,
-            "apns_test_app",
-            {"push_id": "1234", "name": "updated device 1"},
-            blocking=True,
-        )
-
-        devices = {dev.push_id: dev for dev in written_devices}
-
-        test_device_1 = devices.get("1234")
-        test_device_2 = devices.get("5678")
-
-        assert test_device_1 is not None
-        assert test_device_2 is not None
-
-        assert "updated device 1" == test_device_1.name
-
-    @patch("homeassistant.components.apns.notify._write_device")
-    def test_update_existing_device_with_tracking_id(self, mock_write):
-        """Test updating an existing device that has a tracking id."""
-        yaml_file = {
-            1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
-            5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
-        }
-
-        written_devices = []
-
-        def fake_write(_out, device):
-            """Fake write_device."""
-            written_devices.append(device)
-
-        mock_write.side_effect = fake_write
-
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ):
-            self._setup_notify()
-
-        assert self.hass.services.call(
-            apns.DOMAIN,
-            "apns_test_app",
-            {"push_id": "1234", "name": "updated device 1"},
-            blocking=True,
-        )
-
-        devices = {dev.push_id: dev for dev in written_devices}
-
-        test_device_1 = devices.get("1234")
-        test_device_2 = devices.get("5678")
-
-        assert test_device_1 is not None
-        assert test_device_2 is not None
-
-        assert "tracking123" == test_device_1.tracking_device_id
-        assert "tracking456" == test_device_2.tracking_device_id
-
-    @patch("homeassistant.components.apns.notify.APNsClient")
-    def test_send(self, mock_client):
-        """Test updating an existing device."""
-        send = mock_client.return_value.send_notification
-
-        yaml_file = {1234: {"name": "test device 1"}}
-
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ):
-            self._setup_notify()
-
-        assert self.hass.services.call(
-            "notify",
-            "test_app",
-            {
-                "message": "Hello",
-                "data": {"badge": 1, "sound": "test.mp3", "category": "testing"},
-            },
-            blocking=True,
-        )
-
-        assert send.called
-        assert 1 == len(send.mock_calls)
-
-        target = send.mock_calls[0][1][0]
-        payload = send.mock_calls[0][1][1]
-
-        assert "1234" == target
-        assert "Hello" == payload.alert
-        assert 1 == payload.badge
-        assert "test.mp3" == payload.sound
-        assert "testing" == payload.category
-
-    @patch("homeassistant.components.apns.notify.APNsClient")
-    def test_send_when_disabled(self, mock_client):
-        """Test updating an existing device."""
-        send = mock_client.return_value.send_notification
-
-        yaml_file = {1234: {"name": "test device 1", "disabled": True}}
-
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ):
-            self._setup_notify()
-
-        assert self.hass.services.call(
-            "notify",
-            "test_app",
-            {
-                "message": "Hello",
-                "data": {"badge": 1, "sound": "test.mp3", "category": "testing"},
-            },
-            blocking=True,
-        )
-
-        assert not send.called
-
-    @patch("homeassistant.components.apns.notify.APNsClient")
-    def test_send_with_state(self, mock_client):
-        """Test updating an existing device."""
-        send = mock_client.return_value.send_notification
-
-        yaml_file = {
-            1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
-            5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
-        }
-
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ), patch("os.path.isfile", Mock(return_value=True)):
-            notify_service = apns.ApnsNotificationService(
-                self.hass, "test_app", "testapp.appname", False, "test_app.pem"
-            )
-
-        notify_service.device_state_changed_listener(
-            "device_tracker.tracking456",
-            State("device_tracker.tracking456", None),
-            State("device_tracker.tracking456", "home"),
-        )
-
-        notify_service.send_message(message="Hello", target="home")
-
-        assert send.called
-        assert 1 == len(send.mock_calls)
-
-        target = send.mock_calls[0][1][0]
-        payload = send.mock_calls[0][1][1]
-
-        assert "5678" == target
-        assert "Hello" == payload.alert
-
-    @patch("homeassistant.components.apns.notify.APNsClient")
-    @patch("homeassistant.components.apns.notify._write_device")
-    def test_disable_when_unregistered(self, mock_write, mock_client):
-        """Test disabling a device when it is unregistered."""
-        send = mock_client.return_value.send_notification
-        send.side_effect = Unregistered()
-
-        yaml_file = {
-            1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
-            5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
-        }
-
-        written_devices = []
-
-        def fake_write(_out, device):
-            """Fake write_device."""
-            written_devices.append(device)
-
-        mock_write.side_effect = fake_write
-
-        with patch(
-            "homeassistant.components.apns.notify.load_yaml_config_file",
-            Mock(return_value=yaml_file),
-        ):
-            self._setup_notify()
-
-        assert self.hass.services.call(
-            "notify", "test_app", {"message": "Hello"}, blocking=True
-        )
-
-        devices = {dev.push_id: dev for dev in written_devices}
-
-        test_device_1 = devices.get("1234")
-        assert test_device_1 is not None
-        assert test_device_1.disabled is True
+    hass.stop()
 
 
-def test_write_device():
+@patch("homeassistant.components.apns.notify.APNsClient")
+@patch("homeassistant.components.apns.notify._write_device")
+async def test_disable_when_unregistered(mock_write, mock_client, hass):
+    """Test disabling a device when it is unregistered."""
+    send = mock_client.return_value.send_notification
+    send.side_effect = Unregistered()
+
+    yaml_file = {
+        1234: {"name": "test device 1", "tracking_device_id": "tracking123"},
+        5678: {"name": "test device 2", "tracking_device_id": "tracking456"},
+    }
+
+    written_devices = []
+
+    def fake_write(_out, device):
+        """Fake write_device."""
+        written_devices.append(device)
+
+    mock_write.side_effect = fake_write
+
+    with patch(
+        "homeassistant.components.apns.notify.load_yaml_config_file",
+        Mock(return_value=yaml_file),
+    ):
+        await _setup_notify(hass)
+
+    assert await hass.services.async_call(
+        "notify", "test_app", {"message": "Hello"}, blocking=True
+    )
+
+    devices = {dev.push_id: dev for dev in written_devices}
+
+    test_device_1 = devices.get("1234")
+    assert test_device_1 is not None
+    assert test_device_1.disabled is True
+
+
+async def test_write_device():
     """Test writing device."""
     out = io.StringIO()
     device = apns.ApnsDevice("123", "name", "track_id", True)


### PR DESCRIPTION
## Proposed change
Refactoring of tests for the APNS component from unittest to pytest.

I had difficulty updating one of the functions, `test_send_with_state`, to be async due to a deadlock issue when initialising `ApnsNotificationService` (specifically on `track_state_change`), but I have removed the dependency on unittest.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #40823
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
