### PR TITLE
Fix duplicate lg_soundbar entities and disable polling

### DIFF
--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -29,8 +29,8 @@ class LGDevice(MediaPlayerEntity):
 
     def __init__(self, discovery_info):
         """Initialize the LG speakers."""
-        self._host = discovery_info.get("host")
-        self._port = discovery_info.get("port")
+        self._host = discovery_info["host"]
+        self._port = discovery_info["port"]
         self._hostname = discovery_info["hostname"]
 
         self._name = self._hostname.split(".")[0]

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -31,7 +31,7 @@ class LGDevice(MediaPlayerEntity):
         """Initialize the LG speakers."""
         self._host = discovery_info.get("host")
         self._port = discovery_info.get("port")
-        self._hostname = discovery_info.get("hostname")
+        self._hostname = discovery_info["hostname"]
 
         self._name = self._hostname.split(".")[0]
         self._volume = 0

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -121,6 +121,11 @@ class LGDevice(MediaPlayerEntity):
         self._device.get_product_info()
 
     @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
     def unique_id(self):
         """Return the device's unique ID."""
         return self._hostname

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -31,10 +31,9 @@ class LGDevice(MediaPlayerEntity):
         """Initialize the LG speakers."""
         self._host = discovery_info.get("host")
         self._port = discovery_info.get("port")
-        properties = discovery_info.get("properties")
-        self._uuid = properties.get("UUID")
+        self._hostname = discovery_info.get("hostname")
 
-        self._name = ""
+        self._name = self._hostname.split(".")[0]
         self._volume = 0
         self._volume_min = 0
         self._volume_max = 0
@@ -124,7 +123,7 @@ class LGDevice(MediaPlayerEntity):
     @property
     def unique_id(self):
         """Return the device's unique ID."""
-        return self._uuid
+        return self._hostname
 
     @property
     def name(self):

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -126,11 +126,6 @@ class LGDevice(MediaPlayerEntity):
         return False
 
     @property
-    def unique_id(self):
-        """Return the device's unique ID."""
-        return self._hostname
-
-    @property
     def name(self):
         """Return the name of the device."""
         return self._name


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

If `discovery` is used the entity will get a new entity_id derived from the hostname. This means the entity_id can not be changed anymore since there is currently no way to get a unique_id from the device.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Combines two small fixes which depend on one another:
1. Remove the unique_id since the zeroconf published uuid changes regularly (can be readded with a config flow)
2. Disabled polling so that the soundbar can go to sleep (python-temescal version > 0.2 reworked the socket connection which fixes connection loss)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41121
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
