### PR TITLE
Remove deprecated YAML config from sonarr

### DIFF
--- a/homeassistant/components/sonarr/config_flow.py
+++ b/homeassistant/components/sonarr/config_flow.py
@@ -74,12 +74,6 @@ class SonarrConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return SonarrOptionsFlowHandler(config_entry)
 
-    async def async_step_import(
-        self, user_input: Optional[ConfigType] = None
-    ) -> Dict[str, Any]:
-        """Handle a flow initiated by configuration file."""
-        return await self.async_step_user(user_input)
-
     async def async_step_reauth(
         self, data: Optional[ConfigType] = None
     ) -> Dict[str, Any]:

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -165,10 +165,6 @@ class SonarrDiskspaceSensor(SonarrSensor):
             enabled_default=False,
         )
 
-    def _to_unit(value):
-        """Return a value converted to unit of measurement."""
-        return value / 1024 ** 3
-
     @sonarr_exception_handler
     async def async_update(self) -> None:
         """Update entity."""
@@ -182,8 +178,8 @@ class SonarrDiskspaceSensor(SonarrSensor):
         attrs = {}
 
         for disk in self._disks:
-            free = self._to_unit(disk.free)
-            total = self._to_unit(disk.total)
+            free = disk.free / 1024 ** 3
+            total = disk.total / 1024 ** 3
             usage = free / total * 100
 
             attrs[
@@ -195,7 +191,7 @@ class SonarrDiskspaceSensor(SonarrSensor):
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
-        free = self._to_unit(self._total_free)
+        free = self._total_free / 1024 ** 3
         return f"{free:.2f}"
 
 

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any, Callable, Dict, List, Optional
 
 from sonarr import Sonarr, SonarrConnectionError, SonarrError
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DATA_GIGABYTES
@@ -168,7 +167,7 @@ class SonarrDiskspaceSensor(SonarrSensor):
 
     def _to_unit(self, value):
         """Return a value converted to unit of measurement."""
-        return value / 1024 ** BYTE_SIZES.index(self._unit_of_measurement)
+        return value / 1024 ** 3
 
     @sonarr_exception_handler
     async def async_update(self) -> None:

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -62,55 +62,6 @@ BYTE_SIZES = [
     DATA_YOTTABYTES,
 ]
 
-DEFAULT_URLBASE = ""
-DEFAULT_DAYS = "1"
-DEFAULT_UNIT = DATA_GIGABYTES
-
-PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_INCLUDED, invalidation_version="0.112"),
-    cv.deprecated(CONF_MONITORED_CONDITIONS, invalidation_version="0.112"),
-    cv.deprecated(CONF_UNIT, invalidation_version="0.112"),
-    PLATFORM_SCHEMA.extend(
-        {
-            vol.Required(CONF_API_KEY): cv.string,
-            vol.Optional(CONF_DAYS, default=DEFAULT_DAYS): cv.string,
-            vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-            vol.Optional(CONF_INCLUDED, default=[]): cv.ensure_list,
-            vol.Optional(CONF_MONITORED_CONDITIONS, default=[]): cv.ensure_list,
-            vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-            vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-            vol.Optional(CONF_UNIT, default=DEFAULT_UNIT): vol.In(BYTE_SIZES),
-            vol.Optional(CONF_URLBASE, default=DEFAULT_URLBASE): cv.string,
-        }
-    ),
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistantType,
-    config: ConfigType,
-    async_add_entities: Callable[[List[Entity], bool], None],
-    discovery_info: Any = None,
-) -> None:
-    """Import the platform into a config entry."""
-    if len(hass.config_entries.async_entries(DOMAIN)) > 0:
-        return True
-
-    config[CONF_BASE_PATH] = f"{config[CONF_URLBASE]}{DEFAULT_BASE_PATH}"
-    config[CONF_UPCOMING_DAYS] = int(config[CONF_DAYS])
-    config[CONF_VERIFY_SSL] = False
-
-    del config[CONF_DAYS]
-    del config[CONF_INCLUDED]
-    del config[CONF_MONITORED_CONDITIONS]
-    del config[CONF_URLBASE]
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
-
 
 async def async_setup_entry(
     hass: HomeAssistantType,

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -165,7 +165,7 @@ class SonarrDiskspaceSensor(SonarrSensor):
             enabled_default=False,
         )
 
-    def _to_unit(self, value):
+    def _to_unit(value):
         """Return a value converted to unit of measurement."""
         return value / 1024 ** 3
 

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -6,21 +6,15 @@ from typing import Any, Callable, Dict, List, Optional
 from sonarr import Sonarr, SonarrConnectionError, SonarrError
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DATA_GIGABYTES
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.dt as dt_util
 
 from . import SonarrEntity
-from .const import (
-    CONF_UPCOMING_DAYS,
-    CONF_WANTED_MAX_ITEMS,
-    DATA_SONARR,
-    DOMAIN,
-)
+from .const import CONF_UPCOMING_DAYS, CONF_WANTED_MAX_ITEMS, DATA_SONARR, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -8,24 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_MONITORED_CONDITIONS,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_VERIFY_SSL,
-    DATA_BYTES,
-    DATA_EXABYTES,
-    DATA_GIGABYTES,
-    DATA_KILOBYTES,
-    DATA_MEGABYTES,
-    DATA_PETABYTES,
-    DATA_TERABYTES,
-    DATA_YOTTABYTES,
-    DATA_ZETTABYTES,
-)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import DATA_GIGABYTES
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
@@ -33,34 +16,13 @@ import homeassistant.util.dt as dt_util
 
 from . import SonarrEntity
 from .const import (
-    CONF_BASE_PATH,
-    CONF_DAYS,
-    CONF_INCLUDED,
-    CONF_UNIT,
     CONF_UPCOMING_DAYS,
-    CONF_URLBASE,
     CONF_WANTED_MAX_ITEMS,
     DATA_SONARR,
-    DEFAULT_BASE_PATH,
-    DEFAULT_HOST,
-    DEFAULT_PORT,
-    DEFAULT_SSL,
     DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-BYTE_SIZES = [
-    DATA_BYTES,
-    DATA_KILOBYTES,
-    DATA_MEGABYTES,
-    DATA_GIGABYTES,
-    DATA_TERABYTES,
-    DATA_PETABYTES,
-    DATA_EXABYTES,
-    DATA_ZETTABYTES,
-    DATA_YOTTABYTES,
-]
 
 
 async def async_setup_entry(

--- a/tests/components/sonarr/__init__.py
+++ b/tests/components/sonarr/__init__.py
@@ -28,13 +28,6 @@ PORT = 8989
 BASE_PATH = "/api"
 API_KEY = "MOCK_API_KEY"
 
-MOCK_SENSOR_CONFIG = {
-    "platform": DOMAIN,
-    "host": HOST,
-    "api_key": API_KEY,
-    "days": 3,
-}
-
 MOCK_REAUTH_INPUT = {CONF_API_KEY: "test-api-key-reauth"}
 
 MOCK_USER_INPUT = {

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -6,7 +6,7 @@ from homeassistant.components.sonarr.const import (
     DEFAULT_WANTED_MAX_ITEMS,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_SOURCE, CONF_VERIFY_SSL
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -94,28 +94,6 @@ async def test_unknown_error(
 
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "unknown"
-
-
-async def test_full_import_flow_implementation(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test the full manual import flow from start to finish."""
-    mock_connection(aioclient_mock)
-
-    user_input = MOCK_USER_INPUT.copy()
-
-    with _patch_async_setup(), _patch_async_setup_entry():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={CONF_SOURCE: SOURCE_IMPORT},
-            data=user_input,
-        )
-
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == HOST
-
-    assert result["data"]
-    assert result["data"][CONF_HOST] == HOST
 
 
 async def test_full_reauth_flow_implementation(

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.util import dt as dt_util
 
 from tests.async_mock import patch
 from tests.common import async_fire_time_changed
-from tests.components.sonarr import mock_connection, setup_integration,
+from tests.components.sonarr import mock_connection, setup_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 UPCOMING_ENTITY_ID = f"{SENSOR_DOMAIN}.sonarr_upcoming"

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.sonarr.const import CONF_BASE_PATH, DOMAIN
+from homeassistant.components.sonarr.const import DOMAIN
 from homeassistant.const import (
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -19,7 +19,6 @@ from homeassistant.util import dt as dt_util
 from tests.async_mock import patch
 from tests.common import async_fire_time_changed
 from tests.components.sonarr import (
-    MOCK_SENSOR_CONFIG,
     _patch_async_setup,
     _patch_async_setup_entry,
     mock_connection,
@@ -28,25 +27,6 @@ from tests.components.sonarr import (
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 UPCOMING_ENTITY_ID = f"{SENSOR_DOMAIN}.sonarr_upcoming"
-
-
-async def test_import_from_sensor_component(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test import from sensor platform."""
-    mock_connection(aioclient_mock)
-
-    with _patch_async_setup(), _patch_async_setup_entry():
-        assert await async_setup_component(
-            hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: MOCK_SENSOR_CONFIG}
-        )
-        await hass.async_block_till_done()
-
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(entries) == 1
-
-    assert entries[0].state == ENTRY_STATE_LOADED
-    assert entries[0].data[CONF_BASE_PATH] == "/api"
 
 
 async def test_sensors(

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -5,7 +5,6 @@ import pytest
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.sonarr.const import CONF_BASE_PATH, DOMAIN
-from homeassistant.config_entries import ENTRY_STATE_LOADED
 from homeassistant.const import (
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -13,17 +12,11 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.async_mock import patch
 from tests.common import async_fire_time_changed
-from tests.components.sonarr import (
-    _patch_async_setup,
-    _patch_async_setup_entry,
-    mock_connection,
-    setup_integration,
-)
+from tests.components.sonarr import mock_connection, setup_integration,
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 UPCOMING_ENTITY_ID = f"{SENSOR_DOMAIN}.sonarr_upcoming"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Sonarr has fully transitioned to configuration via UI. YAML configuration is no longer supported after being deprecated for several releases.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
