### PR TITLE
Fix onvif sensor detection and onvif stop service call

### DIFF
--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -379,7 +379,9 @@ class ONVIFDevice:
                 await asyncio.sleep(continuous_duration)
                 req = ptz_service.create_type("Stop")
                 req.ProfileToken = profile.token
-                await ptz_service.Stop({"ProfileToken": req.ProfileToken, 'PanTilt': True, 'Zoom': False})
+                await ptz_service.Stop(
+                    {"ProfileToken": req.ProfileToken, "PanTilt": True, "Zoom": False}
+                )
             elif move_mode == RELATIVE_MOVE:
                 # Guard against unsupported operation
                 if not profile.ptz.relative:

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -379,7 +379,7 @@ class ONVIFDevice:
                 await asyncio.sleep(continuous_duration)
                 req = ptz_service.create_type("Stop")
                 req.ProfileToken = profile.token
-                await ptz_service.Stop({"ProfileToken": req.ProfileToken})
+                await ptz_service.Stop({"ProfileToken": req.ProfileToken, 'PanTilt': True, 'Zoom': False})
             elif move_mode == RELATIVE_MOVE:
                 # Guard against unsupported operation
                 if not profile.ptz.relative:

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -76,6 +76,10 @@ class EventManager:
         if await self.device.create_pullpoint_subscription():
             # Initialize events
             pullpoint = self.device.create_pullpoint_service()
+            try:
+                await pullpoint.SetSynchronizationPoint()
+            except SUBSCRIPTION_ERRORS:
+                pass
             response = await pullpoint.PullMessages(
                 {"MessageLimit": 100, "Timeout": dt.timedelta(seconds=5)}
             )

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -77,7 +77,7 @@ class EventManager:
             # Initialize events
             pullpoint = self.device.create_pullpoint_service()
             response = await pullpoint.PullMessages(
-                {"MessageLimit":100, "Timeout":dt.timedelta(seconds=5)}
+                {"MessageLimit": 100, "Timeout": dt.timedelta(seconds=5)}
             )
 
             # Parse event initialization
@@ -156,7 +156,7 @@ class EventManager:
             try:
                 pullpoint = self.device.create_pullpoint_service()
                 response = await pullpoint.PullMessages(
-                    {"MessageLimit":100, "Timeout":dt.timedelta(seconds=60)}
+                    {"MessageLimit": 100, "Timeout": dt.timedelta(seconds=60)}
                 )
 
                 # Renew subscription if less than two hours is left

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -76,11 +76,9 @@ class EventManager:
         if await self.device.create_pullpoint_subscription():
             # Initialize events
             pullpoint = self.device.create_pullpoint_service()
-            await pullpoint.SetSynchronizationPoint()
-            req = pullpoint.create_type("PullMessages")
-            req.MessageLimit = 100
-            req.Timeout = dt.timedelta(seconds=5)
-            response = await pullpoint.PullMessages(req)
+            response = await pullpoint.PullMessages(
+                {"MessageLimit":100, "Timeout":dt.timedelta(seconds=5)}
+            )
 
             # Parse event initialization
             await self.async_parse_messages(response.NotificationMessage)
@@ -157,10 +155,9 @@ class EventManager:
         if self.hass.state == CoreState.running:
             try:
                 pullpoint = self.device.create_pullpoint_service()
-                req = pullpoint.create_type("PullMessages")
-                req.MessageLimit = 100
-                req.Timeout = dt.timedelta(seconds=60)
-                response = await pullpoint.PullMessages(req)
+                response = await pullpoint.PullMessages(
+                    {"MessageLimit":100, "Timeout":dt.timedelta(seconds=5)}
+                )
 
                 # Renew subscription if less than two hours is left
                 if (

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -156,7 +156,7 @@ class EventManager:
             try:
                 pullpoint = self.device.create_pullpoint_service()
                 response = await pullpoint.PullMessages(
-                    {"MessageLimit":100, "Timeout":dt.timedelta(seconds=5)}
+                    {"MessageLimit":100, "Timeout":dt.timedelta(seconds=60)}
                 )
 
                 # Renew subscription if less than two hours is left

--- a/homeassistant/components/onvif/parsers.py
+++ b/homeassistant/components/onvif/parsers.py
@@ -214,6 +214,37 @@ async def async_parse_cell_motion_detector(uid: str, msg) -> Event:
         return None
 
 
+@PARSERS.register("tns1:RuleEngine/MotionRegionDetector/Motion")
+# pylint: disable=protected-access
+async def async_parse_motion_region_detector(uid: str, msg) -> Event:
+    """Handle parsing event message.
+
+    Topic: tns1:RuleEngine/MotionRegionDetector/Motion
+    """
+    try:
+        video_source = ""
+        video_analytics = ""
+        rule = ""
+        for source in msg.Message._value_1.Source.SimpleItem:
+            if source.Name == "VideoSourceConfigurationToken":
+                video_source = source.Value
+            if source.Name == "VideoAnalyticsConfigurationToken":
+                video_analytics = source.Value
+            if source.Name == "Rule":
+                rule = source.Value
+
+        return Event(
+            f"{uid}_{msg.Topic._value_1}_{video_source}_{video_analytics}_{rule}",
+            f"{rule} Motion Region Detection",
+            "binary_sensor",
+            "motion",
+            None,
+            msg.Message._value_1.Data.SimpleItem[0].Value == "true",
+        )
+    except (AttributeError, KeyError):
+        return None
+
+
 @PARSERS.register("tns1:RuleEngine/TamperDetector/Tamper")
 # pylint: disable=protected-access
 async def async_parse_tamper_detector(uid: str, msg) -> Event:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the stop service call, added the Zoom and PanTilt parameters because some cameras required them.
Fix the way how home assistant detect available sensors on camera. Comment out SetSynchronizationPoint because is not always available and correct PullMessages service call. Also add rule for topic: "tns1:RuleEngine/MotionRegionDetector/Motion" and change the name of the sensor to more generic ones.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
