### PR TITLE
Improve mobile app template handling

### DIFF
--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -32,10 +32,13 @@ from homeassistant.const import (
     HTTP_CREATED,
 )
 from homeassistant.core import EventOrigin
-from homeassistant.exceptions import HomeAssistantError, ServiceNotFound, TemplateError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    template,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.template import attach
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.decorator import Registry
 
@@ -285,7 +288,7 @@ async def webhook_stream_camera(hass, config_entry, data):
 @validate_schema(
     {
         str: {
-            vol.Required(ATTR_TEMPLATE): cv.template,
+            vol.Required(ATTR_TEMPLATE): cv.string,
             vol.Optional(ATTR_TEMPLATE_VARIABLES, default={}): dict,
         }
     }
@@ -295,10 +298,11 @@ async def webhook_render_template(hass, config_entry, data):
     resp = {}
     for key, item in data.items():
         try:
-            tpl = item[ATTR_TEMPLATE]
-            attach(hass, tpl)
+            tpl = template.Template(item[ATTR_TEMPLATE])
+            tpl.ensure_valid()
+            tpl.hass = hass
             resp[key] = tpl.async_render(item.get(ATTR_TEMPLATE_VARIABLES))
-        except TemplateError as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             resp[key] = {"error": str(ex)}
 
     return webhook_response(resp, registration=config_entry.data)

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -300,7 +300,7 @@ async def webhook_render_template(hass, config_entry, data):
         try:
             tpl = template.Template(item[ATTR_TEMPLATE], hass)
             resp[key] = tpl.async_render(item.get(ATTR_TEMPLATE_VARIABLES))
-        except TemplateError as ex:
+        except template.TemplateError as ex:
             resp[key] = {"error": str(ex)}
 
     return webhook_response(resp, registration=config_entry.data)

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -298,11 +298,9 @@ async def webhook_render_template(hass, config_entry, data):
     resp = {}
     for key, item in data.items():
         try:
-            tpl = template.Template(item[ATTR_TEMPLATE])
-            tpl.ensure_valid()
-            tpl.hass = hass
+            tpl = template.Template(item[ATTR_TEMPLATE], hass)
             resp[key] = tpl.async_render(item.get(ATTR_TEMPLATE_VARIABLES))
-        except Exception as ex:  # pylint: disable=broad-except
+        except TemplateError as ex:
             resp[key] = {"error": str(ex)}
 
     return webhook_response(resp, registration=config_entry.data)

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -85,7 +85,7 @@ async def test_webhook_handle_render_template(create_registrations, webhook_clie
     json = await resp.json()
     assert json == {
         "one": "Hello world",
-        "two": {"error": "object of type 'datetime.datetime' has no len()"},
+        "two": {"error": "TypeError: object of type 'datetime.datetime' has no len()"},
         "three": {
             "error": "TemplateSyntaxError: expected token 'end of print statement', got 'integer'"
         },

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -70,13 +70,26 @@ async def test_webhook_handle_render_template(create_registrations, webhook_clie
     """Test that we render templates properly."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
-        json=RENDER_TEMPLATE,
+        json={
+            "type": "render_template",
+            "data": {
+                "one": {"template": "Hello world"},
+                "two": {"template": "{{ now() | random }}"},
+                "three": {"template": "{{ now() 3 }}"},
+            },
+        },
     )
 
     assert resp.status == 200
 
     json = await resp.json()
-    assert json == {"one": "Hello world"}
+    assert json == {
+        "one": "Hello world",
+        "two": {"error": "object of type 'datetime.datetime' has no len()"},
+        "three": {
+            "error": "TemplateSyntaxError: expected token 'end of print statement', got 'integer'"
+        },
+    }
 
 
 async def test_webhook_handle_call_services(hass, create_registrations, webhook_client):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rendering templates via the mobile app was a little cumbersome. Invalid templates would fail the payload and errors in templates would propagate up. 

This makes sure we catch them all.

Note, our current template return type is a little problematic, since starting with 117 we will be able to return native values from templates, and so the user could return a similar shaped error object from a template 🤔 

CC @zacwest 



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
