### PR TITLE
Update litejet and zwave tests to use async_add_executor_job

### DIFF
--- a/tests/components/litejet/test_trigger.py
+++ b/tests/components/litejet/test_trigger.py
@@ -73,7 +73,7 @@ async def simulate_press(hass, mock_lj, number):
         return_value=mock_lj.start_time + mock_lj.last_delta,
     ):
         if callback is not None:
-            await hass.async_add_job(callback)
+            await hass.async_add_executor_job(callback)
         await hass.async_block_till_done()
 
 
@@ -86,7 +86,7 @@ async def simulate_release(hass, mock_lj, number):
         return_value=mock_lj.start_time + mock_lj.last_delta,
     ):
         if callback is not None:
-            await hass.async_add_job(callback)
+            await hass.async_add_executor_job(callback)
         await hass.async_block_till_done()
 
 

--- a/tests/components/zwave/test_binary_sensor.py
+++ b/tests/components/zwave/test_binary_sensor.py
@@ -80,13 +80,13 @@ async def test_trigger_sensor_value_changed(hass, mock_openzwave):
     assert not device.is_on
 
     value.data = True
-    await hass.async_add_job(value_changed, value)
+    await hass.async_add_executor_job(value_changed, value)
     assert device.invalidate_after is None
 
     device.hass = hass
 
     value.data = True
-    await hass.async_add_job(value_changed, value)
+    await hass.async_add_executor_job(value_changed, value)
     assert device.is_on
 
     test_time = device.invalidate_after - datetime.timedelta(seconds=1)

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -298,7 +298,7 @@ async def test_node_discovery(hass, mock_openzwave):
     assert len(mock_receivers) == 1
 
     node = MockNode(node_id=14)
-    hass.async_add_job(mock_receivers[0], node)
+    hass.async_add_executor_job(mock_receivers[0], node)
     await hass.async_block_till_done()
 
     assert hass.states.get("zwave.mock_node").state == "unknown"
@@ -335,7 +335,7 @@ async def test_unparsed_node_discovery(hass, mock_openzwave):
     with patch("homeassistant.components.zwave.dt_util.utcnow", new=utcnow):
         with patch("asyncio.sleep", new=sleep):
             with patch.object(zwave, "_LOGGER") as mock_logger:
-                hass.async_add_job(mock_receivers[0], node)
+                hass.async_add_executor_job(mock_receivers[0], node)
                 await hass.async_block_till_done()
 
                 assert len(sleeps) == const.NODE_READY_WAIT_SECS
@@ -367,7 +367,7 @@ async def test_node_ignored(hass, mock_openzwave):
     assert len(mock_receivers) == 1
 
     node = MockNode(node_id=14)
-    hass.async_add_job(mock_receivers[0], node)
+    hass.async_add_executor_job(mock_receivers[0], node)
     await hass.async_block_till_done()
 
     assert hass.states.get("zwave.mock_node") is None
@@ -397,7 +397,7 @@ async def test_value_discovery(hass, mock_openzwave):
         type=const.TYPE_BOOL,
         genre=const.GENRE_USER,
     )
-    hass.async_add_job(mock_receivers[0], node, value)
+    hass.async_add_executor_job(mock_receivers[0], node, value)
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.mock_node_mock_value").state == "off"
@@ -421,7 +421,7 @@ async def test_value_entities(hass, mock_openzwave):
 
     assert mock_receivers
 
-    hass.async_add_job(mock_receivers[MockNetwork.SIGNAL_ALL_NODES_QUERIED])
+    hass.async_add_executor_job(mock_receivers[MockNetwork.SIGNAL_ALL_NODES_QUERIED])
     node = MockNode(node_id=11, generic=const.GENERIC_TYPE_SENSOR_BINARY)
     zwave_network.nodes = {node.node_id: node}
     value = MockValue(
@@ -446,9 +446,13 @@ async def test_value_entities(hass, mock_openzwave):
     )
     node.values[value2.value_id] = value2
 
-    hass.async_add_job(mock_receivers[MockNetwork.SIGNAL_NODE_ADDED], node)
-    hass.async_add_job(mock_receivers[MockNetwork.SIGNAL_VALUE_ADDED], node, value)
-    hass.async_add_job(mock_receivers[MockNetwork.SIGNAL_VALUE_ADDED], node, value2)
+    hass.async_add_executor_job(mock_receivers[MockNetwork.SIGNAL_NODE_ADDED], node)
+    hass.async_add_executor_job(
+        mock_receivers[MockNetwork.SIGNAL_VALUE_ADDED], node, value
+    )
+    hass.async_add_executor_job(
+        mock_receivers[MockNetwork.SIGNAL_VALUE_ADDED], node, value2
+    )
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.mock_node_mock_value").state == "off"
@@ -594,7 +598,7 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
         genre=const.GENRE_USER,
     )
 
-    hass.async_add_job(mock_receivers[0], node, thermostat_mode)
+    hass.async_add_executor_job(mock_receivers[0], node, thermostat_mode)
     await hass.async_block_till_done()
 
     def mock_update(self):
@@ -603,7 +607,7 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
     with patch.object(
         zwave.node_entity.ZWaveBaseEntity, "maybe_schedule_update", new=mock_update
     ):
-        hass.async_add_job(mock_receivers[0], node, setpoint_heating)
+        hass.async_add_executor_job(mock_receivers[0], node, setpoint_heating)
         await hass.async_block_till_done()
 
     assert (
@@ -628,7 +632,7 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
             genre=const.GENRE_USER,
             units="C",
         )
-        hass.async_add_job(mock_receivers[0], node, temperature)
+        hass.async_add_executor_job(mock_receivers[0], node, temperature)
         await hass.async_block_till_done()
 
     assert (
@@ -670,7 +674,7 @@ async def test_value_discovery_legacy_thermostat(hass, mock_openzwave):
         genre=const.GENRE_USER,
     )
 
-    hass.async_add_job(mock_receivers[0], node, setpoint_heating)
+    hass.async_add_executor_job(mock_receivers[0], node, setpoint_heating)
     await hass.async_block_till_done()
 
     assert (
@@ -703,7 +707,7 @@ async def test_power_schemes(hass, mock_openzwave):
         genre=const.GENRE_USER,
         type=const.TYPE_BOOL,
     )
-    await hass.async_add_job(mock_receivers[0], node, switch)
+    await hass.async_add_executor_job(mock_receivers[0], node, switch)
 
     await hass.async_block_till_done()
 
@@ -727,7 +731,7 @@ async def test_power_schemes(hass, mock_openzwave):
             command_class=const.COMMAND_CLASS_SENSOR_MULTILEVEL,
             genre=const.GENRE_USER,  # to avoid exception
         )
-        await hass.async_add_job(mock_receivers[0], node, power)
+        await hass.async_add_executor_job(mock_receivers[0], node, power)
         await hass.async_block_till_done()
 
     assert (
@@ -757,7 +761,7 @@ async def test_network_ready(hass, mock_openzwave):
 
     hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE, listener)
 
-    hass.async_add_job(mock_receivers[0])
+    hass.async_add_executor_job(mock_receivers[0])
     await hass.async_block_till_done()
 
     assert len(events) == 1
@@ -784,7 +788,7 @@ async def test_network_complete(hass, mock_openzwave):
 
     hass.bus.async_listen(const.EVENT_NETWORK_READY, listener)
 
-    hass.async_add_job(mock_receivers[0])
+    hass.async_add_executor_job(mock_receivers[0])
     await hass.async_block_till_done()
 
     assert len(events) == 1
@@ -811,7 +815,7 @@ async def test_network_complete_some_dead(hass, mock_openzwave):
 
     hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE_SOME_DEAD, listener)
 
-    hass.async_add_job(mock_receivers[0])
+    hass.async_add_executor_job(mock_receivers[0])
     await hass.async_block_till_done()
 
     assert len(events) == 1

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -298,7 +298,7 @@ async def test_node_discovery(hass, mock_openzwave):
     assert len(mock_receivers) == 1
 
     node = MockNode(node_id=14)
-    hass.async_add_executor_job(mock_receivers[0], node)
+    await hass.async_add_executor_job(mock_receivers[0], node)
     await hass.async_block_till_done()
 
     assert hass.states.get("zwave.mock_node").state == "unknown"
@@ -335,7 +335,7 @@ async def test_unparsed_node_discovery(hass, mock_openzwave):
     with patch("homeassistant.components.zwave.dt_util.utcnow", new=utcnow):
         with patch("asyncio.sleep", new=sleep):
             with patch.object(zwave, "_LOGGER") as mock_logger:
-                hass.async_add_executor_job(mock_receivers[0], node)
+                await hass.async_add_executor_job(mock_receivers[0], node)
                 await hass.async_block_till_done()
 
                 assert len(sleeps) == const.NODE_READY_WAIT_SECS
@@ -367,7 +367,7 @@ async def test_node_ignored(hass, mock_openzwave):
     assert len(mock_receivers) == 1
 
     node = MockNode(node_id=14)
-    hass.async_add_executor_job(mock_receivers[0], node)
+    await hass.async_add_executor_job(mock_receivers[0], node)
     await hass.async_block_till_done()
 
     assert hass.states.get("zwave.mock_node") is None
@@ -397,7 +397,7 @@ async def test_value_discovery(hass, mock_openzwave):
         type=const.TYPE_BOOL,
         genre=const.GENRE_USER,
     )
-    hass.async_add_executor_job(mock_receivers[0], node, value)
+    await hass.async_add_executor_job(mock_receivers[0], node, value)
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.mock_node_mock_value").state == "off"
@@ -421,7 +421,9 @@ async def test_value_entities(hass, mock_openzwave):
 
     assert mock_receivers
 
-    hass.async_add_executor_job(mock_receivers[MockNetwork.SIGNAL_ALL_NODES_QUERIED])
+    await hass.async_add_executor_job(
+        mock_receivers[MockNetwork.SIGNAL_ALL_NODES_QUERIED]
+    )
     node = MockNode(node_id=11, generic=const.GENERIC_TYPE_SENSOR_BINARY)
     zwave_network.nodes = {node.node_id: node}
     value = MockValue(
@@ -446,11 +448,13 @@ async def test_value_entities(hass, mock_openzwave):
     )
     node.values[value2.value_id] = value2
 
-    hass.async_add_executor_job(mock_receivers[MockNetwork.SIGNAL_NODE_ADDED], node)
-    hass.async_add_executor_job(
+    await hass.async_add_executor_job(
+        mock_receivers[MockNetwork.SIGNAL_NODE_ADDED], node
+    )
+    await hass.async_add_executor_job(
         mock_receivers[MockNetwork.SIGNAL_VALUE_ADDED], node, value
     )
-    hass.async_add_executor_job(
+    await hass.async_add_executor_job(
         mock_receivers[MockNetwork.SIGNAL_VALUE_ADDED], node, value2
     )
     await hass.async_block_till_done()
@@ -598,7 +602,7 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
         genre=const.GENRE_USER,
     )
 
-    hass.async_add_executor_job(mock_receivers[0], node, thermostat_mode)
+    await hass.async_add_executor_job(mock_receivers[0], node, thermostat_mode)
     await hass.async_block_till_done()
 
     def mock_update(self):
@@ -607,7 +611,7 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
     with patch.object(
         zwave.node_entity.ZWaveBaseEntity, "maybe_schedule_update", new=mock_update
     ):
-        hass.async_add_executor_job(mock_receivers[0], node, setpoint_heating)
+        await hass.async_add_executor_job(mock_receivers[0], node, setpoint_heating)
         await hass.async_block_till_done()
 
     assert (
@@ -632,7 +636,7 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
             genre=const.GENRE_USER,
             units="C",
         )
-        hass.async_add_executor_job(mock_receivers[0], node, temperature)
+        await hass.async_add_executor_job(mock_receivers[0], node, temperature)
         await hass.async_block_till_done()
 
     assert (
@@ -674,7 +678,7 @@ async def test_value_discovery_legacy_thermostat(hass, mock_openzwave):
         genre=const.GENRE_USER,
     )
 
-    hass.async_add_executor_job(mock_receivers[0], node, setpoint_heating)
+    await hass.async_add_executor_job(mock_receivers[0], node, setpoint_heating)
     await hass.async_block_till_done()
 
     assert (
@@ -761,7 +765,7 @@ async def test_network_ready(hass, mock_openzwave):
 
     hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE, listener)
 
-    hass.async_add_executor_job(mock_receivers[0])
+    await hass.async_add_executor_job(mock_receivers[0])
     await hass.async_block_till_done()
 
     assert len(events) == 1
@@ -788,7 +792,7 @@ async def test_network_complete(hass, mock_openzwave):
 
     hass.bus.async_listen(const.EVENT_NETWORK_READY, listener)
 
-    hass.async_add_executor_job(mock_receivers[0])
+    await hass.async_add_executor_job(mock_receivers[0])
     await hass.async_block_till_done()
 
     assert len(events) == 1
@@ -815,7 +819,7 @@ async def test_network_complete_some_dead(hass, mock_openzwave):
 
     hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE_SOME_DEAD, listener)
 
-    hass.async_add_executor_job(mock_receivers[0])
+    await hass.async_add_executor_job(mock_receivers[0])
     await hass.async_block_till_done()
 
     assert len(events) == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update litejet and zwave tests to use async_add_executor_job

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
