### PR TITLE
Migrated coinmarketcap tests to utilise pytests instead of unittests

### DIFF
--- a/tests/components/coinmarketcap/test_sensor.py
+++ b/tests/components/coinmarketcap/test_sensor.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 
-import homeassistant.components.sensor as sensor
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/coinmarketcap/test_sensor.py
+++ b/tests/components/coinmarketcap/test_sensor.py
@@ -19,6 +19,7 @@ VALID_CONFIG = {
     }
 }
 
+
 @pytest.fixture
 async def setup_sensor(hass):
     """Set up demo sensor component."""
@@ -29,6 +30,7 @@ async def setup_sensor(hass):
         ):
             await async_setup_component(hass, DOMAIN, VALID_CONFIG)
             await hass.async_block_till_done()
+
 
 async def test_setup(hass, setup_sensor):
     """Test the setup with custom settings."""

--- a/tests/components/coinmarketcap/test_sensor.py
+++ b/tests/components/coinmarketcap/test_sensor.py
@@ -1,43 +1,41 @@
 """Tests for the CoinMarketCap sensor platform."""
 import json
-import unittest
+
+import pytest
 
 import homeassistant.components.sensor as sensor
-from homeassistant.setup import setup_component
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
-from tests.common import assert_setup_component, get_test_home_assistant, load_fixture
+from tests.common import assert_setup_component, load_fixture
 
 VALID_CONFIG = {
-    "platform": "coinmarketcap",
-    "currency_id": 1027,
-    "display_currency": "EUR",
-    "display_currency_decimals": 3,
+    DOMAIN: {
+        "platform": "coinmarketcap",
+        "currency_id": 1027,
+        "display_currency": "EUR",
+        "display_currency_decimals": 3,
+    }
 }
 
+@pytest.fixture
+async def setup_sensor(hass):
+    """Set up demo sensor component."""
+    with assert_setup_component(1, DOMAIN):
+        with patch(
+            "coinmarketcap.Market.ticker",
+            return_value=json.loads(load_fixture("coinmarketcap.json")),
+        ):
+            await async_setup_component(hass, DOMAIN, VALID_CONFIG)
+            await hass.async_block_till_done()
 
-class TestCoinMarketCapSensor(unittest.TestCase):
-    """Test the CoinMarketCap sensor."""
+async def test_setup(hass, setup_sensor):
+    """Test the setup with custom settings."""
+    state = hass.states.get("sensor.ethereum")
+    assert state is not None
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.config = VALID_CONFIG
-        self.addCleanup(self.hass.stop)
-
-    @patch(
-        "coinmarketcap.Market.ticker",
-        return_value=json.loads(load_fixture("coinmarketcap.json")),
-    )
-    def test_setup(self, mock_request):
-        """Test the setup with custom settings."""
-        with assert_setup_component(1, sensor.DOMAIN):
-            assert setup_component(self.hass, sensor.DOMAIN, {"sensor": VALID_CONFIG})
-            self.hass.block_till_done()
-
-        state = self.hass.states.get("sensor.ethereum")
-        assert state is not None
-
-        assert state.state == "493.455"
-        assert state.attributes.get("symbol") == "ETH"
-        assert state.attributes.get("unit_of_measurement") == "EUR"
+    assert state.name == "Ethereum"
+    assert state.state == "493.455"
+    assert state.attributes.get("symbol") == "ETH"
+    assert state.attributes.get("unit_of_measurement") == "EUR"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40828
- This PR is related to issue: #40828
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io