### PR TITLE
Improve Advantage Air integration to Platinum quality

### DIFF
--- a/homeassistant/components/advantage_air/__init__.py
+++ b/homeassistant/components/advantage_air/__init__.py
@@ -8,11 +8,7 @@ from advantage_air import ApiError, advantage_air
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import ADVANTAGE_AIR_RETRY, DOMAIN
 
@@ -76,35 +72,3 @@ async def async_setup_entry(hass, config_entry):
         )
 
     return True
-
-
-class AdvantageAirEntity(CoordinatorEntity):
-    """Parent class for Advantage Air Entities."""
-
-    def __init__(self, instance, ac_key, zone_key=None):
-        """Initialize common aspects of an Advantage Air sensor."""
-        super().__init__(instance["coordinator"])
-        self.async_change = instance["async_change"]
-        self.ac_key = ac_key
-        self.zone_key = zone_key
-
-    @property
-    def _ac(self):
-        return self.coordinator.data["aircons"][self.ac_key]["info"]
-
-    @property
-    def _zone(self):
-        if not self.zone_key:
-            return None
-        return self.coordinator.data["aircons"][self.ac_key]["zones"][self.zone_key]
-
-    @property
-    def device_info(self):
-        """Return parent device information."""
-        return {
-            "identifiers": {(DOMAIN, self.coordinator.data["system"]["rid"])},
-            "name": self.coordinator.data["system"]["name"],
-            "manufacturer": "Advantage Air",
-            "model": self.coordinator.data["system"]["sysType"],
-            "sw_version": self.coordinator.data["system"]["myAppRev"],
-        }

--- a/homeassistant/components/advantage_air/__init__.py
+++ b/homeassistant/components/advantage_air/__init__.py
@@ -72,3 +72,13 @@ async def async_setup_entry(hass, config_entry):
         )
 
     return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload Advantage Air Config."""
+    for platform in ADVANTAGE_AIR_PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_unload(config_entry, platform)
+        )
+    hass.data[DOMAIN].pop(config_entry.entry_id)
+    return await hass.data[DOMAIN].async_unload_entry(config_entry)

--- a/homeassistant/components/advantage_air/__init__.py
+++ b/homeassistant/components/advantage_air/__init__.py
@@ -20,13 +20,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass, config):
-    """Set up AdvantageAir."""
+    """Set up Advantage Air integration."""
     hass.data[DOMAIN] = {}
     return True
 
 
 async def async_setup_entry(hass, entry):
-    """Set up AdvantageAir Config."""
+    """Set up Advantage Air config."""
     ip_address = entry.data[CONF_IP_ADDRESS]
     port = entry.data[CONF_PORT]
     api = advantage_air(

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -17,15 +17,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     instance = hass.data[ADVANTAGE_AIR_DOMAIN][config_entry.entry_id]
 
-    if "aircons" in instance["coordinator"].data:
-        entities = []
-        for ac_key, ac_device in instance["coordinator"].data["aircons"].items():
-            entities.append(AdvantageAirZoneFilter(instance, ac_key))
-            for zone_key, zone in ac_device["zones"].items():
-                # Only add motion sensor when motion is enabled
-                if zone["motionConfig"] >= 2:
-                    entities.append(AdvantageAirZoneMotion(instance, ac_key, zone_key))
-        async_add_entities(entities)
+    entities = []
+    for ac_key, ac_device in instance["coordinator"].data["aircons"].items():
+        entities.append(AdvantageAirZoneFilter(instance, ac_key))
+        for zone_key, zone in ac_device["zones"].items():
+            # Only add motion sensor when motion is enabled
+            if zone["motionConfig"] >= 2:
+                entities.append(AdvantageAirZoneMotion(instance, ac_key, zone_key))
+    async_add_entities(entities)
 
 
 class AdvantageAirZoneFilter(AdvantageAirEntity, BinarySensorEntity):

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -1,6 +1,5 @@
 """Binary Sensor platform for Advantage Air integration."""
 
-from homeassistant.components.advantage_air import AdvantageAirEntity
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_PROBLEM,
@@ -8,6 +7,7 @@ from homeassistant.components.binary_sensor import (
 )
 
 from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
+from .entity import AdvantageAirEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entities.append(AdvantageAirZoneFilter(instance, ac_key))
             for zone_key, zone in ac_device["zones"].items():
                 # Only add motion sensor when motion is enabled
-                if zone["motionConfig"] == 2:
+                if zone["motionConfig"] >= 2:
                     entities.append(AdvantageAirZoneMotion(instance, ac_key, zone_key))
         async_add_entities(entities)
 

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -28,7 +28,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 class AdvantageAirZoneFilter(AdvantageAirEntity, BinarySensorEntity):
-    """AdvantageAir Filter."""
+    """Advantage Air Filter."""
+
+    def __init__(self, instance, ac_key):
+        """Initialize the Advantage Air Filter entity."""
+        super().__init__(instance, ac_key)
 
     @property
     def name(self):
@@ -52,7 +56,11 @@ class AdvantageAirZoneFilter(AdvantageAirEntity, BinarySensorEntity):
 
 
 class AdvantageAirZoneMotion(AdvantageAirEntity, BinarySensorEntity):
-    """AdvantageAir Zone Motion."""
+    """Advantage Air Zone Motion."""
+
+    def __init__(self, instance, ac_key, zone_key):
+        """Initialize the Advantage Air Zone Motion entity."""
+        super().__init__(instance, ac_key, zone_key)
 
     @property
     def name(self):

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -72,8 +72,3 @@ class AdvantageAirZoneMotion(AdvantageAirEntity, BinarySensorEntity):
     def is_on(self):
         """Return if motion is detect."""
         return self._zone["motion"]
-
-    @property
-    def device_state_attributes(self):
-        """Return additional motion configuration."""
-        return {"motionConfig": self._zone["motionConfig"]}

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -9,6 +9,8 @@ from homeassistant.components.binary_sensor import (
 from .const import DOMAIN as ADVANTAGE_AIR_DOMAIN
 from .entity import AdvantageAirEntity
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up AdvantageAir motion platform."""

--- a/homeassistant/components/advantage_air/binary_sensor.py
+++ b/homeassistant/components/advantage_air/binary_sensor.py
@@ -30,10 +30,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AdvantageAirZoneFilter(AdvantageAirEntity, BinarySensorEntity):
     """Advantage Air Filter."""
 
-    def __init__(self, instance, ac_key):
-        """Initialize the Advantage Air Filter entity."""
-        super().__init__(instance, ac_key)
-
     @property
     def name(self):
         """Return the name."""
@@ -57,10 +53,6 @@ class AdvantageAirZoneFilter(AdvantageAirEntity, BinarySensorEntity):
 
 class AdvantageAirZoneMotion(AdvantageAirEntity, BinarySensorEntity):
     """Advantage Air Zone Motion."""
-
-    def __init__(self, instance, ac_key, zone_key):
-        """Initialize the Advantage Air Zone Motion entity."""
-        super().__init__(instance, ac_key, zone_key)
 
     @property
     def name(self):

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -22,7 +22,7 @@ from .const import (
     ADVANTAGE_AIR_STATE_OFF,
     ADVANTAGE_AIR_STATE_ON,
     ADVANTAGE_AIR_STATE_OPEN,
-    DOMAIN,
+    DOMAIN as ADVANTAGE_AIR_DOMAIN,
 )
 
 ADVANTAGE_AIR_HVAC_MODES = {
@@ -55,7 +55,7 @@ ZONE_HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_FAN_ONLY]
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up AdvantageAir climate platform."""
 
-    instance = hass.data[DOMAIN][config_entry.entry_id]
+    instance = hass.data[ADVANTAGE_AIR_DOMAIN][config_entry.entry_id]
 
     entities = []
     for ac_key, ac_device in instance["coordinator"].data["aircons"].items():

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -51,6 +51,8 @@ AC_HVAC_MODES = [
 ]
 ZONE_HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_FAN_ONLY]
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up AdvantageAir climate platform."""

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -1,6 +1,5 @@
 """Climate platform for Advantage Air integration."""
 
-from homeassistant.components.advantage_air import AdvantageAirEntity
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     FAN_AUTO,
@@ -24,6 +23,7 @@ from .const import (
     ADVANTAGE_AIR_STATE_OPEN,
     DOMAIN as ADVANTAGE_AIR_DOMAIN,
 )
+from .entity import AdvantageAirEntity
 
 ADVANTAGE_AIR_HVAC_MODES = {
     "heat": HVAC_MODE_HEAT,

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -96,6 +96,10 @@ class AdvantageAirClimateEntity(AdvantageAirEntity, ClimateEntity):
 class AdvantageAirAC(AdvantageAirClimateEntity):
     """AdvantageAir AC unit."""
 
+    def __init__(self, instance, ac_key):
+        """Initialize the Advantage Air Climate entity."""
+        super().__init__(instance, ac_key)
+
     @property
     def name(self):
         """Return the name."""
@@ -170,6 +174,10 @@ class AdvantageAirAC(AdvantageAirClimateEntity):
 
 class AdvantageAirZone(AdvantageAirClimateEntity):
     """AdvantageAir Zone control."""
+
+    def __init__(self, instance, ac_key, zone_key):
+        """Initialize the Advantage Air Zone Climate entity."""
+        super().__init__(instance, ac_key, zone_key)
 
     @property
     def name(self):

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -96,10 +96,6 @@ class AdvantageAirClimateEntity(AdvantageAirEntity, ClimateEntity):
 class AdvantageAirAC(AdvantageAirClimateEntity):
     """AdvantageAir AC unit."""
 
-    def __init__(self, instance, ac_key):
-        """Initialize the Advantage Air Climate entity."""
-        super().__init__(instance, ac_key)
-
     @property
     def name(self):
         """Return the name."""
@@ -174,10 +170,6 @@ class AdvantageAirAC(AdvantageAirClimateEntity):
 
 class AdvantageAirZone(AdvantageAirClimateEntity):
     """AdvantageAir Zone control."""
-
-    def __init__(self, instance, ac_key, zone_key):
-        """Initialize the Advantage Air Zone Climate entity."""
-        super().__init__(instance, ac_key, zone_key)
 
     @property
     def name(self):

--- a/homeassistant/components/advantage_air/cover.py
+++ b/homeassistant/components/advantage_air/cover.py
@@ -36,10 +36,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AdvantageAirZoneVent(AdvantageAirEntity, CoverEntity):
     """Advantage Air Cover Class."""
 
-    def __init__(self, instance, ac_key, zone_key):
-        """Initialize the Advantage Air Zone Cover entity."""
-        super().__init__(instance, ac_key, zone_key)
-
     @property
     def name(self):
         """Return the name."""

--- a/homeassistant/components/advantage_air/cover.py
+++ b/homeassistant/components/advantage_air/cover.py
@@ -16,6 +16,8 @@ from .const import (
 )
 from .entity import AdvantageAirEntity
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up AdvantageAir cover platform."""

--- a/homeassistant/components/advantage_air/cover.py
+++ b/homeassistant/components/advantage_air/cover.py
@@ -36,6 +36,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AdvantageAirZoneVent(AdvantageAirEntity, CoverEntity):
     """Advantage Air Cover Class."""
 
+    def __init__(self, instance, ac_key, zone_key):
+        """Initialize the Advantage Air Zone Cover entity."""
+        super().__init__(instance, ac_key, zone_key)
+
     @property
     def name(self):
         """Return the name."""

--- a/homeassistant/components/advantage_air/cover.py
+++ b/homeassistant/components/advantage_air/cover.py
@@ -1,6 +1,5 @@
 """Cover platform for Advantage Air integration."""
 
-from homeassistant.components.advantage_air import AdvantageAirEntity
 from homeassistant.components.cover import (
     ATTR_POSITION,
     DEVICE_CLASS_DAMPER,
@@ -10,13 +9,18 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 
-from .const import ADVANTAGE_AIR_STATE_CLOSE, ADVANTAGE_AIR_STATE_OPEN, DOMAIN
+from .const import (
+    ADVANTAGE_AIR_STATE_CLOSE,
+    ADVANTAGE_AIR_STATE_OPEN,
+    DOMAIN as ADVANTAGE_AIR_DOMAIN,
+)
+from .entity import AdvantageAirEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up AdvantageAir cover platform."""
 
-    instance = hass.data[DOMAIN][config_entry.entry_id]
+    instance = hass.data[ADVANTAGE_AIR_DOMAIN][config_entry.entry_id]
 
     entities = []
     for ac_key, ac_device in instance["coordinator"].data["aircons"].items():

--- a/homeassistant/components/advantage_air/entity.py
+++ b/homeassistant/components/advantage_air/entity.py
@@ -1,0 +1,35 @@
+"""Advantage Air parent entity class."""
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+class AdvantageAirEntity(CoordinatorEntity):
+    """Parent class for Advantage Air Entities."""
+
+    def __init__(self, instance, ac_key, zone_key=None):
+        """Initialize common aspects of an Advantage Air sensor."""
+        super().__init__(instance["coordinator"])
+        self.async_change = instance["async_change"]
+        self.ac_key = ac_key
+        self.zone_key = zone_key
+
+    @property
+    def _ac(self):
+        return self.coordinator.data["aircons"][self.ac_key]["info"]
+
+    @property
+    def _zone(self):
+        return self.coordinator.data["aircons"][self.ac_key]["zones"][self.zone_key]
+
+    @property
+    def device_info(self):
+        """Return parent device information."""
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.data["system"]["rid"])},
+            "name": self.coordinator.data["system"]["name"],
+            "manufacturer": "Advantage Air",
+            "model": self.coordinator.data["system"]["sysType"],
+            "sw_version": self.coordinator.data["system"]["myAppRev"],
+        }

--- a/homeassistant/components/advantage_air/manifest.json
+++ b/homeassistant/components/advantage_air/manifest.json
@@ -3,11 +3,7 @@
   "name": "Advantage Air",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/advantage_air",
-  "codeowners": [
-    "@Bre77"
-  ],
-  "requirements": [
-    "advantage_air==0.2.1"
-  ],
+  "codeowners": ["@Bre77"],
+  "requirements": ["advantage_air==0.2.1"],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/advantage_air/manifest.json
+++ b/homeassistant/components/advantage_air/manifest.json
@@ -8,5 +8,6 @@
   ],
   "requirements": [
     "advantage_air==0.2.1"
-  ]
+  ],
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -85,10 +85,6 @@ class AdvantageAirTimeTo(AdvantageAirEntity):
 class AdvantageAirZoneVent(AdvantageAirEntity):
     """Representation of Advantage Air Zone Vent Sensor."""
 
-    def __init__(self, instance, ac_key, zone_key):
-        """Initialize the Advantage Air Zone Vent entity."""
-        super().__init__(instance, ac_key, zone_key)
-
     @property
     def name(self):
         """Return the name."""
@@ -121,10 +117,6 @@ class AdvantageAirZoneVent(AdvantageAirEntity):
 
 class AdvantageAirZoneSignal(AdvantageAirEntity):
     """Representation of Advantage Air Zone wireless signal sensor."""
-
-    def __init__(self, instance, ac_key, zone_key):
-        """Initialize the Advantage Air Zone Signal entity."""
-        super().__init__(instance, ac_key, zone_key)
 
     @property
     def name(self):

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -85,6 +85,10 @@ class AdvantageAirTimeTo(AdvantageAirEntity):
 class AdvantageAirZoneVent(AdvantageAirEntity):
     """Representation of Advantage Air Zone Vent Sensor."""
 
+    def __init__(self, instance, ac_key, zone_key):
+        """Initialize the Advantage Air Zone Vent entity."""
+        super().__init__(instance, ac_key, zone_key)
+
     @property
     def name(self):
         """Return the name."""
@@ -117,6 +121,10 @@ class AdvantageAirZoneVent(AdvantageAirEntity):
 
 class AdvantageAirZoneSignal(AdvantageAirEntity):
     """Representation of Advantage Air Zone wireless signal sensor."""
+
+    def __init__(self, instance, ac_key, zone_key):
+        """Initialize the Advantage Air Zone Signal entity."""
+        super().__init__(instance, ac_key, zone_key)
 
     @property
     def name(self):

--- a/homeassistant/components/advantage_air/switch.py
+++ b/homeassistant/components/advantage_air/switch.py
@@ -25,6 +25,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AdvantageAirFreshAir(AdvantageAirEntity, ToggleEntity):
     """Representation of Advantage Air fresh air control."""
 
+    def __init__(self, instance, ac_key):
+        """Initialize the Advantage Air fresh air entity."""
+        super().__init__(instance, ac_key)
+
     @property
     def name(self):
         """Return the name."""

--- a/homeassistant/components/advantage_air/switch.py
+++ b/homeassistant/components/advantage_air/switch.py
@@ -25,10 +25,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AdvantageAirFreshAir(AdvantageAirEntity, ToggleEntity):
     """Representation of Advantage Air fresh air control."""
 
-    def __init__(self, instance, ac_key):
-        """Initialize the Advantage Air fresh air entity."""
-        super().__init__(instance, ac_key)
-
     @property
     def name(self):
         """Return the name."""

--- a/homeassistant/components/advantage_air/switch.py
+++ b/homeassistant/components/advantage_air/switch.py
@@ -1,6 +1,5 @@
 """Switch platform for Advantage Air integration."""
 
-from homeassistant.components.advantage_air import AdvantageAirEntity
 from homeassistant.helpers.entity import ToggleEntity
 
 from .const import (
@@ -8,6 +7,7 @@ from .const import (
     ADVANTAGE_AIR_STATE_ON,
     DOMAIN as ADVANTAGE_AIR_DOMAIN,
 )
+from .entity import AdvantageAirEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/tests/components/advantage_air/test_init.py
+++ b/tests/components/advantage_air/test_init.py
@@ -1,6 +1,10 @@
 """Test the Advantage Air Initialization."""
 
-from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_SETUP_RETRY
+from homeassistant.config_entries import (
+    ENTRY_STATE_LOADED,
+    ENTRY_STATE_NOT_LOADED,
+    ENTRY_STATE_SETUP_RETRY,
+)
 
 from tests.components.advantage_air import (
     TEST_SYSTEM_DATA,

--- a/tests/components/advantage_air/test_init.py
+++ b/tests/components/advantage_air/test_init.py
@@ -20,7 +20,9 @@ async def test_async_setup_entry(hass, aioclient_mock):
     entry = await add_mock_config(hass)
     assert entry.state == ENTRY_STATE_LOADED
 
-    await entry.async_unload(hass)
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ENTRY_STATE_NOT_LOADED
 
 
 async def test_async_setup_entry_failure(hass, aioclient_mock):

--- a/tests/components/advantage_air/test_init.py
+++ b/tests/components/advantage_air/test_init.py
@@ -14,7 +14,7 @@ from tests.components.advantage_air import (
 
 
 async def test_async_setup_entry(hass, aioclient_mock):
-    """Test a successful setup entry."""
+    """Test a successful setup entry and unload."""
 
     aioclient_mock.get(
         TEST_SYSTEM_URL,

--- a/tests/components/advantage_air/test_init.py
+++ b/tests/components/advantage_air/test_init.py
@@ -20,6 +20,8 @@ async def test_async_setup_entry(hass, aioclient_mock):
     entry = await add_mock_config(hass)
     assert entry.state == ENTRY_STATE_LOADED
 
+    await entry.async_unload(hass)
+
 
 async def test_async_setup_entry_failure(hass, aioclient_mock):
     """Test a unsuccessful setup entry."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some final minor improvements to the Advantage Air integration to ensure consistent code style and naming.

Silver 
- [X] Connection/configuration is handled via a component.
DataUpdateCoordinator and advantage_air
- [ ] Set an appropriate SCAN_INTERVAL (if a polling integration)
N/A - should_poll = False
- [ ] Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
N/A, platforms are not independent.
- [ ] Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.
N/A - No Auth
- [ ] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
N/A - Local polling
- [X] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
Handled by DataUpdateCoordinator 
- [X] Set available property to False if appropriate
Handled by DataUpdateCoordinator with UpdateFailed from async_get
- [X] Entities have unique ID (if available)
IDs are based on combinations of system unique ID, AC Key, Zone Key, and a descriptive string if multiple in the same platform.

Gold
- [X] Configurable via config entries.
- - [X] Don't allow configuring already configured device/service (example: no 2 entries for same hub)
Deduped by System ID
- - [X] Tests for the config flow
100% coverage
- - [ ] Discoverable (if available)
N/A - Not supported by hardware
- - [X] Set unique ID in config flow (if available)
System Unique ID
- - [X] Entities have device info (if available)
1 Device per system (which can have multiple ACs and will have multiple zones)
- [X] Tests for fetching data from the integration and controlling it
100% Coverage
- [X] Has a code owner
Me
- [ ] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass
N/A - Doesnt subscribe
- [X] Entities have correct device classes where appropriate 
Covers are Damper, Binary Sensors are motion and problem
- [X] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities
Entities are only created if they are present, and I don't believe any present sensors are less popular.
Air Filter might be the only candidate here, but also a really good one to setup an alert automation on too.
- [ ] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.
N/A The hardware will not add or remove entities.

Platinum
- [X] Set appropriate PARALLEL_UPDATES constant
Set in every platform
- [X] Support config entry unloading (called when config entry is removed)
Removal and Reloading tested and working
- [X] Integration + dependency are async
Fully Async
- [X] Uses aiohttp and allows passing in websession (if making HTTP requests)
Library uses aiohttp and the HASS websession (thanks to @MartinHjelmare)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Config Flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
