### PR TITLE
Rewrite logentries unittest tests to pytest style test functions

### DIFF
--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -53,9 +53,7 @@ async def test_event_listener(hass, mock_dump, mock_requests):
 
     valid = {"1": 1, "1.0": 1.0, STATE_ON: 1, STATE_OFF: 0, "foo": "foo"}
     for in_, out in valid.items():
-        state = MagicMock(
-            state=in_, domain="fake", object_id="entity", attributes={}
-        )
+        state = MagicMock(state=in_, domain="fake", object_id="entity", attributes={})
         event = MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
@@ -72,7 +70,5 @@ async def test_event_listener(hass, mock_dump, mock_requests):
         }
         handler_method(event)
         assert mock_post.call_count == 1
-        assert mock_post.call_args == call(
-            payload["host"], data=payload, timeout=10
-        )
+        assert mock_post.call_args == call(payload["host"], data=payload, timeout=10)
         mock_post.reset_mock()

--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -1,12 +1,12 @@
 """The tests for the Logentries component."""
 
-from unittest import mock
-
 import pytest
 
 import homeassistant.components.logentries as logentries
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
+
+from tests.async_mock import mock
 
 
 async def test_setup_config_full(hass):

--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -6,13 +6,13 @@ import homeassistant.components.logentries as logentries
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import mock
+from tests.async_mock import MagicMock, call, patch
 
 
 async def test_setup_config_full(hass):
     """Test setup with all data."""
     config = {"logentries": {"token": "secret"}}
-    hass.bus.listen = mock.MagicMock()
+    hass.bus.listen = MagicMock()
     assert await async_setup_component(hass, logentries.DOMAIN, config)
     assert hass.bus.listen.called
     assert EVENT_STATE_CHANGED == hass.bus.listen.call_args_list[0][0][0]
@@ -21,7 +21,7 @@ async def test_setup_config_full(hass):
 async def test_setup_config_defaults(hass):
     """Test setup with defaults."""
     config = {"logentries": {"token": "token"}}
-    hass.bus.listen = mock.MagicMock()
+    hass.bus.listen = MagicMock()
     assert await async_setup_component(hass, logentries.DOMAIN, config)
     assert hass.bus.listen.called
     assert EVENT_STATE_CHANGED == hass.bus.listen.call_args_list[0][0][0]
@@ -30,14 +30,14 @@ async def test_setup_config_defaults(hass):
 @pytest.fixture
 def mock_dump():
     """Mock json dumps."""
-    with mock.patch("json.dumps") as mock_dump:
+    with patch("json.dumps") as mock_dump:
         yield mock_dump
 
 
 @pytest.fixture
 def mock_requests():
     """Mock requests."""
-    with mock.patch.object(logentries, "requests") as mock_requests:
+    with patch.object(logentries, "requests") as mock_requests:
         yield mock_requests
 
 
@@ -47,16 +47,16 @@ async def test_event_listener(hass, mock_dump, mock_requests):
     mock_post = mock_requests.post
     mock_requests.exceptions.RequestException = Exception
     config = {"logentries": {"token": "token"}}
-    hass.bus.listen = mock.MagicMock()
+    hass.bus.listen = MagicMock()
     assert await async_setup_component(hass, logentries.DOMAIN, config)
     handler_method = hass.bus.listen.call_args_list[0][0][1]
 
     valid = {"1": 1, "1.0": 1.0, STATE_ON: 1, STATE_OFF: 0, "foo": "foo"}
     for in_, out in valid.items():
-        state = mock.MagicMock(
+        state = MagicMock(
             state=in_, domain="fake", object_id="entity", attributes={}
         )
-        event = mock.MagicMock(data={"new_state": state}, time_fired=12345)
+        event = MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "domain": "fake",
@@ -72,7 +72,7 @@ async def test_event_listener(hass, mock_dump, mock_requests):
         }
         handler_method(event)
         assert mock_post.call_count == 1
-        assert mock_post.call_args == mock.call(
+        assert mock_post.call_args == call(
             payload["host"], data=payload, timeout=10
         )
         mock_post.reset_mock()

--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -1,82 +1,78 @@
 """The tests for the Logentries component."""
 
-import unittest
 from unittest import mock
+
+import pytest
 
 import homeassistant.components.logentries as logentries
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
-from homeassistant.setup import setup_component
-
-from tests.common import get_test_home_assistant
+from homeassistant.setup import async_setup_component
 
 
-class TestLogentries(unittest.TestCase):
-    """Test the Logentries component."""
+async def test_setup_config_full(hass):
+    """Test setup with all data."""
+    config = {"logentries": {"token": "secret"}}
+    hass.bus.listen = mock.MagicMock()
+    assert await async_setup_component(hass, logentries.DOMAIN, config)
+    assert hass.bus.listen.called
+    assert EVENT_STATE_CHANGED == hass.bus.listen.call_args_list[0][0][0]
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.tear_down_cleanup)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+async def test_setup_config_defaults(hass):
+    """Test setup with defaults."""
+    config = {"logentries": {"token": "token"}}
+    hass.bus.listen = mock.MagicMock()
+    assert await async_setup_component(hass, logentries.DOMAIN, config)
+    assert hass.bus.listen.called
+    assert EVENT_STATE_CHANGED == hass.bus.listen.call_args_list[0][0][0]
 
-    def test_setup_config_full(self):
-        """Test setup with all data."""
-        config = {"logentries": {"token": "secret"}}
-        self.hass.bus.listen = mock.MagicMock()
-        assert setup_component(self.hass, logentries.DOMAIN, config)
-        assert self.hass.bus.listen.called
-        assert EVENT_STATE_CHANGED == self.hass.bus.listen.call_args_list[0][0][0]
 
-    def test_setup_config_defaults(self):
-        """Test setup with defaults."""
-        config = {"logentries": {"token": "token"}}
-        self.hass.bus.listen = mock.MagicMock()
-        assert setup_component(self.hass, logentries.DOMAIN, config)
-        assert self.hass.bus.listen.called
-        assert EVENT_STATE_CHANGED == self.hass.bus.listen.call_args_list[0][0][0]
+@pytest.fixture
+def mock_dump():
+    """Mock json dumps."""
+    with mock.patch("json.dumps") as mock_dump:
+        yield mock_dump
 
-    def _setup(self, mock_requests):
-        """Test the setup."""
-        self.mock_post = mock_requests.post
-        self.mock_request_exception = Exception
-        mock_requests.exceptions.RequestException = self.mock_request_exception
-        config = {"logentries": {"token": "token"}}
-        self.hass.bus.listen = mock.MagicMock()
-        setup_component(self.hass, logentries.DOMAIN, config)
-        self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
 
-    @mock.patch.object(logentries, "requests")
-    @mock.patch("json.dumps")
-    def test_event_listener(self, mock_dump, mock_requests):
-        """Test event listener."""
-        mock_dump.side_effect = lambda x: x
-        self._setup(mock_requests)
+@pytest.fixture
+def mock_requests():
+    """Mock requests."""
+    with mock.patch.object(logentries, "requests") as mock_requests:
+        yield mock_requests
 
-        valid = {"1": 1, "1.0": 1.0, STATE_ON: 1, STATE_OFF: 0, "foo": "foo"}
-        for in_, out in valid.items():
-            state = mock.MagicMock(
-                state=in_, domain="fake", object_id="entity", attributes={}
-            )
-            event = mock.MagicMock(data={"new_state": state}, time_fired=12345)
-            body = [
-                {
-                    "domain": "fake",
-                    "entity_id": "entity",
-                    "attributes": {},
-                    "time": "12345",
-                    "value": out,
-                }
-            ]
-            payload = {
-                "host": "https://webhook.logentries.com/noformat/logs/token",
-                "event": body,
+
+async def test_event_listener(hass, mock_dump, mock_requests):
+    """Test event listener."""
+    mock_dump.side_effect = lambda x: x
+    mock_post = mock_requests.post
+    mock_requests.exceptions.RequestException = Exception
+    config = {"logentries": {"token": "token"}}
+    hass.bus.listen = mock.MagicMock()
+    assert await async_setup_component(hass, logentries.DOMAIN, config)
+    handler_method = hass.bus.listen.call_args_list[0][0][1]
+
+    valid = {"1": 1, "1.0": 1.0, STATE_ON: 1, STATE_OFF: 0, "foo": "foo"}
+    for in_, out in valid.items():
+        state = mock.MagicMock(
+            state=in_, domain="fake", object_id="entity", attributes={}
+        )
+        event = mock.MagicMock(data={"new_state": state}, time_fired=12345)
+        body = [
+            {
+                "domain": "fake",
+                "entity_id": "entity",
+                "attributes": {},
+                "time": "12345",
+                "value": out,
             }
-            self.handler_method(event)
-            assert self.mock_post.call_count == 1
-            assert self.mock_post.call_args == mock.call(
-                payload["host"], data=payload, timeout=10
-            )
-            self.mock_post.reset_mock()
+        ]
+        payload = {
+            "host": "https://webhook.logentries.com/noformat/logs/token",
+            "event": body,
+        }
+        handler_method(event)
+        assert mock_post.call_count == 1
+        assert mock_post.call_args == mock.call(
+            payload["host"], data=payload, timeout=10
+        )
+        mock_post.reset_mock()


### PR DESCRIPTION
Issue: https://github.com/home-assistant/core/issues/40862

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite logentries unittest tests to pytest style test functions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40862
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
