### PR TITLE
Add optimistic closing/opening to gogogate2

### DIFF
--- a/homeassistant/components/gogogate2/cover.py
+++ b/homeassistant/components/gogogate2/cover.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from gogogate2_api.common import (
+from ismartgate.common import (
     AbstractDoor,
     DoorStatus,
     TransitionDoorStatus,

--- a/homeassistant/components/gogogate2/cover.py
+++ b/homeassistant/components/gogogate2/cover.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import logging
 
-from ismartgate.common import AbstractDoor, DoorStatus, get_configured_doors
+from gogogate2_api.common import (
+    AbstractDoor,
+    DoorStatus,
+    TransitionDoorStatus,
+    get_configured_doors,
+)
 
 from homeassistant.components.cover import (
     DEVICE_CLASS_GARAGE,
@@ -84,11 +89,10 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
     @property
     def is_closed(self):
         """Return true if cover is closed, else False."""
-        door = self._get_door()
-
-        if door.status == DoorStatus.OPENED:
+        door_status = self._get_door_status()
+        if door_status == DoorStatus.OPENED:
             return False
-        if door.status == DoorStatus.CLOSED:
+        if door_status == DoorStatus.CLOSED:
             return True
 
         return None
@@ -96,8 +100,7 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
     @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
-        door = self._get_door()
-        if door.gate:
+        if self._get_door().gate:
             return DEVICE_CLASS_GATE
 
         return DEVICE_CLASS_GARAGE
@@ -107,15 +110,32 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
         """Flag supported features."""
         return SUPPORT_OPEN | SUPPORT_CLOSE
 
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return self._get_door_status() == TransitionDoorStatus.CLOSING
+
+    @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return self._get_door_status() == TransitionDoorStatus.OPENING
+
     async def async_open_cover(self, **kwargs):
         """Open the door."""
         await self._api.async_open_door(self._get_door().door_id)
+        await self.coordinator.async_refresh()
 
     async def async_close_cover(self, **kwargs):
         """Close the door."""
         await self._api.async_close_door(self._get_door().door_id)
+        await self.coordinator.async_refresh()
 
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        return {"door_id": self._get_door().door_id}
+        return {**super().state_attributes, "door_id": self._get_door().door_id}
+
+    def _get_door_status(self) -> AbstractDoor:
+        return self._api.async_get_door_statuses_from_info(self.coordinator.data)[
+            self._door.door_id
+        ]

--- a/homeassistant/components/gogogate2/cover.py
+++ b/homeassistant/components/gogogate2/cover.py
@@ -133,7 +133,7 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        return {**super().state_attributes, "door_id": self._get_door().door_id}
+        return {"door_id": self._get_door().door_id}
 
     def _get_door_status(self) -> AbstractDoor:
         return self._api.async_get_door_statuses_from_info(self.coordinator.data)[

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -14,6 +14,7 @@ from ismartgate.common import (
     ISmartGateInfoResponse,
     Network,
     Outputs,
+    TransitionDoorStatus,
     Wifi,
 )
 
@@ -44,7 +45,9 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM_METRIC,
     CONF_USERNAME,
     STATE_CLOSED,
+    STATE_CLOSING,
     STATE_OPEN,
+    STATE_OPENING,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -331,6 +334,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     api = MagicMock(GogoGate2Api)
     api.async_activate.return_value = GogoGate2ActivateResponse(result=True)
     api.async_info.return_value = info_response(DoorStatus.OPENED)
+    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
     gogogate2api_mock.return_value = api
 
     config_entry = MockConfigEntry(
@@ -351,31 +355,86 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     assert dict(hass.states.get("cover.door1").attributes) == expected_attributes
 
     api.async_info.return_value = info_response(DoorStatus.CLOSED)
+    api._get_door_statuses.return_value = {1: DoorStatus.CLOSED, 2: DoorStatus.CLOSED}
     await hass.services.async_call(
         COVER_DOMAIN,
         "close_cover",
         service_data={"entity_id": "cover.door1"},
     )
+    api._get_door_statuses.return_value = {
+        1: TransitionDoorStatus.CLOSING,
+        2: TransitionDoorStatus.CLOSING,
+    }
+    async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
+    await hass.async_block_till_done()
+    assert hass.states.get("cover.door1").state == STATE_CLOSING
+    api.async_close_door.assert_called_with(1)
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert hass.states.get("cover.door1").state == STATE_CLOSING
+
+    api.async_info.return_value = info_response(DoorStatus.CLOSED)
+    api._get_door_statuses.return_value = {1: DoorStatus.CLOSED, 2: DoorStatus.CLOSED}
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_CLOSED
-    api.async_close_door.assert_called_with(1)
 
     api.async_info.return_value = info_response(DoorStatus.OPENED)
+    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
     await hass.services.async_call(
         COVER_DOMAIN,
         "open_cover",
         service_data={"entity_id": "cover.door1"},
     )
+    api._get_door_statuses.return_value = {
+        1: TransitionDoorStatus.OPENING,
+        2: TransitionDoorStatus.OPENING,
+    }
+    async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
+    await hass.async_block_till_done()
+    assert hass.states.get("cover.door1").state == STATE_OPENING
+    api.async_open_door.assert_called_with(1)
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert hass.states.get("cover.door1").state == STATE_OPENING
+
+    api.async_info.return_value = info_response(DoorStatus.OPENED)
+    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_OPEN
-    api.async_open_door.assert_called_with(1)
 
     api.async_info.return_value = info_response(DoorStatus.UNDEFINED)
+    api._get_door_statuses.return_value = {
+        1: DoorStatus.UNDEFINED,
+        2: DoorStatus.UNDEFINED,
+    }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_UNKNOWN
+
+    api.async_info.return_value = info_response(DoorStatus.OPENED)
+    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        "close_cover",
+        service_data={"entity_id": "cover.door1"},
+    )
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        "open_cover",
+        service_data={"entity_id": "cover.door1"},
+    )
+    api._get_door_statuses.return_value = {
+        1: TransitionDoorStatus.OPENING,
+        2: TransitionDoorStatus.OPENING,
+    }
+    async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
+    await hass.async_block_till_done()
+    assert hass.states.get("cover.door1").state == STATE_OPENING
+    api.async_open_door.assert_called_with(1)
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert not hass.states.async_entity_ids(DOMAIN)
@@ -430,6 +489,7 @@ async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
 
     api.async_info.side_effect = None
     api.async_info.return_value = closed_door_response
+    api._get_door_statuses.return_value = {1: DoorStatus.CLOSED, 2: DoorStatus.CLOSED}
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_CLOSED

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -334,7 +334,10 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     api = MagicMock(GogoGate2Api)
     api.async_activate.return_value = GogoGate2ActivateResponse(result=True)
     api.async_info.return_value = info_response(DoorStatus.OPENED)
-    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
+    api.async_get_door_statuses_from_info.return_value = {
+        1: DoorStatus.OPENED,
+        2: DoorStatus.OPENED,
+    }
     gogogate2api_mock.return_value = api
 
     config_entry = MockConfigEntry(
@@ -355,13 +358,16 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     assert dict(hass.states.get("cover.door1").attributes) == expected_attributes
 
     api.async_info.return_value = info_response(DoorStatus.CLOSED)
-    api._get_door_statuses.return_value = {1: DoorStatus.CLOSED, 2: DoorStatus.CLOSED}
+    api.async_get_door_statuses_from_info.return_value = {
+        1: DoorStatus.CLOSED,
+        2: DoorStatus.CLOSED,
+    }
     await hass.services.async_call(
         COVER_DOMAIN,
         "close_cover",
         service_data={"entity_id": "cover.door1"},
     )
-    api._get_door_statuses.return_value = {
+    api.async_get_door_statuses_from_info.return_value = {
         1: TransitionDoorStatus.CLOSING,
         2: TransitionDoorStatus.CLOSING,
     }
@@ -375,19 +381,25 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     assert hass.states.get("cover.door1").state == STATE_CLOSING
 
     api.async_info.return_value = info_response(DoorStatus.CLOSED)
-    api._get_door_statuses.return_value = {1: DoorStatus.CLOSED, 2: DoorStatus.CLOSED}
+    api.async_get_door_statuses_from_info.return_value = {
+        1: DoorStatus.CLOSED,
+        2: DoorStatus.CLOSED,
+    }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_CLOSED
 
     api.async_info.return_value = info_response(DoorStatus.OPENED)
-    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
+    api.async_get_door_statuses_from_info.return_value = {
+        1: DoorStatus.OPENED,
+        2: DoorStatus.OPENED,
+    }
     await hass.services.async_call(
         COVER_DOMAIN,
         "open_cover",
         service_data={"entity_id": "cover.door1"},
     )
-    api._get_door_statuses.return_value = {
+    api.async_get_door_statuses_from_info.return_value = {
         1: TransitionDoorStatus.OPENING,
         2: TransitionDoorStatus.OPENING,
     }
@@ -401,13 +413,16 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     assert hass.states.get("cover.door1").state == STATE_OPENING
 
     api.async_info.return_value = info_response(DoorStatus.OPENED)
-    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
+    api.async_get_door_statuses_from_info.return_value = {
+        1: DoorStatus.OPENED,
+        2: DoorStatus.OPENED,
+    }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_OPEN
 
     api.async_info.return_value = info_response(DoorStatus.UNDEFINED)
-    api._get_door_statuses.return_value = {
+    api.async_get_door_statuses_from_info.return_value = {
         1: DoorStatus.UNDEFINED,
         2: DoorStatus.UNDEFINED,
     }
@@ -416,7 +431,10 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     assert hass.states.get("cover.door1").state == STATE_UNKNOWN
 
     api.async_info.return_value = info_response(DoorStatus.OPENED)
-    api._get_door_statuses.return_value = {1: DoorStatus.OPENED, 2: DoorStatus.OPENED}
+    api.async_get_door_statuses_from_info.return_value = {
+        1: DoorStatus.OPENED,
+        2: DoorStatus.OPENED,
+    }
     await hass.services.async_call(
         COVER_DOMAIN,
         "close_cover",
@@ -427,7 +445,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
         "open_cover",
         service_data={"entity_id": "cover.door1"},
     )
-    api._get_door_statuses.return_value = {
+    api.async_get_door_statuses_from_info.return_value = {
         1: TransitionDoorStatus.OPENING,
         2: TransitionDoorStatus.OPENING,
     }
@@ -489,7 +507,10 @@ async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
 
     api.async_info.side_effect = None
     api.async_info.return_value = closed_door_response
-    api._get_door_statuses.return_value = {1: DoorStatus.CLOSED, 2: DoorStatus.CLOSED}
+    api.async_get_door_statuses_from_info.return_value = {
+        1: DoorStatus.CLOSED,
+        2: DoorStatus.CLOSED,
+    }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_CLOSED


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add optimistic closing/opening to gogogate2

The UI will now reflect
the opening/closing state when the cover is activated
from the UI which solves the case where you are unsure
if you hit the button and end up cycling the cover again
and accidentally crush your car in the gate.

I ended up forking the pypi since PRs went stale since Jan. The only changes are: ( https://github.com/vangorra/python_gogogate2_api/pull/26 &  https://github.com/vangorra/python_gogogate2_api/pull/25)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
