### PR TITLE
Rest test style

### DIFF
--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -22,6 +22,13 @@ from tests.common import assert_setup_component
 
 """Tests for setting up the REST switch platform."""
 
+NAME = "foo"
+METHOD = "post"
+RESOURCE = "http://localhost/"
+STATE_RESOURCE = RESOURCE
+HEADERS = {"Content-type": CONTENT_TYPE_JSON}
+AUTH = None
+
 
 async def test_setup_missing_config(hass):
     """Test setup with configuration missing required entries."""
@@ -120,24 +127,17 @@ async def test_setup_with_state_resource(hass, aioclient_mock):
 
 """Tests for REST switch platform."""
 
-name = "foo"
-method = "post"
-resource = "http://localhost/"
-state_resource = resource
-headers = {"Content-type": CONTENT_TYPE_JSON}
-auth = None
-
 
 def _setup_test_switch(hass):
     body_on = Template("on", hass)
     body_off = Template("off", hass)
     switch = rest.RestSwitch(
-        name,
-        resource,
-        state_resource,
-        method,
-        headers,
-        auth,
+        NAME,
+        RESOURCE,
+        STATE_RESOURCE,
+        METHOD,
+        HEADERS,
+        AUTH,
         body_on,
         body_off,
         None,
@@ -151,7 +151,7 @@ def _setup_test_switch(hass):
 def test_name(hass):
     """Test the name."""
     switch, body_on, body_off = _setup_test_switch(hass)
-    assert name == switch.name
+    assert NAME == switch.name
 
 
 def test_is_on_before_update(hass):
@@ -162,7 +162,7 @@ def test_is_on_before_update(hass):
 
 async def test_turn_on_success(hass, aioclient_mock):
     """Test turn_on."""
-    aioclient_mock.post(resource, status=HTTP_OK)
+    aioclient_mock.post(RESOURCE, status=HTTP_OK)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_on()
 
@@ -172,7 +172,7 @@ async def test_turn_on_success(hass, aioclient_mock):
 
 async def test_turn_on_status_not_ok(hass, aioclient_mock):
     """Test turn_on when error status returned."""
-    aioclient_mock.post(resource, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.post(RESOURCE, status=HTTP_INTERNAL_SERVER_ERROR)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_on()
 
@@ -182,7 +182,7 @@ async def test_turn_on_status_not_ok(hass, aioclient_mock):
 
 async def test_turn_on_timeout(hass, aioclient_mock):
     """Test turn_on when timeout occurs."""
-    aioclient_mock.post(resource, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.post(RESOURCE, status=HTTP_INTERNAL_SERVER_ERROR)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_on()
 
@@ -191,7 +191,7 @@ async def test_turn_on_timeout(hass, aioclient_mock):
 
 async def test_turn_off_success(hass, aioclient_mock):
     """Test turn_off."""
-    aioclient_mock.post(resource, status=HTTP_OK)
+    aioclient_mock.post(RESOURCE, status=HTTP_OK)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_off()
 
@@ -201,7 +201,7 @@ async def test_turn_off_success(hass, aioclient_mock):
 
 async def test_turn_off_status_not_ok(hass, aioclient_mock):
     """Test turn_off when error status returned."""
-    aioclient_mock.post(resource, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.post(RESOURCE, status=HTTP_INTERNAL_SERVER_ERROR)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_off()
 
@@ -211,7 +211,7 @@ async def test_turn_off_status_not_ok(hass, aioclient_mock):
 
 async def test_turn_off_timeout(hass, aioclient_mock):
     """Test turn_off when timeout occurs."""
-    aioclient_mock.post(resource, exc=asyncio.TimeoutError())
+    aioclient_mock.post(RESOURCE, exc=asyncio.TimeoutError())
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_on()
 
@@ -221,7 +221,7 @@ async def test_turn_off_timeout(hass, aioclient_mock):
 async def test_update_when_on(hass, aioclient_mock):
     """Test update when switch is on."""
     switch, body_on, body_off = _setup_test_switch(hass)
-    aioclient_mock.get(resource, text=body_on.template)
+    aioclient_mock.get(RESOURCE, text=body_on.template)
     await switch.async_update()
 
     assert switch.is_on
@@ -230,7 +230,7 @@ async def test_update_when_on(hass, aioclient_mock):
 async def test_update_when_off(hass, aioclient_mock):
     """Test update when switch is off."""
     switch, body_on, body_off = _setup_test_switch(hass)
-    aioclient_mock.get(resource, text=body_off.template)
+    aioclient_mock.get(RESOURCE, text=body_off.template)
     await switch.async_update()
 
     assert not switch.is_on
@@ -238,7 +238,7 @@ async def test_update_when_off(hass, aioclient_mock):
 
 async def test_update_when_unknown(hass, aioclient_mock):
     """Test update when unknown status returned."""
-    aioclient_mock.get(resource, text="unknown status")
+    aioclient_mock.get(RESOURCE, text="unknown status")
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_update()
 
@@ -247,7 +247,7 @@ async def test_update_when_unknown(hass, aioclient_mock):
 
 async def test_update_timeout(hass, aioclient_mock):
     """Test update when timeout occurs."""
-    aioclient_mock.get(resource, exc=asyncio.TimeoutError())
+    aioclient_mock.get(RESOURCE, exc=asyncio.TimeoutError())
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_update()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert REST tests to pytest method style. Tests for 'binary_sensor', 'sensor' and 'notify' have already been converted for solving #41973 (kudos @bdraco), so not touching them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40885
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
