### PR TITLE
Use common strings in Azure DevOps config flow

### DIFF
--- a/homeassistant/components/azure_devops/config_flow.py
+++ b/homeassistant/components/azure_devops/config_flow.py
@@ -67,7 +67,7 @@ class AzureDevOpsFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "project_error"
                 return errors
         except aiohttp.ClientError:
-            errors["base"] = "connection_error"
+            errors["base"] = "cannot_connect"
             return errors
         return None
 

--- a/homeassistant/components/azure_devops/config_flow.py
+++ b/homeassistant/components/azure_devops/config_flow.py
@@ -60,7 +60,7 @@ class AzureDevOpsFlowHandler(ConfigFlow, domain=DOMAIN):
             if self._pat is not None:
                 await client.authorize(self._pat, self._organization)
                 if not client.authorized:
-                    errors["base"] = "authorization_error"
+                    errors["base"] = "invalid_auth"
                     return errors
             project_info = await client.get_project(self._organization, self._project)
             if project_info is None:

--- a/homeassistant/components/azure_devops/strings.json
+++ b/homeassistant/components/azure_devops/strings.json
@@ -2,8 +2,8 @@
   "config": {
     "flow_title": "Azure DevOps: {project_url}",
     "error": {
-      "authorization_error": "Authorization error. Check you have access to the project and have the correct credentials.",
-      "connection_error": "Could not connect to Azure DevOps.",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "project_error": "Could not get project info."
     },
     "step": {

--- a/tests/components/azure_devops/test_config_flow.py
+++ b/tests/components/azure_devops/test_config_flow.py
@@ -51,7 +51,7 @@ async def test_authorization_error(hass: HomeAssistant) -> None:
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result2["step_id"] == "user"
-        assert result2["errors"] == {"base": "authorization_error"}
+        assert result2["errors"] == {"base": "invalid_auth"}
 
 
 async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
@@ -75,7 +75,7 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result2["step_id"] == "reauth"
-        assert result2["errors"] == {"base": "authorization_error"}
+        assert result2["errors"] == {"base": "invalid_auth"}
 
 
 async def test_connection_error(hass: HomeAssistant) -> None:
@@ -99,7 +99,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result2["step_id"] == "user"
-        assert result2["errors"] == {"base": "connection_error"}
+        assert result2["errors"] == {"base": "cannot_connect"}
 
 
 async def test_reauth_connection_error(hass: HomeAssistant) -> None:
@@ -123,7 +123,7 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result2["step_id"] == "reauth"
-        assert result2["errors"] == {"base": "connection_error"}
+        assert result2["errors"] == {"base": "cannot_connect"}
 
 
 async def test_project_error(hass: HomeAssistant) -> None:
@@ -201,7 +201,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "reauth"
-        assert result["errors"] == {"base": "authorization_error"}
+        assert result["errors"] == {"base": "invalid_auth"}
 
     with patch(
         "homeassistant.components.azure_devops.config_flow.DevOpsClient.authorize",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
