### PR TITLE
Permit event trackers to accept an empty list of entities or domains

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -236,6 +236,9 @@ def async_track_state_change_event(
     care about the state change events so we can
     do a fast dict lookup to route events.
     """
+    entity_ids = _async_string_to_lower_list(entity_ids)
+    if not entity_ids:
+        return _remove_empty_listener
 
     entity_callbacks = hass.data.setdefault(TRACK_STATE_CHANGE_CALLBACKS, {})
 
@@ -263,8 +266,6 @@ def async_track_state_change_event(
 
     job = HassJob(action)
 
-    entity_ids = _async_string_to_lower_list(entity_ids)
-
     for entity_id in entity_ids:
         entity_callbacks.setdefault(entity_id, []).append(job)
 
@@ -280,6 +281,11 @@ def async_track_state_change_event(
         )
 
     return remove_listener
+
+
+@callback
+def _remove_empty_listener() -> None:
+    """Remove a listener that does nothing."""
 
 
 @callback
@@ -314,6 +320,9 @@ def async_track_entity_registry_updated_event(
 
     Similar to async_track_state_change_event.
     """
+    entity_ids = _async_string_to_lower_list(entity_ids)
+    if not entity_ids:
+        return _remove_empty_listener
 
     entity_callbacks = hass.data.setdefault(TRACK_ENTITY_REGISTRY_UPDATED_CALLBACKS, {})
 
@@ -341,8 +350,6 @@ def async_track_entity_registry_updated_event(
         )
 
     job = HassJob(action)
-
-    entity_ids = _async_string_to_lower_list(entity_ids)
 
     for entity_id in entity_ids:
         entity_callbacks.setdefault(entity_id, []).append(job)
@@ -388,6 +395,9 @@ def async_track_state_added_domain(
     action: Callable[[Event], Any],
 ) -> Callable[[], None]:
     """Track state change events when an entity is added to domains."""
+    domains = _async_string_to_lower_list(domains)
+    if not domains:
+        return _remove_empty_listener
 
     domain_callbacks = hass.data.setdefault(TRACK_STATE_ADDED_DOMAIN_CALLBACKS, {})
 
@@ -406,8 +416,6 @@ def async_track_state_added_domain(
         )
 
     job = HassJob(action)
-
-    domains = _async_string_to_lower_list(domains)
 
     for domain in domains:
         domain_callbacks.setdefault(domain, []).append(job)
@@ -433,6 +441,9 @@ def async_track_state_removed_domain(
     action: Callable[[Event], Any],
 ) -> Callable[[], None]:
     """Track state change events when an entity is removed from domains."""
+    domains = _async_string_to_lower_list(domains)
+    if not domains:
+        return _remove_empty_listener
 
     domain_callbacks = hass.data.setdefault(TRACK_STATE_REMOVED_DOMAIN_CALLBACKS, {})
 
@@ -451,8 +462,6 @@ def async_track_state_removed_domain(
         )
 
     job = HassJob(action)
-
-    domains = _async_string_to_lower_list(domains)
 
     for domain in domains:
         domain_callbacks.setdefault(domain, []).append(job)

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -486,6 +486,19 @@ async def test_async_track_state_change_event(hass):
     unsub_throws()
 
 
+async def test_async_track_state_change_event_with_empty_list(hass):
+    """Test async_track_state_change_event passing an empty list of entities."""
+    unsub_single = async_track_state_change_event(
+        hass, [], ha.callback(lambda event: None)
+    )
+    unsub_single2 = async_track_state_change_event(
+        hass, [], ha.callback(lambda event: None)
+    )
+
+    unsub_single2()
+    unsub_single()
+
+
 async def test_async_track_state_added_domain(hass):
     """Test async_track_state_added_domain."""
     single_entity_id_tracker = []
@@ -566,6 +579,32 @@ async def test_async_track_state_added_domain(hass):
 
     unsub_multi()
     unsub_throws()
+
+
+async def test_async_track_state_added_domain_with_empty_list(hass):
+    """Test async_track_state_added_domain passing an empty list of domains."""
+    unsub_single = async_track_state_added_domain(
+        hass, [], ha.callback(lambda event: None)
+    )
+    unsub_single2 = async_track_state_added_domain(
+        hass, [], ha.callback(lambda event: None)
+    )
+
+    unsub_single2()
+    unsub_single()
+
+
+async def test_async_track_state_removed_domain_with_empty_list(hass):
+    """Test async_track_state_removed_domain passing an empty list of domains."""
+    unsub_single = async_track_state_removed_domain(
+        hass, [], ha.callback(lambda event: None)
+    )
+    unsub_single2 = async_track_state_removed_domain(
+        hass, [], ha.callback(lambda event: None)
+    )
+
+    unsub_single2()
+    unsub_single()
 
 
 async def test_async_track_state_removed_domain(hass):
@@ -2876,3 +2915,16 @@ async def test_async_track_entity_registry_updated_event_with_a_callback_that_th
     unsub2()
 
     assert event_data[0] == {"action": "create", "entity_id": "switch.puppy_feeder"}
+
+
+async def test_async_track_entity_registry_updated_event_with_empty_list(hass):
+    """Test async_track_entity_registry_updated_event passing an empty list of entities."""
+    unsub_single = hass.helpers.event.async_track_entity_registry_updated_event(
+        [], ha.callback(lambda event: None)
+    )
+    unsub_single2 = hass.helpers.event.async_track_entity_registry_updated_event(
+        [], ha.callback(lambda event: None)
+    )
+
+    unsub_single2()
+    unsub_single()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Permit event trackers to accept an empty list of entities or domains

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41738 fixes #41594
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
