### PR TITLE
Don't swallow all errors when checking for config validator platform

### DIFF
--- a/homeassistant/components/apache_kafka/__init__.py
+++ b/homeassistant/components/apache_kafka/__init__.py
@@ -60,7 +60,7 @@ async def async_setup(hass, config):
         conf.get(CONF_PASSWORD),
     )
 
-    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, kafka.shutdown())
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, kafka.shutdown)
 
     await kafka.start()
 
@@ -130,7 +130,7 @@ class KafkaManager:
         self._hass.bus.async_listen(EVENT_STATE_CHANGED, self.write)
         await self._producer.start()
 
-    async def shutdown(self):
+    async def shutdown(self, _):
         """Shut the manager down."""
         await self._producer.stop()
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -750,8 +750,14 @@ async def async_process_component_config(
     config_validator = None
     try:
         config_validator = integration.get_platform("config")
-    except ImportError:
-        pass
+    except ImportError as err:
+        # Filter out import error of the config platform.
+        # If the config platform contains bad imports, make sure
+        # that still fails.
+        if err.name != f"{integration.pkg_path}.config":
+            _LOGGER.error("Error importing config platform %s: %s", domain, err)
+            return None
+
     if config_validator is not None and hasattr(
         config_validator, "async_validate_config"
     ):

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -419,10 +419,12 @@ class Integration:
         cache = self.hass.data.setdefault(DATA_COMPONENTS, {})
         full_name = f"{self.domain}.{platform_name}"
         if full_name not in cache:
-            cache[full_name] = importlib.import_module(
-                f"{self.pkg_path}.{platform_name}"
-            )
+            cache[full_name] = self._import_platform(platform_name)
         return cache[full_name]  # type: ignore
+
+    def _import_platform(self, platform_name: str) -> ModuleType:
+        """Import the platform."""
+        return importlib.import_module(f"{self.pkg_path}.{platform_name}")
 
     def __repr__(self) -> str:
         """Text representation of class."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -973,6 +973,14 @@ def mock_integration(hass, module):
         hass, f"homeassistant.components.{module.DOMAIN}", None, module.mock_manifest()
     )
 
+    def mock_import_platform(platform_name):
+        raise ImportError(
+            "Mocked unable to import platform",
+            name=f"{integration.pkg_path}.{platform_name}",
+        )
+
+    integration._import_platform = mock_import_platform
+
     _LOGGER.info("Adding mock integration: %s", module.DOMAIN)
     hass.data.setdefault(loader.DATA_INTEGRATIONS, {})[module.DOMAIN] = integration
     hass.data.setdefault(loader.DATA_COMPONENTS, {})[module.DOMAIN] = module

--- a/tests/common.py
+++ b/tests/common.py
@@ -975,7 +975,7 @@ def mock_integration(hass, module):
 
     def mock_import_platform(platform_name):
         raise ImportError(
-            "Mocked unable to import platform",
+            f"Mocked unable to import platform '{platform_name}'",
             name=f"{integration.pkg_path}.{platform_name}",
         )
 

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -14,17 +14,18 @@ from homeassistant.const import CONF_PLATFORM, CONF_SCAN_INTERVAL
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockModule, async_fire_time_changed, mock_integration
+from tests.async_mock import patch
+from tests.common import async_fire_time_changed
 
 
 @pytest.fixture()
 def mock_hub(hass):
     """Mock hub."""
-    mock_integration(hass, MockModule(DOMAIN))
-    hub = mock.MagicMock()
-    hub.name = "hub"
-    hass.data[DOMAIN] = {DEFAULT_HUB: hub}
-    return hub
+    with patch("homeassistant.components.modbus.setup", return_value=True):
+        hub = mock.MagicMock()
+        hub.name = "hub"
+        hass.data[DOMAIN] = {DEFAULT_HUB: hub}
+        yield hub
 
 
 class ReadResult:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1064,6 +1064,30 @@ async def test_component_config_exceptions(hass, caplog):
             in caplog.text
         )
 
+    # get_platform("config") raising
+    caplog.clear()
+    assert (
+        await config_util.async_process_component_config(
+            hass,
+            {"test_domain": {}},
+            integration=Mock(
+                pkg_path="homeassistant.components.test_domain",
+                domain="test_domain",
+                get_platform=Mock(
+                    side_effect=ImportError(
+                        "ModuleNotFoundError: No module named 'not_installed_something'",
+                        name="not_installed_something",
+                    )
+                ),
+            ),
+        )
+        is None
+    )
+    assert (
+        "Error importing config platform test_domain: ModuleNotFoundError: No module named 'not_installed_something'"
+        in caplog.text
+    )
+
 
 @pytest.mark.parametrize(
     "domain, schema, expected",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When we would test if an integration supported async config validation, we accepted all import errors as if the config platform doesn't exist. This is wrong, the config platform could have contained an incorrect reference triggering an import error. This should be considered a failure to set up the integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
