### PR TITLE
Add device classes to battery, illuminance and temperature miflora sensor

### DIFF
--- a/homeassistant/components/miflora/sensor.py
+++ b/homeassistant/components/miflora/sensor.py
@@ -16,6 +16,9 @@ from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_TEMPERATURE,
     EVENT_HOMEASSISTANT_START,
     LIGHT_LUX,
     PERCENTAGE,
@@ -51,13 +54,13 @@ SCAN_INTERVAL = timedelta(seconds=1200)
 
 ATTR_LAST_SUCCESSFUL_UPDATE = "last_successful_update"
 
-# Sensor types are defined like: Name, units, icon
+# Sensor types are defined like: Name, units, icon, device_class
 SENSOR_TYPES = {
-    "temperature": ["Temperature", TEMP_CELSIUS, "mdi:thermometer"],
-    "light": ["Light intensity", LIGHT_LUX, "mdi:white-balance-sunny"],
-    "moisture": ["Moisture", PERCENTAGE, "mdi:water-percent"],
-    "conductivity": ["Conductivity", CONDUCTIVITY, "mdi:flash-circle"],
-    "battery": ["Battery", PERCENTAGE, "mdi:battery-charging"],
+    "temperature": ["Temperature", TEMP_CELSIUS, None, DEVICE_CLASS_TEMPERATURE],
+    "light": ["Light intensity", LIGHT_LUX, None, DEVICE_CLASS_ILLUMINANCE],
+    "moisture": ["Moisture", PERCENTAGE, "mdi:water-percent", None],
+    "conductivity": ["Conductivity", CONDUCTIVITY, "mdi:flash-circle", None],
+    "battery": ["Battery", PERCENTAGE, None, DEVICE_CLASS_BATTERY],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -104,6 +107,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             else SENSOR_TYPES[parameter][1]
         )
         icon = SENSOR_TYPES[parameter][2]
+        device_class = SENSOR_TYPES[parameter][3]
 
         prefix = config.get(CONF_NAME)
         if prefix:
@@ -116,6 +120,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 name,
                 unit,
                 icon,
+                device_class,
                 force_update,
                 median,
                 go_unavailable_timeout,
@@ -135,6 +140,7 @@ class MiFloraSensor(Entity):
         name,
         unit,
         icon,
+        device_class,
         force_update,
         median,
         go_unavailable_timeout,
@@ -146,6 +152,7 @@ class MiFloraSensor(Entity):
         self._icon = icon
         self._name = name
         self._state = None
+        self._device_class = device_class
         self.data = []
         self._force_update = force_update
         self.go_unavailable_timeout = go_unavailable_timeout
@@ -185,6 +192,11 @@ class MiFloraSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes of the device."""
         return {ATTR_LAST_SUCCESSFUL_UPDATE: self.last_successful_update}
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The [Mi Flora plant sensor](https://www.home-assistant.io/integrations/miflora) provides sensor entities which have not yet been assigned their respective [device classes](https://www.home-assistant.io/integrations/sensor/#device-class) (see https://github.com/home-assistant/core/issues/33562).

This pr adds device classes to the following sensor entities provided by this integration:

- battery
- illuminance
- temperature

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Example entry for `configuration.yaml`:
*(Nothing changed regarding the config entry)*
```yaml
# Example configuration.yaml
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #33562
- This PR is related to issue: *(see above)*
- Link to documentation pull request: *(no documentation change was necessary)*

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. *(no tests existed)*

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`. *(no new requirements)*
- [ ] Untested files have been added to `.coveragerc`. *(already included)*

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
