### PR TITLE
Correct logging and add test case for sharkiq

### DIFF
--- a/homeassistant/components/sharkiq/update_coordinator.py
+++ b/homeassistant/components/sharkiq/update_coordinator.py
@@ -74,7 +74,7 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator):
             SharkIqNotAuthedError,
             SharkIqAuthExpiringError,
         ) as err:
-            _LOGGER.debug("Bad auth state.  Attempting re-auth.", exc_info=err)
+            _LOGGER.debug("Bad auth state.  Attempting re-auth", exc_info=err)
             flow_context = {
                 "source": "reauth",
                 "unique_id": self._config_entry.unique_id,
@@ -87,7 +87,7 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator):
             ]
 
             if not matching_flows:
-                _LOGGER.debug("Re-initializing flows.  Attempting re-auth.")
+                _LOGGER.debug("Re-initializing flows.  Attempting re-auth")
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_init(
                         DOMAIN,
@@ -96,7 +96,7 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator):
                     )
                 )
             else:
-                _LOGGER.debug("Matching flow found.")
+                _LOGGER.debug("Matching flow found")
 
             raise UpdateFailed(err) from err
         except Exception as err:  # pylint: disable=broad-except

--- a/homeassistant/components/sharkiq/update_coordinator.py
+++ b/homeassistant/components/sharkiq/update_coordinator.py
@@ -74,7 +74,7 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator):
             SharkIqNotAuthedError,
             SharkIqAuthExpiringError,
         ) as err:
-            _LOGGER.exception("Bad auth state")
+            _LOGGER.debug("Bad auth state.  Attempting re-auth.", exc_info=err)
             flow_context = {
                 "source": "reauth",
                 "unique_id": self._config_entry.unique_id,
@@ -87,6 +87,7 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator):
             ]
 
             if not matching_flows:
+                _LOGGER.debug("Re-initializing flows.  Attempting re-auth.")
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_init(
                         DOMAIN,
@@ -94,6 +95,8 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator):
                         data=self._config_entry.data,
                     )
                 )
+            else:
+                _LOGGER.debug("Matching flow found.")
 
             raise UpdateFailed(err) from err
         except Exception as err:  # pylint: disable=broad-except

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -4,7 +4,7 @@ import enum
 from typing import Any, Iterable, List, Optional
 
 import pytest
-from sharkiqpy import AylaApi, SharkIqAuthError, SharkIqVacuum
+from sharkiqpy import AylaApi, SharkIqAuthError, SharkIqNotAuthedError, SharkIqVacuum
 
 from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.components.sharkiq import DOMAIN
@@ -217,6 +217,7 @@ async def test_locate(hass):
     [
         (None, True),
         (SharkIqAuthError, False),
+        (SharkIqNotAuthedError, False),
         (RuntimeError, False),
     ],
 )


### PR DESCRIPTION
## Proposed change
Correct the logging level when attempting reauth the sharkiq integration.  Also, add some more logging and another test case.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
Currently, an expected exception is being logged at the `error` level, so let's change that to `debug` level. 

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
