### PR TITLE
Catch it when files are ignored by coverage but shouldn't

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,5 +87,5 @@ repos:
         entry: script/run-in-env.sh python3 -m script.hassfest
         pass_filenames: false
         language: script
-        types: [json]
-        files: ^homeassistant/.+/(manifest|strings)\.json$
+        types: [text]
+        files: ^(homeassistant/.+/(manifest|strings)\.json|\.coveragerc)$

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -121,7 +121,7 @@ def validate(integrations: Dict[str, Integration], config: Config):
                 if (integration_path / check).exists():
                     integration.add_error(
                         "coverage",
-                        f"coveragerc incorrectly set up to ignore coverage for {check}",
+                        f"{check} must not be ignored by the .coveragerc file",
                     )
 
     if not not_found:

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -4,6 +4,70 @@ from typing import Dict
 
 from .model import Config, Integration
 
+DONT_IGNORE = (
+    "config_flow.py",
+    "device_action.py",
+    "device_condition.py",
+    "device_trigger.py",
+    "group.py",
+    "intent.py",
+    "logbook.py",
+    "media_source.py",
+    "scene.py",
+)
+
+# They were violating when we introduced this check
+# Need to be fixed in a future PR.
+ALLOWED_IGNORE_VIOLATIONS = {
+    ("ambient_station", "config_flow.py"),
+    ("cast", "config_flow.py"),
+    ("daikin", "config_flow.py"),
+    ("doorbird", "config_flow.py"),
+    ("doorbird", "logbook.py"),
+    ("elkm1", "config_flow.py"),
+    ("elkm1", "scene.py"),
+    ("fibaro", "scene.py"),
+    ("flume", "config_flow.py"),
+    ("hangouts", "config_flow.py"),
+    ("harmony", "config_flow.py"),
+    ("hisense_aehw4a1", "config_flow.py"),
+    ("home_connect", "config_flow.py"),
+    ("huawei_lte", "config_flow.py"),
+    ("ifttt", "config_flow.py"),
+    ("ios", "config_flow.py"),
+    ("iqvia", "config_flow.py"),
+    ("knx", "scene.py"),
+    ("konnected", "config_flow.py"),
+    ("lcn", "scene.py"),
+    ("life360", "config_flow.py"),
+    ("lifx", "config_flow.py"),
+    ("lutron", "scene.py"),
+    ("mobile_app", "config_flow.py"),
+    ("nest", "config_flow.py"),
+    ("plaato", "config_flow.py"),
+    ("point", "config_flow.py"),
+    ("rachio", "config_flow.py"),
+    ("sense", "config_flow.py"),
+    ("sms", "config_flow.py"),
+    ("solarlog", "config_flow.py"),
+    ("somfy", "config_flow.py"),
+    ("sonos", "config_flow.py"),
+    ("speedtestdotnet", "config_flow.py"),
+    ("spider", "config_flow.py"),
+    ("starline", "config_flow.py"),
+    ("tado", "config_flow.py"),
+    ("tahoma", "scene.py"),
+    ("totalconnect", "config_flow.py"),
+    ("tradfri", "config_flow.py"),
+    ("tuya", "config_flow.py"),
+    ("tuya", "scene.py"),
+    ("upnp", "config_flow.py"),
+    ("velux", "scene.py"),
+    ("wemo", "config_flow.py"),
+    ("wiffi", "config_flow.py"),
+    ("wink", "scene.py"),
+}
+
 
 def validate(integrations: Dict[str, Integration], config: Config):
     """Validate coverage."""
@@ -31,11 +95,34 @@ def validate(integrations: Dict[str, Integration], config: Config):
             path = Path(line)
 
             # Discard wildcard
-            while "*" in path.name:
-                path = path.parent
+            path_exists = path
+            while "*" in path_exists.name:
+                path_exists = path_exists.parent
 
-            if not path.exists():
+            if not path_exists.exists():
                 not_found.append(line)
+                continue
+
+            if (
+                not line.startswith("homeassistant/components/")
+                or not len(path.parts) == 4
+                or not path.parts[-1] == "*"
+            ):
+                continue
+
+            integration_path = path.parent
+
+            integration = integrations[integration_path.name]
+
+            for check in DONT_IGNORE:
+                if (integration_path.name, check) in ALLOWED_IGNORE_VIOLATIONS:
+                    continue
+
+                if (integration_path / check).exists():
+                    integration.add_error(
+                        "coverage",
+                        f"coveragerc incorrectly set up to ignore coverage for {check}",
+                    )
 
     if not not_found:
         return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update hassfest to catch it when an integration ignores all test coverage but has certain files that require tests. 

Currently added all existing violations to an ignore list so it can be fixed outside of this PR.

Example output:

```
Integration ambient_station:
* [COVERAGE] coveragerc incorrectly set up to ignore coverage for config_flow.py

Integration cast:
* [COVERAGE] coveragerc incorrectly set up to ignore coverage for config_flow.py

Integration daikin:
* [COVERAGE] coveragerc incorrectly set up to ignore coverage for config_flow.py

Integration doorbird:
* [COVERAGE] coveragerc incorrectly set up to ignore coverage for config_flow.py
* [COVERAGE] coveragerc incorrectly set up to ignore coverage for logbook.py

Integration elkm1:
* [COVERAGE] coveragerc incorrectly set up to ignore coverage for config_flow.py
* [COVERAGE] coveragerc incorrectly set up to ignore coverage for scene.py
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
