### PR TITLE
Fix event test

### DIFF
--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -12,6 +12,7 @@ ORIG_TZ = dt_util.DEFAULT_TIME_ZONE
 @pytest.fixture(autouse=True)
 def restore_ts():
     """Restore default TZ."""
+    yield
     dt_util.DEFAULT_TIME_ZONE = ORIG_TZ
 
 

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -1,8 +1,18 @@
 """The tests for time_date sensor platform."""
+import pytest
+
 import homeassistant.components.time_date.sensor as time_date
 import homeassistant.util.dt as dt_util
 
 from tests.async_mock import patch
+
+ORIG_TZ = dt_util.DEFAULT_TIME_ZONE
+
+
+@pytest.fixture(autouse=True)
+def restore_ts():
+    """Restore default TZ."""
+    dt_util.DEFAULT_TIME_ZONE = ORIG_TZ
 
 
 # pylint: disable=protected-access

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -2,6 +2,8 @@
 from contextlib import contextmanager
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.utility_meter.const import (
     ATTR_TARIFF,
@@ -21,6 +23,8 @@ import homeassistant.util.dt as dt_util
 
 from tests.async_mock import patch
 from tests.common import async_fire_time_changed
+
+pytestmark = pytest.mark.skip("Fails on CI")
 
 
 @contextmanager

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -2,8 +2,6 @@
 from contextlib import contextmanager
 from datetime import timedelta
 
-import pytest
-
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.utility_meter.const import (
     ATTR_TARIFF,
@@ -23,8 +21,6 @@ import homeassistant.util.dt as dt_util
 
 from tests.async_mock import patch
 from tests.common import async_fire_time_changed
-
-pytestmark = pytest.mark.skip("Fails on CI")
 
 
 @contextmanager

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1545,7 +1545,12 @@ async def test_track_template_rate_limit_suppress_listener(hass):
     await hass.async_block_till_done()
     info.async_refresh()
 
-    assert info.listeners == {"all": True, "domains": set(), "entities": set()}
+    assert info.listeners == {
+        "all": True,
+        "domains": set(),
+        "entities": set(),
+        "time": False,
+    }
     await hass.async_block_till_done()
 
     assert refresh_runs == [0]
@@ -1557,7 +1562,12 @@ async def test_track_template_rate_limit_suppress_listener(hass):
     hass.states.async_set("sensor.two", "any")
     await hass.async_block_till_done()
     # Should be suppressed during the rate limit
-    assert info.listeners == {"all": False, "domains": set(), "entities": set()}
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": set(),
+        "time": False,
+    }
     assert refresh_runs == [0, 1]
     next_time = dt_util.utcnow() + timedelta(seconds=0.125)
     with patch(
@@ -1566,7 +1576,12 @@ async def test_track_template_rate_limit_suppress_listener(hass):
         async_fire_time_changed(hass, next_time)
         await hass.async_block_till_done()
     # Rate limit released and the all listener returns
-    assert info.listeners == {"all": True, "domains": set(), "entities": set()}
+    assert info.listeners == {
+        "all": True,
+        "domains": set(),
+        "entities": set(),
+        "time": False,
+    }
     assert refresh_runs == [0, 1, 2]
     hass.states.async_set("sensor.three", "any")
     await hass.async_block_till_done()
@@ -1575,7 +1590,12 @@ async def test_track_template_rate_limit_suppress_listener(hass):
     await hass.async_block_till_done()
     assert refresh_runs == [0, 1, 2]
     # Rate limit hit and the all listener is shut off
-    assert info.listeners == {"all": False, "domains": set(), "entities": set()}
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": set(),
+        "time": False,
+    }
     next_time = dt_util.utcnow() + timedelta(seconds=0.125 * 2)
     with patch(
         "homeassistant.helpers.ratelimit.dt_util.utcnow", return_value=next_time
@@ -1583,12 +1603,22 @@ async def test_track_template_rate_limit_suppress_listener(hass):
         async_fire_time_changed(hass, next_time)
         await hass.async_block_till_done()
     # Rate limit released and the all listener returns
-    assert info.listeners == {"all": True, "domains": set(), "entities": set()}
+    assert info.listeners == {
+        "all": True,
+        "domains": set(),
+        "entities": set(),
+        "time": False,
+    }
     assert refresh_runs == [0, 1, 2, 4]
     hass.states.async_set("sensor.five", "any")
     await hass.async_block_till_done()
     # Rate limit hit and the all listener is shut off
-    assert info.listeners == {"all": False, "domains": set(), "entities": set()}
+    assert info.listeners == {
+        "all": False,
+        "domains": set(),
+        "entities": set(),
+        "time": False,
+    }
     assert refresh_runs == [0, 1, 2, 4]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We added an event test while the new time listeners in templates was created. That one needed some updating.

By merging more tests to use async, all of a sudden utility_meter started to fail. I can't currently figure it out, so opting to skip these tests for now. Created #42081 to fix it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
