### PR TITLE
Add entity ID to time trigger

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -37,11 +37,18 @@ async def async_attach_trigger(hass, config, action, automation_info):
     job = HassJob(action)
 
     @callback
-    def time_automation_listener(description, now):
+    def time_automation_listener(description, now, *, entity_id=None):
         """Listen for time changes and calls action."""
         hass.async_run_hass_job(
             job,
-            {"trigger": {"platform": "time", "now": now, "description": description}},
+            {
+                "trigger": {
+                    "platform": "time",
+                    "now": now,
+                    "description": description,
+                    "entity_id": entity_id,
+                }
+            },
         )
 
     @callback
@@ -84,14 +91,22 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 if trigger_dt >= dt_util.now():
                     remove = async_track_point_in_time(
                         hass,
-                        partial(time_automation_listener, f"time set in {entity_id}"),
+                        partial(
+                            time_automation_listener,
+                            f"time set in {entity_id}",
+                            entity_id=entity_id,
+                        ),
                         trigger_dt,
                     )
             elif has_time:
                 # Else if it has time, then track time change.
                 remove = async_track_time_change(
                     hass,
-                    partial(time_automation_listener, f"time set in {entity_id}"),
+                    partial(
+                        time_automation_listener,
+                        f"time set in {entity_id}",
+                        entity_id=entity_id,
+                    ),
                     hour=hour,
                     minute=minute,
                     second=second,

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -93,7 +93,7 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
 
     time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
 
-    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}"
+    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{trigger.entity_id}}"
     with patch(
         "homeassistant.util.dt.utcnow",
         return_value=dt_util.as_utc(time_that_will_not_match_right_away),
@@ -117,7 +117,10 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert calls[0].data["some"] == f"time-{trigger_dt.day}-{trigger_dt.hour}"
+    assert (
+        calls[0].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-input_datetime.trigger"
+    )
 
     if has_date:
         trigger_dt += timedelta(days=1)
@@ -138,7 +141,10 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
     await hass.async_block_till_done()
 
     assert len(calls) == 2
-    assert calls[1].data["some"] == f"time-{trigger_dt.day}-{trigger_dt.hour}"
+    assert (
+        calls[1].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-input_datetime.trigger"
+    )
 
 
 async def test_if_fires_using_multiple_at(hass, calls):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity_id to time trigger variable.

Fixes #41653

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
