### PR TITLE
Add persistent notification for reauth config flows

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1021,7 +1021,11 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     ) -> Dict[str, Any]:
         """Abort the config flow."""
         assert self.hass
-        if not self._async_in_progress():
+        if not any(
+            ent["context"]["source"] == SOURCE_REAUTH
+            for ent in self.hass.config_entries.flow.async_progress()
+            if ent["flow_id"] != self.flow_id
+        ):
             self.hass.components.persistent_notification.async_dismiss(
                 RECONFIGURE_NOTIFICATION_ID
             )

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -572,7 +572,7 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
             self.hass.components.persistent_notification.async_create(
                 title="Devices require reconfiguration",
                 message=(
-                    "At least one of your devices requires reconfiguration to "
+                    "At least one of your integrations requires reconfiguration to "
                     "continue functioning. [Check it out](/config/integrations)"
                 ),
                 notification_id=RECONFIGURE_NOTIFICATION_ID,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1021,6 +1021,8 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     ) -> Dict[str, Any]:
         """Abort the config flow."""
         assert self.hass
+
+        # Remove reauth notification if no reauth flows are in progress
         if not any(
             ent["context"]["source"] == SOURCE_REAUTH
             for ent in self.hass.config_entries.flow.async_progress()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1023,7 +1023,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         assert self.hass
 
         # Remove reauth notification if no reauth flows are in progress
-        if not any(
+        if self.source == SOURCE_REAUTH and not any(
             ent["context"]["source"] == SOURCE_REAUTH
             for ent in self.hass.config_entries.flow.async_progress()
             if ent["flow_id"] != self.flow_id

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -570,7 +570,7 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
             )
         elif source == SOURCE_REAUTH:
             self.hass.components.persistent_notification.async_create(
-                title="Devices require reconfiguration",
+                title="Integration requires reconfiguration",
                 message=(
                     "At least one of your integrations requires reconfiguration to "
                     "continue functioning. [Check it out](/config/integrations)"

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -261,7 +261,7 @@ class FlowHandler:
     @property
     def source(self) -> Optional[str]:
         """Source that initialized the flow."""
-        if not self.context:
+        if not hasattr(self, "context"):
             return None
 
         return self.context.get("source", None)
@@ -269,7 +269,7 @@ class FlowHandler:
     @property
     def show_advanced_options(self) -> bool:
         """If we should show advanced options."""
-        if not self.context:
+        if not hasattr(self, "context"):
             return False
 
         return self.context.get("show_advanced_options", False)

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -269,6 +269,9 @@ class FlowHandler:
     @property
     def show_advanced_options(self) -> bool:
         """If we should show advanced options."""
+        if not self.context:
+            return False
+
         return self.context.get("show_advanced_options", False)
 
     @callback

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -261,6 +261,9 @@ class FlowHandler:
     @property
     def source(self) -> Optional[str]:
         """Source that initialized the flow."""
+        if not self.context:
+            return None
+
         return self.context.get("source", None)
 
     @property

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,7 +1,6 @@
 """Test the config manager."""
 import asyncio
 from datetime import timedelta
-from logging import getLogger
 
 import pytest
 
@@ -23,8 +22,6 @@ from tests.common import (
     mock_integration,
     mock_registry,
 )
-
-_LOGGER = getLogger(__name__)
 
 
 @pytest.fixture(autouse=True)
@@ -659,8 +656,6 @@ async def test_reauth_notification(hass):
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-
-        _LOGGER.error(result)
 
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_reconfigure")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Creates a persistent notification when a reauth config flow has been initiated, similar to how one gets created for discovery config flows.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #41801, https://github.com/home-assistant/core/pull/39138#discussion_r502243752
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
