### PR TITLE
Removed unneccessary dependency on adafruit-blinka

### DIFF
--- a/homeassistant/components/mcp23017/manifest.json
+++ b/homeassistant/components/mcp23017/manifest.json
@@ -4,7 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/mcp23017",
   "requirements": [
     "RPi.GPIO==0.7.0",
-    "adafruit-blinka==3.9.0",
     "adafruit-circuitpython-mcp230xx==2.2.2"
   ],
   "codeowners": ["@jardiamj"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -104,9 +104,6 @@ abodepy==1.1.0
 # homeassistant.components.accuweather
 accuweather==0.0.11
 
-# homeassistant.components.mcp23017
-adafruit-blinka==3.9.0
-
 # homeassistant.components.bmp280
 adafruit-circuitpython-bmp280==3.1.1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After I've received a bug report #41250 I did some investigation which revealed the following:
* `adafruit-circuitpython-bmp280` depends on any version of `adafruit-blinka`
* `adafruit-blinka==3.9.0` depended on any version of `Adafruit-PlatformDetect`
* In reality `adafruit-blinka==3.9.0` is only compatible with `Adafruit-PlatformDetect<=2.18.0` [due to a breaking change implemented in 2.18.1](https://github.com/adafruit/Adafruit_Blinka/commit/f8a13c038c45aa5e88ccbc64bf359b77ed938c01#diff-2f24eddf30df964d922ef3a801d37c2a)

This could cause the following
1. If the latest version of `adafruit-blinka` was somehow installed in the Python environment then pip would also upgrade `Adafruit-PlatformDetect` to satisfy its dependency tree
1. home-assistant would then downgrade `adafruit-blinka` to satisfy the requirements of home-assistant component `mcp23017`
1. This breaks both `mcp23017` and `bmp280` causing the issues described in #41250 and #40192 

To avoid this issue I have removed the direct dependency of `adafruit-blinka==3.9.0` from `mcp23017`. It is not required as it is an indirect dependency of `adafruit-circuitpython-mcp230xx` anyway.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41250 fixes #40192 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
