### PR TITLE
Add ElkM1 time and counter services and keypress event

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -245,7 +245,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             },
         )
 
-    for keypad in elk.keypads:
+    for keypad in elk.keypads:  # pylint: disable=no-member
         keypad.add_callback(_element_changed)
 
     if not await async_wait_for_elk_to_sync(elk, SYNC_TIMEOUT):

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -19,10 +19,11 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
+import homeassistant.util.dt as dt_util
 
 from .const import (
     ATTR_KEY,
@@ -324,29 +325,21 @@ async def async_wait_for_elk_to_sync(elk, timeout):
 
 
 def _create_elk_services(hass):
-    def _speak_word_service(service):
+    def _getelk(service):
         prefix = service.data["prefix"]
         elk = _find_elk_by_prefix(hass, prefix)
         if elk is None:
-            _LOGGER.error("No elk m1 with prefix for speak_word: '%s'", prefix)
-            return
-        elk.panel.speak_word(service.data["number"])
+            raise HomeAssistantError(f"No ElkM1 with prefix '{prefix}' found")
+        return elk
+
+    def _speak_word_service(service):
+        _getelk(service).panel.speak_word(service.data["number"])
 
     def _speak_phrase_service(service):
-        prefix = service.data["prefix"]
-        elk = _find_elk_by_prefix(hass, prefix)
-        if elk is None:
-            _LOGGER.error("No elk m1 with prefix for speak_phrase: '%s'", prefix)
-            return
-        elk.panel.speak_phrase(service.data["number"])
+        _getelk(service).panel.speak_phrase(service.data["number"])
 
     def _set_time_service(service):
-        prefix = service.data["prefix"]
-        elk = _find_elk_by_prefix(hass, prefix)
-        if elk is None:
-            _LOGGER.error("No ElkM1 with prefix for set_time: '%s'", prefix)
-            return
-        elk.panel.set_time()
+        _getelk(service).panel.set_time(dt_util.now())
 
     hass.services.async_register(
         DOMAIN, "speak_word", _speak_word_service, SPEAK_SERVICE_SCHEMA

--- a/homeassistant/components/elkm1/const.py
+++ b/homeassistant/components/elkm1/const.py
@@ -36,10 +36,16 @@ ELK_ELEMENTS = {
     CONF_ZONE: Max.ZONES.value,
 }
 
+EVENT_ELKM1_KEYPAD_KEY_PRESSED = "elkm1.keypad_key_pressed"
 
+
+ATTR_KEYPAD_ID = "keypad_id"
+ATTR_KEY = "key"
+ATTR_KEY_NAME = "key_name"
 ATTR_CHANGED_BY_KEYPAD = "changed_by_keypad"
 ATTR_CHANGED_BY_ID = "changed_by_id"
 ATTR_CHANGED_BY_TIME = "changed_by_time"
+ATTR_VALUE = "value"
 
 ELK_USER_CODE_SERVICE_SCHEMA = {
     vol.Required(ATTR_CODE): vol.All(vol.Coerce(int), vol.Range(0, 999999))

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -2,7 +2,7 @@
   "domain": "elkm1",
   "name": "Elk-M1 Control",
   "documentation": "https://www.home-assistant.io/integrations/elkm1",
-  "requirements": ["elkm1-lib==0.8.2"],
+  "requirements": ["elkm1-lib==0.8.3"],
   "codeowners": ["@gwww", "@bdraco"],
   "config_flow": true
 }

--- a/homeassistant/components/elkm1/services.yaml
+++ b/homeassistant/components/elkm1/services.yaml
@@ -70,6 +70,13 @@ alarm_display_message:
       description: Up to 16 characters of text (truncated if too long). Default blank.
       example: the universe, and everything.
 
+set_time:
+  description: Set the time for the panel.
+  fields:
+    prefix:
+      description: Prefix for the panel.
+      example: gatehouse
+
 speak_phrase:
   description: Speak a phrase. See list of phrases in ElkM1 ASCII Protocol documentation.
   fields:
@@ -83,6 +90,23 @@ speak_word:
     number:
       description: Word number to speak.
       example: 142
+
+sensor_counter_refresh:
+  description: Refresh the value of a counter from the panel.
+  fields:
+    entity_id:
+      description: Name of counter to refresh.
+      example: "sensor.counting_sheep"
+
+sensor_counter_set:
+  description: Set the value of a counter on the panel.
+  fields:
+    entity_id:
+      description: Name of counter to set.
+      example: "sensor.test42"
+    value:
+      description: Value to set the counter to.
+      example: 4242
 
 sensor_zone_bypass:
   description: Bypass zone.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -541,7 +541,7 @@ elgato==0.2.0
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==0.8.2
+elkm1-lib==0.8.3
 
 # homeassistant.components.mobile_app
 emoji==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ eebrightbox==0.0.4
 elgato==0.2.0
 
 # homeassistant.components.elkm1
-elkm1-lib==0.8.2
+elkm1-lib==0.8.3
 
 # homeassistant.components.mobile_app
 emoji==0.5.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds 3 new services and 1 new event to the ElkM1 integration.

The services are: `set_time` to set the time on the ElkM1 panel to the current HA time, `sensor_counter_refresh` to refresh the value of a counter from the panel (ElkM1 does not automatically send changed counters), and `sensor_counter_set` to set a counter to a value.

The new event is `elkm1.keypad_key_pressed` and is triggered whenever a key on an ElkM1 keypad is pressed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: Docs are ready to create PR, however I'm waiting for previous docs PR to get merged before submitted as there is likely a merge conflict.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (Kind of; see note above)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
