### PR TITLE
Log the correct line numbers for config validation errors

### DIFF
--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -51,7 +51,7 @@ async def _try_async_validate_config_item(hass, config, full_config=None):
         IntegrationNotFound,
         InvalidDeviceAutomationConfig,
     ) as ex:
-        async_log_exception(ex, DOMAIN, full_config or config, hass)
+        async_log_exception(ex, DOMAIN, config or full_config, hass)
         return None
 
     return config

--- a/homeassistant/components/script/config.py
+++ b/homeassistant/components/script/config.py
@@ -31,7 +31,7 @@ async def _try_async_validate_config_item(hass, object_id, config, full_config=N
         cv.slug(object_id)
         config = await async_validate_config_item(hass, config, full_config)
     except (vol.Invalid, HomeAssistantError) as ex:
-        async_log_exception(ex, DOMAIN, full_config or config, hass)
+        async_log_exception(ex, DOMAIN, config or full_config, hass)
         return None
 
     return config

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -447,7 +447,7 @@ def _format_config_error(
     )
 
     if domain != CONF_CORE and link:
-        message += f"Please check the docs at {link}"
+        message += f"Please check the docs at {link}."
 
     return message
 

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -95,7 +95,9 @@ def _add_reference(obj, loader: SafeLineLoader, node: yaml.nodes.Node):  # type:
     if isinstance(obj, str):
         obj = NodeStrClass(obj)
     setattr(obj, "__config_file__", loader.name)
-    setattr(obj, "__line__", node.start_mark.line)
+    setattr(
+        obj, "__line__", node.start_mark.line + 1
+    )  # +1 to convert technical 0..n lines to human friendly 1..n
     return obj
 
 
@@ -210,8 +212,10 @@ def _ordered_dict(loader: SafeLineLoader, node: yaml.nodes.MappingNode) -> Order
                 'YAML file %s contains duplicate key "%s". Check lines %d and %d',
                 fname,
                 key,
-                seen[key],
-                line,
+                # +1 to convert technical 0..n lines to human friendly 1..n
+                seen[key] + 1,
+                # +1 to convert technical 0..n lines to human friendly 1..n
+                line + 1,
             )
         seen[key] = line
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Currently the logged errors contain the technical 0..n line numbers instead of the human friendly 1..n numbers. This PR fixes that.

Also for automation and script loading, use the `config` rather than the `full_config` for the error information. This means if e.g. your configuration.yaml contains an `automation:` block with two automations and the second one has an error, the old coding could only print the line number for the beginning of the whole automation block rather than the line number of the actual automation that contains the error. By using `config` now, we get the more specific error / line number for the log.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

The second automation is invalid and the log will now contain the line number of the second "id" element (= start of the second automation).

```yaml
# Example configuration.yaml

automation:
  - id: '1600806059931'
    alias: Pattern Test Valid
    description: ''
    trigger:
    - platform: time_pattern
      hours: '23'
      minutes: '*'
      seconds: '10'
    condition: []
    action:
    - event: test/test
      event_data: {}
    mode: single    
  - id: '16008060599312'
    alias: Pattern Test Invalid
    description: ''
    trigger:
    - platform: time_pattern
      hours: '23'
      minutes: '*'
      seconds: '/100222'
    condition: []
    action:
    - event: test/test
      event_data: {}
    mode: single 

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
