### PR TITLE
Reduce domain states rate limit to 1 per second

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -73,7 +73,8 @@ _COLLECTABLE_STATE_ATTRIBUTES = {
     "name",
 }
 
-DEFAULT_RATE_LIMIT = timedelta(minutes=1)
+ALL_STATES_RATE_LIMIT = timedelta(minutes=1)
+DOMAIN_STATES_RATE_LIMIT = timedelta(seconds=1)
 
 
 @bind_hass
@@ -240,12 +241,11 @@ class RenderInfo:
     def _freeze(self) -> None:
         self._freeze_sets()
 
-        if self.rate_limit is None and (
-            self.domains or self.domains_lifecycle or self.all_states or self.exception
-        ):
-            # If the template accesses all states or an entire
-            # domain, and no rate limit is set, we use the default.
-            self.rate_limit = DEFAULT_RATE_LIMIT
+        if self.rate_limit is None:
+            if self.all_states or self.exception:
+                self.rate_limit = ALL_STATES_RATE_LIMIT
+            elif self.domains or self.domains_lifecycle:
+                self.rate_limit = DOMAIN_STATES_RATE_LIMIT
 
         if self.exception:
             return

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -150,7 +150,7 @@ def test_iterating_all_states(hass):
 
     info = render_to_info(hass, tmpl_str)
     assert_result_info(info, "", all_states=True)
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.ALL_STATES_RATE_LIMIT
 
     hass.states.async_set("test.object", "happy")
     hass.states.async_set("sensor.temperature", 10)
@@ -168,7 +168,7 @@ def test_iterating_all_states_unavailable(hass):
     info = render_to_info(hass, tmpl_str)
 
     assert info.all_states is True
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.ALL_STATES_RATE_LIMIT
 
     hass.states.async_set("test.object", "unknown")
     hass.states.async_set("sensor.temperature", 10)
@@ -183,7 +183,7 @@ def test_iterating_domain_states(hass):
 
     info = render_to_info(hass, tmpl_str)
     assert_result_info(info, "", domains=["sensor"])
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
 
     hass.states.async_set("test.object", "happy")
     hass.states.async_set("sensor.back_door", "open")
@@ -1420,7 +1420,7 @@ async def test_expand(hass):
         hass, "{{ expand(states.group) | map(attribute='entity_id') | join(', ') }}"
     )
     assert_result_info(info, "", [], ["group"])
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
 
     assert await async_setup_component(hass, "group", {})
     await hass.async_block_till_done()
@@ -1437,7 +1437,7 @@ async def test_expand(hass):
         hass, "{{ expand(states.group) | map(attribute='entity_id') | join(', ') }}"
     )
     assert_result_info(info, "test.object", {"test.object"}, ["group"])
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
 
     info = render_to_info(
         hass,
@@ -1588,7 +1588,7 @@ def test_async_render_to_info_with_complex_branching(hass):
     )
 
     assert_result_info(info, ["sensor.a"], {"light.a", "light.b"}, {"sensor"})
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
 
 
 async def test_async_render_to_info_with_wildcard_matching_entity_id(hass):
@@ -1610,7 +1610,7 @@ async def test_async_render_to_info_with_wildcard_matching_entity_id(hass):
     assert info.domains == {"cover"}
     assert info.entities == set()
     assert info.all_states is False
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
 
 
 async def test_async_render_to_info_with_wildcard_matching_state(hass):
@@ -1635,7 +1635,7 @@ async def test_async_render_to_info_with_wildcard_matching_state(hass):
     assert not info.domains
     assert info.entities == set()
     assert info.all_states is True
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.ALL_STATES_RATE_LIMIT
 
     hass.states.async_set("binary_sensor.door", "closed")
     info = render_to_info(hass, template_complex_str)
@@ -1643,7 +1643,7 @@ async def test_async_render_to_info_with_wildcard_matching_state(hass):
     assert not info.domains
     assert info.entities == set()
     assert info.all_states is True
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.ALL_STATES_RATE_LIMIT
 
     template_cover_str = """
 
@@ -1660,7 +1660,7 @@ async def test_async_render_to_info_with_wildcard_matching_state(hass):
     assert info.domains == {"cover"}
     assert info.entities == set()
     assert info.all_states is False
-    assert info.rate_limit == template.DEFAULT_RATE_LIMIT
+    assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
 
 
 def test_nested_async_render_to_info_case(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

#41225 implemented a rate limit of 1 update per minute for `states.DOMAIN` in templates. This works fine for all `states`, however it turned out to be too conservative for `states.DOMAIN` per https://github.com/home-assistant/architecture/issues/449#issuecomment-711032893


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15291

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
