### PR TITLE
Improve deCONZ fan platform handling unsupported commands

### DIFF
--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -106,7 +106,7 @@ class DeconzFan(DeconzDevice, FanEntity):
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         if speed not in SPEEDS:
-            return
+            raise ValueError("Unsupported speed %s", speed)
 
         data = {"speed": SPEEDS[speed]}
 

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -106,7 +106,7 @@ class DeconzFan(DeconzDevice, FanEntity):
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         if speed not in SPEEDS:
-            raise ValueError("Unsupported speed %s", speed)
+            raise ValueError(f"Unsupported speed {speed}")
 
         data = {"speed": SPEEDS[speed]}
 

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -105,7 +105,11 @@ class DeconzFan(DeconzDevice, FanEntity):
 
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
+        if speed not in SPEEDS:
+            return
+
         data = {"speed": SPEEDS[speed]}
+
         await self._device.async_set_state(data)
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -1,6 +1,8 @@
 """deCONZ fan platform tests."""
 from copy import deepcopy
 
+import pytest
+
 from homeassistant.components import deconz
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 import homeassistant.components.fan as fan
@@ -169,7 +171,7 @@ async def test_fans(hass):
 
     with patch.object(
         ceiling_fan_device, "_request", return_value=True
-    ) as set_callback:
+    ) as set_callback, pytest.raises(ValueError):
         await hass.services.async_call(
             fan.DOMAIN,
             fan.SERVICE_SET_SPEED,
@@ -177,7 +179,6 @@ async def test_fans(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_not_called()
 
     # Events with an unsupported speed gets converted to default speed "medium"
 

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -165,7 +165,21 @@ async def test_fans(hass):
         await hass.async_block_till_done()
         set_callback.assert_called_with("put", "/lights/1/state", json={"speed": 0})
 
-    # Verify that an unsupported speed gets converted to default speed "medium"
+    # Service set fan speed to unsupported value
+
+    with patch.object(
+        ceiling_fan_device, "_request", return_value=True
+    ) as set_callback:
+        await hass.services.async_call(
+            fan.DOMAIN,
+            fan.SERVICE_SET_SPEED,
+            {"entity_id": "fan.ceiling_fan", fan.ATTR_SPEED: "bad value"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        set_callback.assert_not_called()
+
+    # Events with an unsupported speed gets converted to default speed "medium"
 
     state_changed_event = {
         "t": "event",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up PR handling @MartinHjelmare comment from https://github.com/home-assistant/core/pull/40806

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
