### PR TITLE
Add Netatmo sensor enable default

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -71,8 +71,6 @@ SENSOR_TYPES = {
         DEVICE_CLASS_BATTERY,
         True,
     ],
-    "min_temp": ["Min Temp.", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE, True],
-    "max_temp": ["Max Temp.", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE, True],
     "windangle": ["Direction", None, "mdi:compass-outline", None, True],
     "windangle_value": ["Angle", DEGREE, "mdi:compass-outline", None, False],
     "windstrength": [
@@ -353,10 +351,6 @@ class NetatmoSensor(NetatmoBase):
                 self._state = data["pressure_trend"]
             elif self.type == "battery_percent":
                 self._state = data["battery_percent"]
-            elif self.type == "min_temp":
-                self._state = data["min_temp"]
-            elif self.type == "max_temp":
-                self._state = data["max_temp"]
             elif self.type == "windangle_value":
                 self._state = fix_angle(data["WindAngle"])
             elif self.type == "windangle":

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -48,39 +48,55 @@ SUPPORTED_PUBLIC_SENSOR_TYPES = [
 ]
 
 SENSOR_TYPES = {
-    "temperature": ["Temperature", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE],
-    "temp_trend": ["Temperature trend", None, "mdi:trending-up", None],
-    "co2": ["CO2", CONCENTRATION_PARTS_PER_MILLION, "mdi:molecule-co2", None],
-    "pressure": ["Pressure", PRESSURE_MBAR, None, DEVICE_CLASS_PRESSURE],
-    "pressure_trend": ["Pressure trend", None, "mdi:trending-up", None],
-    "noise": ["Noise", "dB", "mdi:volume-high", None],
-    "humidity": ["Humidity", PERCENTAGE, None, DEVICE_CLASS_HUMIDITY],
-    "rain": ["Rain", LENGTH_MILLIMETERS, "mdi:weather-rainy", None],
-    "sum_rain_1": ["Rain last hour", LENGTH_MILLIMETERS, "mdi:weather-rainy", None],
-    "sum_rain_24": ["Rain today", LENGTH_MILLIMETERS, "mdi:weather-rainy", None],
-    "battery_percent": ["Battery Percent", PERCENTAGE, None, DEVICE_CLASS_BATTERY],
-    "windangle": ["Direction", None, "mdi:compass-outline", None],
-    "windangle_value": ["Angle", DEGREE, "mdi:compass-outline", None],
+    "temperature": ["Temperature", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE, True],
+    "temp_trend": ["Temperature trend", None, "mdi:trending-up", None, False],
+    "co2": ["CO2", CONCENTRATION_PARTS_PER_MILLION, "mdi:molecule-co2", None, True],
+    "pressure": ["Pressure", PRESSURE_MBAR, None, DEVICE_CLASS_PRESSURE, True],
+    "pressure_trend": ["Pressure trend", None, "mdi:trending-up", None, False],
+    "noise": ["Noise", "dB", "mdi:volume-high", None, True],
+    "humidity": ["Humidity", PERCENTAGE, None, DEVICE_CLASS_HUMIDITY, True],
+    "rain": ["Rain", LENGTH_MILLIMETERS, "mdi:weather-rainy", None, True],
+    "sum_rain_1": [
+        "Rain last hour",
+        LENGTH_MILLIMETERS,
+        "mdi:weather-rainy",
+        None,
+        False,
+    ],
+    "sum_rain_24": ["Rain today", LENGTH_MILLIMETERS, "mdi:weather-rainy", None, True],
+    "battery_percent": [
+        "Battery Percent",
+        PERCENTAGE,
+        None,
+        DEVICE_CLASS_BATTERY,
+        True,
+    ],
+    "min_temp": ["Min Temp.", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE, True],
+    "max_temp": ["Max Temp.", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE, True],
+    "windangle": ["Direction", None, "mdi:compass-outline", None, True],
+    "windangle_value": ["Angle", DEGREE, "mdi:compass-outline", None, False],
     "windstrength": [
         "Wind Strength",
         SPEED_KILOMETERS_PER_HOUR,
         "mdi:weather-windy",
         None,
+        True,
     ],
-    "gustangle": ["Gust Direction", None, "mdi:compass-outline", None],
-    "gustangle_value": ["Gust Angle", DEGREE, "mdi:compass-outline", None],
+    "gustangle": ["Gust Direction", None, "mdi:compass-outline", None, False],
+    "gustangle_value": ["Gust Angle", DEGREE, "mdi:compass-outline", None, False],
     "guststrength": [
         "Gust Strength",
         SPEED_KILOMETERS_PER_HOUR,
         "mdi:weather-windy",
         None,
+        False,
     ],
-    "reachable": ["Reachability", None, "mdi:signal", None],
-    "rf_status": ["Radio", None, "mdi:signal", None],
-    "rf_status_lvl": ["Radio Level", "", None, DEVICE_CLASS_SIGNAL_STRENGTH],
-    "wifi_status": ["Wifi", None, "mdi:wifi", None],
-    "wifi_status_lvl": ["Wifi Level", "dBm", None, DEVICE_CLASS_SIGNAL_STRENGTH],
-    "health_idx": ["Health", None, "mdi:cloud", None],
+    "reachable": ["Reachability", None, "mdi:signal", None, False],
+    "rf_status": ["Radio", None, "mdi:signal", None, False],
+    "rf_status_lvl": ["Radio Level", "", None, DEVICE_CLASS_SIGNAL_STRENGTH, False],
+    "wifi_status": ["Wifi", None, "mdi:wifi", None, False],
+    "wifi_status_lvl": ["Wifi Level", "dBm", None, DEVICE_CLASS_SIGNAL_STRENGTH, False],
+    "health_idx": ["Health", None, "mdi:cloud", None, True],
 }
 
 MODULE_TYPE_OUTDOOR = "NAModule1"
@@ -257,6 +273,7 @@ class NetatmoSensor(NetatmoBase):
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._model = device["type"]
         self._unique_id = f"{self._id}-{self.type}"
+        self._enabled_default = SENSOR_TYPES[self.type][4]
 
     @property
     def icon(self):
@@ -282,6 +299,11 @@ class NetatmoSensor(NetatmoBase):
     def available(self):
         """Return entity availability."""
         return self._state is not None
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return self._enabled_default
 
     @callback
     def async_update_callback(self):
@@ -331,6 +353,10 @@ class NetatmoSensor(NetatmoBase):
                 self._state = data["pressure_trend"]
             elif self.type == "battery_percent":
                 self._state = data["battery_percent"]
+            elif self.type == "min_temp":
+                self._state = data["min_temp"]
+            elif self.type == "max_temp":
+                self._state = data["max_temp"]
             elif self.type == "windangle_value":
                 self._state = fix_angle(data["WindAngle"])
             elif self.type == "windangle":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To reduce the sensor clutter for new users not all sensors are going to be enabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to comment: https://github.com/home-assistant/core/pull/41859#discussion_r505260297
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
