### PR TITLE
No update before adding entity in deCONZ

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(DeconzBinarySensor(sensor, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(DeconzThermostat(sensor, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -38,7 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(DeconzCover(light, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -50,7 +50,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
                 entities.append(DeconzFan(light, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(DeconzLight(light, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(
@@ -79,7 +79,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(new_group)
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(DeconzLock(light, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -109,7 +109,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(DeconzSensor(sensor, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -35,7 +35,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(DeconzSiren(light, gateway))
 
         if entities:
-            async_add_entities(entities, True)
+            async_add_entities(entities)
 
     gateway.listeners.append(
         async_dispatcher_connect(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
No need to do update before add, all data should already be available on creation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
