### PR TITLE
Add Fordpass integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -286,6 +286,9 @@ omit =
     homeassistant/components/folder/sensor.py
     homeassistant/components/folder_watcher/*
     homeassistant/components/foobot/sensor.py
+    homeassistant/components/fordpass/__init__.py
+    homeassistant/components/fordpass/const.py
+    homeassistant/components/fordpass/lock.py
     homeassistant/components/fortios/device_tracker.py
     homeassistant/components/foscam/camera.py
     homeassistant/components/foscam/const.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -142,6 +142,7 @@ homeassistant/components/flo/* @dmulcahey
 homeassistant/components/flock/* @fabaff
 homeassistant/components/flume/* @ChrisMandich @bdraco
 homeassistant/components/flunearyou/* @bachya
+homeassistant/components/fordpass/* @clarkd
 homeassistant/components/forked_daapd/* @uvjustin
 homeassistant/components/fortios/* @kimfrellsen
 homeassistant/components/foscam/* @skgsergio

--- a/homeassistant/components/fordpass/__init__.py
+++ b/homeassistant/components/fordpass/__init__.py
@@ -1,0 +1,139 @@
+"""The FordPass integration."""
+import asyncio
+from datetime import timedelta
+import logging
+
+import async_timeout
+from dotted.collection import DottedDict
+from fordpass import Vehicle
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+from .const import DOMAIN, MANUFACTURER, VEHICLE, VIN
+
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+
+PLATFORMS = ["lock"]
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=300)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the FordPass component."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up FordPass from a config entry."""
+    user = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+    vin = entry.data[VIN]
+
+    coordinator = FordPassDataUpdateCoordinator(hass, user, password, vin)
+
+    await coordinator.async_refresh()  # Get initial data
+
+    if not coordinator.last_update_success:
+        raise ConfigEntryNotReady
+
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+class FordPassDataUpdateCoordinator(DataUpdateCoordinator):
+    """DataUpdateCoordinator to handle fetching new data about the vehicle."""
+
+    def __init__(self, hass, user, password, vin):
+        """Initialize the coordinator and set up the Vehicle object."""
+        self._hass = hass
+        self.vin = vin
+        self.vehicle = Vehicle(user, password, vin)
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+
+    async def _async_update_data(self):
+        """Fetch data from FordPass."""
+
+        try:
+            async with async_timeout.timeout(30):
+                data = await self._hass.async_add_executor_job(
+                    self.vehicle.status  # Fetch new status
+                )
+                return DottedDict(data)
+        except Exception as ex:
+            raise UpdateFailed(
+                f"Error communicating with FordPass for {self.vin}"
+            ) from ex
+
+
+class FordPassEntity(CoordinatorEntity):
+    """Defines a base FordPass entity."""
+
+    def __init__(
+        self, *, device_id: str, name: str, coordinator: FordPassDataUpdateCoordinator
+    ):
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the entity."""
+        return f"{self.coordinator.vin}-{self._device_id}"
+
+    @property
+    def device_info(self):
+        """Return device information about this device."""
+        if self._device_id is None:
+            return None
+
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.vin)},
+            "name": f"{VEHICLE} ({self.coordinator.vin})",
+            "manufacturer": MANUFACTURER,
+        }

--- a/homeassistant/components/fordpass/__init__.py
+++ b/homeassistant/components/fordpass/__init__.py
@@ -92,7 +92,6 @@ class FordPassDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Fetch data from FordPass."""
-
         try:
             async with async_timeout.timeout(30):
                 data = await self._hass.async_add_executor_job(

--- a/homeassistant/components/fordpass/__init__.py
+++ b/homeassistant/components/fordpass/__init__.py
@@ -101,13 +101,13 @@ class FordPassDataUpdateCoordinator(DataUpdateCoordinator):
 
                 # If data has now been fetched but was previously unavailable, log and reset
                 if not self._available:
-                    _LOGGER.info(f"Restored connection to FordPass for {self.vin}")
+                    _LOGGER.info("Restored connection to FordPass for %s", self.vin)
                     self._available = True
 
                 return DottedDict(data)
         except Exception as ex:
             self._available = False  # Mark as unavailable
-            _LOGGER.warning(f"Error communicating with FordPass for {self.vin}")
+            _LOGGER.warning("Error communicating with FordPass for %s", self.vin)
             raise UpdateFailed(
                 f"Error communicating with FordPass for {self.vin}"
             ) from ex

--- a/homeassistant/components/fordpass/config_flow.py
+++ b/homeassistant/components/fordpass/config_flow.py
@@ -30,11 +30,12 @@ async def validate_input(hass: core.HomeAssistant, data):
     try:
         result = await hass.async_add_executor_job(vehicle.auth)
 
-        if not result:
-            _LOGGER.error("Failed to authenticate with fordpass")
-            raise CannotConnect
     except Exception as ex:
         raise InvalidAuth from ex
+
+    if not result:
+        _LOGGER.error("Failed to authenticate with fordpass")
+        raise CannotConnect
 
     # Return info that you want to store in the config entry.
     return {"title": f"Vehicle ({data[VIN]})"}
@@ -52,9 +53,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 info = await validate_input(self.hass, user_input)
-
                 return self.async_create_entry(title=info["title"], data=user_input)
             except CannotConnect:
+                print("EXCEPT")
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"

--- a/homeassistant/components/fordpass/config_flow.py
+++ b/homeassistant/components/fordpass/config_flow.py
@@ -13,9 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_USERNAME): vol.All(str, vol.Email),
         vol.Required(CONF_PASSWORD): str,
-        vol.Required(VIN): str,
+        vol.Required(VIN): vol.All(str, vol.Length(min=17, max=17)),
     }
 )
 

--- a/homeassistant/components/fordpass/config_flow.py
+++ b/homeassistant/components/fordpass/config_flow.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): vol.All(str, vol.Email),
+        vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Required(VIN): vol.All(str, vol.Length(min=17, max=17)),
     }

--- a/homeassistant/components/fordpass/config_flow.py
+++ b/homeassistant/components/fordpass/config_flow.py
@@ -1,0 +1,75 @@
+"""Config flow for FordPass integration."""
+import logging
+
+from fordpass import Vehicle
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from .const import DOMAIN, VIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(VIN): str,
+    }
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    vehicle = Vehicle(data[CONF_USERNAME], data[CONF_PASSWORD], data[VIN])
+
+    try:
+        result = await hass.async_add_executor_job(vehicle.auth)
+
+        if not result:
+            _LOGGER.error("Failed to authenticate with fordpass")
+            raise CannotConnect
+    except Exception as ex:
+        raise InvalidAuth from ex
+
+    # Return info that you want to store in the config entry.
+    return {"title": f"Vehicle ({data[VIN]})"}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for FordPass."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/fordpass/const.py
+++ b/homeassistant/components/fordpass/const.py
@@ -1,0 +1,9 @@
+"""Constants for the FordPass integration."""
+
+DOMAIN = "fordpass"
+
+VIN = "vin"
+
+MANUFACTURER = "Ford Motor Company"
+
+VEHICLE = "Ford Vehicle"

--- a/homeassistant/components/fordpass/lock.py
+++ b/homeassistant/components/fordpass/lock.py
@@ -24,17 +24,17 @@ class Lock(FordPassEntity, LockEntity):
         """Initialize."""
         super().__init__(device_id="lock", name="Lock", coordinator=coordinator)
 
-    async def async_lock(self):
+    async def async_lock(self, **kwargs):
         """Locks the vehicle."""
-        _LOGGER.info(f"Locking {self.coordinator.vin}")
+        _LOGGER.debug("Locking %s", self.coordinator.vin)
         await self.coordinator.hass.async_add_executor_job(
             self.coordinator.vehicle.lock
         )
         await self.coordinator.async_request_refresh()
 
-    async def async_unlock(self):
+    async def async_unlock(self, **kwargs):
         """Unlocks the vehicle."""
-        _LOGGER.info(f"Unlocking {self.coordinator.vin}")
+        _LOGGER.debug("Unlocking %s", self.coordinator.vin)
         await self.coordinator.hass.async_add_executor_job(
             self.coordinator.vehicle.unlock
         )

--- a/homeassistant/components/fordpass/lock.py
+++ b/homeassistant/components/fordpass/lock.py
@@ -1,0 +1,48 @@
+"""Represents the primary lock of the vehicle."""
+import logging
+
+from homeassistant.components.lock import LockEntity
+
+from . import FordPassEntity
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Add the lock from the config."""
+    entry = hass.data[DOMAIN][config_entry.entry_id]
+
+    locks = [Lock(entry)]
+    async_add_entities(locks, False)
+
+
+class Lock(FordPassEntity, LockEntity):
+    """Defines the vehicle's lock."""
+
+    def __init__(self, coordinator):
+        """Initialize."""
+        super().__init__(device_id="lock", name="Lock", coordinator=coordinator)
+
+    async def async_lock(self):
+        """Locks the vehicle."""
+        _LOGGER.info(f"Locking {self.coordinator.vin}")
+        await self.coordinator.hass.async_add_executor_job(
+            self.coordinator.vehicle.lock
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_unlock(self):
+        """Unlocks the vehicle."""
+        _LOGGER.info(f"Unlocking {self.coordinator.vin}")
+        await self.coordinator.hass.async_add_executor_job(
+            self.coordinator.vehicle.unlock
+        )
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def is_locked(self):
+        """Determine if the lock is locked."""
+        if self.coordinator.data is None or self.coordinator.data["lockStatus"] is None:
+            return None
+        return self.coordinator.data["lockStatus"]["value"] == "LOCKED"

--- a/homeassistant/components/fordpass/manifest.json
+++ b/homeassistant/components/fordpass/manifest.json
@@ -9,5 +9,6 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "codeowners": ["@clarkd"]
+  "codeowners": ["@clarkd"],
+  "quality_scale": "silver"
 }

--- a/homeassistant/components/fordpass/manifest.json
+++ b/homeassistant/components/fordpass/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "fordpass",
+  "name": "FordPass",
+  "config_flow": true,
+  "documentation": "https://github.com/clarkd/fordpass-homeassistant",
+  "issue_tracker": "https://github.com/clarkd/fordpass-homeassistant/issues",
+  "requirements": ["fordpass==0.0.4", "dotted==0.1.8"],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": ["@clarkd"]
+}

--- a/homeassistant/components/fordpass/strings.json
+++ b/homeassistant/components/fordpass/strings.json
@@ -1,0 +1,22 @@
+{
+  "title": "FordPass",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "vin": "VIN",
+          "username": "FordPass Username (Email)",
+          "password": "FordPass Password"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Could not connect to FordPass, please try again.",
+      "invalid_auth": "Authentication failed to FordPass, please check your credentials and try again.",
+      "unknown": "An unknown error occured."
+    },
+    "abort": {
+      "already_configured": "This vehicle is already configured."
+    }
+  }
+}

--- a/homeassistant/components/fordpass/strings.json
+++ b/homeassistant/components/fordpass/strings.json
@@ -11,12 +11,12 @@
       }
     },
     "error": {
-      "cannot_connect": "Could not connect to FordPass, please try again.",
-      "invalid_auth": "Authentication failed to FordPass, please check your credentials and try again.",
-      "unknown": "An unknown error occured."
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "This vehicle is already configured."
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   }
 }

--- a/homeassistant/components/fordpass/translations/en.json
+++ b/homeassistant/components/fordpass/translations/en.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "This vehicle is already configured"
+        },
+        "error": {
+            "cannot_connect": "Could not connect to FordPass",
+            "invalid_auth": "Authentication failed to FordPass",
+            "unknown": "An unknown error occured"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "password": "FordPass Password",
+                    "username": "FordPass Username (Email)",
+                    "vin": "VIN"
+                }
+            }
+        }
+    },
+    "title": "FordPass"
+}

--- a/homeassistant/components/fordpass/translations/en.json
+++ b/homeassistant/components/fordpass/translations/en.json
@@ -1,12 +1,12 @@
 {
     "config": {
         "abort": {
-            "already_configured": "This vehicle is already configured"
+            "already_configured": "Account is already configured"
         },
         "error": {
-            "cannot_connect": "Could not connect to FordPass",
-            "invalid_auth": "Authentication failed to FordPass",
-            "unknown": "An unknown error occured"
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
         },
         "step": {
             "user": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -59,6 +59,7 @@ FLOWS = [
     "flo",
     "flume",
     "flunearyou",
+    "fordpass",
     "forked_daapd",
     "freebox",
     "fritzbox",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -501,6 +501,9 @@ dlipower==0.7.165
 # homeassistant.components.doorbird
 doorbirdpy==2.1.0
 
+# homeassistant.components.fordpass
+dotted==0.1.8
+
 # homeassistant.components.dovado
 dovado==0.4.1
 
@@ -606,6 +609,9 @@ fnvhash==0.1.0
 
 # homeassistant.components.foobot
 foobot_async==0.3.2
+
+# homeassistant.components.fordpass
+fordpass==0.0.4
 
 # homeassistant.components.fortios
 fortiosapi==0.10.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -265,6 +265,9 @@ distro==1.5.0
 # homeassistant.components.doorbird
 doorbirdpy==2.1.0
 
+# homeassistant.components.fordpass
+dotted==0.1.8
+
 # homeassistant.components.dsmr
 dsmr_parser==0.18
 
@@ -300,6 +303,9 @@ fnvhash==0.1.0
 
 # homeassistant.components.foobot
 foobot_async==0.3.2
+
+# homeassistant.components.fordpass
+fordpass==0.0.4
 
 # homeassistant.components.google_translate
 gTTS-token==1.1.3

--- a/tests/components/fordpass/__init__.py
+++ b/tests/components/fordpass/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for the Fordpass integration."""
+"""Tests for the FordPass integration."""

--- a/tests/components/fordpass/__init__.py
+++ b/tests/components/fordpass/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Fordpass integration."""

--- a/tests/components/fordpass/test_config_flow.py
+++ b/tests/components/fordpass/test_config_flow.py
@@ -24,16 +24,16 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "vin": "WX123456789",
+                "vin": "WX123456789101112",
                 "username": "test-username",
                 "password": "test-password",
             },
         )
 
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "Vehicle (WX123456789)"
+    assert result2["title"] == "Vehicle (WX123456789101112)"
     assert result2["data"] == {
-        "vin": "WX123456789",
+        "vin": "WX123456789101112",
         "username": "test-username",
         "password": "test-password",
     }
@@ -55,7 +55,7 @@ async def test_form_invalid_auth(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "vin": "WX123456789",
+                "vin": "WX123456789101112",
                 "username": "test-username",
                 "password": "test-password",
             },
@@ -78,7 +78,7 @@ async def test_form_cannot_connect(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "vin": "WX123456789",
+                "vin": "WX123456789101112",
                 "username": "test-username",
                 "password": "test-password",
             },
@@ -101,7 +101,7 @@ async def test_form_unknown_exception(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "vin": "WX123456789",
+                "vin": "WX123456789101112",
                 "username": "test-username",
                 "password": "test-password",
             },

--- a/tests/components/fordpass/test_config_flow.py
+++ b/tests/components/fordpass/test_config_flow.py
@@ -1,0 +1,91 @@
+"""Test the fordpass config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.fordpass.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.fordpass.const import DOMAIN
+
+from tests.async_mock import patch
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.fordpass.config_flow.fordpass.authenticate",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.fordpass.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.fordpass.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "vin": "WX123456789",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Vehicle (WX123456789)"
+    assert result2["data"] == {
+        "vin": "WX123456789",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.fordpass.config_flow.fordpass.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "vin": "WX123456789",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.fordpass.config_flow.fordpass.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "vin": "WX123456789",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/fordpass/test_config_flow.py
+++ b/tests/components/fordpass/test_config_flow.py
@@ -86,3 +86,26 @@ async def test_form_cannot_connect(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_unknown_exception(hass):
+    """Test we handle unknown exceptions."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.fordpass.config_flow.validate_input",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "vin": "WX123456789",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "unknown"}

--- a/tests/components/fordpass/test_config_flow.py
+++ b/tests/components/fordpass/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the fordpass config flow."""
 from homeassistant import config_entries, setup
-from homeassistant.components.fordpass.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.fordpass.config_flow import InvalidAuth
 from homeassistant.components.fordpass.const import DOMAIN
 
 from tests.async_mock import patch
@@ -15,10 +15,7 @@ async def test_form(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.fordpass.config_flow.fordpass.authenticate",
-        return_value=True,
-    ), patch(
+    with patch("fordpass.Vehicle.auth", return_value=True,), patch(
         "homeassistant.components.fordpass.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.fordpass.async_setup_entry",
@@ -52,7 +49,7 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "homeassistant.components.fordpass.config_flow.fordpass.authenticate",
+        "fordpass.Vehicle.auth",
         side_effect=InvalidAuth,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -75,8 +72,8 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "homeassistant.components.fordpass.config_flow.fordpass.authenticate",
-        side_effect=CannotConnect,
+        "fordpass.Vehicle.auth",
+        return_value=False,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a basic new integration for FordPass. FordPass is Ford's offering for a connected vehicle API/app. This basic integration allows the user to add a vehicle via a config flow and the integration sets up a single entity: the lock. This allows the vehicle to be locked/unlocked remotely.

This uses a Python library (published to PyPi), [fordpass](https://pypi.org/project/fordpass/), I created that interacts with the FordPass API.

The integration uses a DataUpdateCoordinator as a single request via the API returns a lot of information that we can later create many sensors etc. for.

I'm creating this PR now as a means to get early feedback before I go on to add further features, e.g. binary_sensors for doors, windows, sensors for fuel level etc.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
    - https://github.com/home-assistant/home-assistant.io/pull/15317
    - https://github.com/home-assistant/brands/pull/1950
- See more: https://www.ford.co.uk/owner/owner-services/fordpass

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [X] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
