### PR TITLE
Use async support and clean up tests for Ruckus Unleashed integration

### DIFF
--- a/homeassistant/components/ruckus_unleashed/__init__.py
+++ b/homeassistant/components/ruckus_unleashed/__init__.py
@@ -36,11 +36,8 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Ruckus Unleashed from a config entry."""
     try:
-        ruckus = await hass.async_add_executor_job(
-            Ruckus,
-            entry.data[CONF_HOST],
-            entry.data[CONF_USERNAME],
-            entry.data[CONF_PASSWORD],
+        ruckus = await Ruckus.create(
+            entry.data[CONF_HOST], entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
         )
     except ConnectionError as error:
         raise ConfigEntryNotReady from error
@@ -51,10 +48,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not coordinator.last_update_success:
         raise ConfigEntryNotReady
 
-    system_info = await hass.async_add_executor_job(ruckus.system_info)
+    system_info = await ruckus.system_info()
 
     registry = await device_registry.async_get_registry(hass)
-    ap_info = await hass.async_add_executor_job(ruckus.ap_info)
+    ap_info = await ruckus.ap_info()
     for device in ap_info[API_AP][API_ID].values():
         registry.async_get_or_create(
             config_entry_id=entry.entry_id,

--- a/homeassistant/components/ruckus_unleashed/config_flow.py
+++ b/homeassistant/components/ruckus_unleashed/config_flow.py
@@ -19,22 +19,24 @@ _LOGGER = logging.getLogger(__package__)
 DATA_SCHEMA = vol.Schema({"host": str, "username": str, "password": str})
 
 
-def validate_input(hass: core.HomeAssistant, data):
+async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect.
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
 
     try:
-        ruckus = Ruckus(data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD])
+        ruckus = await Ruckus.create(
+            data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD]
+        )
     except AuthenticationError as error:
         raise InvalidAuth from error
     except ConnectionError as error:
         raise CannotConnect from error
 
-    mesh_name = ruckus.mesh_name()
+    mesh_name = await ruckus.mesh_name()
 
-    system_info = ruckus.system_info()
+    system_info = await ruckus.system_info()
     try:
         host_serial = system_info[API_SYSTEM_OVERVIEW][API_SERIAL]
     except KeyError as error:
@@ -57,9 +59,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             try:
-                info = await self.hass.async_add_executor_job(
-                    validate_input, self.hass, user_input
-                )
+                info = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:

--- a/homeassistant/components/ruckus_unleashed/coordinator.py
+++ b/homeassistant/components/ruckus_unleashed/coordinator.py
@@ -37,9 +37,7 @@ class RuckusUnleashedDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _fetch_clients(self) -> dict:
         """Fetch clients from the API and format them."""
-        clients = await self.hass.async_add_executor_job(
-            self.ruckus.current_active_clients
-        )
+        clients = await self.ruckus.current_active_clients()
         return {e[API_MAC]: e for e in clients[API_CURRENT_ACTIVE_CLIENTS][API_CLIENTS]}
 
     async def _async_update_data(self) -> dict:

--- a/homeassistant/components/ruckus_unleashed/manifest.json
+++ b/homeassistant/components/ruckus_unleashed/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ruckus_unleashed",
   "requirements": [
-    "pyruckus==0.12"
+    "pyruckus==0.13"
   ],
   "codeowners": [
     "@gabe565"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1633,7 +1633,7 @@ pyrepetier==3.0.5
 pyrisco==0.3.1
 
 # homeassistant.components.ruckus_unleashed
-pyruckus==0.12
+pyruckus==0.13
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -804,7 +804,7 @@ pyqwikswitch==0.93
 pyrisco==0.3.1
 
 # homeassistant.components.ruckus_unleashed
-pyruckus==0.12
+pyruckus==0.13
 
 # homeassistant.components.acer_projector
 # homeassistant.components.zha

--- a/tests/components/ruckus_unleashed/__init__.py
+++ b/tests/components/ruckus_unleashed/__init__.py
@@ -53,6 +53,74 @@ TEST_CLIENT = {
 }
 
 
+def _patch_create(**kwargs):
+    """Patch the `Ruckus.create()` method."""
+    return patch(
+        "homeassistant.components.ruckus_unleashed.Ruckus.create",
+        **kwargs,
+    )
+
+
+def _patch_connect(**kwargs):
+    """Patch the `Ruckus.connect()` method."""
+    if not kwargs:
+        kwargs["return_value"] = None
+    return patch(
+        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
+        **kwargs,
+    )
+
+
+def _patch_mesh_name(**kwargs):
+    """Patch the `Ruckus.mesh_name()` method."""
+    if not kwargs:
+        kwargs["return_value"] = DEFAULT_TITLE
+    return patch(
+        "homeassistant.components.ruckus_unleashed.Ruckus.mesh_name",
+        **kwargs,
+    )
+
+
+def _patch_system_info(**kwargs):
+    """Patch the `Ruckus.system_info()` method."""
+    if not kwargs:
+        kwargs["return_value"] = DEFAULT_SYSTEM_INFO
+    return patch(
+        "homeassistant.components.ruckus_unleashed.Ruckus.system_info",
+        **kwargs,
+    )
+
+
+def _patch_ap_info(**kwargs):
+    """Patch the `Ruckus.ap_info()` method."""
+    if not kwargs:
+        kwargs["return_value"] = DEFAULT_AP_INFO
+    return patch(
+        "homeassistant.components.ruckus_unleashed.Ruckus.ap_info",
+        **kwargs,
+    )
+
+
+def _patch_fetch_clients(**kwargs):
+    """Patch the `RuckusUnleashedDataUpdateCoordinator._fetch_clients()` method."""
+    if not kwargs:
+        kwargs["return_value"] = {
+            TEST_CLIENT[API_MAC]: TEST_CLIENT,
+        }
+    return patch(
+        "homeassistant.components.ruckus_unleashed.RuckusUnleashedDataUpdateCoordinator._fetch_clients",
+        **kwargs,
+    )
+
+
+def _patch_async_update_data(**kwargs):
+    """Patch the `RuckusUnleashedDataUpdateCoordinator._async_update_data()` method."""
+    return patch(
+        "homeassistant.components.ruckus_unleashed.RuckusUnleashedDataUpdateCoordinator._async_update_data",
+        **kwargs,
+    )
+
+
 def mock_config_entry() -> MockConfigEntry:
     """Return a Ruckus Unleashed mock config entry."""
     return MockConfigEntry(
@@ -67,24 +135,7 @@ def mock_config_entry() -> MockConfigEntry:
 async def init_integration(hass) -> MockConfigEntry:
     """Set up the Ruckus Unleashed integration in Home Assistant."""
     entry = mock_config_entry()
-    with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.mesh_name",
-        return_value=DEFAULT_TITLE,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.system_info",
-        return_value=DEFAULT_SYSTEM_INFO,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.ap_info",
-        return_value=DEFAULT_AP_INFO,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.RuckusUnleashedDataUpdateCoordinator._fetch_clients",
-        return_value={
-            TEST_CLIENT[API_MAC]: TEST_CLIENT,
-        },
-    ):
+    with _patch_connect(), _patch_mesh_name(), _patch_system_info(), _patch_ap_info(), _patch_fetch_clients():
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/ruckus_unleashed/test_config_flow.py
+++ b/tests/components/ruckus_unleashed/test_config_flow.py
@@ -9,7 +9,13 @@ from homeassistant.util import utcnow
 
 from tests.async_mock import patch
 from tests.common import async_fire_time_changed
-from tests.components.ruckus_unleashed import CONFIG, DEFAULT_SYSTEM_INFO, DEFAULT_TITLE
+from tests.components.ruckus_unleashed import (
+    CONFIG,
+    DEFAULT_TITLE,
+    _patch_connect,
+    _patch_mesh_name,
+    _patch_system_info,
+)
 
 
 async def test_form(hass):
@@ -20,16 +26,7 @@ async def test_form(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.mesh_name",
-        return_value=DEFAULT_TITLE,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.system_info",
-        return_value=DEFAULT_SYSTEM_INFO,
-    ), patch(
+    with _patch_connect(), _patch_mesh_name(), _patch_system_info(), patch(
         "homeassistant.components.ruckus_unleashed.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.ruckus_unleashed.async_setup_entry",
@@ -54,10 +51,7 @@ async def test_form_invalid_auth(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
-        side_effect=AuthenticationError,
-    ):
+    with _patch_connect(side_effect=AuthenticationError):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG,
@@ -73,10 +67,7 @@ async def test_form_cannot_connect(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
-        side_effect=ConnectionError,
-    ):
+    with _patch_connect(side_effect=ConnectionError):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG,
@@ -92,10 +83,7 @@ async def test_form_unknown_error(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
-        side_effect=Exception,
-    ):
+    with _patch_connect():
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG,
@@ -113,16 +101,7 @@ async def test_form_cannot_connect_unknown_serial(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.mesh_name",
-        return_value=DEFAULT_TITLE,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.system_info",
-        return_value={},
-    ):
+    with _patch_connect(), _patch_mesh_name(), _patch_system_info(return_value={}):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG,
@@ -138,16 +117,7 @@ async def test_form_duplicate_error(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.connect",
-        return_value=None,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.mesh_name",
-        return_value=DEFAULT_TITLE,
-    ), patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus.system_info",
-        return_value=DEFAULT_SYSTEM_INFO,
-    ):
+    with _patch_connect(), _patch_mesh_name(), _patch_system_info():
         await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG,

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -33,7 +33,7 @@ async def test_setup_entry_login_error(hass):
     """Test entry setup failed due to login error."""
     entry = mock_config_entry()
     with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus",
+        "homeassistant.components.ruckus_unleashed.Ruckus.create",
         side_effect=AuthenticationError,
     ):
         entry.add_to_hass(hass)
@@ -47,7 +47,7 @@ async def test_setup_entry_connection_error(hass):
     """Test entry setup failed due to connection error."""
     entry = mock_config_entry()
     with patch(
-        "homeassistant.components.ruckus_unleashed.Ruckus",
+        "homeassistant.components.ruckus_unleashed.Ruckus.create",
         side_effect=ConnectionError,
     ):
         entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

External library function calls will now utilize async functionality where relevant instead of relying on `hass. async_add_executor_job()`.

Also, duplicated calls to `patch()` in tests have now been pulled out into dedicated patch functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
