### PR TITLE
Axis lib migrates to httpx

### DIFF
--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
-  "requirements": ["axis==37"],
+  "requirements": ["axis==38"],
   "zeroconf": [
     { "type": "_axis-video._tcp.local.", "macaddress": "00408C*" },
     { "type": "_axis-video._tcp.local.", "macaddress": "ACCC8E*" },

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
-  "requirements": ["axis==38"],
+  "requirements": ["axis==39"],
   "zeroconf": [
     { "type": "_axis-video._tcp.local.", "macaddress": "00408C*" },
     { "type": "_axis-video._tcp.local.", "macaddress": "ACCC8E*" },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==37
+axis==38
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==38
+axis==39
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -180,7 +180,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==38
+axis==39
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -180,7 +180,7 @@ av==8.0.2
 avri-api==0.1.7
 
 # homeassistant.components.axis
-axis==37
+axis==38
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 
-from .test_device import MAC, MODEL, NAME, setup_axis_integration, vapix_session_request
+from .test_device import MAC, MODEL, NAME, setup_axis_integration, vapix_request
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
@@ -32,7 +32,7 @@ async def test_flow_manual_configuration(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "user"
 
-    with patch("axis.vapix.session_request", new=vapix_session_request):
+    with patch("axis.vapix.Vapix.request", new=vapix_request):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -70,9 +70,7 @@ async def test_manual_configuration_update_configuration(hass):
     with patch(
         "homeassistant.components.axis.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry, patch(
-        "axis.vapix.session_request", new=vapix_session_request
-    ):
+    ) as mock_setup_entry, patch("axis.vapix.Vapix.request", new=vapix_request):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -101,7 +99,7 @@ async def test_flow_fails_already_configured(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "user"
 
-    with patch("axis.vapix.session_request", new=vapix_session_request):
+    with patch("axis.vapix.Vapix.request", new=vapix_request):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -188,7 +186,7 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "user"
 
-    with patch("axis.vapix.session_request", new=vapix_session_request):
+    with patch("axis.vapix.Vapix.request", new=vapix_request):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -230,7 +228,7 @@ async def test_zeroconf_flow(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "user"
 
-    with patch("axis.vapix.session_request", new=vapix_session_request):
+    with patch("axis.vapix.Vapix.request", new=vapix_request):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -294,9 +292,7 @@ async def test_zeroconf_flow_updated_configuration(hass):
     with patch(
         "homeassistant.components.axis.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry, patch(
-        "axis.vapix.session_request", new=vapix_session_request
-    ):
+    ) as mock_setup_entry, patch("axis.vapix.Vapix.request", new=vapix_request):
         result = await hass.config_entries.flow.async_init(
             AXIS_DOMAIN,
             data={

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -1,6 +1,5 @@
 """Test Axis device."""
 from copy import deepcopy
-import json
 from unittest import mock
 
 import axis as axislib
@@ -197,22 +196,22 @@ root.StreamProfile.S1.Parameters=videocodec=h265
 """
 
 
-def vapix_session_request(session, url, **kwargs):
+def vapix_request(self, session, url, **kwargs):
     """Return data based on url."""
     if API_DISCOVERY_URL in url:
-        return json.dumps(API_DISCOVERY_RESPONSE)
+        return API_DISCOVERY_RESPONSE
     if APPLICATIONS_URL in url:
         return APPLICATIONS_LIST_RESPONSE
     if BASIC_DEVICE_INFO_URL in url:
-        return json.dumps(BASIC_DEVICE_INFO_RESPONSE)
+        return BASIC_DEVICE_INFO_RESPONSE
     if LIGHT_CONTROL_URL in url:
-        return json.dumps(LIGHT_CONTROL_RESPONSE)
+        return LIGHT_CONTROL_RESPONSE
     if MQTT_CLIENT_URL in url:
-        return json.dumps(MQTT_CLIENT_RESPONSE)
+        return MQTT_CLIENT_RESPONSE
     if PORT_MANAGEMENT_URL in url:
-        return json.dumps(PORT_MANAGEMENT_RESPONSE)
+        return PORT_MANAGEMENT_RESPONSE
     if VMD4_URL in url:
-        return json.dumps(VMD4_RESPONSE)
+        return VMD4_RESPONSE
     if BRAND_URL in url:
         return BRAND_RESPONSE
     if IOPORT_URL in url or INPUT_URL in url or OUTPUT_URL in url:
@@ -235,7 +234,7 @@ async def setup_axis_integration(hass, config=ENTRY_CONFIG, options=ENTRY_OPTION
     )
     config_entry.add_to_hass(hass)
 
-    with patch("axis.vapix.session_request", new=vapix_session_request), patch(
+    with patch("axis.vapix.Vapix.request", new=vapix_request), patch(
         "axis.rtsp.RTSPClient.start",
         return_value=True,
     ):
@@ -314,7 +313,7 @@ async def test_update_address(hass):
     device = await setup_axis_integration(hass)
     assert device.api.config.host == "1.2.3.4"
 
-    with patch("axis.vapix.session_request", new=vapix_session_request), patch(
+    with patch("axis.vapix.Vapix.request", new=vapix_request), patch(
         "homeassistant.components.axis.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -394,7 +393,7 @@ async def test_shutdown():
 async def test_get_device_fails(hass):
     """Device unauthorized yields authentication required error."""
     with patch(
-        "axis.vapix.session_request", side_effect=axislib.Unauthorized
+        "axis.vapix.Vapix.request", side_effect=axislib.Unauthorized
     ), pytest.raises(axis.errors.AuthenticationRequired):
         await axis.device.get_device(hass, host="", port="", username="", password="")
 
@@ -402,7 +401,7 @@ async def test_get_device_fails(hass):
 async def test_get_device_device_unavailable(hass):
     """Device unavailable yields cannot connect error."""
     with patch(
-        "axis.vapix.session_request", side_effect=axislib.RequestError
+        "axis.vapix.Vapix.request", side_effect=axislib.RequestError
     ), pytest.raises(axis.errors.CannotConnect):
         await axis.device.get_device(hass, host="", port="", username="", password="")
 
@@ -410,6 +409,6 @@ async def test_get_device_device_unavailable(hass):
 async def test_get_device_unknown_error(hass):
     """Device yield unknown error."""
     with patch(
-        "axis.vapix.session_request", side_effect=axislib.AxisException
+        "axis.vapix.Vapix.request", side_effect=axislib.AxisException
     ), pytest.raises(axis.errors.AuthenticationRequired):
         await axis.device.get_device(hass, host="", port="", username="", password="")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Lib migrates from requests to httpx, next step will be to go full async
Lib change log https://github.com/Kane610/axis/compare/v37...v39

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
