### PR TITLE
Use common strings in emulated roku

### DIFF
--- a/homeassistant/components/emulated_roku/config_flow.py
+++ b/homeassistant/components/emulated_roku/config_flow.py
@@ -31,7 +31,7 @@ class EmulatedRokuFlowHandler(config_entries.ConfigFlow):
             name = user_input[CONF_NAME]
 
             if name in configured_servers(self.hass):
-                return self.async_abort(reason="name_exists")
+                return self.async_abort(reason="already_configured")
 
             return self.async_create_entry(title=name, data=user_input)
 

--- a/homeassistant/components/emulated_roku/strings.json
+++ b/homeassistant/components/emulated_roku/strings.json
@@ -1,14 +1,14 @@
 {
   "title": "Emulated Roku",
   "config": {
-    "abort": { "name_exists": "Name already exists" },
+    "abort": { "already_configured": "[%key:common::config_flow::abort::already_configured_device%]" }, 
     "step": {
       "user": {
         "data": {
-          "advertise_ip": "Advertise [%key:common::config_flow::data::ip%]",
-          "advertise_port": "Advertise [%key:common::config_flow::data::port%]",
-          "host_ip": "Host [%key:common::config_flow::data::ip%]",
-          "listen_port": "Listen [%key:common::config_flow::data::port%]",
+          "advertise_ip": "Advertise IP Address",
+          "advertise_port": "Advertise Port",
+          "host_ip": "Host IP Address",
+          "listen_port": "Listen Port",
           "name": "[%key:common::config_flow::data::name%]",
           "upnp_bind_multicast": "Bind multicast (True/False)"
         },

--- a/homeassistant/components/emulated_roku/strings.json
+++ b/homeassistant/components/emulated_roku/strings.json
@@ -5,10 +5,10 @@
     "step": {
       "user": {
         "data": {
-          "advertise_ip": "Advertise IP",
-          "advertise_port": "Advertise port",
-          "host_ip": "Host IP",
-          "listen_port": "Listen port",
+          "advertise_ip": "Advertise [%key:common::config_flow::data::ip%]",
+          "advertise_port": "Advertise [%key:common::config_flow::data::port%]",
+          "host_ip": "Host [%key:common::config_flow::data::ip%]",
+          "listen_port": "Listen [%key:common::config_flow::data::port%]",
           "name": "[%key:common::config_flow::data::name%]",
           "upnp_bind_multicast": "Bind multicast (True/False)"
         },


### PR DESCRIPTION
## Proposed change
Use common strings in emulated_roku integration as described in #40578

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40578
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
