### PR TITLE
Fix kodi media_player unavailable at start

### DIFF
--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -57,8 +57,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raw_version = (await kodi.get_application_properties(["version"]))["version"]
         version = f"{raw_version['major']}.{raw_version['minor']}"
     except CannotConnectError as error:
-        dr = await device_registry.async_get_registry(hass)
-        device = dr.async_get_device({(DOMAIN, entry.entry_id)}, [])
+        dev_reg = await device_registry.async_get_registry(hass)
+        device = dev_reg.async_get_device({(DOMAIN, entry.entry_id)}, [])
         if not device:
             raise ConfigEntryNotReady from error
         version = device.sw_version

--- a/homeassistant/components/kodi/const.py
+++ b/homeassistant/components/kodi/const.py
@@ -6,7 +6,6 @@ CONF_WS_PORT = "ws_port"
 DATA_CONNECTION = "connection"
 DATA_KODI = "kodi"
 DATA_REMOVE_LISTENER = "remove_listener"
-DATA_VERSION = "version"
 
 DEFAULT_PORT = 8080
 DEFAULT_SSL = False

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -432,7 +432,11 @@ class KodiEntity(MediaPlayerEntity):
             self._reset_state()
             return
 
-        self._players = await self._kodi.get_players()
+        try:
+            self._players = await self._kodi.get_players()
+        except jsonrpc_base.jsonrpc.TransportError:
+            self._reset_state()
+            return
 
         if self._kodi_is_off:
             self._reset_state()

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -55,7 +55,11 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.core import CoreState, callback
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry,
+    entity_platform,
+)
 from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.util.dt as dt_util
 
@@ -64,7 +68,6 @@ from .const import (
     CONF_WS_PORT,
     DATA_CONNECTION,
     DATA_KODI,
-    DATA_VERSION,
     DEFAULT_PORT,
     DEFAULT_SSL,
     DEFAULT_TIMEOUT,
@@ -230,14 +233,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     data = hass.data[DOMAIN][config_entry.entry_id]
     connection = data[DATA_CONNECTION]
-    version = data[DATA_VERSION]
     kodi = data[DATA_KODI]
     name = config_entry.data[CONF_NAME]
     uid = config_entry.unique_id
     if uid is None:
         uid = config_entry.entry_id
 
-    entity = KodiEntity(connection, kodi, name, uid, version)
+    entity = KodiEntity(connection, kodi, name, uid)
     async_add_entities([entity])
 
 
@@ -265,13 +267,12 @@ def cmd(func):
 class KodiEntity(MediaPlayerEntity):
     """Representation of a XBMC/Kodi device."""
 
-    def __init__(self, connection, kodi, name, uid, version):
+    def __init__(self, connection, kodi, name, uid):
         """Initialize the Kodi entity."""
         self._connection = connection
         self._kodi = kodi
         self._name = name
         self._unique_id = uid
-        self._version = version
         self._players = None
         self._properties = {}
         self._item = {}
@@ -348,7 +349,6 @@ class KodiEntity(MediaPlayerEntity):
             "identifiers": {(DOMAIN, self.unique_id)},
             "name": self.name,
             "manufacturer": "Kodi",
-            "sw_version": self._version,
         }
 
     @property
@@ -371,7 +371,7 @@ class KodiEntity(MediaPlayerEntity):
             return
 
         if self._connection.connected:
-            self._on_ws_connected()
+            await self._on_ws_connected()
 
         def start_watchdog(event=None):
             """Start websocket watchdog."""
@@ -390,17 +390,23 @@ class KodiEntity(MediaPlayerEntity):
         else:
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, start_watchdog)
 
-    @callback
-    def _on_ws_connected(self):
+    async def _on_ws_connected(self):
         """Call after ws is connected."""
         self._register_ws_callbacks()
+
+        version = (await self._kodi.get_application_properties(["version"]))["version"]
+        sw_version = f"{version['major']}.{version['minor']}"
+        dev_reg = await device_registry.async_get_registry(self.hass)
+        device = dev_reg.async_get_device({(DOMAIN, self.unique_id)}, [])
+        dev_reg.async_update_device(device.id, sw_version=sw_version)
+
         self.async_schedule_update_ha_state(True)
 
     async def _async_ws_connect(self):
         """Connect to Kodi via websocket protocol."""
         try:
             await self._connection.connect()
-            self._on_ws_connected()
+            await self._on_ws_connected()
         except (jsonrpc_base.jsonrpc.TransportError, CannotConnectError):
             _LOGGER.debug("Unable to connect to Kodi via websocket", exc_info=True)
             await self._clear_connection(False)
@@ -436,17 +442,14 @@ class KodiEntity(MediaPlayerEntity):
         self._connection.server.System.OnRestart = self.async_on_quit
         self._connection.server.System.OnSleep = self.async_on_quit
 
+    @cmd
     async def async_update(self):
         """Retrieve latest state."""
         if not self._connection.connected:
             self._reset_state()
             return
 
-        try:
-            self._players = await self._kodi.get_players()
-        except jsonrpc_base.jsonrpc.TransportError:
-            self._reset_state()
-            return
+        self._players = await self._kodi.get_players()
 
         if self._kodi_is_off:
             self._reset_state()

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -373,8 +373,9 @@ class KodiEntity(MediaPlayerEntity):
         if self._connection.connected:
             await self._on_ws_connected()
 
-        def start_watchdog(event=None):
+        async def start_watchdog(event=None):
             """Start websocket watchdog."""
+            await self._async_connect_websocket_if_disconnected()
             self.async_on_remove(
                 async_track_time_interval(
                     self.hass,
@@ -386,7 +387,7 @@ class KodiEntity(MediaPlayerEntity):
         # If Home Assistant is already in a running state, start the watchdog
         # immediately, else trigger it after Home Assistant has finished starting.
         if self.hass.state == CoreState.running:
-            start_watchdog()
+            await start_watchdog()
         else:
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, start_watchdog)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After the recent overhaul of the kodi integration, the media player entity is `unavailable` when Home Assistant starts until the related kodi instance comes online. This prevents the power button from showing up on the media player card.
This PR changes the behavior so the media player entities are `off` at startup, allowing for power-on actions through the UI.
The changes are largely based on changes made by https://github.com/alexanv1/core/commit/571780f5048879bfe9a19ff9e29fca5dd42037e5 with some additional fixes as mentioned in the discussion of the issue at #40450 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40450 and fixes #43269 and fixes #40970 and fixes #40482
- This PR is related to issue: #40450
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- (N/A) Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
