### PR TITLE
Bump aioshelly library to 0.4.0

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -129,7 +129,8 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         if self._unsub_stop:
             self._unsub_stop()
             self._unsub_stop = None
-        await self.hass.data[DOMAIN].pop(COAP_CONTEXT).shutdown()
+        if self.hass.data[DOMAIN].get(COAP_CONTEXT):
+            await self.hass.data[DOMAIN].pop(COAP_CONTEXT).shutdown()
 
     async def _handle_ha_stop(self, _):
         """Handle Home Assistant stopping."""

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -18,7 +18,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, device_registry, update_coordinator
 
-from .const import COAP_CONTEXT, CONFIG_ENTRY, DOMAIN, GENERAL, UNDO_SHUTDOWN_LISTENER
+from .const import (
+    COAP_CONTEXT,
+    DATA_CONFIG_ENTRY,
+    DATA_GENERAL,
+    DOMAIN,
+    UNDO_SHUTDOWN_LISTENER,
+)
 
 PLATFORMS = ["binary_sensor", "cover", "light", "sensor", "switch"]
 _LOGGER = logging.getLogger(__name__)
@@ -26,11 +32,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Shelly component."""
-    hass.data[DOMAIN] = {GENERAL: {}, CONFIG_ENTRY: {}}
-    hass.data[DOMAIN][GENERAL][
+    hass.data[DOMAIN] = {DATA_GENERAL: {}, DATA_CONFIG_ENTRY: {}}
+    hass.data[DOMAIN][DATA_GENERAL][
         COAP_CONTEXT
     ] = await aiocoap.Context.create_client_context()
-    hass.data[DOMAIN][GENERAL][UNDO_SHUTDOWN_LISTENER] = hass.bus.async_listen(
+    hass.data[DOMAIN][DATA_GENERAL][UNDO_SHUTDOWN_LISTENER] = hass.bus.async_listen(
         EVENT_HOMEASSISTANT_STOP, shutdown_listener(hass)
     )
     return True
@@ -45,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry.data.get(CONF_PASSWORD),
         temperature_unit,
     )
-    coap_context = hass.data[DOMAIN][GENERAL][COAP_CONTEXT]
+    coap_context = hass.data[DOMAIN][DATA_GENERAL][COAP_CONTEXT]
 
     try:
         async with async_timeout.timeout(10):
@@ -57,9 +63,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except (asyncio.TimeoutError, OSError) as err:
         raise ConfigEntryNotReady from err
 
-    wrapper = hass.data[DOMAIN][CONFIG_ENTRY][entry.entry_id] = ShellyDeviceWrapper(
-        hass, entry, device
-    )
+    wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
+        entry.entry_id
+    ] = ShellyDeviceWrapper(hass, entry, device)
     await wrapper.async_setup()
 
     for component in PLATFORMS:
@@ -149,14 +155,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
     )
     if unload_ok:
-        await hass.data[DOMAIN][CONFIG_ENTRY].pop(entry.entry_id).shutdown()
-        if not hass.data[DOMAIN][CONFIG_ENTRY]:
-            await hass.data[DOMAIN][GENERAL].pop(COAP_CONTEXT).shutdown()
-            hass.data[DOMAIN][GENERAL][UNDO_SHUTDOWN_LISTENER]()
+        await hass.data[DOMAIN][DATA_CONFIG_ENTRY].pop(entry.entry_id).shutdown()
+        if not hass.data[DOMAIN][DATA_CONFIG_ENTRY]:
+            await hass.data[DOMAIN][DATA_GENERAL].pop(COAP_CONTEXT).shutdown()
+            hass.data[DOMAIN][DATA_GENERAL][UNDO_SHUTDOWN_LISTENER]()
 
     return unload_ok
 
 
 async def shutdown_listener(hass: HomeAssistant):
     """Home Assistant shutdown listener."""
-    await hass.data[DOMAIN][GENERAL].pop(COAP_CONTEXT).shutdown()
+    await hass.data[DOMAIN][DATA_GENERAL].pop(COAP_CONTEXT).shutdown()

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry.data.get(CONF_PASSWORD),
         temperature_unit,
     )
-    if not hass.data[DOMAIN].get(COAP_CONTEXT):
+    if COAP_CONTEXT not in hass.data[DOMAIN]:
         coap_context = hass.data[DOMAIN][
             COAP_CONTEXT
         ] = await aiocoap.Context.create_client_context()
@@ -129,7 +129,7 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         if self._unsub_stop:
             self._unsub_stop()
             self._unsub_stop = None
-        if self.hass.data[DOMAIN].get(COAP_CONTEXT):
+        if COAP_CONTEXT in self.hass.data[DOMAIN]:
             await self.hass.data[DOMAIN].pop(COAP_CONTEXT).shutdown()
 
     async def _handle_ha_stop(self, _):

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -129,8 +129,6 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         if self._unsub_stop:
             self._unsub_stop()
             self._unsub_stop = None
-        _LOGGER.debug("Home Assistant is shutting down")
-        await self.hass.data[DOMAIN]["coap_context"].shutdown()
 
     async def _handle_ha_stop(self, _):
         """Handle Home Assistant stopping."""

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -37,7 +37,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         COAP_CONTEXT
     ] = await aiocoap.Context.create_client_context()
     hass.data[DOMAIN][DATA_GENERAL][UNDO_SHUTDOWN_LISTENER] = hass.bus.async_listen(
-        EVENT_HOMEASSISTANT_STOP, shutdown_listener(hass)
+        EVENT_HOMEASSISTANT_STOP, shutdown_listener
     )
     return True
 

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -26,9 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Shelly component."""
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][GENERAL] = {}
-    hass.data[DOMAIN][CONFIG_ENTRY] = {}
+    hass.data[DOMAIN] = {GENERAL: {}, CONFIG_ENTRY: {}}
     hass.data[DOMAIN][GENERAL][
         COAP_CONTEXT
     ] = await aiocoap.Context.create_client_context()

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -129,7 +129,7 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         if self._unsub_stop:
             self._unsub_stop()
             self._unsub_stop = None
-            await self.hass.data[DOMAIN].pop(COAP_CONTEXT).shutdown()
+        await self.hass.data[DOMAIN].pop(COAP_CONTEXT).shutdown()
 
     async def _handle_ha_stop(self, _):
         """Handle Home Assistant stopping."""

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 
+import aiocoap
 import aiohttp
 import aioshelly
 import async_timeout
@@ -33,13 +34,15 @@ async def validate_input(hass: core.HomeAssistant, host, data):
     options = aioshelly.ConnectionOptions(
         host, data.get(CONF_USERNAME), data.get(CONF_PASSWORD)
     )
+    coap_context = await aiocoap.Context.create_client_context()
     async with async_timeout.timeout(5):
         device = await aioshelly.Device.create(
             aiohttp_client.async_get_clientsession(hass),
+            coap_context,
             options,
         )
 
-    await device.shutdown()
+    await coap_context.shutdown()
 
     # Return info that you want to store in the config entry.
     return {"title": device.settings["name"], "mac": device.settings["device"]["mac"]}

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -2,6 +2,4 @@
 
 COAP_CONTEXT = "coap_context"
 DATA_CONFIG_ENTRY = "config_entry"
-DATA_GENERAL = "general"
 DOMAIN = "shelly"
-UNDO_SHUTDOWN_LISTENER = "undo_shutdown_listener"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -1,3 +1,4 @@
 """Constants for the Shelly integration."""
 
+COAP_CONTEXT = "coap_context"
 DOMAIN = "shelly"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -2,3 +2,4 @@
 
 COAP_CONTEXT = "coap_context"
 DOMAIN = "shelly"
+UNDO_SHUTDOWN_LISTENER = "undo_shutdown_listener"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -1,7 +1,7 @@
 """Constants for the Shelly integration."""
 
 COAP_CONTEXT = "coap_context"
-CONFIG_ENTRY = "config_entry"
+DATA_CONFIG_ENTRY = "config_entry"
+DATA_GENERAL = "general"
 DOMAIN = "shelly"
-GENERAL = "general"
 UNDO_SHUTDOWN_LISTENER = "undo_shutdown_listener"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -1,5 +1,7 @@
 """Constants for the Shelly integration."""
 
 COAP_CONTEXT = "coap_context"
+CONFIG_ENTRY = "config_entry"
 DOMAIN = "shelly"
+GENERAL = "general"
 UNDO_SHUTDOWN_LISTENER = "undo_shutdown_listener"

--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -12,13 +12,13 @@ from homeassistant.components.cover import (
 from homeassistant.core import callback
 
 from . import ShellyDeviceWrapper
-from .const import DOMAIN
+from .const import CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up cover for device."""
-    wrapper = hass.data[DOMAIN][config_entry.entry_id]
+    wrapper = hass.data[DOMAIN][CONFIG_ENTRY][config_entry.entry_id]
     blocks = [block for block in wrapper.device.blocks if block.type == "roller"]
 
     if not blocks:

--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -12,13 +12,13 @@ from homeassistant.components.cover import (
 from homeassistant.core import callback
 
 from . import ShellyDeviceWrapper
-from .const import CONFIG_ENTRY, DOMAIN
+from .const import DATA_CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up cover for device."""
-    wrapper = hass.data[DOMAIN][CONFIG_ENTRY][config_entry.entry_id]
+    wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
     blocks = [block for block in wrapper.device.blocks if block.type == "roller"]
 
     if not blocks:

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -10,7 +10,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry, entity
 
 from . import ShellyDeviceWrapper
-from .const import CONFIG_ENTRY, DOMAIN
+from .const import DATA_CONFIG_ENTRY, DOMAIN
 
 
 def temperature_unit(block_info: dict) -> str:
@@ -64,7 +64,7 @@ async def async_setup_entry_attribute_entities(
     hass, config_entry, async_add_entities, sensors, sensor_class
 ):
     """Set up entities for block attributes."""
-    wrapper: ShellyDeviceWrapper = hass.data[DOMAIN][CONFIG_ENTRY][
+    wrapper: ShellyDeviceWrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
         config_entry.entry_id
     ]
     blocks = []

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -10,7 +10,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry, entity
 
 from . import ShellyDeviceWrapper
-from .const import DOMAIN
+from .const import CONFIG_ENTRY, DOMAIN
 
 
 def temperature_unit(block_info: dict) -> str:
@@ -64,7 +64,9 @@ async def async_setup_entry_attribute_entities(
     hass, config_entry, async_add_entities, sensors, sensor_class
 ):
     """Set up entities for block attributes."""
-    wrapper: ShellyDeviceWrapper = hass.data[DOMAIN][config_entry.entry_id]
+    wrapper: ShellyDeviceWrapper = hass.data[DOMAIN][CONFIG_ENTRY][
+        config_entry.entry_id
+    ]
     blocks = []
 
     for block in wrapper.device.blocks:

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -17,13 +17,13 @@ from homeassistant.util.color import (
 )
 
 from . import ShellyDeviceWrapper
-from .const import CONFIG_ENTRY, DOMAIN
+from .const import DATA_CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up lights for device."""
-    wrapper = hass.data[DOMAIN][CONFIG_ENTRY][config_entry.entry_id]
+    wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
     blocks = [block for block in wrapper.device.blocks if block.type == "light"]
 
     if not blocks:

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -17,13 +17,13 @@ from homeassistant.util.color import (
 )
 
 from . import ShellyDeviceWrapper
-from .const import DOMAIN
+from .const import CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up lights for device."""
-    wrapper = hass.data[DOMAIN][config_entry.entry_id]
+    wrapper = hass.data[DOMAIN][CONFIG_ENTRY][config_entry.entry_id]
     blocks = [block for block in wrapper.device.blocks if block.type == "light"]
 
     if not blocks:

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==0.3.4"],
+  "requirements": ["aioshelly==0.4.0"],
   "zeroconf": [{ "type": "_http._tcp.local.", "name": "shelly*" }],
   "codeowners": ["@balloob", "@bieniu"]
 }

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -5,13 +5,13 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 
 from . import ShellyDeviceWrapper
-from .const import DOMAIN
+from .const import CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switches for device."""
-    wrapper = hass.data[DOMAIN][config_entry.entry_id]
+    wrapper = hass.data[DOMAIN][CONFIG_ENTRY][config_entry.entry_id]
 
     # In roller mode the relay blocks exist but do not contain required info
     if (

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -5,13 +5,13 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 
 from . import ShellyDeviceWrapper
-from .const import CONFIG_ENTRY, DOMAIN
+from .const import DATA_CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switches for device."""
-    wrapper = hass.data[DOMAIN][CONFIG_ENTRY][config_entry.entry_id]
+    wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
 
     # In roller mode the relay blocks exist but do not contain required info
     if (

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -221,7 +221,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.3.4
+aioshelly==0.4.0
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -137,7 +137,7 @@ aiopvpc==2.0.2
 aiopylgtv==0.3.3
 
 # homeassistant.components.shelly
-aioshelly==0.3.4
+aioshelly==0.4.0
 
 # homeassistant.components.switcher_kis
 aioswitcher==1.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `aioshelly` library to version 0.4.0 to:
- share `coap_context` with all configured Shelly devices
- ensure maximum one request at a time per device

Changelog: https://github.com/home-assistant-libs/aioshelly/compare/0.3.4...0.4.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
