### PR TITLE
Add Remote entity to Xbox Integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1006,6 +1006,7 @@ omit =
     homeassistant/components/xbox/api.py
     homeassistant/components/xbox/browse_media.py
     homeassistant/components/xbox/media_player.py
+    homeassistant/components/xbox/remote.py
     homeassistant/components/xbox_live/sensor.py
     homeassistant/components/xeoma/camera.py
     homeassistant/components/xfinity/device_tracker.py

--- a/homeassistant/components/xbox/remote.py
+++ b/homeassistant/components/xbox/remote.py
@@ -1,0 +1,94 @@
+"""Xbox Remote support."""
+import asyncio
+from typing import Any, Iterable
+
+from xbox.webapi.api.client import XboxLiveClient
+from xbox.webapi.api.provider.smartglass.models import (
+    InputKeyType,
+    PowerState,
+    SmartglassConsole,
+    SmartglassConsoleList,
+)
+
+from homeassistant.components.remote import (
+    ATTR_DELAY_SECS,
+    ATTR_NUM_REPEATS,
+    DEFAULT_DELAY_SECS,
+    RemoteEntity,
+)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import XboxData, XboxUpdateCoordinator
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Xbox media_player from a config entry."""
+    client: XboxLiveClient = hass.data[DOMAIN][entry.entry_id]["client"]
+    consoles: SmartglassConsoleList = hass.data[DOMAIN][entry.entry_id]["consoles"]
+    coordinator: XboxUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
+        "coordinator"
+    ]
+
+    async_add_entities(
+        [XboxRemote(client, console, coordinator) for console in consoles.result]
+    )
+
+
+class XboxRemote(CoordinatorEntity, RemoteEntity):
+    """Representation of an Xbox remote."""
+
+    def __init__(
+        self,
+        client: XboxLiveClient,
+        console: SmartglassConsole,
+        coordinator: XboxUpdateCoordinator,
+    ) -> None:
+        """Initialize the Xbox Media Player."""
+        super().__init__(coordinator)
+        self.client: XboxLiveClient = client
+        self._console: SmartglassConsole = console
+
+    @property
+    def name(self):
+        """Return the device name."""
+        return f"{self._console.name} Remote"
+
+    @property
+    def unique_id(self):
+        """Console device ID."""
+        return self._console.id
+
+    @property
+    def data(self) -> XboxData:
+        """Return coordinator data for this console."""
+        return self.coordinator.data[self._console.id]
+
+    @property
+    def is_on(self):
+        """Return True if device is on."""
+        return self.data.status.power_state == PowerState.On
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the Xbox on."""
+        await self.client.smartglass.wake_up(self._console.id)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the Xbox off."""
+        await self.client.smartglass.turn_off(self._console.id)
+
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send controller or text input to the Xbox."""
+        num_repeats = kwargs[ATTR_NUM_REPEATS]
+        delay = kwargs.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
+
+        for _ in range(num_repeats):
+            for single_command in command:
+                try:
+                    button = InputKeyType(single_command)
+                    await self.client.smartglass.press_button(self._console.id, button)
+                except ValueError:
+                    await self.client.smartglass.insert_text(
+                        self._console.id, single_command
+                    )
+                await asyncio.sleep(delay)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This switches the Xbox Integration to use `DataUpdateCoordinator` and adds a Remote entity implementation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
xbox:
  client_id: !secret xbox_client_id
  client_secret: !secret xbox_client_secret
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15223

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
