### PR TITLE
Add a manual step to the Broadlink configuration flow

### DIFF
--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -1,9 +1,13 @@
 """Constants for the Broadlink integration."""
+import broadlink as blk
+
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
 DOMAIN = "broadlink"
+
+LIBRARY_URL = "https://github.com/mjg59/python-broadlink"
 
 DOMAINS_AND_TYPES = {
     REMOTE_DOMAIN: {"RM4MINI", "RM4PRO", "RMMINI", "RMMINIB", "RMPRO"},
@@ -24,6 +28,24 @@ DOMAINS_AND_TYPES = {
         "SP4",
         "SP4B",
     },
+}
+
+TYPES_AND_CLASSES = {
+    "A1": blk.a1,
+    "BG1": blk.bg1,
+    "MP1": blk.mp1,
+    "RM4MINI": blk.rm4mini,
+    "RM4PRO": blk.rm4pro,
+    "RMMINI": blk.rmmini,
+    "RMMINIB": blk.rmminib,
+    "RMPRO": blk.rmpro,
+    "SP1": blk.sp1,
+    "SP2": blk.sp2,
+    "SP2S": blk.sp2s,
+    "SP3": blk.sp3,
+    "SP3S": blk.sp3s,
+    "SP4": blk.sp4,
+    "SP4B": blk.sp4b,
 }
 
 DEFAULT_PORT = 80

--- a/homeassistant/components/broadlink/device.py
+++ b/homeassistant/components/broadlink/device.py
@@ -105,8 +105,8 @@ class BroadlinkDevice:
             )
             _LOGGER.warning(
                 "You have configured an unknown device: %s. If you manage "
-                "to make it work, please consider opening an issue or "
-                "creating a pull request at %s",
+                "to make it work, please open an issue or pull request at "
+                "%s",
                 api,
                 LIBRARY_URL,
             )

--- a/homeassistant/components/broadlink/strings.json
+++ b/homeassistant/components/broadlink/strings.json
@@ -9,6 +9,13 @@
           "timeout": "Timeout"
         }
       },
+      "manual": {
+        "title": "Manual configuration",
+        "description": "Sorry, we don't know this device: {name} ({type} at {host}). You can try to configure it manually by selecting an appropriate device class.\n\nIf you manage to make it work, please consider opening an issue or creating a pull request in the [python-broadlink]({url}) library.",
+        "data": {
+          "device_class": "Device class"
+        }
+      },
       "auth": {
         "title": "Authenticate to the device"
       },

--- a/homeassistant/components/broadlink/strings.json
+++ b/homeassistant/components/broadlink/strings.json
@@ -11,7 +11,7 @@
       },
       "manual": {
         "title": "Manual configuration",
-        "description": "Sorry, we don't know this device: {name} ({type} at {host}). You can try to configure it manually by selecting an appropriate device class.\n\nIf you manage to make it work, please consider opening an issue or creating a pull request in the [python-broadlink]({url}) library.",
+        "description": "Sorry, we don't know this device: {name} ({type} at {host}). You can try to configure it manually by selecting an appropriate device class.\n\nIf you manage to make it work, please open an issue or pull request in the [python-broadlink]({url}) repository.",
         "data": {
           "device_class": "Device class"
         }

--- a/homeassistant/components/broadlink/translations/en.json
+++ b/homeassistant/components/broadlink/translations/en.json
@@ -26,7 +26,7 @@
             },
             "manual": {
                 "title": "Manual configuration",
-                "description": "Sorry, we don't know this device: {name} ({type} at {host}). You can try to configure it manually by selecting an appropriate device class.\n\nIf you manage to make it work, please consider opening an issue or creating a pull request in the [python-broadlink]({url}) library.",
+                "description": "Sorry, we don't know this device: {name} ({type} at {host}). You can try to configure it manually by selecting an appropriate device class.\n\nIf you manage to make it work, please open an issue or pull request in the [python-broadlink]({url}) repository.",
                 "data": {
                     "device_class": "Device class"
                 }

--- a/homeassistant/components/broadlink/translations/en.json
+++ b/homeassistant/components/broadlink/translations/en.json
@@ -24,6 +24,13 @@
                 },
                 "title": "Choose a name for the device"
             },
+            "manual": {
+                "title": "Manual configuration",
+                "description": "Sorry, we don't know this device: {name} ({type} at {host}). You can try to configure it manually by selecting an appropriate device class.\n\nIf you manage to make it work, please consider opening an issue or creating a pull request in the [python-broadlink]({url}) library.",
+                "data": {
+                    "device_class": "Device class"
+                }
+            },
             "reset": {
                 "description": "{name} ({model} at {host}) is locked. You need to unlock the device in order to authenticate and complete the configuration. Instructions:\n1. Open the Broadlink app.\n2. Click on the device.\n3. Click `...` in the upper right.\n4. Scroll to the bottom of the page.\n5. Disable the lock.",
                 "title": "Unlock the device"

--- a/tests/components/broadlink/__init__.py
+++ b/tests/components/broadlink/__init__.py
@@ -67,6 +67,16 @@ BROADLINK_DEVICES = {
         57,
         5,
     ),
+    "Attic": (  # Unknown device type.
+        "109.97.99.104",
+        "696e65667265",
+        "",
+        "",
+        "Unknown",
+        0x6E63,
+        107,
+        5,
+    ),
 }
 
 
@@ -94,7 +104,7 @@ class BroadlinkDevice:
         mock_entry.add_to_hass(hass)
 
         with patch(
-            "homeassistant.components.broadlink.device.blk.gendevice",
+            "homeassistant.components.broadlink.device.blk.device.__new__",
             return_value=mock_api,
         ):
             await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -118,13 +128,17 @@ class BroadlinkDevice:
         mock_api.get_fwversion.return_value = self.fwversion
         return mock_api
 
-    def get_mock_entry(self):
+    def get_mock_entry(self, extra_config=None):
         """Return a mock config entry."""
+        data = self.get_entry_data()
+        if extra_config is not None:
+            data.update(extra_config)
+
         return MockConfigEntry(
             domain=DOMAIN,
             unique_id=self.mac,
             title=self.name,
-            data=self.get_entry_data(),
+            data=data,
         )
 
     def get_entry_data(self):

--- a/tests/components/broadlink/test_device.py
+++ b/tests/components/broadlink/test_device.py
@@ -1,6 +1,7 @@
 """Tests for Broadlink devices."""
-from unittest.mock import patch
+from unittest.mock import call, patch
 
+import broadlink as blk
 import broadlink.exceptions as blke
 
 from homeassistant.components.broadlink.const import DOMAIN
@@ -29,6 +30,51 @@ async def test_device_setup(hass):
     ) as mock_init:
         mock_api, mock_entry = await device.setup_entry(hass)
 
+    assert mock_entry.state == ENTRY_STATE_LOADED
+    assert mock_api.auth.call_count == 1
+    assert mock_api.get_fwversion.call_count == 1
+    forward_entries = {c[1][1] for c in mock_forward.mock_calls}
+    domains = get_domains(mock_api.type)
+    assert mock_forward.call_count == len(domains)
+    assert forward_entries == domains
+    assert mock_init.call_count == 0
+
+
+async def test_unknown_device_setup(hass):
+    """Test we set up an unknown device."""
+    device = get_device("Attic")
+    forced_type = "RM4PRO"
+
+    mock_entry = device.get_mock_entry({"device_class": forced_type})
+    mock_entry.add_to_hass(hass)
+
+    mock_api = device.get_mock_api()
+    mock_api.type = forced_type
+    mock_api.model = forced_type
+    mock_api.manufacturer = "Unknown"
+
+    with patch(
+        "homeassistant.components.broadlink.device.blk.device.__new__",
+        return_value=mock_api,
+    ) as mock_factory, patch.object(
+        hass.config_entries, "async_forward_entry_setup"
+    ) as mock_forward, patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_init:
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_factory.call_count == 1
+    assert mock_factory.call_args == call(
+        blk.rm4pro,
+        mock_api.host,
+        mock_api.mac.hex(),
+        mock_api.devtype,
+        manufacturer=mock_api.manufacturer,
+        model=mock_api.model,
+        name=mock_api.name,
+        timeout=mock_api.timeout,
+    )
     assert mock_entry.state == ENTRY_STATE_LOADED
     assert mock_api.auth.call_count == 1
     assert mock_api.get_fwversion.call_count == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a manual step to the Broadlink configuration flow.

We show this step when we encounter an unknown device type. Then we allow the user to select an appropriate device class in order to configure the device manually.

Advantages:
- users don't need to wait for library updates when the type is already supported, but unknown
- users can easily run compatibility tests, so they don't need to do hackish stuff to find out if the type is supported

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
