### PR TITLE
Add support for speech voice and rate

### DIFF
--- a/homeassistant/components/voicerss/tts.py
+++ b/homeassistant/components/voicerss/tts.py
@@ -81,6 +81,30 @@ SUPPORT_LANGUAGES = [
 
 SUPPORT_CODECS = ["mp3", "wav", "aac", "ogg", "caf"]
 
+SUPPORT_RATE = [
+    "-10",
+    "-9",
+    "-8",
+    "-7",
+    "-6",
+    "-5",
+    "-4",
+    "-3",
+    "-2",
+    "-1",
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+]
+
 SUPPORT_FORMATS = [
     "8khz_8bit_mono",
     "8khz_8bit_stereo",
@@ -138,10 +162,13 @@ SUPPORT_FORMATS = [
 
 CONF_CODEC = "codec"
 CONF_FORMAT = "format"
+CONF_VOICE = "voice"
+CONF_RATE = "speed"
 
 DEFAULT_LANG = "en-us"
 DEFAULT_CODEC = "mp3"
 DEFAULT_FORMAT = "8khz_8bit_mono"
+DEFAULT_RATE = "0"
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -150,6 +177,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
         vol.Optional(CONF_CODEC, default=DEFAULT_CODEC): vol.In(SUPPORT_CODECS),
         vol.Optional(CONF_FORMAT, default=DEFAULT_FORMAT): vol.In(SUPPORT_FORMATS),
+        vol.Optional(CONF_RATE, default=DEFAULT_RATE): vol.In(SUPPORT_RATE),
+        vol.Optional(CONF_VOICE, default="unconfigured"): cv.string,
     }
 )
 
@@ -169,12 +198,23 @@ class VoiceRSSProvider(Provider):
         self._lang = conf[CONF_LANG]
         self.name = "VoiceRSS"
 
-        self._form_data = {
-            "key": conf[CONF_API_KEY],
-            "hl": conf[CONF_LANG],
-            "c": (conf[CONF_CODEC]).upper(),
-            "f": conf[CONF_FORMAT],
-        }
+        if conf[CONF_VOICE] != "unconfigured":
+            self._form_data = {
+                "key": conf[CONF_API_KEY],
+                "hl": conf[CONF_LANG],
+                "v": conf[CONF_VOICE],
+                "r": conf[CONF_RATE],
+                "c": (conf[CONF_CODEC]).upper(),
+                "f": conf[CONF_FORMAT],
+            }
+        else:
+            self._form_data = {
+                "key": conf[CONF_API_KEY],
+                "hl": conf[CONF_LANG],
+                "r": conf[CONF_RATE],
+                "c": (conf[CONF_CODEC]).upper(),
+                "f": conf[CONF_FORMAT],
+            }
 
     @property
     def default_language(self):

--- a/homeassistant/components/voicerss/tts.py
+++ b/homeassistant/components/voicerss/tts.py
@@ -198,23 +198,17 @@ class VoiceRSSProvider(Provider):
         self._lang = conf[CONF_LANG]
         self.name = "VoiceRSS"
 
+        self._form_data = {
+            "key": conf[CONF_API_KEY],
+            "hl": conf[CONF_LANG],
+            "c": (conf[CONF_CODEC]).upper(),
+            "f": conf[CONF_FORMAT],
+        }
+
         if conf[CONF_VOICE] != "unconfigured":
-            self._form_data = {
-                "key": conf[CONF_API_KEY],
-                "hl": conf[CONF_LANG],
-                "v": conf[CONF_VOICE],
-                "r": conf[CONF_RATE],
-                "c": (conf[CONF_CODEC]).upper(),
-                "f": conf[CONF_FORMAT],
-            }
-        else:
-            self._form_data = {
-                "key": conf[CONF_API_KEY],
-                "hl": conf[CONF_LANG],
-                "r": conf[CONF_RATE],
-                "c": (conf[CONF_CODEC]).upper(),
-                "f": conf[CONF_FORMAT],
-            }
+            self._form_data["v"] = conf[CONF_VOICE]
+        if conf[CONF_RATE] != "0":
+            self._form_data["r"] = conf[CONF_RATE]
 
     @property
     def default_language(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This mod implements the possibility to configure the speech voice (if available for the chosen language) and the rate (speed) using two new, optional config entries. For example:
```
  speed: '-2'
  voice: John
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
tts:
  - platform: voicerss
    api_key: your_key
    language: en-gb
    codec: aac
    format: '44khz_16bit_mono'
    speed: '-2'
    voice: Nancy
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/40502#issuecomment-706562428

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
