### PR TITLE
0.116.4

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -118,7 +118,7 @@ stages:
           -v $(pwd):/data:ro \
           homeassistant/amd64-builder:$(versionBuilder) \
           --homeassistant-machine "$(homeassistantRelease)=$(buildMachine)" \
-          -t /data --docker-hub homeassistant
+          -t /data/machine --docker-hub homeassistant
       displayName: 'Build Release'
 
 - stage: 'Publish'

--- a/homeassistant/components/onvif/manifest.json
+++ b/homeassistant/components/onvif/manifest.json
@@ -2,7 +2,11 @@
   "domain": "onvif",
   "name": "ONVIF",
   "documentation": "https://www.home-assistant.io/integrations/onvif",
-  "requirements": ["onvif-zeep-async==0.5.0", "WSDiscovery==2.0.0"],
+  "requirements": [
+    "onvif-zeep-async==0.6.0",
+    "WSDiscovery==2.0.0",
+    "zeep[async]==3.4.0"
+  ],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@hunterjm"],
   "config_flow": true

--- a/homeassistant/components/stream/fmp4utils.py
+++ b/homeassistant/components/stream/fmp4utils.py
@@ -70,7 +70,8 @@ def get_codec_string(segment: io.BytesIO) -> str:
         ):
             profile = stsd_box[111:112].hex()
             compatibility = stsd_box[112:113].hex()
-            level = stsd_box[113:114].hex()
+            # Cap level at 4.1 for compatibility with some Google Cast devices
+            level = hex(min(stsd_box[113], 41))[2:]
             codec += "." + profile + compatibility + level
 
         # Handle H265

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -32,10 +32,11 @@ class HlsMasterPlaylistView(StreamView):
     def render(track):
         """Render M3U8 file."""
         # Need to calculate max bandwidth as input_container.bit_rate doesn't seem to work
-        # Calculate file size / duration and use a multiplier to account for variation
+        # Calculate file size / duration and use a small multiplier to account for variation
+        # hls spec already allows for 25% variation
         segment = track.get_segment(track.segments[-1])
         bandwidth = round(
-            segment.segment.seek(0, io.SEEK_END) * 8 / segment.duration * 3
+            segment.segment.seek(0, io.SEEK_END) * 8 / segment.duration * 1.2
         )
         codecs = get_codec_string(segment.segment)
         lines = [

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 116
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ omnilogic==0.4.0
 onkyo-eiscp==1.2.7
 
 # homeassistant.components.onvif
-onvif-zeep-async==0.5.0
+onvif-zeep-async==0.6.0
 
 # homeassistant.components.opengarage
 open-garage==0.1.4
@@ -2302,6 +2302,9 @@ yeelightsunflower==0.0.10
 
 # homeassistant.components.media_extractor
 youtube_dl==2020.09.20
+
+# homeassistant.components.onvif
+zeep[async]==3.4.0
 
 # homeassistant.components.zengge
 zengge==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -490,7 +490,7 @@ oauth2client==4.0.0
 omnilogic==0.4.0
 
 # homeassistant.components.onvif
-onvif-zeep-async==0.5.0
+onvif-zeep-async==0.6.0
 
 # homeassistant.components.openerz
 openerz-api==0.1.0
@@ -1065,6 +1065,9 @@ xmltodict==0.12.0
 
 # homeassistant.components.yeelight
 yeelight==0.5.4
+
+# homeassistant.components.onvif
+zeep[async]==3.4.0
 
 # homeassistant.components.zeroconf
 zeroconf==0.28.5


### PR DESCRIPTION
- Bump ONVIF and pin Zeep ([@hunterjm] - [#41907]) ([onvif docs])
- Cap AVC profile level at 4.1 in stream master playlist ([@uvjustin] - [#41592]) ([stream docs])

[#41592]: https://github.com/home-assistant/core/pull/41592
[#41879]: https://github.com/home-assistant/core/pull/41879
[#41907]: https://github.com/home-assistant/core/pull/41907
[@hunterjm]: https://github.com/hunterjm
[@pvizeli]: https://github.com/pvizeli
[@uvjustin]: https://github.com/uvjustin
[onvif docs]: https://www.home-assistant.io/integrations/onvif/
[stream docs]: https://www.home-assistant.io/integrations/stream/