### PR TITLE
Improve deCONZ climate platform handling unsupported commands

### DIFF
--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -99,7 +99,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         if ATTR_TEMPERATURE not in kwargs:
-            return
+            raise ValueError("Expected attribute %s", ATTR_TEMPERATURE)
 
         data = {"heatsetpoint": kwargs[ATTR_TEMPERATURE] * 100}
 
@@ -108,7 +108,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
         if hvac_mode not in HVAC_MODES:
-            return
+            raise ValueError("Unsupported mode %s", hvac_mode)
 
         data = {"mode": HVAC_MODES[hvac_mode]}
 

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -99,7 +99,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         if ATTR_TEMPERATURE not in kwargs:
-            raise ValueError("Expected attribute %s", ATTR_TEMPERATURE)
+            raise ValueError(f"Expected attribute {ATTR_TEMPERATURE}")
 
         data = {"heatsetpoint": kwargs[ATTR_TEMPERATURE] * 100}
 
@@ -108,7 +108,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
         if hvac_mode not in HVAC_MODES:
-            raise ValueError("Unsupported mode %s", hvac_mode)
+            raise ValueError(f"Unsupported mode {hvac_mode}")
 
         data = {"mode": HVAC_MODES[hvac_mode]}
 

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -16,7 +16,7 @@ from .const import ATTR_OFFSET, ATTR_VALVE, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
-SUPPORT_HVAC = [HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+HVAC_MODES = {HVAC_MODE_AUTO: "auto", HVAC_MODE_HEAT: "heat", HVAC_MODE_OFF: "off"}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -72,19 +72,19 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
 
         Need to be one of HVAC_MODE_*.
         """
-        if self._device.mode in SUPPORT_HVAC:
-            return self._device.mode
+        for hass_hvac_mode, device_mode in HVAC_MODES.items():
+            if self._device.mode == device_mode:
+                return hass_hvac_mode
+
         if self._device.state_on:
             return HVAC_MODE_HEAT
+
         return HVAC_MODE_OFF
 
     @property
-    def hvac_modes(self):
-        """Return the list of available hvac operation modes.
-
-        Need to be a subset of HVAC_MODES.
-        """
-        return SUPPORT_HVAC
+    def hvac_modes(self) -> list:
+        """Return the list of available hvac operation modes."""
+        return list(HVAC_MODES)
 
     @property
     def current_temperature(self):
@@ -98,21 +98,19 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
-        data = {}
+        if ATTR_TEMPERATURE not in kwargs:
+            return
 
-        if ATTR_TEMPERATURE in kwargs:
-            data["heatsetpoint"] = kwargs[ATTR_TEMPERATURE] * 100
+        data = {"heatsetpoint": kwargs[ATTR_TEMPERATURE] * 100}
 
         await self._device.async_set_config(data)
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
-        if hvac_mode == HVAC_MODE_AUTO:
-            data = {"mode": "auto"}
-        elif hvac_mode == HVAC_MODE_HEAT:
-            data = {"mode": "heat"}
-        elif hvac_mode == HVAC_MODE_OFF:
-            data = {"mode": "off"}
+        if hvac_mode not in HVAC_MODES:
+            return
+
+        data = {"mode": HVAC_MODES[hvac_mode]}
 
         await self._device.async_set_config(data)
 

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -1,6 +1,8 @@
 """deCONZ climate platform tests."""
 from copy import deepcopy
 
+import pytest
+
 from homeassistant.components import deconz
 import homeassistant.components.climate as climate
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
@@ -157,14 +159,15 @@ async def test_climate_devices(hass):
 
     # Service set HVAC mode to unsupported value
 
-    with patch.object(thermostat_device, "_request", return_value=True) as set_callback:
+    with patch.object(
+        thermostat_device, "_request", return_value=True
+    ) as set_callback, pytest.raises(ValueError):
         await hass.services.async_call(
             climate.DOMAIN,
             climate.SERVICE_SET_HVAC_MODE,
             {"entity_id": "climate.thermostat", "hvac_mode": "cool"},
             blocking=True,
         )
-        set_callback.assert_not_called()
 
     # Service set temperature to 20
 
@@ -181,7 +184,9 @@ async def test_climate_devices(hass):
 
     # Service set temperature without providing temperature attribute
 
-    with patch.object(thermostat_device, "_request", return_value=True) as set_callback:
+    with patch.object(
+        thermostat_device, "_request", return_value=True
+    ) as set_callback, pytest.raises(ValueError):
         await hass.services.async_call(
             climate.DOMAIN,
             climate.SERVICE_SET_TEMPERATURE,
@@ -192,7 +197,6 @@ async def test_climate_devices(hass):
             },
             blocking=True,
         )
-        set_callback.assert_not_called()
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -155,6 +155,17 @@ async def test_climate_devices(hass):
             "put", "/sensors/1/config", json={"mode": "off"}
         )
 
+    # Service set HVAC mode to unsupported value
+
+    with patch.object(thermostat_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            climate.DOMAIN,
+            climate.SERVICE_SET_HVAC_MODE,
+            {"entity_id": "climate.thermostat", "hvac_mode": "cool"},
+            blocking=True,
+        )
+        set_callback.assert_not_called()
+
     # Service set temperature to 20
 
     with patch.object(thermostat_device, "_request", return_value=True) as set_callback:
@@ -167,6 +178,21 @@ async def test_climate_devices(hass):
         set_callback.assert_called_with(
             "put", "/sensors/1/config", json={"heatsetpoint": 2000.0}
         )
+
+    # Service set temperature without providing temperature attribute
+
+    with patch.object(thermostat_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            climate.DOMAIN,
+            climate.SERVICE_SET_TEMPERATURE,
+            {
+                "entity_id": "climate.thermostat",
+                "target_temp_high": 30,
+                "target_temp_low": 10,
+            },
+            blocking=True,
+        )
+        set_callback.assert_not_called()
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mirror implementation in deCONZ fan platform unto climate platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
