### PR TITLE
Show battery level for devices

### DIFF
--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -118,7 +118,7 @@ class TradfriBaseDevice(TradfriBaseClass):
             "identifiers": {(DOMAIN, self._device.id)},
             "manufacturer": info.manufacturer,
             "model": info.model_number,
-            "name": self._name,
+            "name": self._device.name,
             "sw_version": info.firmware_version,
             "via_device": (DOMAIN, self._gateway_id),
         }

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -13,25 +13,21 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     api = tradfri_data[KEY_API]
     devices = tradfri_data[DEVICES]
 
-    sensors = (
-        dev
-        for dev in devices
-        if not dev.has_light_control
-        and not dev.has_socket_control
-        and not dev.has_blind_control
-        and not dev.has_signal_repeater_control
-    )
+    sensors = (dev for dev in devices if dev.device_info.power_source == 3)  # Battery
+
     if sensors:
-        async_add_entities(TradfriSensor(sensor, api, gateway_id) for sensor in sensors)
+        async_add_entities(
+            TradfriBatterySensor(sensor, api, gateway_id) for sensor in sensors
+        )
 
 
-class TradfriSensor(TradfriBaseDevice):
+class TradfriBatterySensor(TradfriBaseDevice):
     """The platform class required by Home Assistant."""
 
     def __init__(self, device, api, gateway_id):
-        """Initialize the device."""
+        """Initialize the battery sensor entity."""
         super().__init__(device, api, gateway_id)
-        self._unique_id = f"{gateway_id}-{device.id}"
+        self._unique_id = f"{gateway_id}-{device.id}-battery-sensor"
 
     @property
     def device_class(self):
@@ -47,3 +43,7 @@ class TradfriSensor(TradfriBaseDevice):
     def unit_of_measurement(self):
         """Return the unit_of_measurement of the device."""
         return PERCENTAGE
+
+    def _refresh(self, device):
+        super()._refresh(device)
+        self._name = f"{device.name} battery sensor"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Existing remotes will no longer be created as their own entities. New entities for their battery level will appear instead. This requires you to delete the old entities, or reinstall the integration to clean out the old entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only remotes currently have their battery level shown in the UI. Other devices such as the Fyrtur/Kadrilj blinds does not have their battery levels shown even though they are battery powered.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
I've removed the TradfriSensor class and replaced it with a TradfriBatterySensor class. Any devices which register as battery-powered will have an additional entity attached to it based on the TradfriBatterySensor. This allows HA to display the battery level for the primary device (like a blind) directly in the Devices list.

It didn't make sense to have the remotes as their own device alongside the battery sensor, since they were basically just a battery sensors themselves. So instead of handling the remotes as a special case, I decided to remove them. They can still be added again later if or when they actually provide some value (like being able to detect button presses or whatever).

They can still be added 
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The PR looks at every device returned by the gateway to check if it's battery powered. If it is, then a battery sensor entity will be created for the device, allowing HA to display the battery level in the UI. The change should be future proof, since it checks the power source returned by the device itself, instead of relying on the type of device to determine whether to create a battery sensor entity for the device.

- This PR fixes or closes issue: fixes #28675
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
