### PR TITLE
Handle overriding of default apps for Android TV

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -412,7 +412,7 @@ class ADBDevice(MediaPlayerEntity):
         }
 
         # Make sure that apps overridden via the `apps` parameter are reflected
-        # in `self._app_name_to_id
+        # in `self._app_name_to_id`
         for key, value in apps.items():
             self._app_name_to_id[value] = key
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -410,6 +410,12 @@ class ADBDevice(MediaPlayerEntity):
         self._app_name_to_id = {
             value: key for key, value in self._app_id_to_name.items() if value
         }
+
+        # Make sure that apps overridden via the `apps` parameter are reflected
+        # in `self._app_name_to_id
+        for key, value in apps.items():
+            self._app_name_to_id[value] = key
+
         self._get_sources = get_sources
         self._keys = KEYS
 

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -3,6 +3,7 @@ import base64
 import copy
 import logging
 
+from androidtv.constants import APPS as ANDROIDTV_APPS
 from androidtv.exceptions import LockNotAcquiredException
 import pytest
 
@@ -476,7 +477,11 @@ async def test_firetv_exclude_sources(hass):
 async def _test_select_source(hass, config0, source, expected_arg, method_patch):
     """Test that the methods for launching and stopping apps are called correctly when selecting a source."""
     config = copy.deepcopy(config0)
-    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1", "com.app.test3": None}
+    config[DOMAIN][CONF_APPS] = {
+        "com.app.test1": "TEST 1",
+        "com.app.test3": None,
+        "com.youtube.test": "YouTube",
+    }
     patch_key, entity_id = _setup(config)
 
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
@@ -541,6 +546,20 @@ async def test_androidtv_select_source_launch_app_hidden(hass):
         CONFIG_ANDROIDTV_ADB_SERVER,
         "com.app.test3",
         "com.app.test3",
+        patchers.PATCH_LAUNCH_APP,
+    )
+
+
+async def test_androidtv_select_source_overridden_app_name(hass):
+    """Test that when an app name is overridden via the `apps` configuration parameter, the app is launched correctly."""
+    # Evidence that the default YouTube app ID will be overridden
+    assert "YouTube" in ANDROIDTV_APPS.values()
+    assert "com.youtube.test" not in ANDROIDTV_APPS
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "YouTube",
+        "com.youtube.test",
         patchers.PATCH_LAUNCH_APP,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This ensures that if a user overrides a built-in app (e.g., overriding the default Android TV YouTube app ID with the Fire TV YouTube app ID via `com.amazon.firetv.youtube: YouTube` in the `apps` configuration parameter), the correct app ID will be used to launch the app if the user provides the friendly name to the `select_source` service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
