### PR TITLE
Support reloading Tasmota config entries

### DIFF
--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -1,4 +1,5 @@
 """The Tasmota integration."""
+import asyncio
 import logging
 
 from hatasmota.const import (
@@ -22,7 +23,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import discovery
-from .const import CONF_DISCOVERY_PREFIX
+from .const import CONF_DISCOVERY_PREFIX, DATA_REMOVE_DISCOVER_COMPONENT, PLATFORMS
 from .discovery import TASMOTA_DISCOVERY_DEVICE
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,14 +55,56 @@ async def async_setup_entry(hass, entry):
 
     tasmota_mqtt = TasmotaMQTTClient(_publish, _subscribe_topics, _unsubscribe_topics)
 
-    discovery_prefix = entry.data[CONF_DISCOVERY_PREFIX]
-    await discovery.async_start(hass, discovery_prefix, entry, tasmota_mqtt)
-
     async def async_discover_device(config, mac):
         """Discover and add a Tasmota device."""
         await async_setup_device(hass, mac, config, entry, tasmota_mqtt)
 
-    async_dispatcher_connect(hass, TASMOTA_DISCOVERY_DEVICE, async_discover_device)
+    hass.data[
+        DATA_REMOVE_DISCOVER_COMPONENT.format("device")
+    ] = async_dispatcher_connect(hass, TASMOTA_DISCOVERY_DEVICE, async_discover_device)
+
+    async def start_platforms():
+        # Local import to avoid circular dependencies
+        # pylint: disable=import-outside-toplevel
+        from . import device_automation
+
+        await device_automation.async_setup_entry(hass, entry)
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_setup(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+
+        discovery_prefix = entry.data[CONF_DISCOVERY_PREFIX]
+        await discovery.async_start(hass, discovery_prefix, entry, tasmota_mqtt)
+
+    hass.async_create_task(start_platforms())
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+
+    # cleanup platforms
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if not unload_ok:
+        return False
+
+    # disable discovery
+    await discovery.async_stop(hass)
+    hass.data.pop(DEVICE_MACS)
+    hass.data[DATA_REMOVE_DISCOVER_COMPONENT.format("device")]()
+    hass.data.pop(DATA_REMOVE_DISCOVER_COMPONENT.format("device_automation"))()
+    for component in PLATFORMS:
+        hass.data.pop(DATA_REMOVE_DISCOVER_COMPONENT.format(component))()
 
     return True
 

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import discovery
+from . import device_automation, discovery
 from .const import CONF_DISCOVERY_PREFIX, DATA_REMOVE_DISCOVER_COMPONENT, PLATFORMS
 from .discovery import TASMOTA_DISCOVERY_DEVICE
 
@@ -64,10 +64,6 @@ async def async_setup_entry(hass, entry):
     ] = async_dispatcher_connect(hass, TASMOTA_DISCOVERY_DEVICE, async_discover_device)
 
     async def start_platforms():
-        # Local import to avoid circular dependencies
-        # pylint: disable=import-outside-toplevel
-        from . import device_automation
-
         await device_automation.async_setup_entry(hass, entry)
         await asyncio.gather(
             *[

--- a/homeassistant/components/tasmota/binary_sensor.py
+++ b/homeassistant/components/tasmota/binary_sensor.py
@@ -6,7 +6,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.helpers.event as evt
 
-from .const import DOMAIN as TASMOTA_DOMAIN
+from .const import DATA_REMOVE_DISCOVER_COMPONENT, DOMAIN as TASMOTA_DOMAIN
 from .discovery import TASMOTA_DISCOVERY_ENTITY_NEW
 from .mixins import TasmotaAvailability, TasmotaDiscoveryUpdate
 
@@ -25,7 +25,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             ]
         )
 
-    async_dispatcher_connect(
+    hass.data[
+        DATA_REMOVE_DISCOVER_COMPONENT.format(binary_sensor.DOMAIN)
+    ] = async_dispatcher_connect(
         hass,
         TASMOTA_DISCOVERY_ENTITY_NEW.format(binary_sensor.DOMAIN, TASMOTA_DOMAIN),
         async_discover,

--- a/homeassistant/components/tasmota/const.py
+++ b/homeassistant/components/tasmota/const.py
@@ -1,8 +1,17 @@
 """Constants used by multiple Tasmota modules."""
 CONF_DISCOVERY_PREFIX = "discovery_prefix"
 
+DATA_REMOVE_DISCOVER_COMPONENT = "tasmota_discover_{}"
+
 DEFAULT_PREFIX = "tasmota/discovery"
 
 DOMAIN = "tasmota"
+
+PLATFORMS = [
+    "binary_sensor",
+    "light",
+    "sensor",
+    "switch",
+]
 
 TASMOTA_EVENT = "tasmota_event"

--- a/homeassistant/components/tasmota/device_automation.py
+++ b/homeassistant/components/tasmota/device_automation.py
@@ -6,6 +6,7 @@ from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import device_trigger
+from .const import DATA_REMOVE_DISCOVER_COMPONENT
 from .discovery import TASMOTA_DISCOVERY_ENTITY_NEW
 
 
@@ -25,7 +26,9 @@ async def async_setup_entry(hass, config_entry):
                 hass, tasmota_automation, config_entry, discovery_hash
             )
 
-    async_dispatcher_connect(
+    hass.data[
+        DATA_REMOVE_DISCOVER_COMPONENT.format("device_automation")
+    ] = async_dispatcher_connect(
         hass,
         TASMOTA_DISCOVERY_ENTITY_NEW.format("device_automation", "tasmota"),
         async_discover,

--- a/homeassistant/components/tasmota/light.py
+++ b/homeassistant/components/tasmota/light.py
@@ -27,7 +27,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.util.color as color_util
 
-from .const import DOMAIN as TASMOTA_DOMAIN
+from .const import DATA_REMOVE_DISCOVER_COMPONENT, DOMAIN as TASMOTA_DOMAIN
 from .discovery import TASMOTA_DISCOVERY_ENTITY_NEW
 from .mixins import TasmotaAvailability, TasmotaDiscoveryUpdate
 
@@ -45,7 +45,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             [TasmotaLight(tasmota_entity=tasmota_entity, discovery_hash=discovery_hash)]
         )
 
-    async_dispatcher_connect(
+    hass.data[
+        DATA_REMOVE_DISCOVER_COMPONENT.format(light.DOMAIN)
+    ] = async_dispatcher_connect(
         hass,
         TASMOTA_DISCOVERY_ENTITY_NEW.format(light.DOMAIN, TASMOTA_DOMAIN),
         async_discover,

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.0.19"],
+  "requirements": ["hatasmota==0.0.20"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/tasmota/mixins.py
+++ b/homeassistant/components/tasmota/mixins.py
@@ -153,6 +153,12 @@ class TasmotaDiscoveryUpdate(TasmotaEntity):
             )
         )
 
+    @callback
+    def add_to_platform_abort(self) -> None:
+        """Abort adding an entity to a platform."""
+        clear_discovery_hash(self.hass, self._discovery_hash)
+        super().add_to_platform_abort()
+
     async def async_will_remove_from_hass(self) -> None:
         """Stop listening to signal and cleanup discovery data.."""
         if not self._removed_from_hass:

--- a/homeassistant/components/tasmota/sensor.py
+++ b/homeassistant/components/tasmota/sensor.py
@@ -58,7 +58,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from .const import DOMAIN as TASMOTA_DOMAIN
+from .const import DATA_REMOVE_DISCOVER_COMPONENT, DOMAIN as TASMOTA_DOMAIN
 from .discovery import TASMOTA_DISCOVERY_ENTITY_NEW
 from .mixins import TasmotaAvailability, TasmotaDiscoveryUpdate
 
@@ -123,7 +123,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             ]
         )
 
-    async_dispatcher_connect(
+    hass.data[
+        DATA_REMOVE_DISCOVER_COMPONENT.format(sensor.DOMAIN)
+    ] = async_dispatcher_connect(
         hass,
         TASMOTA_DISCOVERY_ENTITY_NEW.format(sensor.DOMAIN, TASMOTA_DOMAIN),
         async_discover_sensor,

--- a/homeassistant/components/tasmota/switch.py
+++ b/homeassistant/components/tasmota/switch.py
@@ -5,7 +5,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN as TASMOTA_DOMAIN
+from .const import DATA_REMOVE_DISCOVER_COMPONENT, DOMAIN as TASMOTA_DOMAIN
 from .discovery import TASMOTA_DISCOVERY_ENTITY_NEW
 from .mixins import TasmotaAvailability, TasmotaDiscoveryUpdate
 
@@ -24,7 +24,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             ]
         )
 
-    async_dispatcher_connect(
+    hass.data[
+        DATA_REMOVE_DISCOVER_COMPONENT.format(switch.DOMAIN)
+    ] = async_dispatcher_connect(
         hass,
         TASMOTA_DISCOVERY_ENTITY_NEW.format(switch.DOMAIN, TASMOTA_DOMAIN),
         async_discover,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -729,7 +729,7 @@ hass-nabucasa==0.37.1
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.0.19
+hatasmota==0.0.20
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -364,7 +364,7 @@ hangups==0.4.11
 hass-nabucasa==0.37.1
 
 # homeassistant.components.tasmota
-hatasmota==0.0.19
+hatasmota==0.0.20
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.5

--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -72,6 +72,7 @@ async def setup_tasmota_helper(hass):
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert "tasmota" in hass.config.components
 

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -27,40 +27,41 @@ async def test_valid_discovery_message(hass, mqtt_mock, caplog):
     config = copy.deepcopy(DEFAULT_CONFIG)
 
     with patch(
-        "homeassistant.components.tasmota.discovery.tasmota_has_entities_with_platform"
-    ) as mock_tasmota_has_entities:
+        "homeassistant.components.tasmota.discovery.tasmota_get_device_config",
+        return_value={},
+    ) as mock_tasmota_get_device_config:
         await setup_tasmota_helper(hass)
 
         async_fire_mqtt_message(
             hass, f"{DEFAULT_PREFIX}/00000049A3BC/config", json.dumps(config)
         )
         await hass.async_block_till_done()
-        assert mock_tasmota_has_entities.called
+        assert mock_tasmota_get_device_config.called
 
 
 async def test_invalid_topic(hass, mqtt_mock):
     """Test receiving discovery message on wrong topic."""
     with patch(
-        "homeassistant.components.tasmota.discovery.tasmota_has_entities_with_platform"
-    ) as mock_tasmota_has_entities:
+        "homeassistant.components.tasmota.discovery.tasmota_get_device_config"
+    ) as mock_tasmota_get_device_config:
         await setup_tasmota_helper(hass)
 
         async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/123456/configuration", "{}")
         await hass.async_block_till_done()
-        assert not mock_tasmota_has_entities.called
+        assert not mock_tasmota_get_device_config.called
 
 
 async def test_invalid_message(hass, mqtt_mock, caplog):
     """Test receiving an invalid message."""
     with patch(
-        "homeassistant.components.tasmota.discovery.tasmota_has_entities_with_platform"
-    ) as mock_tasmota_has_entities:
+        "homeassistant.components.tasmota.discovery.tasmota_get_device_config"
+    ) as mock_tasmota_get_device_config:
         await setup_tasmota_helper(hass)
 
         async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/123456/config", "asd")
         await hass.async_block_till_done()
         assert "Invalid discovery message" in caplog.text
-        assert not mock_tasmota_has_entities.called
+        assert not mock_tasmota_get_device_config.called
 
 
 async def test_invalid_mac(hass, mqtt_mock, caplog):
@@ -68,8 +69,8 @@ async def test_invalid_mac(hass, mqtt_mock, caplog):
     config = copy.deepcopy(DEFAULT_CONFIG)
 
     with patch(
-        "homeassistant.components.tasmota.discovery.tasmota_has_entities_with_platform"
-    ) as mock_tasmota_has_entities:
+        "homeassistant.components.tasmota.discovery.tasmota_get_device_config"
+    ) as mock_tasmota_get_device_config:
         await setup_tasmota_helper(hass)
 
         async_fire_mqtt_message(
@@ -77,7 +78,7 @@ async def test_invalid_mac(hass, mqtt_mock, caplog):
         )
         await hass.async_block_till_done()
         assert "MAC mismatch" in caplog.text
-        assert not mock_tasmota_has_entities.called
+        assert not mock_tasmota_get_device_config.called
 
 
 async def test_correct_config_discovery(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support reloading a Tasmota config entry

The main driver is to allow enabling and disabling entities without restarting Home Assistant.
Also bump HATasmota from 0.0.19 to 0.0.20, which adds support to stop discovery, in order to enable reloading.

HATasmota changes:
https://github.com/emontnemery/hatasmota/compare/0.0.19...0.0.20

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
