### PR TITLE
Convert media_player unittest tests to pytest style

### DIFF
--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -80,7 +80,7 @@ def player(hass):
 async def test_volume_up(player):
     """Test the volume_up helper function."""
     assert player.volume_level == 0
-    player.set_volume_level(0.5)
+    await player.async_set_volume_level(0.5)
     assert player.volume_level == 0.5
     await player.async_volume_up()
     assert player.volume_level == 0.7
@@ -89,7 +89,7 @@ async def test_volume_up(player):
 async def test_volume_down(player):
     """Test the volume_down helper function."""
     assert player.volume_level == 0
-    player.set_volume_level(0.5)
+    await player.async_set_volume_level(0.5)
     assert player.volume_level == 0.5
     await player.async_volume_down()
     assert player.volume_level == 0.3

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -86,7 +86,7 @@ def player(hass):
 
 
 async def test_volume_up(player):
-    """Test the volume_up helper function."""
+    """Test the volume_up and set volume methods."""
     assert player.volume_level == 0
     await player.async_set_volume_level(0.5)
     assert player.volume_level == 0.5
@@ -95,7 +95,7 @@ async def test_volume_up(player):
 
 
 async def test_volume_down(player):
-    """Test the volume_down helper function."""
+    """Test the volume_down and set volume methods."""
     assert player.volume_level == 0
     await player.async_set_volume_level(0.5)
     assert player.volume_level == 0.5
@@ -104,7 +104,7 @@ async def test_volume_down(player):
 
 
 async def test_media_play_pause(player):
-    """Test the media_play_pause helper function."""
+    """Test the media_play_pause method."""
     assert player.state == STATE_OFF
     await player.async_media_play_pause()
     assert player.state == STATE_PLAYING
@@ -122,7 +122,7 @@ async def test_turn_on_off(player):
 
 
 async def test_toggle(player):
-    """Test the toggle helper function."""
+    """Test the toggle method."""
     assert player.state == STATE_OFF
     await player.async_toggle()
     assert player.state == STATE_ON

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -1,6 +1,5 @@
 """The tests for the Async Media player helper functions."""
-import asyncio
-import unittest
+import pytest
 
 import homeassistant.components.media_player as mp
 from homeassistant.const import (
@@ -11,62 +10,9 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 
-from tests.common import get_test_home_assistant
 
-
-class AsyncMediaPlayer(mp.MediaPlayerEntity):
-    """Async media player test class."""
-
-    def __init__(self, hass):
-        """Initialize the test media player."""
-        self.hass = hass
-        self._volume = 0
-        self._state = STATE_OFF
-
-    @property
-    def state(self):
-        """State of the player."""
-        return self._state
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def supported_features(self):
-        """Flag media player features that are supported."""
-        return (
-            mp.const.SUPPORT_VOLUME_SET
-            | mp.const.SUPPORT_PLAY
-            | mp.const.SUPPORT_PAUSE
-            | mp.const.SUPPORT_TURN_OFF
-            | mp.const.SUPPORT_TURN_ON
-        )
-
-    async def async_set_volume_level(self, volume):
-        """Set volume level, range 0..1."""
-        self._volume = volume
-
-    async def async_media_play(self):
-        """Send play command."""
-        self._state = STATE_PLAYING
-
-    async def async_media_pause(self):
-        """Send pause command."""
-        self._state = STATE_PAUSED
-
-    async def async_turn_on(self):
-        """Turn the media player on."""
-        self._state = STATE_ON
-
-    async def async_turn_off(self):
-        """Turn the media player off."""
-        self._state = STATE_OFF
-
-
-class SyncMediaPlayer(mp.MediaPlayerEntity):
-    """Sync media player test class."""
+class MediaPlayer(mp.MediaPlayerEntity):
+    """Media player test class."""
 
     def __init__(self, hass):
         """Initialize the test media player."""
@@ -124,136 +70,44 @@ class SyncMediaPlayer(mp.MediaPlayerEntity):
         else:
             self._state = STATE_OFF
 
-    async def async_media_play_pause(self):
-        """Create a coroutine to wrap the future returned by ABC.
 
-        This allows the run_coroutine_threadsafe helper to be used.
-        """
-        await super().async_media_play_pause()
-
-    async def async_toggle(self):
-        """Create a coroutine to wrap the future returned by ABC.
-
-        This allows the run_coroutine_threadsafe helper to be used.
-        """
-        await super().async_toggle()
+@pytest.fixture
+def player(hass):
+    """Fixture of a media player."""
+    return MediaPlayer(hass)
 
 
-class TestAsyncMediaPlayer(unittest.TestCase):
-    """Test the media_player module."""
-
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.player = AsyncMediaPlayer(self.hass)
-        self.addCleanup(self.tear_down_cleanup)
-
-    def tear_down_cleanup(self):
-        """Shut down test instance."""
-        self.hass.stop()
-
-    def test_volume_up(self):
-        """Test the volume_up helper function."""
-        assert self.player.volume_level == 0
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_set_volume_level(0.5), self.hass.loop
-        ).result()
-        assert self.player.volume_level == 0.5
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_volume_up(), self.hass.loop
-        ).result()
-        assert self.player.volume_level == 0.6
-
-    def test_volume_down(self):
-        """Test the volume_down helper function."""
-        assert self.player.volume_level == 0
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_set_volume_level(0.5), self.hass.loop
-        ).result()
-        assert self.player.volume_level == 0.5
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_volume_down(), self.hass.loop
-        ).result()
-        assert self.player.volume_level == 0.4
-
-    def test_media_play_pause(self):
-        """Test the media_play_pause helper function."""
-        assert self.player.state == STATE_OFF
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_media_play_pause(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_PLAYING
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_media_play_pause(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_PAUSED
-
-    def test_toggle(self):
-        """Test the toggle helper function."""
-        assert self.player.state == STATE_OFF
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_toggle(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_ON
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_toggle(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_OFF
+async def test_volume_up(player):
+    """Test the volume_up helper function."""
+    assert player.volume_level == 0
+    player.set_volume_level(0.5)
+    assert player.volume_level == 0.5
+    await player.async_volume_up()
+    assert player.volume_level == 0.7
 
 
-class TestSyncMediaPlayer(unittest.TestCase):
-    """Test the media_player module."""
+async def test_volume_down(player):
+    """Test the volume_down helper function."""
+    assert player.volume_level == 0
+    player.set_volume_level(0.5)
+    assert player.volume_level == 0.5
+    await player.async_volume_down()
+    assert player.volume_level == 0.3
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.player = SyncMediaPlayer(self.hass)
-        self.addCleanup(self.tear_down_cleanup)
 
-    def tear_down_cleanup(self):
-        """Shut down test instance."""
-        self.hass.stop()
+async def test_media_play_pause(player):
+    """Test the media_play_pause helper function."""
+    assert player.state == STATE_OFF
+    await player.async_media_play_pause()
+    assert player.state == STATE_PLAYING
+    await player.async_media_play_pause()
+    assert player.state == STATE_PAUSED
 
-    def test_volume_up(self):
-        """Test the volume_up helper function."""
-        assert self.player.volume_level == 0
-        self.player.set_volume_level(0.5)
-        assert self.player.volume_level == 0.5
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_volume_up(), self.hass.loop
-        ).result()
-        assert self.player.volume_level == 0.7
 
-    def test_volume_down(self):
-        """Test the volume_down helper function."""
-        assert self.player.volume_level == 0
-        self.player.set_volume_level(0.5)
-        assert self.player.volume_level == 0.5
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_volume_down(), self.hass.loop
-        ).result()
-        assert self.player.volume_level == 0.3
-
-    def test_media_play_pause(self):
-        """Test the media_play_pause helper function."""
-        assert self.player.state == STATE_OFF
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_media_play_pause(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_PLAYING
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_media_play_pause(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_PAUSED
-
-    def test_toggle(self):
-        """Test the toggle helper function."""
-        assert self.player.state == STATE_OFF
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_toggle(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_ON
-        asyncio.run_coroutine_threadsafe(
-            self.player.async_toggle(), self.hass.loop
-        ).result()
-        assert self.player.state == STATE_OFF
+async def test_toggle(player):
+    """Test the toggle helper function."""
+    assert player.state == STATE_OFF
+    await player.async_toggle()
+    assert player.state == STATE_ON
+    await player.async_toggle()
+    assert player.state == STATE_OFF

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -63,6 +63,14 @@ class MediaPlayer(mp.MediaPlayerEntity):
         else:
             self._state = STATE_PLAYING
 
+    def turn_on(self):
+        """Turn on state."""
+        self._state = STATE_ON
+
+    def turn_off(self):
+        """Turn off state."""
+        self._state = STATE_OFF
+
     def toggle(self):
         """Toggle the power on the media player."""
         if self._state in [STATE_OFF, STATE_IDLE]:
@@ -102,6 +110,15 @@ async def test_media_play_pause(player):
     assert player.state == STATE_PLAYING
     await player.async_media_play_pause()
     assert player.state == STATE_PAUSED
+
+
+async def test_turn_on_off(player):
+    """Test the turn on and turn off methods."""
+    assert player.state == STATE_OFF
+    await player.async_turn_on()
+    assert player.state == STATE_ON
+    await player.async_turn_off()
+    assert player.state == STATE_OFF
 
 
 async def test_toggle(player):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Rewrote media_player unittest tests to pytest style test functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40838
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
