### PR TITLE
Improve ISY994 NodeServer sorting and format sensor display values

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -162,6 +162,9 @@ async def async_setup_entry(
     if not isy.connected:
         return False
 
+    # Trigger a status update for all nodes, not done automatically in PyISY v2.x
+    await hass.async_add_executor_job(isy.nodes.update)
+
     _categorize_nodes(hass_isy_data, isy.nodes, ignore_identifier, sensor_identifier)
     _categorize_programs(hass_isy_data, isy.programs)
     _categorize_variables(hass_isy_data, isy.variables, variable_identifier)

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -200,7 +200,7 @@ UOM_ON_OFF = "2"
 # Z-Wave Categories: https://www.universal-devices.com/developers/wsdk/5.0.4/4_fam.xml
 NODE_FILTERS = {
     BINARY_SENSOR: {
-        FILTER_UOM: [],
+        FILTER_UOM: [UOM_ON_OFF],
         FILTER_STATES: [],
         FILTER_NODE_DEF_ID: [
             "BinaryAlarm",
@@ -282,7 +282,7 @@ NODE_FILTERS = {
         FILTER_ZWAVE_CAT: ["109", "119"],
     },
     SWITCH: {
-        FILTER_UOM: [UOM_ON_OFF, "78"],
+        FILTER_UOM: ["78"],
         FILTER_STATES: ["on", "off"],
         FILTER_NODE_DEF_ID: [
             "AlertModuleArmed",
@@ -322,6 +322,7 @@ NODE_FILTERS = {
 
 UOM_FRIENDLY_NAME = {
     "1": "A",
+    UOM_ON_OFF: "",  # Binary, no unit
     "3": f"btu/{TIME_HOURS}",
     "4": TEMP_CELSIUS,
     "5": LENGTH_CENTIMETERS,

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -15,6 +15,8 @@ from .const import (
     ISY994_VARIABLES,
     UOM_DOUBLE_TEMP,
     UOM_FRIENDLY_NAME,
+    UOM_INDEX,
+    UOM_ON_OFF,
     UOM_TO_STATES,
 )
 from .entity import ISYEntity, ISYNodeEntity
@@ -58,6 +60,9 @@ class ISYSensorEntity(ISYNodeEntity):
         if isy_states:
             return isy_states
 
+        if uom in [UOM_ON_OFF, UOM_INDEX]:
+            return uom
+
         return UOM_FRIENDLY_NAME.get(uom)
 
     @property
@@ -74,6 +79,9 @@ class ISYSensorEntity(ISYNodeEntity):
         if isinstance(uom, dict):
             return uom.get(value, value)
 
+        if uom in [UOM_INDEX, UOM_ON_OFF]:
+            return self._node.formatted
+
         # Handle ISY precision and rounding
         value = convert_isy_value_to_hass(value, uom, self._node.prec)
 
@@ -88,7 +96,7 @@ class ISYSensorEntity(ISYNodeEntity):
         """Get the Home Assistant unit of measurement for the device."""
         raw_units = self.raw_unit_of_measurement
         # Check if this is a known index pair UOM
-        if isinstance(raw_units, dict):
+        if isinstance(raw_units, dict) or raw_units in [UOM_ON_OFF, UOM_INDEX]:
             return None
         if raw_units in (TEMP_FAHRENHEIT, TEMP_CELSIUS, UOM_DOUBLE_TEMP):
             return self.hass.config.units.temperature_unit


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Two changes may cause some entities to change platforms; however, this should only affect NodeServer nodes.
    - ISY Nodes that use the ON/OFF unit of measurement and cannot be categorized/sorted by another method have been moved from `switch` to `binary_sensor` since it cannot be confirmed if the device supports DON/DOF commands. The `isy994.send_node_command` service may be used to control these devices if you know they are controllable.
    - The status of all nodes is now downloaded before sorting devices, as a result some nodes which defaulted to `sensor` will now be correctly sorted.
- Sensor values which use the ISY994's "index" unit of measurement (UOM=25) now report the "formatted" text value shown in the ISY Admin Console, instead of the integer index. If you have any automations or templates relying on these values, they must be updated.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
PyISY v2.1.0 corrected an issue with the formatted values not being correctly updated when the node updated; as a result the formatted values could not be used for indexed sensor values when changes were made moving to v2.0.0. Since this has been corrected, sensors with a UOM of 2 (on/off) or 25 (index) will be now be translated to their text values.

Another item missed after the upgrade to v2 was querying the ISY for the status values before sorting entities. This will improve sorting of devices which don't report a status property on `/rest/nodes`. It is included with the formatting change because it allows sorting of UOM 2 NodeServer nodes as `binary_sensors` instead of `sensors` which show `True`/`False`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
NO CHANGES
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #42043
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] n/a

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
