### PR TITLE
Use common strings in denonavr integration

### DIFF
--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -158,7 +158,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.zone3,
         )
         if not await connect_denonavr.async_connect_receiver():
-            return self.async_abort(reason="connection_error")
+            return self.async_abort(reason="cannot_connect")
         receiver = connect_denonavr.receiver
 
         mac_address = await self.async_get_mac(self.host)

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Denon AVR Network Receivers",
-        "description": "Connect to your receiver, if the [%key:common::config_flow::data::ip%] is not set, auto-discovery is used",
+        "description": "Connect to your receiver, if the IP address is not set, auto-discovery is used",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]"
         }
@@ -17,7 +17,7 @@
         "title": "Select the receiver that you wish to connect",
         "description": "Run the setup again if you want to connect additional receivers",
         "data": {
-          "select_host": "Receiver [%key:common::config_flow::data::ip%]"
+          "select_host": "Receiver IP address"
         }
       }
     },
@@ -27,7 +27,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%], please try again, disconnecting mains power and ethernet cables and reconnecting them may help",
+      "cannot_connect": "Failed to connect, please try again, disconnecting mains power and ethernet cables and reconnecting them may help",
       "not_denonavr_manufacturer": "Not a Denon AVR Network Receiver, discovered manafucturer did not match",
       "not_denonavr_missing": "Not a Denon AVR Network Receiver, discovery information not complete"
     }

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Denon AVR Network Receivers",
-        "description": "Connect to your receiver, if the IP address is not set, auto-discovery is used",
+        "description": "Connect to your receiver, if the [%key:common::config_flow::data::ip%] is not set, auto-discovery is used",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]"
         }
@@ -17,7 +17,7 @@
         "title": "Select the receiver that you wish to connect",
         "description": "Run the setup again if you want to connect additional receivers",
         "data": {
-          "select_host": "Receiver IP"
+          "select_host": "Receiver [%key:common::config_flow::data::ip%]"
         }
       }
     },
@@ -27,7 +27,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "connection_error": "Failed to connect, please try again, disconnecting mains power and ethernet cables and reconnecting them may help",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%], please try again, disconnecting mains power and ethernet cables and reconnecting them may help",
       "not_denonavr_manufacturer": "Not a Denon AVR Network Receiver, discovered manafucturer did not match",
       "not_denonavr_missing": "Not a Denon AVR Network Receiver, discovery information not complete"
     }

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -389,7 +389,7 @@ async def test_config_flow_manual_host_connection_error(hass):
         )
 
     assert result["type"] == "abort"
-    assert result["reason"] == "connection_error"
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_config_flow_manual_host_no_device_info(hass):
@@ -416,7 +416,7 @@ async def test_config_flow_manual_host_no_device_info(hass):
         )
 
     assert result["type"] == "abort"
-    assert result["reason"] == "connection_error"
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_config_flow_ssdp(hass):


### PR DESCRIPTION
## Proposed change
Use common and standard reference strings in denonavr integration as described in #40578

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40578
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
