### PR TITLE
Clean up SimpliSafe device info and sensor creation

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -597,6 +597,14 @@ class SimpliSafeEntity(Entity):
             ATTR_SYSTEM_ID: system.system_id,
         }
 
+        self._device_info = {
+            "identifiers": {(DOMAIN, self._system.system_id)},
+            "manufacturer": "SimpliSafe",
+            "model": self._system.version,
+            "name": self._name,
+            "via_device": (DOMAIN, self._system.serial),
+        }
+
     @property
     def available(self):
         """Return whether the entity is available."""
@@ -610,13 +618,7 @@ class SimpliSafeEntity(Entity):
     @property
     def device_info(self):
         """Return device registry information for this entity."""
-        return {
-            "identifiers": {(DOMAIN, self._system.system_id)},
-            "manufacturer": "SimpliSafe",
-            "model": self._system.version,
-            "name": self._name,
-            "via_device": (DOMAIN, self._system.serial),
-        }
+        return self._device_info
 
     @property
     def device_state_attributes(self):
@@ -720,4 +722,3 @@ class SimpliSafeEntity(Entity):
     @callback
     def async_update_from_websocket_event(self, event):
         """Update the entity with the provided websocket event."""
-        raise NotImplementedError()

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -598,11 +598,11 @@ class SimpliSafeEntity(Entity):
         }
 
         self._device_info = {
-            "identifiers": {(DOMAIN, self._system.system_id)},
+            "identifiers": {(DOMAIN, system.system_id)},
             "manufacturer": "SimpliSafe",
-            "model": self._system.version,
-            "name": self._name,
-            "via_device": (DOMAIN, self._system.serial),
+            "model": system.version,
+            "name": name,
+            "via_device": (DOMAIN, system.serial),
         }
 
     @property

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -48,23 +48,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SimpliSafe binary sensors based on a config entry."""
     simplisafe = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
 
-    # Add sensor
-    sensors = [
-        SimpliSafeBinarySensor(simplisafe, system, sensor)
-        for system in simplisafe.systems.values()
-        for sensor in system.sensors.values()
-        if sensor.type in SUPPORTED_SENSOR_TYPES
-    ]
+    sensors = []
+    for system in simplisafe.systems.values():
+        for sensor in system.sensors.values():
+            if sensor.type in SUPPORTED_SENSOR_TYPES:
+                sensors.append(SimpliSafeBinarySensor(simplisafe, system, sensor))
+            if sensor.type in SUPPORTED_BATTERY_SENSOR_TYPES:
+                sensors.append(SimpliSafeSensorBattery(simplisafe, system, sensor))
 
-    # Add low battery status entity for every sensor
-    battery_sensors = [
-        SimpliSafeSensorBattery(simplisafe, system, sensor)
-        for system in simplisafe.systems.values()
-        for sensor in system.sensors.values()
-        if sensor.type in SUPPORTED_BATTERY_SENSOR_TYPES
-    ]
-
-    async_add_entities(sensors + battery_sensors)
+    async_add_entities(sensors)
 
 
 class SimpliSafeBinarySensor(SimpliSafeEntity, BinarySensorEntity):
@@ -108,9 +100,12 @@ class SimpliSafeSensorBattery(SimpliSafeEntity, BinarySensorEntity):
     def __init__(self, simplisafe, system, sensor):
         """Initialize."""
         super().__init__(simplisafe, system, sensor.name, serial=sensor.serial)
-        self._system = system
         self._sensor = sensor
         self._is_low = False
+
+        self._device_info["identifiers"] = {(DOMAIN, sensor.serial)}
+        self._device_info["model"] = SENSOR_MODELS[sensor.type]
+        self._device_info["name"] = sensor.name
 
     @property
     def device_class(self):
@@ -121,15 +116,6 @@ class SimpliSafeSensorBattery(SimpliSafeEntity, BinarySensorEntity):
     def unique_id(self):
         """Return unique ID of sensor."""
         return f"{self._sensor.serial}-battery"
-
-    @property
-    def device_info(self):
-        """Return device registry information for this entity."""
-        info = super().device_info
-        info["identifiers"] = {(DOMAIN, self._sensor.serial)}
-        info["model"] = SENSOR_MODELS[self._sensor.type]
-        info["name"] = self._sensor.name
-        return info
 
     @property
     def is_on(self):

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -28,9 +28,12 @@ class SimplisafeFreezeSensor(SimpliSafeEntity):
     def __init__(self, simplisafe, system, sensor):
         """Initialize."""
         super().__init__(simplisafe, system, sensor.name, serial=sensor.serial)
-        self._system = system
         self._sensor = sensor
         self._state = None
+
+        self._device_info["identifiers"] = {(DOMAIN, sensor.serial)}
+        self._device_info["model"] = "Freeze Sensor"
+        self._device_info["name"] = sensor.name
 
     @property
     def device_class(self):
@@ -41,15 +44,6 @@ class SimplisafeFreezeSensor(SimpliSafeEntity):
     def unique_id(self):
         """Return unique ID of sensor."""
         return self._sensor.serial
-
-    @property
-    def device_info(self):
-        """Return device registry information for this entity."""
-        info = super().device_info
-        info["identifiers"] = {(DOMAIN, self._sensor.serial)}
-        info["model"] = "Freeze Sensor"
-        info["name"] = self._sensor.name
-        return info
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR does some additional code cleanup in SimpliSafe:

* Move device info into a private entity attribute for easier overriding.
* Make `async_update_from_websocket_event` "optional" instead of abstract – entities that don't care about the websocket right now (like sensors and binary sensors) don't need to be warned about not implementing it.
* Loop through systems once – not twice – when creating binary sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
