### PR TITLE
ElkM1 fix auto-configure.

### DIFF
--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -60,18 +60,9 @@ SERVICE_ALARM_CLEAR_BYPASS = "alarm_clear_bypass"
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the ElkM1 alarm platform."""
     elk_data = hass.data[DOMAIN][config_entry.entry_id]
-    entities = []
-
     elk = elk_data["elk"]
-    areas_with_keypad = set()
-    for keypad in elk.keypads:
-        areas_with_keypad.add(keypad.area)
-
-    areas = []
-    for area in elk.areas:
-        if area.index in areas_with_keypad or elk_data["auto_configure"] is False:
-            areas.append(area)
-    create_elk_entities(elk_data, areas, "area", ElkArea, entities)
+    entities = []
+    create_elk_entities(elk_data, elk.areas, "area", ElkArea, entities)
     async_add_entities(entities, True)
 
     platform = entity_platform.current_platform.get()

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -2,7 +2,7 @@
   "domain": "elkm1",
   "name": "Elk-M1 Control",
   "documentation": "https://www.home-assistant.io/integrations/elkm1",
-  "requirements": ["elkm1-lib==0.8.3"],
+  "requirements": ["elkm1-lib==0.8.4"],
   "codeowners": ["@gwww", "@bdraco"],
   "config_flow": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -541,7 +541,7 @@ elgato==0.2.0
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==0.8.3
+elkm1-lib==0.8.4
 
 # homeassistant.components.mobile_app
 emoji==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ eebrightbox==0.0.4
 elgato==0.2.0
 
 # homeassistant.components.elkm1
-elkm1-lib==0.8.3
+elkm1-lib==0.8.4
 
 # homeassistant.components.mobile_app
 emoji==0.5.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Auto-configure now only configures elements that have a name or description associated with them. The previous mechanism for automatically detecting if element are configured on the ElkM1 panel was to note any element that have attributes different than the elkm1-lib's defaults. This is error prone and made the library fragile when defaults change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The elkm1-lib autoconfigure sets the `configured` flag based on an attribute of the element being changed. This approach misses counters and thermostats. It also does not work well when an "unconfigured" element's default value is different from what is on the panel. This was the case for zones (the `area` attribute was different). This also made the base classes in the library fragile (harder to maintain).

The fix in the library is to mark an element as `configured` when the element has a name (description) associated with it. This change is technically breaking, although I imagine, few if any people will be affected as (1) they configure names on all elements (2) the functionality was not working properly, so element would not be missing.

The HA docs will be updated to add a section on auto-configure. It will describe that to have an element automatically configured then the element must be configured on the ElkM1 panel with a name.

This particular patch is for ElkM1 areas. The existing logic assumes that an area is configured if it has an associated keypad. Not all areas have keypads (I have an area only armable through HA). The library fix should catch all configured areas.

Link to change in elkm1-lib: https://github.com/gwww/elkm1/commit/b2b5e991ab5a04b8db1dcc0199ae2f072f9618ed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42021
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

Since document update PRs are behind, I propose that I submit one PR with all the ElkM1 changes over the last two weeks. I propose submitting the doc PR against the current branch as soon as 0.117 is released. Docs are written for the last two core PRs already (one submitted, one waiting as there's a conflict). Docs for this PR would be a new section, enhancing existing documents.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
