### PR TITLE
Rewrite homematic unittest tests to pytest style test functions

### DIFF
--- a/tests/components/homematic/test_notify.py
+++ b/tests/components/homematic/test_notify.py
@@ -1,77 +1,65 @@
 """The tests for the Homematic notification platform."""
 
-import unittest
-
 import homeassistant.components.notify as notify_comp
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import assert_setup_component, get_test_home_assistant
+from tests.common import assert_setup_component
 
 
-class TestHomematicNotify(unittest.TestCase):
-    """Test the Homematic notifications."""
-
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Stop down everything that was started."""
-        self.hass.stop()
-
-    def test_setup_full(self):
-        """Test valid configuration."""
-        setup_component(
-            self.hass,
-            "homematic",
-            {"homematic": {"hosts": {"ccu2": {"host": "127.0.0.1"}}}},
+async def test_setup_full(hass):
+    """Test valid configuration."""
+    await async_setup_component(
+        hass,
+        "homematic",
+        {"homematic": {"hosts": {"ccu2": {"host": "127.0.0.1"}}}},
+    )
+    with assert_setup_component(1) as handle_config:
+        assert await async_setup_component(
+            hass,
+            "notify",
+            {
+                "notify": {
+                    "name": "test",
+                    "platform": "homematic",
+                    "address": "NEQXXXXXXX",
+                    "channel": 2,
+                    "param": "SUBMIT",
+                    "value": "1,1,108000,2",
+                    "interface": "my-interface",
+                }
+            },
         )
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(
-                self.hass,
-                "notify",
-                {
-                    "notify": {
-                        "name": "test",
-                        "platform": "homematic",
-                        "address": "NEQXXXXXXX",
-                        "channel": 2,
-                        "param": "SUBMIT",
-                        "value": "1,1,108000,2",
-                        "interface": "my-interface",
-                    }
-                },
-            )
-        assert handle_config[notify_comp.DOMAIN]
+    assert handle_config[notify_comp.DOMAIN]
 
-    def test_setup_without_optional(self):
-        """Test valid configuration without optional."""
-        setup_component(
-            self.hass,
-            "homematic",
-            {"homematic": {"hosts": {"ccu2": {"host": "127.0.0.1"}}}},
+
+async def test_setup_without_optional(hass):
+    """Test valid configuration without optional."""
+    await async_setup_component(
+        hass,
+        "homematic",
+        {"homematic": {"hosts": {"ccu2": {"host": "127.0.0.1"}}}},
+    )
+    with assert_setup_component(1) as handle_config:
+        assert await async_setup_component(
+            hass,
+            "notify",
+            {
+                "notify": {
+                    "name": "test",
+                    "platform": "homematic",
+                    "address": "NEQXXXXXXX",
+                    "channel": 2,
+                    "param": "SUBMIT",
+                    "value": "1,1,108000,2",
+                }
+            },
         )
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(
-                self.hass,
-                "notify",
-                {
-                    "notify": {
-                        "name": "test",
-                        "platform": "homematic",
-                        "address": "NEQXXXXXXX",
-                        "channel": 2,
-                        "param": "SUBMIT",
-                        "value": "1,1,108000,2",
-                    }
-                },
-            )
-        assert handle_config[notify_comp.DOMAIN]
+    assert handle_config[notify_comp.DOMAIN]
 
-    def test_bad_config(self):
-        """Test invalid configuration."""
-        config = {notify_comp.DOMAIN: {"name": "test", "platform": "homematic"}}
-        with assert_setup_component(0) as handle_config:
-            assert setup_component(self.hass, notify_comp.DOMAIN, config)
-        assert not handle_config[notify_comp.DOMAIN]
+
+async def test_bad_config(hass):
+    """Test invalid configuration."""
+    config = {notify_comp.DOMAIN: {"name": "test", "platform": "homematic"}}
+    with assert_setup_component(0) as handle_config:
+        assert await async_setup_component(hass, notify_comp.DOMAIN, config)
+    assert not handle_config[notify_comp.DOMAIN]


### PR DESCRIPTION
Issue: https://github.com/home-assistant/core/issues/40856

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite homematic unittest tests to pytest style test functions


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40856
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
