### PR TITLE
Geo rss test style

### DIFF
--- a/tests/components/geo_rss_events/test_sensor.py
+++ b/tests/components/geo_rss_events/test_sensor.py
@@ -1,6 +1,5 @@
 """The test for the geo rss events sensor platform."""
-import unittest
-from unittest import mock
+import pytest
 
 from homeassistant.components import sensor
 import homeassistant.components.geo_rss_events.sensor as geo_rss_events
@@ -10,7 +9,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     EVENT_HOMEASSISTANT_START,
 )
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.async_mock import MagicMock, patch
@@ -34,124 +33,124 @@ VALID_CONFIG = {
     sensor.DOMAIN: [{"platform": "geo_rss_events", geo_rss_events.CONF_URL: URL}]
 }
 
+"""Test the GeoRss service updater."""
 
-class TestGeoRssServiceUpdater(unittest.TestCase):
-    """Test the GeoRss service updater."""
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
-        # self.config = VALID_CONFIG_WITHOUT_CATEGORIES
-        self.addCleanup(self.hass.stop)
+@pytest.fixture
+def mock_feed():
+    with patch(
+        "homeassistant.components.geo_rss_events.sensor.GenericFeed"
+    ) as mock_feed:
+        yield mock_feed
 
-    @staticmethod
-    def _generate_mock_feed_entry(
-        external_id, title, distance_to_home, coordinates, category
-    ):
-        """Construct a mock feed entry for testing purposes."""
-        feed_entry = MagicMock()
-        feed_entry.external_id = external_id
-        feed_entry.title = title
-        feed_entry.distance_to_home = distance_to_home
-        feed_entry.coordinates = coordinates
-        feed_entry.category = category
-        return feed_entry
 
-    @mock.patch("homeassistant.components.geo_rss_events.sensor.GenericFeed")
-    def test_setup(self, mock_feed):
-        """Test the general setup of the platform."""
-        # Set up some mock feed entries for this test.
-        mock_entry_1 = self._generate_mock_feed_entry(
-            "1234", "Title 1", 15.5, (-31.0, 150.0), "Category 1"
-        )
-        mock_entry_2 = self._generate_mock_feed_entry(
-            "2345", "Title 2", 20.5, (-31.1, 150.1), "Category 1"
-        )
-        mock_feed.return_value.update.return_value = "OK", [mock_entry_1, mock_entry_2]
+def _generate_mock_feed_entry(
+    external_id, title, distance_to_home, coordinates, category
+):
+    """Construct a mock feed entry for testing purposes."""
+    feed_entry = MagicMock()
+    feed_entry.external_id = external_id
+    feed_entry.title = title
+    feed_entry.distance_to_home = distance_to_home
+    feed_entry.coordinates = coordinates
+    feed_entry.category = category
+    return feed_entry
 
-        utcnow = dt_util.utcnow()
-        # Patching 'utcnow' to gain more control over the timed update.
-        with patch("homeassistant.util.dt.utcnow", return_value=utcnow):
-            with assert_setup_component(1, sensor.DOMAIN):
-                assert setup_component(self.hass, sensor.DOMAIN, VALID_CONFIG)
-                # Artificially trigger update.
-                self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
-                # Collect events.
-                self.hass.block_till_done()
 
-                all_states = self.hass.states.all()
-                assert len(all_states) == 1
+async def test_setup(hass, mock_feed):
+    """Test the general setup of the platform."""
+    # Set up some mock feed entries for this test.
+    mock_entry_1 = _generate_mock_feed_entry(
+        "1234", "Title 1", 15.5, (-31.0, 150.0), "Category 1"
+    )
+    mock_entry_2 = _generate_mock_feed_entry(
+        "2345", "Title 2", 20.5, (-31.1, 150.1), "Category 1"
+    )
+    mock_feed.return_value.update.return_value = "OK", [mock_entry_1, mock_entry_2]
 
-                state = self.hass.states.get("sensor.event_service_any")
-                assert state is not None
-                assert state.name == "Event Service Any"
-                assert int(state.state) == 2
-                assert state.attributes == {
-                    ATTR_FRIENDLY_NAME: "Event Service Any",
-                    ATTR_UNIT_OF_MEASUREMENT: "Events",
-                    ATTR_ICON: "mdi:alert",
-                    "Title 1": "16km",
-                    "Title 2": "20km",
-                }
-
-                # Simulate an update - empty data, but successful update,
-                # so no changes to entities.
-                mock_feed.return_value.update.return_value = "OK_NO_DATA", None
-                fire_time_changed(self.hass, utcnow + geo_rss_events.SCAN_INTERVAL)
-                self.hass.block_till_done()
-
-                all_states = self.hass.states.all()
-                assert len(all_states) == 1
-                state = self.hass.states.get("sensor.event_service_any")
-                assert int(state.state) == 2
-
-                # Simulate an update - empty data, removes all entities
-                mock_feed.return_value.update.return_value = "ERROR", None
-                fire_time_changed(self.hass, utcnow + 2 * geo_rss_events.SCAN_INTERVAL)
-                self.hass.block_till_done()
-
-                all_states = self.hass.states.all()
-                assert len(all_states) == 1
-                state = self.hass.states.get("sensor.event_service_any")
-                assert int(state.state) == 0
-                assert state.attributes == {
-                    ATTR_FRIENDLY_NAME: "Event Service Any",
-                    ATTR_UNIT_OF_MEASUREMENT: "Events",
-                    ATTR_ICON: "mdi:alert",
-                }
-
-    @mock.patch("homeassistant.components.geo_rss_events.sensor.GenericFeed")
-    def test_setup_with_categories(self, mock_feed):
-        """Test the general setup of the platform."""
-        # Set up some mock feed entries for this test.
-        mock_entry_1 = self._generate_mock_feed_entry(
-            "1234", "Title 1", 15.5, (-31.0, 150.0), "Category 1"
-        )
-        mock_entry_2 = self._generate_mock_feed_entry(
-            "2345", "Title 2", 20.5, (-31.1, 150.1), "Category 1"
-        )
-        mock_feed.return_value.update.return_value = "OK", [mock_entry_1, mock_entry_2]
-
+    utcnow = dt_util.utcnow()
+    # Patching 'utcnow' to gain more control over the timed update.
+    with patch("homeassistant.util.dt.utcnow", return_value=utcnow):
         with assert_setup_component(1, sensor.DOMAIN):
-            assert setup_component(
-                self.hass, sensor.DOMAIN, VALID_CONFIG_WITH_CATEGORIES
-            )
+            assert await async_setup_component(hass, sensor.DOMAIN, VALID_CONFIG)
             # Artificially trigger update.
-            self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
+            hass.bus.fire(EVENT_HOMEASSISTANT_START)
             # Collect events.
-            self.hass.block_till_done()
+            await hass.block_till_done()
 
-            all_states = self.hass.states.all()
+            all_states = hass.states.all()
             assert len(all_states) == 1
 
-            state = self.hass.states.get("sensor.event_service_category_1")
+            state = hass.states.get("sensor.event_service_any")
             assert state is not None
-            assert state.name == "Event Service Category 1"
+            assert state.name == "Event Service Any"
             assert int(state.state) == 2
             assert state.attributes == {
-                ATTR_FRIENDLY_NAME: "Event Service Category 1",
+                ATTR_FRIENDLY_NAME: "Event Service Any",
                 ATTR_UNIT_OF_MEASUREMENT: "Events",
                 ATTR_ICON: "mdi:alert",
                 "Title 1": "16km",
                 "Title 2": "20km",
             }
+
+            # Simulate an update - empty data, but successful update,
+            # so no changes to entities.
+            mock_feed.return_value.update.return_value = "OK_NO_DATA", None
+            fire_time_changed(hass, utcnow + geo_rss_events.SCAN_INTERVAL)
+            hass.block_till_done()
+
+            all_states = hass.states.all()
+            assert len(all_states) == 1
+            state = hass.states.get("sensor.event_service_any")
+            assert int(state.state) == 2
+
+            # Simulate an update - empty data, removes all entities
+            mock_feed.return_value.update.return_value = "ERROR", None
+            fire_time_changed(hass, utcnow + 2 * geo_rss_events.SCAN_INTERVAL)
+            hass.block_till_done()
+
+            all_states = hass.states.all()
+            assert len(all_states) == 1
+            state = hass.states.get("sensor.event_service_any")
+            assert int(state.state) == 0
+            assert state.attributes == {
+                ATTR_FRIENDLY_NAME: "Event Service Any",
+                ATTR_UNIT_OF_MEASUREMENT: "Events",
+                ATTR_ICON: "mdi:alert",
+            }
+
+
+async def test_setup_with_categories(hass, mock_feed):
+    """Test the general setup of the platform."""
+    # Set up some mock feed entries for this test.
+    mock_entry_1 = _generate_mock_feed_entry(
+        "1234", "Title 1", 15.5, (-31.0, 150.0), "Category 1"
+    )
+    mock_entry_2 = _generate_mock_feed_entry(
+        "2345", "Title 2", 20.5, (-31.1, 150.1), "Category 1"
+    )
+    mock_feed.return_value.update.return_value = "OK", [mock_entry_1, mock_entry_2]
+
+    with assert_setup_component(1, sensor.DOMAIN):
+        assert await async_setup_component(
+            hass, sensor.DOMAIN, VALID_CONFIG_WITH_CATEGORIES
+        )
+        # Artificially trigger update.
+        hass.bus.fire(EVENT_HOMEASSISTANT_START)
+        # Collect events.
+        hass.block_till_done()
+
+        all_states = hass.states.all()
+        assert len(all_states) == 1
+
+        state = hass.states.get("sensor.event_service_category_1")
+        assert state is not None
+        assert state.name == "Event Service Category 1"
+        assert int(state.state) == 2
+        assert state.attributes == {
+            ATTR_FRIENDLY_NAME: "Event Service Category 1",
+            ATTR_UNIT_OF_MEASUREMENT: "Events",
+            ATTR_ICON: "mdi:alert",
+            "Title 1": "16km",
+            "Title 2": "20km",
+        }


### PR DESCRIPTION
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rework geo_rss_events tests to pytest method style.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40847
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
