### PR TITLE
Add quarter-hour period feature for utility_meter component

### DIFF
--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -1,6 +1,7 @@
 """Constants for the utility meter component."""
 DOMAIN = "utility_meter"
 
+QUARTER_HOURLY = "quarter-hourly"
 HOURLY = "hourly"
 DAILY = "daily"
 WEEKLY = "weekly"
@@ -9,7 +10,16 @@ BIMONTHLY = "bimonthly"
 QUARTERLY = "quarterly"
 YEARLY = "yearly"
 
-METER_TYPES = [HOURLY, DAILY, WEEKLY, MONTHLY, BIMONTHLY, QUARTERLY, YEARLY]
+METER_TYPES = [
+    QUARTER_HOURLY,
+    HOURLY,
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    BIMONTHLY,
+    QUARTERLY,
+    YEARLY,
+]
 
 DATA_UTILITY = "utility_meter_data"
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -36,6 +36,7 @@ from .const import (
     DATA_UTILITY,
     HOURLY,
     MONTHLY,
+    QUARTER_HOURLY,
     QUARTERLY,
     SERVICE_CALIBRATE_METER,
     SIGNAL_RESET_METER,
@@ -241,7 +242,16 @@ class UtilityMeterSensor(RestoreEntity):
         """Handle entity which will be added."""
         await super().async_added_to_hass()
 
-        if self._period == HOURLY:
+        if self._period == QUARTER_HOURLY:
+            for quarter in [0, 1, 2, 3]:
+                async_track_time_change(
+                    self.hass,
+                    self._async_reset_meter,
+                    minute=(quarter * 15)
+                    + self._period_offset.seconds % (15 * 60) // 60,
+                    second=self._period_offset.seconds % 60,
+                )
+        elif self._period == HOURLY:
             async_track_time_change(
                 self.hass,
                 self._async_reset_meter,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -243,7 +243,7 @@ class UtilityMeterSensor(RestoreEntity):
         await super().async_added_to_hass()
 
         if self._period == QUARTER_HOURLY:
-            for quarter in [0, 1, 2, 3]:
+            for quarter in range(4):
                 async_track_time_change(
                     self.hass,
                     self._async_reset_meter,

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -274,6 +274,27 @@ async def test_self_reset_quarter_hourly(hass, legacy_patchable_time):
     )
 
 
+async def test_self_reset_quarter_hourly_first_quarter(hass, legacy_patchable_time):
+    """Test quarter-hourly reset of meter."""
+    await _test_self_reset(
+        hass, gen_config("quarter-hourly"), "2017-12-31T23:14:00.000000+00:00"
+    )
+
+
+async def test_self_reset_quarter_hourly_second_quarter(hass, legacy_patchable_time):
+    """Test quarter-hourly reset of meter."""
+    await _test_self_reset(
+        hass, gen_config("quarter-hourly"), "2017-12-31T23:29:00.000000+00:00"
+    )
+
+
+async def test_self_reset_quarter_hourly_third_quarter(hass, legacy_patchable_time):
+    """Test quarter-hourly reset of meter."""
+    await _test_self_reset(
+        hass, gen_config("quarter-hourly"), "2017-12-31T23:44:00.000000+00:00"
+    )
+
+
 async def test_self_reset_hourly(hass, legacy_patchable_time):
     """Test hourly reset of meter."""
     await _test_self_reset(

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -267,6 +267,13 @@ async def _test_self_reset(hass, config, start_time, expect_reset=True):
         assert state.state == "5"
 
 
+async def test_self_reset_quarter_hourly(hass, legacy_patchable_time):
+    """Test quarter-hourly reset of meter."""
+    await _test_self_reset(
+        hass, gen_config("quarter-hourly"), "2017-12-31T23:59:00.000000+00:00"
+    )
+
+
 async def test_self_reset_hourly(hass, legacy_patchable_time):
     """Test hourly reset of meter."""
     await _test_self_reset(


### PR DESCRIPTION
## Proposed change

In the utility_meter component, add support for 15 minute intervals (quarter-hours).

one (and my :-) use case for this is that in Belgium, a significant part of your electricity bill is going to be based on your peak usage per 15 minute interval. Measuring and managing this peak usage can help to reduce cost.

Documentation at https://github.com/home-assistant/home-assistant.io/pull/15384

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
utility_meter:
  energy:
    source: sensor.energy_in_kwh
    cycle: quarter-hourly
```

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
