### PR TITLE
Convert nx584 tests to pytest

### DIFF
--- a/tests/components/nx584/test_binary_sensor.py
+++ b/tests/components/nx584/test_binary_sensor.py
@@ -37,16 +37,12 @@ def client(fake_zones):
     Yields:
         MagicMock: Client Mock
     """
-    _mock_client = mock.patch.object(nx584_client, "Client")
-    _mock_client.start()
+    with mock.patch.object(nx584_client, "Client") as _mock_client:
+        client = nx584_client.Client.return_value
+        client.list_zones.return_value = fake_zones
+        client.get_version.return_value = "1.1"
 
-    client = nx584_client.Client.return_value
-    client.list_zones.return_value = fake_zones
-    client.get_version.return_value = "1.1"
-
-    yield _mock_client
-
-    _mock_client.stop()
+        yield _mock_client
 
 
 @pytest.mark.usefixtures("client")


### PR DESCRIPTION
## Proposed change
Updates the tests for the nx584 functionality to use pytest style tests.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes #40873
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.