### PR TITLE
Rewrite configurator tests to pytest

### DIFF
--- a/tests/components/configurator/test_init.py
+++ b/tests/components/configurator/test_init.py
@@ -1,117 +1,106 @@
 """The tests for the Configurator component."""
-# pylint: disable=protected-access
-import unittest
 
 import homeassistant.components.configurator as configurator
 from homeassistant.const import ATTR_FRIENDLY_NAME, EVENT_TIME_CHANGED
 
-from tests.common import get_test_home_assistant
+
+async def test_request_least_info(hass):
+    """Test request config with least amount of data."""
+    request_id = configurator.async_request_config(hass, "Test Request", lambda _: None)
+
+    assert 1 == len(
+        hass.services.async_services().get(configurator.DOMAIN, [])
+    ), "No new service registered"
+
+    states = hass.states.async_all()
+
+    assert 1 == len(states), "Expected a new state registered"
+
+    state = states[0]
+
+    assert configurator.STATE_CONFIGURE == state.state
+    assert request_id == state.attributes.get(configurator.ATTR_CONFIGURE_ID)
 
 
-class TestConfigurator(unittest.TestCase):
-    """Test the Configurator component."""
-
-    # pylint: disable=invalid-name
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
-
-    def test_request_least_info(self):
-        """Test request config with least amount of data."""
-        request_id = configurator.request_config(
-            self.hass, "Test Request", lambda _: None
-        )
-
-        assert 1 == len(
-            self.hass.services.services.get(configurator.DOMAIN, [])
-        ), "No new service registered"
-
-        states = self.hass.states.all()
-
-        assert 1 == len(states), "Expected a new state registered"
-
-        state = states[0]
-
-        assert configurator.STATE_CONFIGURE == state.state
-        assert request_id == state.attributes.get(configurator.ATTR_CONFIGURE_ID)
-
-    def test_request_all_info(self):
-        """Test request config with all possible info."""
-        exp_attr = {
-            ATTR_FRIENDLY_NAME: "Test Request",
-            configurator.ATTR_DESCRIPTION: """config description
+async def test_request_all_info(hass):
+    """Test request config with all possible info."""
+    exp_attr = {
+        ATTR_FRIENDLY_NAME: "Test Request",
+        configurator.ATTR_DESCRIPTION: """config description
 
 [link name](link url)
 
 ![Description image](config image url)""",
-            configurator.ATTR_SUBMIT_CAPTION: "config submit caption",
-            configurator.ATTR_FIELDS: [],
-            configurator.ATTR_ENTITY_PICTURE: "config entity picture",
-            configurator.ATTR_CONFIGURE_ID: configurator.request_config(
-                self.hass,
-                name="Test Request",
-                callback=lambda _: None,
-                description="config description",
-                description_image="config image url",
-                submit_caption="config submit caption",
-                fields=None,
-                link_name="link name",
-                link_url="link url",
-                entity_picture="config entity picture",
-            ),
-        }
+        configurator.ATTR_SUBMIT_CAPTION: "config submit caption",
+        configurator.ATTR_FIELDS: [],
+        configurator.ATTR_ENTITY_PICTURE: "config entity picture",
+        configurator.ATTR_CONFIGURE_ID: configurator.async_request_config(
+            hass,
+            name="Test Request",
+            callback=lambda _: None,
+            description="config description",
+            description_image="config image url",
+            submit_caption="config submit caption",
+            fields=None,
+            link_name="link name",
+            link_url="link url",
+            entity_picture="config entity picture",
+        ),
+    }
 
-        states = self.hass.states.all()
-        assert 1 == len(states)
-        state = states[0]
+    states = hass.states.async_all()
+    assert 1 == len(states)
+    state = states[0]
 
-        assert configurator.STATE_CONFIGURE == state.state
-        assert exp_attr == state.attributes
+    assert configurator.STATE_CONFIGURE == state.state
+    assert exp_attr == state.attributes
 
-    def test_callback_called_on_configure(self):
-        """Test if our callback gets called when configure service called."""
-        calls = []
-        request_id = configurator.request_config(
-            self.hass, "Test Request", lambda _: calls.append(1)
-        )
 
-        self.hass.services.call(
-            configurator.DOMAIN,
-            configurator.SERVICE_CONFIGURE,
-            {configurator.ATTR_CONFIGURE_ID: request_id},
-        )
+async def test_callback_called_on_configure(hass):
+    """Test if our callback gets called when configure service called."""
+    calls = []
+    request_id = configurator.async_request_config(
+        hass, "Test Request", lambda _: calls.append(1)
+    )
 
-        self.hass.block_till_done()
-        assert 1 == len(calls), "Callback not called"
+    await hass.services.async_call(
+        configurator.DOMAIN,
+        configurator.SERVICE_CONFIGURE,
+        {configurator.ATTR_CONFIGURE_ID: request_id},
+    )
 
-    def test_state_change_on_notify_errors(self):
-        """Test state change on notify errors."""
-        request_id = configurator.request_config(
-            self.hass, "Test Request", lambda _: None
-        )
-        error = "Oh no bad bad bad"
-        configurator.notify_errors(self.hass, request_id, error)
+    await hass.async_block_till_done()
+    assert 1 == len(calls), "Callback not called"
 
-        state = self.hass.states.all()[0]
-        assert error == state.attributes.get(configurator.ATTR_ERRORS)
 
-    def test_notify_errors_fail_silently_on_bad_request_id(self):
-        """Test if notify errors fails silently with a bad request id."""
-        configurator.notify_errors(self.hass, 2015, "Try this error")
+async def test_state_change_on_notify_errors(hass):
+    """Test state change on notify errors."""
+    request_id = configurator.async_request_config(hass, "Test Request", lambda _: None)
+    error = "Oh no bad bad bad"
+    configurator.async_notify_errors(hass, request_id, error)
 
-    def test_request_done_works(self):
-        """Test if calling request done works."""
-        request_id = configurator.request_config(
-            self.hass, "Test Request", lambda _: None
-        )
-        configurator.request_done(self.hass, request_id)
-        assert 1 == len(self.hass.states.all())
+    states = hass.states.async_all()
+    assert 1 == len(states)
+    state = states[0]
+    assert error == state.attributes.get(configurator.ATTR_ERRORS)
 
-        self.hass.bus.fire(EVENT_TIME_CHANGED)
-        self.hass.block_till_done()
-        assert 0 == len(self.hass.states.all())
 
-    def test_request_done_fail_silently_on_bad_request_id(self):
-        """Test that request_done fails silently with a bad request id."""
-        configurator.request_done(self.hass, 2016)
+async def test_notify_errors_fail_silently_on_bad_request_id(hass):
+    """Test if notify errors fails silently with a bad request id."""
+    configurator.async_notify_errors(hass, 2015, "Try this error")
+
+
+async def test_request_done_works(hass):
+    """Test if calling request done works."""
+    request_id = configurator.async_request_config(hass, "Test Request", lambda _: None)
+    configurator.async_request_done(hass, request_id)
+    assert 1 == len(hass.states.async_all())
+
+    hass.bus.async_fire(EVENT_TIME_CHANGED)
+    await hass.async_block_till_done()
+    assert 0 == len(hass.states.async_all())
+
+
+async def test_request_done_fail_silently_on_bad_request_id(hass):
+    """Test that request_done fails silently with a bad request id."""
+    configurator.async_request_done(hass, 2016)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40830
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
