### PR TITLE
Only one reauth flow for an icloud Config Entry can be in progress

### DIFF
--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -124,17 +124,25 @@ class IcloudAccount:
                 ),
                 self._config_entry.data[CONF_USERNAME],
             )
-
-            self.hass.add_job(
-                self.hass.config_entries.flow.async_init(
-                    DOMAIN,
-                    context={"source": SOURCE_REAUTH},
-                    data={
-                        **self._config_entry.data,
-                        "unique_id": self._config_entry.unique_id,
-                    },
+            context = {
+                "source": SOURCE_REAUTH,
+                "unique_id": self._config_entry.unique_id,
+            }
+            if not any(
+                [
+                    flow
+                    for flow in self.hass.config_entries.flow.async_progress()
+                    if flow["context"] == context
+                ]
+            ):
+                self.hass.add_job(
+                    self.hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context=context,
+                        data=self._config_entry.data,
+                    )
                 )
-            )
+
             return
 
         try:

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -129,11 +129,9 @@ class IcloudAccount:
                 "unique_id": self._config_entry.unique_id,
             }
             if not any(
-                [
-                    flow
-                    for flow in self.hass.config_entries.flow.async_progress()
-                    if flow["context"] == context
-                ]
+                flow
+                for flow in self.hass.config_entries.flow.async_progress()
+                if flow["context"] == context
             ):
                 self.hass.add_job(
                     self.hass.config_entries.flow.async_init(

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -1,4 +1,5 @@
 """iCloud account."""
+import asyncio
 from datetime import timedelta
 import logging
 import operator
@@ -130,7 +131,9 @@ class IcloudAccount:
             }
             if not any(
                 flow
-                for flow in self.hass.config_entries.flow.async_progress()
+                for flow in asyncio.run_coroutine_threadsafe(
+                    self.hass.config_entries.flow.async_progress(), self.hass.loop
+                ).result()
                 if flow["context"] == context
             ):
                 self.hass.add_job(

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -180,7 +180,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # Store existing entry data so it can be used later and set unique ID
         # so existing config entry can be updated
         if not self._existing_entry:
-            await self.async_set_unique_id(user_input.pop("unique_id"))
             self._existing_entry = user_input.copy()
             self._description_placeholders = {"username": user_input[CONF_USERNAME]}
             user_input = None

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -420,8 +420,8 @@ async def test_password_update(
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": SOURCE_REAUTH},
-        data={**MOCK_CONFIG, "unique_id": USERNAME},
+        context={"source": SOURCE_REAUTH, "unique_id": USERNAME},
+        data=MOCK_CONFIG,
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -444,8 +444,8 @@ async def test_password_update_wrong_password(hass: HomeAssistantType):
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": SOURCE_REAUTH},
-        data={**MOCK_CONFIG, "unique_id": USERNAME},
+        context={"source": SOURCE_REAUTH, "unique_id": USERNAME},
+        data=MOCK_CONFIG,
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM


### PR DESCRIPTION
## Proposed change
Similar to https://github.com/home-assistant/core/pull/41801, this change prevents multiple reauth flows from being triggered for the same config entry


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/41801

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
