### PR TITLE
Deprecate OWFS/FUSE implementation in onewire integration

### DIFF
--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -234,10 +234,8 @@ def get_entities(config):
         # https://developers.home-assistant.io/docs/creating_platform_code_review/#5-communication-with-devicesservices
         _LOGGER.debug("Initializing using OWFS %s", base_dir)
         _LOGGER.warning(
-            "The OWFS implementation of 1-Wire sensors is deprecated, and should be migrated to OWServer (on localhost:4304)."
-        )
-        _LOGGER.warning(
-            "If migration to OWServer is not feasible on your installation, please raise an issue at https://github.com/home-assistant/core/issues/new?title=Unable%20to%20migrate%20onewire%20from%20OWFS%20to%20OWServer"
+            "The OWFS implementation of 1-Wire sensors is deprecated, and should be migrated to OWServer (on localhost:4304). %s",
+            "If migration to OWServer is not feasible on your installation, please raise an issue at https://github.com/home-assistant/core/issues/new?title=Unable%20to%20migrate%20onewire%20from%20OWFS%20to%20OWServer",
         )
         for family_file_path in glob(os.path.join(base_dir, "*", "family")):
             with open(family_file_path) as family_file:

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -233,6 +233,8 @@ def get_entities(config):
         # This part of the implementation does not conform to policy regarding 3rd-party libraries, and will not longer be updated.
         # https://developers.home-assistant.io/docs/creating_platform_code_review/#5-communication-with-devicesservices
         _LOGGER.debug("Initializing using OWFS %s", base_dir)
+        _LOGGER.warning("The OWFS implementation of 1-Wire sensors is deprecated, and should be migrated to OWServer (on localhost:4304).")
+        _LOGGER.warning("If migration to OWServer is not feasible on your installation, please raise an issue at https://github.com/home-assistant/core/issues/new?title=Unable%20to%20migrate%20onewire%20from%20OWFS%20to%20OWServer")
         for family_file_path in glob(os.path.join(base_dir, "*", "family")):
             with open(family_file_path) as family_file:
                 family = family_file.read()

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -234,8 +234,11 @@ def get_entities(config):
         # https://developers.home-assistant.io/docs/creating_platform_code_review/#5-communication-with-devicesservices
         _LOGGER.debug("Initializing using OWFS %s", base_dir)
         _LOGGER.warning(
-            "The OWFS implementation of 1-Wire sensors is deprecated, and should be migrated to OWServer (on localhost:4304). %s",
-            "If migration to OWServer is not feasible on your installation, please raise an issue at https://github.com/home-assistant/core/issues/new?title=Unable%20to%20migrate%20onewire%20from%20OWFS%20to%20OWServer",
+            "The OWFS implementation of 1-Wire sensors is deprecated, "
+            "and should be migrated to OWServer (on localhost:4304). "
+            "If migration to OWServer is not feasible on your installation, "
+            "please raise an issue at https://github.com/home-assistant/core/issues/new"
+            "?title=Unable%20to%20migrate%20onewire%20from%20OWFS%20to%20OWServer",
         )
         for family_file_path in glob(os.path.join(base_dir, "*", "family")):
             with open(family_file_path) as family_file:

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -233,8 +233,12 @@ def get_entities(config):
         # This part of the implementation does not conform to policy regarding 3rd-party libraries, and will not longer be updated.
         # https://developers.home-assistant.io/docs/creating_platform_code_review/#5-communication-with-devicesservices
         _LOGGER.debug("Initializing using OWFS %s", base_dir)
-        _LOGGER.warning("The OWFS implementation of 1-Wire sensors is deprecated, and should be migrated to OWServer (on localhost:4304).")
-        _LOGGER.warning("If migration to OWServer is not feasible on your installation, please raise an issue at https://github.com/home-assistant/core/issues/new?title=Unable%20to%20migrate%20onewire%20from%20OWFS%20to%20OWServer")
+        _LOGGER.warning(
+            "The OWFS implementation of 1-Wire sensors is deprecated, and should be migrated to OWServer (on localhost:4304)."
+        )
+        _LOGGER.warning(
+            "If migration to OWServer is not feasible on your installation, please raise an issue at https://github.com/home-assistant/core/issues/new?title=Unable%20to%20migrate%20onewire%20from%20OWFS%20to%20OWServer"
+        )
         for family_file_path in glob(os.path.join(base_dir, "*", "family")):
             with open(family_file_path) as family_file:
                 family = family_file.read()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Despite the project name, the owfs package (which depends on fuse and exposes filesystem calls in the appropriate directory to this program itself) is NOT recommended for any real use, it has well known issues with races etc.
The owfs/fuse implementation is therefore deprecated in favour of the owserver implementation

Before this change:

```yaml
sensor:
  - platform: onewire
    mount_dir: /mnt/1Wire
```

After this change:

```yaml
sensor:
  - platform: onewire
    host: localhost
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15314

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
