### PR TITLE
Use native utc timezone for utcnow()

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -11,6 +11,7 @@ import pytz.tzinfo as pytzinfo
 from homeassistant.const import MATCH_ALL
 
 DATE_STR_FORMAT = "%Y-%m-%d"
+NATIVE_UTC = dt.timezone.utc
 UTC = pytz.utc
 DEFAULT_TIME_ZONE: dt.tzinfo = pytz.utc
 
@@ -52,7 +53,7 @@ def get_time_zone(time_zone_str: str) -> Optional[dt.tzinfo]:
 
 def utcnow() -> dt.datetime:
     """Get now in UTC time."""
-    return dt.datetime.utcnow().replace(tzinfo=UTC)
+    return dt.datetime.now(NATIVE_UTC)
 
 
 def now(time_zone: Optional[dt.tzinfo] = None) -> dt.datetime:
@@ -314,7 +315,7 @@ def find_next_time_expression_time(
     # Now we need to handle timezones. We will make this datetime object
     # "naive" first and then re-convert it to the target timezone.
     # This is so that we can call pytz's localize and handle DST changes.
-    tzinfo: pytzinfo.DstTzInfo = result.tzinfo
+    tzinfo: pytzinfo.DstTzInfo = UTC if result.tzinfo == NATIVE_UTC else result.tzinfo
     result = result.replace(tzinfo=None)
 
     try:
@@ -337,7 +338,7 @@ def find_next_time_expression_time(
         return find_next_time_expression_time(result, seconds, minutes, hours)
 
     result_dst = cast(dt.timedelta, result.dst())
-    now_dst = cast(dt.timedelta, now.dst())
+    now_dst = cast(dt.timedelta, now.dst()) or dt.timedelta(0)
     if result_dst >= now_dst:
         return result
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#39145 improved the performance of `utcnow()`, even after this change, its still almost 50% of the time to create the `Event` object.

This allows timezone operations to happen in machine code instead
of the pure-python code of pytz

```
['datetime.now(UTC)',
 datetime.datetime(2020, 10, 12, 18, 35, 9, 848711, tzinfo=<UTC>)]
['datetime.now(NATIVE_UTC)',
 datetime.datetime(2020, 10, 12, 18, 35, 9, 848821, tzinfo=datetime.timezone.utc)]
['datetime.utcnow().replace(tzinfo=UTC)',
 datetime.datetime(2020, 10, 12, 18, 35, 9, 848879, tzinfo=<UTC>)]
['datetime.utcnow().replace(tzinfo=NATIVE_UTC)',
 datetime.datetime(2020, 10, 12, 18, 35, 9, 848938, tzinfo=datetime.timezone.utc)]
['now_native', 0.40638334630057216]
['now_pytz', 2.7024609656073153]
['utcnow_replace_native', 2.278446536976844]
['utcnow_replace_pytz', 2.650175557937473]
```

Before:
<img width="677" alt="Screen Shot 2020-10-12 at 1 32 39 PM" src="https://user-images.githubusercontent.com/663432/95779396-997e9b00-0c8f-11eb-9478-ea785f436217.png">



After:
<img width="540" alt="Screen Shot 2020-10-12 at 1 32 30 PM" src="https://user-images.githubusercontent.com/663432/95779387-92f02380-0c8f-11eb-9a65-4ef39d424c0e.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
