### PR TITLE
Move sleepiq tests to pytest style functions

### DIFF
--- a/tests/components/sleepiq/test_binary_sensor.py
+++ b/tests/components/sleepiq/test_binary_sensor.py
@@ -1,67 +1,44 @@
 """The tests for SleepIQ binary sensor platform."""
-import unittest
-
-import requests_mock
-
 from homeassistant.components.sleepiq import binary_sensor as sleepiq
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import MagicMock
-from tests.common import get_test_home_assistant
 from tests.components.sleepiq.test_init import mock_responses
 
+CONFIG = {"username": "foo", "password": "bar"}
 
-class TestSleepIQBinarySensorSetup(unittest.TestCase):
-    """Tests the SleepIQ Binary Sensor platform."""
 
-    DEVICES = []
+async def test_sensor_setup(hass, requests_mock):
+    """Test for successfully setting up the SleepIQ platform."""
+    mock_responses(requests_mock)
 
-    def add_entities(self, devices):
-        """Mock add devices."""
-        for device in devices:
-            self.DEVICES.append(device)
+    await async_setup_component(hass, "sleepiq", {"sleepiq": CONFIG})
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        self.username = "foo"
-        self.password = "bar"
-        self.config = {"username": self.username, "password": self.password}
-        self.DEVICES = []
-        self.addCleanup(self.tear_down_cleanup)
+    device_mock = MagicMock()
+    sleepiq.setup_platform(hass, CONFIG, device_mock, MagicMock())
+    devices = device_mock.call_args[0][0]
+    assert 2 == len(devices)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+    left_side = devices[1]
+    assert "SleepNumber ILE Test1 Is In Bed" == left_side.name
+    assert "on" == left_side.state
 
-    @requests_mock.Mocker()
-    def test_setup(self, mock):
-        """Test for successfully setting up the SleepIQ platform."""
-        mock_responses(mock)
+    right_side = devices[0]
+    assert "SleepNumber ILE Test2 Is In Bed" == right_side.name
+    assert "off" == right_side.state
 
-        setup_component(self.hass, "sleepiq", {"sleepiq": self.config})
 
-        sleepiq.setup_platform(self.hass, self.config, self.add_entities, MagicMock())
-        assert 2 == len(self.DEVICES)
+async def test_setup_single(hass, requests_mock):
+    """Test for successfully setting up the SleepIQ platform."""
+    mock_responses(requests_mock, single=True)
 
-        left_side = self.DEVICES[1]
-        assert "SleepNumber ILE Test1 Is In Bed" == left_side.name
-        assert "on" == left_side.state
+    await async_setup_component(hass, "sleepiq", {"sleepiq": CONFIG})
 
-        right_side = self.DEVICES[0]
-        assert "SleepNumber ILE Test2 Is In Bed" == right_side.name
-        assert "off" == right_side.state
+    device_mock = MagicMock()
+    sleepiq.setup_platform(hass, CONFIG, device_mock, MagicMock())
+    devices = device_mock.call_args[0][0]
+    assert 1 == len(devices)
 
-    @requests_mock.Mocker()
-    def test_setup_single(self, mock):
-        """Test for successfully setting up the SleepIQ platform."""
-        mock_responses(mock, single=True)
-
-        setup_component(self.hass, "sleepiq", {"sleepiq": self.config})
-
-        sleepiq.setup_platform(self.hass, self.config, self.add_entities, MagicMock())
-        assert 1 == len(self.DEVICES)
-
-        right_side = self.DEVICES[0]
-        assert "SleepNumber ILE Test1 Is In Bed" == right_side.name
-        assert "on" == right_side.state
+    right_side = devices[0]
+    assert "SleepNumber ILE Test1 Is In Bed" == right_side.name
+    assert "on" == right_side.state

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -1,13 +1,11 @@
 """The tests for the SleepIQ component."""
-import unittest
-
-import requests_mock
-
 from homeassistant import setup
 import homeassistant.components.sleepiq as sleepiq
 
 from tests.async_mock import MagicMock, patch
-from tests.common import get_test_home_assistant, load_fixture
+from tests.common import load_fixture
+
+CONFIG = {"sleepiq": {"username": "foo", "password": "bar"}}
 
 
 def mock_responses(mock, single=False):
@@ -26,55 +24,40 @@ def mock_responses(mock, single=False):
     )
 
 
-class TestSleepIQ(unittest.TestCase):
-    """Tests the SleepIQ component."""
+async def test_setup(hass, requests_mock):
+    """Test the setup."""
+    mock_responses(requests_mock)
 
-    def setUp(self):
-        """Initialize values for this test case class."""
-        self.hass = get_test_home_assistant()
-        self.username = "foo"
-        self.password = "bar"
-        self.config = {
-            "sleepiq": {"username": self.username, "password": self.password}
-        }
-        self.addCleanup(self.tear_down_cleanup)
+    # We're mocking the load_platform discoveries or else the platforms
+    # will be setup during tear down when blocking till done, but the mocks
+    # are no longer active.
+    with patch("homeassistant.helpers.discovery.load_platform", MagicMock()):
+        assert sleepiq.setup(hass, CONFIG)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
 
-    @requests_mock.Mocker()
-    def test_setup(self, mock):
-        """Test the setup."""
-        mock_responses(mock)
+async def test_setup_login_failed(hass, requests_mock):
+    """Test the setup if a bad username or password is given."""
+    mock_responses(requests_mock)
+    requests_mock.put(
+        "https://prod-api.sleepiq.sleepnumber.com/rest/login",
+        status_code=401,
+        json=load_fixture("sleepiq-login-failed.json"),
+    )
 
-        # We're mocking the load_platform discoveries or else the platforms
-        # will be setup during tear down when blocking till done, but the mocks
-        # are no longer active.
-        with patch("homeassistant.helpers.discovery.load_platform", MagicMock()):
-            assert sleepiq.setup(self.hass, self.config)
+    response = sleepiq.setup(hass, CONFIG)
+    assert not response
 
-    @requests_mock.Mocker()
-    def test_setup_login_failed(self, mock):
-        """Test the setup if a bad username or password is given."""
-        mock.put(
-            "https://prod-api.sleepiq.sleepnumber.com/rest/login",
-            status_code=401,
-            json=load_fixture("sleepiq-login-failed.json"),
-        )
 
-        response = sleepiq.setup(self.hass, self.config)
-        assert not response
+async def test_setup_component_no_login(hass):
+    """Test the setup when no login is configured."""
+    conf = CONFIG.copy()
+    del conf["sleepiq"]["username"]
+    assert not await setup.async_setup_component(hass, sleepiq.DOMAIN, conf)
 
-    def test_setup_component_no_login(self):
-        """Test the setup when no login is configured."""
-        conf = self.config.copy()
-        del conf["sleepiq"]["username"]
-        assert not setup.setup_component(self.hass, sleepiq.DOMAIN, conf)
 
-    def test_setup_component_no_password(self):
-        """Test the setup when no password is configured."""
-        conf = self.config.copy()
-        del conf["sleepiq"]["password"]
+async def test_setup_component_no_password(hass):
+    """Test the setup when no password is configured."""
+    conf = CONFIG.copy()
+    del conf["sleepiq"]["password"]
 
-        assert not setup.setup_component(self.hass, sleepiq.DOMAIN, conf)
+    assert not await setup.async_setup_component(hass, sleepiq.DOMAIN, conf)

--- a/tests/components/sleepiq/test_sensor.py
+++ b/tests/components/sleepiq/test_sensor.py
@@ -1,67 +1,44 @@
 """The tests for SleepIQ sensor platform."""
-import unittest
-
-import requests_mock
-
 import homeassistant.components.sleepiq.sensor as sleepiq
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import MagicMock
-from tests.common import get_test_home_assistant
 from tests.components.sleepiq.test_init import mock_responses
 
+CONFIG = {"username": "foo", "password": "bar"}
 
-class TestSleepIQSensorSetup(unittest.TestCase):
-    """Tests the SleepIQ Sensor platform."""
 
-    DEVICES = []
+async def test_setup(hass, requests_mock):
+    """Test for successfully setting up the SleepIQ platform."""
+    mock_responses(requests_mock)
 
-    def add_entities(self, devices):
-        """Mock add devices."""
-        for device in devices:
-            self.DEVICES.append(device)
+    assert await async_setup_component(hass, "sleepiq", {"sleepiq": CONFIG})
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        self.username = "foo"
-        self.password = "bar"
-        self.config = {"username": self.username, "password": self.password}
-        self.DEVICES = []
-        self.addCleanup(self.tear_down_cleanup)
+    device_mock = MagicMock()
+    sleepiq.setup_platform(hass, CONFIG, device_mock, MagicMock())
+    devices = device_mock.call_args[0][0]
+    assert 2 == len(devices)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+    left_side = devices[1]
+    assert "SleepNumber ILE Test1 SleepNumber" == left_side.name
+    assert 40 == left_side.state
 
-    @requests_mock.Mocker()
-    def test_setup(self, mock):
-        """Test for successfully setting up the SleepIQ platform."""
-        mock_responses(mock)
+    right_side = devices[0]
+    assert "SleepNumber ILE Test2 SleepNumber" == right_side.name
+    assert 80 == right_side.state
 
-        assert setup_component(self.hass, "sleepiq", {"sleepiq": self.config})
 
-        sleepiq.setup_platform(self.hass, self.config, self.add_entities, MagicMock())
-        assert 2 == len(self.DEVICES)
+async def test_setup_sigle(hass, requests_mock):
+    """Test for successfully setting up the SleepIQ platform."""
+    mock_responses(requests_mock, single=True)
 
-        left_side = self.DEVICES[1]
-        assert "SleepNumber ILE Test1 SleepNumber" == left_side.name
-        assert 40 == left_side.state
+    assert await async_setup_component(hass, "sleepiq", {"sleepiq": CONFIG})
 
-        right_side = self.DEVICES[0]
-        assert "SleepNumber ILE Test2 SleepNumber" == right_side.name
-        assert 80 == right_side.state
+    device_mock = MagicMock()
+    sleepiq.setup_platform(hass, CONFIG, device_mock, MagicMock())
+    devices = device_mock.call_args[0][0]
+    assert 1 == len(devices)
 
-    @requests_mock.Mocker()
-    def test_setup_sigle(self, mock):
-        """Test for successfully setting up the SleepIQ platform."""
-        mock_responses(mock, single=True)
-
-        assert setup_component(self.hass, "sleepiq", {"sleepiq": self.config})
-
-        sleepiq.setup_platform(self.hass, self.config, self.add_entities, MagicMock())
-        assert 1 == len(self.DEVICES)
-
-        right_side = self.DEVICES[0]
-        assert "SleepNumber ILE Test1 SleepNumber" == right_side.name
-        assert 40 == right_side.state
+    right_side = devices[0]
+    assert "SleepNumber ILE Test1 SleepNumber" == right_side.name
+    assert 40 == right_side.state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This updates the tests for the sleepiq functionality to use pytest style tests.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40849
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
