### PR TITLE
Bump PAHO MQTT to 1.5.1

### DIFF
--- a/homeassistant/components/mqtt/manifest.json
+++ b/homeassistant/components/mqtt/manifest.json
@@ -3,7 +3,7 @@
   "name": "MQTT",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mqtt",
-  "requirements": ["paho-mqtt==1.5.0"],
+  "requirements": ["paho-mqtt==1.5.1"],
   "dependencies": ["http"],
   "codeowners": ["@home-assistant/core", "@emontnemery"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -18,7 +18,7 @@ httpx==0.16.1
 importlib-metadata==1.6.0;python_version<'3.8'
 jinja2>=2.11.2
 netdisco==2.8.2
-paho-mqtt==1.5.0
+paho-mqtt==1.5.1
 pillow==7.2.0
 pip>=8.0.3
 python-slugify==4.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1061,8 +1061,6 @@ orvibo==1.1.1
 ovoenergy==1.1.7
 
 # homeassistant.components.mqtt
-paho-mqtt==1.5.0
-
 # homeassistant.components.shiftr
 paho-mqtt==1.5.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -505,7 +505,8 @@ openerz-api==0.1.0
 ovoenergy==1.1.7
 
 # homeassistant.components.mqtt
-paho-mqtt==1.5.0
+# homeassistant.components.shiftr
+paho-mqtt==1.5.1
 
 # homeassistant.components.panasonic_viera
 panasonic_viera==0.3.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrades `paho-mqtt` to 1.5.1.
Suggest to hold this until after 0.117 beta is cut since there were issues reported when this was bumped last time: #41423

Changelog:

- Exceptions that occur in callbacks are no longer suppressed by default. They
  can optionally be suppressed by setting `client.suppress_exceptions = True`.
- Fix PUBREL remaining length of > 2 not being accepted for MQTT v5 message
  flows.
- Fix MQTT v5 properties not being sent on retried or queued messages.
- Fix errors related to detection of MQTT v5 first connections.
- Fix for changes related to Python 3.9.

(source: <https://github.com/eclipse/paho.mqtt.python/blob/master/ChangeLog.txt>)
Full compare view: <https://github.com/eclipse/paho.mqtt.python/compare/v1.5.0...v1.5.1>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
