### PR TITLE
Add Sonos support for media_player.repeat_set service

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -970,8 +970,8 @@ class SonosEntity(MediaPlayerEntity):
             return REPEAT_MODE_ALL
         elif self._repeat == "ONE":
             return REPEAT_MODE_ONE
-
-        return REPEAT_MODE_OFF
+        else:
+            return REPEAT_MODE_OFF
 
     @property
     @soco_coordinator

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -968,10 +968,11 @@ class SonosEntity(MediaPlayerEntity):
         """Return current repeat mode."""
         if self._repeat is True:
             return REPEAT_MODE_ALL
-        elif self._repeat == "ONE":
+
+        if self._repeat == "ONE":
             return REPEAT_MODE_ONE
-        else:
-            return REPEAT_MODE_OFF
+
+        return REPEAT_MODE_OFF
 
     @property
     @soco_coordinator

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -33,6 +33,9 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_PLAYLIST,
     MEDIA_TYPE_TRACK,
+    REPEAT_MODE_ALL,
+    REPEAT_MODE_OFF,
+    REPEAT_MODE_ONE,
     SUPPORT_BROWSE_MEDIA,
     SUPPORT_CLEAR_PLAYLIST,
     SUPPORT_NEXT_TRACK,
@@ -40,6 +43,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_REPEAT_SET,
     SUPPORT_SEEK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_SHUFFLE_SET,
@@ -86,6 +90,7 @@ SUPPORT_SONOS = (
     | SUPPORT_PLAY
     | SUPPORT_PLAY_MEDIA
     | SUPPORT_PREVIOUS_TRACK
+    | SUPPORT_REPEAT_SET
     | SUPPORT_SEEK
     | SUPPORT_SELECT_SOURCE
     | SUPPORT_SHUFFLE_SET
@@ -502,6 +507,7 @@ class SonosEntity(MediaPlayerEntity):
         self._player_volume = None
         self._player_muted = None
         self._shuffle = None
+        self._repeat = None
         self._coordinator = None
         self._sonos_group = [self]
         self._status = None
@@ -674,6 +680,7 @@ class SonosEntity(MediaPlayerEntity):
         """Get basic information and add event subscriptions."""
         try:
             self._shuffle = self.soco.shuffle
+            self._repeat = self.soco.repeat
             self.update_volume()
             self._set_favorites()
 
@@ -719,6 +726,7 @@ class SonosEntity(MediaPlayerEntity):
             return
 
         self._shuffle = self.soco.shuffle
+        self._repeat = self.soco.repeat
         self._uri = None
         self._media_duration = None
         self._media_image_url = None
@@ -956,6 +964,17 @@ class SonosEntity(MediaPlayerEntity):
 
     @property
     @soco_coordinator
+    def repeat(self):
+        """Return current repeat mode."""
+        if self._repeat is True:
+            return REPEAT_MODE_ALL
+        elif self._repeat == "ONE":
+            return REPEAT_MODE_ONE
+
+        return REPEAT_MODE_OFF
+
+    @property
+    @soco_coordinator
     def media_content_id(self):
         """Content id of current playing media."""
         return self._uri
@@ -1054,6 +1073,17 @@ class SonosEntity(MediaPlayerEntity):
     def set_shuffle(self, shuffle):
         """Enable/Disable shuffle mode."""
         self.soco.shuffle = shuffle
+
+    @soco_error(UPNP_ERRORS_TO_IGNORE)
+    @soco_coordinator
+    def set_repeat(self, repeat):
+        """Set repeat mode."""
+        repeat_map = {
+            REPEAT_MODE_OFF: False,
+            REPEAT_MODE_ALL: True,
+            REPEAT_MODE_ONE: "ONE",
+        }
+        self.soco.repeat = repeat_map[repeat]
 
     @soco_error()
     def mute_volume(self, mute):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
      - service: media_player.repeat_set
        data:
          entity_id: media_player.kitchen
          repeat: "off"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
