### PR TITLE
Upgrade PyISY to v2.1.0, add support for variable precision

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -156,7 +156,6 @@ async def async_setup_entry(
             password=password,
             use_https=https,
             tls_ver=tls_version,
-            log=_LOGGER,
             webroot=host.path,
         )
     )

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -94,13 +94,12 @@ def _fetch_isy_configuration(
             password,
             use_https,
             tls_ver,
-            log=_LOGGER,
             webroot=webroot,
         )
     except ValueError as err:
         raise InvalidAuth(err.args[0]) from err
 
-    return Configuration(log=_LOGGER, xml=isy_conn.get_config())
+    return Configuration(xml=isy_conn.get_config())
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -402,7 +402,7 @@ async def migrate_old_unique_ids(
 def convert_isy_value_to_hass(
     value: Union[int, float, None],
     uom: str,
-    precision: str,
+    precision: Union[int, str],
     fallback_precision: Optional[int] = None,
 ) -> Union[float, int]:
     """Fix ISY Reported Values.
@@ -418,7 +418,7 @@ def convert_isy_value_to_hass(
         return None
     if uom in [UOM_DOUBLE_TEMP, UOM_ISYV4_DEGREES]:
         return round(float(value) / 2.0, 1)
-    if precision != "0":
+    if precision not in ("0", 0):
         return round(float(value) / 10 ** int(precision), int(precision))
     if fallback_precision:
         return round(float(value), fallback_precision)

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -2,7 +2,7 @@
   "domain": "isy994",
   "name": "Universal Devices ISY994",
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "requirements": ["pyisy==2.0.2"],
+  "requirements": ["pyisy==2.1.0"],
   "codeowners": ["@bdraco", "@shbatm"],
   "config_flow": true,
   "ssdp": [

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -106,12 +106,16 @@ class ISYSensorVariableEntity(ISYEntity):
     @property
     def state(self):
         """Return the state of the variable."""
-        return self._node.status
+        return convert_isy_value_to_hass(self._node.status, "", self._node.prec)
 
     @property
     def device_state_attributes(self) -> Dict:
         """Get the state attributes for the device."""
-        return {"init_value": int(self._node.init)}
+        return {
+            "init_value": convert_isy_value_to_hass(
+                self._node.init, "", self._node.prec
+            )
+        }
 
     @property
     def icon(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1451,7 +1451,7 @@ pyirishrail==0.0.2
 pyiss==1.0.1
 
 # homeassistant.components.isy994
-pyisy==2.0.2
+pyisy==2.1.0
 
 # homeassistant.components.itach
 pyitachip2ir==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -709,7 +709,7 @@ pyipp==0.11.0
 pyiqvia==0.2.1
 
 # homeassistant.components.isy994
-pyisy==2.0.2
+pyisy==2.1.0
 
 # homeassistant.components.kira
 pykira==0.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- This update to PyISY adds native support for decimal precision in ISY Variable sensors, any template sensors created to adjust the rounding or precision shown in Home Assistant should be updated/removed.
- The way logging is handled in PyISY has been changed. If you previously set a different logging level for `homeassistant.components.isy994` in your `logger` configuration, you will also need to set the level for `pyisy` and/or `pyisy.events`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrade the PyISY module to the latest version, which contains various bug fixes, consolidation of the logging to a module level, and addition of support for last_update/last_changed timestamps, connection events, and decimal precision in ISY Variables (HA support included in this PR).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
NO CHANGES
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40134, fixes #39592, fixes #37537, also resolves [this](https://community.home-assistant.io/t/calling-all-isy994-users/36205/192?u=shbatm)
- This PR is related to issue: 
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] n/a

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

CC: @bluemantwo