### PR TITLE
Add media browser support to roon media player

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -731,6 +731,7 @@ omit =
     homeassistant/components/roomba/vacuum.py
     homeassistant/components/roon/__init__.py
     homeassistant/components/roon/const.py
+    homeassistant/components/roon/media_browser.py
     homeassistant/components/roon/media_player.py
     homeassistant/components/roon/server.py
     homeassistant/components/route53/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -730,6 +730,7 @@ omit =
     homeassistant/components/roomba/vacuum.py
     homeassistant/components/roon/__init__.py
     homeassistant/components/roon/const.py
+    homeassistant/components/roon/media_browser.py
     homeassistant/components/roon/media_player.py
     homeassistant/components/roon/server.py
     homeassistant/components/route53/*

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 
-from roon import RoonApi
+from roonapi import RoonApi
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions

--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
   "requirements": [
-    "roonapi==0.0.21"
+    "roonapi==0.0.22dev1"
   ],
   "codeowners": [
     "@pavoni"

--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
   "requirements": [
-    "roonapi==0.0.22dev1"
+    "roonapi==0.0.23"
   ],
   "codeowners": [
     "@pavoni"

--- a/homeassistant/components/roon/media_browser.py
+++ b/homeassistant/components/roon/media_browser.py
@@ -1,4 +1,4 @@
-"""Support to interface with the Plex API."""
+"""Support to interface with the Roon API."""
 import logging
 
 from homeassistant.components.media_player import BrowseMedia
@@ -87,9 +87,6 @@ def item_payload(roon_server, item, list_image_id):
         can_expand = True
         _LOGGER.warning("Unknown hint %s - %s", title, hint)
 
-    if title in EXCLUDE_ITEMS:
-        return None
-
     payload = {
         "title": display_title,
         "media_class": media_class,
@@ -153,13 +150,14 @@ def library_payload(roon_server, zone_id, media_content_id):
     count = len(items)
 
     if count < total_count:
-        _LOGGER.error(
+        _LOGGER.debug(
             "Exceeded limit of %d, loaded %d/%d", ITEM_LIMIT, count, total_count
         )
 
     for item in items:
-        item = item_payload(roon_server, item, library_image_id)
-        if not (item is None):
-            library_info.children.append(item)
+        if item.get("title") in EXCLUDE_ITEMS:
+            continue
+        entry = item_payload(roon_server, item, library_image_id)
+        library_info.children.append(entry)
 
     return library_info

--- a/homeassistant/components/roon/media_browser.py
+++ b/homeassistant/components/roon/media_browser.py
@@ -1,0 +1,153 @@
+"""Support to interface with the Plex API."""
+import logging
+
+from homeassistant.components.media_player import BrowseMedia
+from homeassistant.components.media_player.const import (
+    MEDIA_CLASS_ALBUM,
+    MEDIA_CLASS_ARTIST,
+    MEDIA_CLASS_DIRECTORY,
+    MEDIA_CLASS_PLAYLIST,
+    MEDIA_CLASS_TRACK,
+)
+from homeassistant.components.media_player.errors import BrowseError
+
+
+class UnknownMediaType(BrowseError):
+    """Unknown media type."""
+
+
+EXPANDABLES = ["album", "artist", "playlist"]
+PLAYLISTS_BROWSE_PAYLOAD = {
+    "title": "Playlists",
+    "media_class": MEDIA_CLASS_DIRECTORY,
+    "media_content_id": "all",
+    "media_content_type": "playlists",
+    "can_play": False,
+    "can_expand": True,
+}
+
+ITEM_TYPE_MEDIA_CLASS = {
+    "album": MEDIA_CLASS_ALBUM,
+    "artist": MEDIA_CLASS_ARTIST,
+    "playlist": MEDIA_CLASS_PLAYLIST,
+    "track": MEDIA_CLASS_TRACK,
+}
+
+UNPLAYABLE_ITEMS = {
+    "Play Album",
+    "Play Artist",
+    "Play Playlist",
+    "Play Now",
+    "Play From Here",
+    "Queue",
+    "Start Radio",
+    "Add Next",
+    "Play Radio",
+    "Settings",
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def browse_media(zone_id, roon_server, media_content_type=None, media_content_id=None):
+    """Implement the websocket media browsing helper."""
+    try:
+        _LOGGER.warning("browse_media: %s: %s", media_content_type, media_content_id)
+        if media_content_type in [None, "library"]:
+            return library_payload(roon_server, zone_id, media_content_id)
+
+    except UnknownMediaType as err:
+        raise BrowseError(
+            f"Media not found: {media_content_type} / {media_content_id}"
+        ) from err
+
+
+def item_payload(roon_server, item):
+    """Create response payload for a single media item."""
+
+    title = item.get("title")
+    subtitle = item.get("subtitle")
+    if subtitle is None:
+        display_title = title
+    else:
+        display_title = f"{title} - {subtitle}"
+
+    image_id = item.get("image_key")
+    if image_id is None:
+        image = None
+    else:
+        image = roon_server.roonapi.get_image(image_id)
+
+    media_content_id = item.get("item_key")
+
+    can_play = True
+    can_expand = True
+    media_class = MEDIA_CLASS_TRACK
+    hint = item.get("hint")
+    if hint == "list":
+        can_play = True
+        can_expand = True
+        media_class = MEDIA_CLASS_DIRECTORY
+    elif hint == "action_list":
+        can_play = True
+        can_expand = True
+        media_class = MEDIA_CLASS_PLAYLIST
+    elif hint == "action":
+        can_play = True
+        can_expand = True
+        media_class = MEDIA_CLASS_TRACK
+
+    if title in UNPLAYABLE_ITEMS:
+        _LOGGER.debug("Skipping %s", title)
+        return None
+
+    payload = {
+        "title": display_title,
+        "media_class": media_class,
+        "media_content_id": media_content_id,
+        "media_content_type": "library",
+        "can_play": can_play,
+        "can_expand": can_expand,
+        "thumbnail": image,
+    }
+
+    return BrowseMedia(**payload)
+
+
+def library_payload(roon_server, zone_id, media_content_id):
+    """Create response payload for the library."""
+
+    library_info = BrowseMedia(
+        title="Media Library",
+        media_content_id="library",
+        media_content_type="library",
+        media_class=MEDIA_CLASS_DIRECTORY,
+        can_play=False,
+        can_expand=True,
+        children=[],
+    )
+
+    opts = {
+        "hierarchy": "browse",
+        "zone_or_output_id": zone_id,
+    }
+
+    # Roon starts browsing for a zone where it left off - so start from the top unless otherwise specified
+    if media_content_id is None or media_content_id == "library":
+        opts["pop_all"] = True
+    else:
+        opts["item_key"] = media_content_id
+
+    # _LOGGER.error(opts)
+    res1 = roon_server.roonapi.browse_browse(opts)
+    _LOGGER.error(res1)
+    result = roon_server.roonapi.browse_load(opts)
+    # _LOGGER.error(result)
+
+    for item in result["items"]:
+        _LOGGER.warn(item)
+        item = item_payload(roon_server, item)
+        if not (item is None):
+            library_info.children.append(item)
+
+    return library_info

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -469,41 +469,8 @@ class RoonDevice(MediaPlayerEntity):
             self._server.roonapi.queue_playlist(self.zone_id, media_id)
         elif media_type == "genre":
             self._server.roonapi.play_genre(self.zone_id, media_id)
-        elif media_type == "library":
-            _LOGGER.error(
-                "Playback requested: %s --> %s",
-                media_type,
-                media_id,
-            )
-            opts = {
-                "zone_or_output_id": self.zone_id,
-                "item_key": media_id,
-                "hierarchy": "browse",
-            }
-
-            old_level = 0
-            while True:
-                # For some ids the following will start playback
-                res1 = self._server.roonapi.browse_browse(opts)
-                if res1 is None:
-                    _LOGGER.error(
-                        "Playback requested of unsupported id: %s --> %s",
-                        media_type,
-                        media_id,
-                    )
-                    return
-
-                level = res1["list"]["level"]
-                _LOGGER.debug("Hierarchy old(%s)/new(%s)", old_level, level)
-                if level <= old_level:
-                    break
-                old_level = level
-                # Otherwise bounce down the left most path - when the level increases we've started playback!
-                result = self._server.roonapi.browse_load(opts)
-                first_item = result["items"][0]
-                _LOGGER.debug("Next command - %s)", first_item["title"])
-                play_item_id = first_item["item_key"]
-                opts["item_key"] = play_item_id
+        elif media_type == "library" or media_type == "track":
+            self._server.roonapi.play_id(self.zone_id, media_id)
         else:
             _LOGGER.error(
                 "Playback requested of unsupported type: %s --> %s",

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -3,6 +3,7 @@ import logging
 
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
+    SUPPORT_BROWSE_MEDIA,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
@@ -33,9 +34,11 @@ from homeassistant.util import convert
 from homeassistant.util.dt import utcnow
 
 from .const import DOMAIN
+from .media_browser import browse_media
 
 SUPPORT_ROON = (
-    SUPPORT_PAUSE
+    SUPPORT_BROWSE_MEDIA
+    | SUPPORT_PAUSE
     | SUPPORT_VOLUME_SET
     | SUPPORT_STOP
     | SUPPORT_PREVIOUS_TRACK
@@ -466,9 +469,54 @@ class RoonDevice(MediaPlayerEntity):
             self._server.roonapi.queue_playlist(self.zone_id, media_id)
         elif media_type == "genre":
             self._server.roonapi.play_genre(self.zone_id, media_id)
+        elif media_type == "library":
+            _LOGGER.error(
+                "Playback requested: %s --> %s",
+                media_type,
+                media_id,
+            )
+            opts = {
+                "zone_or_output_id": self.zone_id,
+                "item_key": media_id,
+                "hierarchy": "browse",
+            }
+
+            old_level = 0
+            while True:
+                # For some ids the following will start playback
+                res1 = self._server.roonapi.browse_browse(opts)
+                if res1 is None:
+                    _LOGGER.error(
+                        "Playback requested of unsupported id: %s --> %s",
+                        media_type,
+                        media_id,
+                    )
+                    return
+
+                level = res1["list"]["level"]
+                _LOGGER.debug("Hierarchy old(%s)/new(%s)", old_level, level)
+                if level <= old_level:
+                    break
+                old_level = level
+                # Otherwise bounce down the left most path - when the level increases we've started playback!
+                result = self._server.roonapi.browse_load(opts)
+                first_item = result["items"][0]
+                _LOGGER.debug("Next command - %s)", first_item["title"])
+                play_item_id = first_item["item_key"]
+                opts["item_key"] = play_item_id
         else:
             _LOGGER.error(
                 "Playback requested of unsupported type: %s --> %s",
                 media_type,
                 media_id,
             )
+
+    async def async_browse_media(self, media_content_type=None, media_content_id=None):
+        """Implement the websocket media browsing helper."""
+        return await self.hass.async_add_executor_job(
+            browse_media,
+            self.zone_id,
+            self._server,
+            media_content_type,
+            media_content_id,
+        )

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -469,7 +469,7 @@ class RoonDevice(MediaPlayerEntity):
             self._server.roonapi.queue_playlist(self.zone_id, media_id)
         elif media_type == "genre":
             self._server.roonapi.play_genre(self.zone_id, media_id)
-        elif media_type == "library" or media_type == "track":
+        elif media_type in ("library", "track"):
             self._server.roonapi.play_id(self.zone_id, media_id)
         else:
             _LOGGER.error(

--- a/homeassistant/components/roon/server.py
+++ b/homeassistant/components/roon/server.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 
-from roon import RoonApi
+from roonapi import RoonApi
 
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.helpers.dispatcher import async_dispatcher_send

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1948,7 +1948,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.22dev1
+roonapi==0.0.23
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1948,7 +1948,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.21
+roonapi==0.0.22dev1
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1950,7 +1950,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.22dev1
+roonapi==0.0.23
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1950,7 +1950,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.21
+roonapi==0.0.22dev1
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -932,7 +932,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.21
+roonapi==0.0.22dev1
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -928,7 +928,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.22dev1
+roonapi==0.0.23
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -932,7 +932,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.22dev1
+roonapi==0.0.23
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -928,7 +928,7 @@ rokuecp==0.6.0
 roombapy==1.6.1
 
 # homeassistant.components.roon
-roonapi==0.0.21
+roonapi==0.0.22dev1
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.0.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for the media browser to the roon media player.

The roon api provide quite a good browsing facility - so this works pretty well.

Only real limit is that this has a limit of 3000 items to return - a good additional enhancement would be to use the paging ability provided by roon, although ideally this would be via support from the `media_browser`

The other limit is that it isn't possible to tell while browsing what items are playable without making an additional roonapi call for every item, so this code just marks everything as playable - and catches the error when someone tries to play something that can't be played.

Example screen shots here:
![Screenshot 2020-10-18 at 22 44 14](https://user-images.githubusercontent.com/4487313/96386540-a4579500-1193-11eb-83f2-0c1cf56e9bbd.png)
![Screenshot 2020-10-18 at 22 44 22](https://user-images.githubusercontent.com/4487313/96386541-a6215880-1193-11eb-8edf-a102861a44eb.png)
![Screenshot 2020-10-18 at 22 44 31](https://user-images.githubusercontent.com/4487313/96386542-a7eb1c00-1193-11eb-9788-f0d3865a2701.png)
![Screenshot 2020-10-18 at 22 44 47](https://user-images.githubusercontent.com/4487313/96386543-a91c4900-1193-11eb-9424-0175bc1559ca.png)




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
