### PR TITLE
Add config flow to avea and remove yaml configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -66,6 +66,8 @@ omit =
     homeassistant/components/aten_pe/*
     homeassistant/components/atome/*
     homeassistant/components/aurora_abb_powerone/sensor.py
+    homeassistant/components/avea/__init__.py
+    homeassistant/components/avea/const.py
     homeassistant/components/avea/light.py
     homeassistant/components/avion/light.py
     homeassistant/components/avri/const.py

--- a/homeassistant/components/avea/__init__.py
+++ b/homeassistant/components/avea/__init__.py
@@ -4,8 +4,6 @@ import asyncio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-
 PLATFORMS = ["light"]
 
 
@@ -34,7 +32,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             ]
         )
     )
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/avea/__init__.py
+++ b/homeassistant/components/avea/__init__.py
@@ -1,1 +1,40 @@
-"""The avea component."""
+"""The avea integration."""
+import asyncio
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+PLATFORMS = ["light"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Avea component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Avea from a config entry."""
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/avea/config_flow.py
+++ b/homeassistant/components/avea/config_flow.py
@@ -1,0 +1,18 @@
+"""Config flow for Avea."""
+import avea
+
+from homeassistant import config_entries
+from homeassistant.helpers import config_entry_flow
+
+from .const import DOMAIN
+
+
+async def _async_has_devices(hass) -> bool:
+    """Return if there are devices that can be discovered."""
+    devices = await hass.async_add_executor_job(avea.discover_avea_bulbs)
+    return len(devices) > 0
+
+
+config_entry_flow.register_discovery_flow(
+    DOMAIN, "Avea", _async_has_devices, config_entries.CONN_CLASS_LOCAL_POLL
+)

--- a/homeassistant/components/avea/const.py
+++ b/homeassistant/components/avea/const.py
@@ -1,0 +1,3 @@
+"""Const for Avea."""
+
+DOMAIN = "avea"

--- a/homeassistant/components/avea/light.py
+++ b/homeassistant/components/avea/light.py
@@ -1,46 +1,89 @@
 """Support for the Elgato Avea lights."""
-import avea  # pylint: disable=import-error
+import logging
+
+import avea
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
-    LightEntity,
+    Light,
 )
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.device_registry as dr
 import homeassistant.util.color as color_util
+
+from .const import DOMAIN as AVEA_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 SUPPORT_AVEA = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Avea platform."""
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Avea Light from a config entry."""
+    lights = await hass.async_add_executor_job(discovery, hass)
+    entities = []
+
+    for light in lights:
+        entities.append(AveaLight(light))
+
+    async_add_entities(entities, True)
+
+
+def discovery(hass):
+    """Scan for Avea lightbulbs."""
+    lights = []
     try:
         nearby_bulbs = avea.discover_avea_bulbs()
         for bulb in nearby_bulbs:
             bulb.get_name()
             bulb.get_brightness()
+            if bulb.name != "Unknown":
+                lights.append(bulb)
+            else:
+                _LOGGER.warning(
+                    "Found Avea bulb but could not get the name: %s", vars(bulb)
+                )
     except OSError as err:
         raise PlatformNotReady from err
+    return lights
 
-    add_entities(AveaLight(bulb) for bulb in nearby_bulbs)
 
-
-class AveaLight(LightEntity):
+class AveaLight(Light):
     """Representation of an Avea."""
 
     def __init__(self, light):
         """Initialize an AveaLight."""
         self._light = light
+        self._mac = light.addr
         self._name = light.name
         self._state = None
         self._brightness = light.brightness
 
     @property
+    def device_info(self):
+        """Return information about the device."""
+        info = {
+            "identifiers": {(AVEA_DOMAIN, self.unique_id)},
+            "name": self._name,
+            "connections": {(dr.CONNECTION_NETWORK_MAC, self._mac)},
+            "manufacturer": "Elgato",
+            "model": "Avea",
+        }
+
+        return info
+
+    @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_AVEA
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._mac
 
     @property
     def name(self):

--- a/homeassistant/components/avea/manifest.json
+++ b/homeassistant/components/avea/manifest.json
@@ -2,6 +2,11 @@
   "domain": "avea",
   "name": "Elgato Avea",
   "documentation": "https://www.home-assistant.io/integrations/avea",
-  "codeowners": ["@pattyland"],
-  "requirements": ["avea==1.4"]
+  "codeowners": [
+    "@pattyland"
+  ],
+  "requirements": [
+    "avea==1.4"
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/avea/strings.json
+++ b/homeassistant/components/avea/strings.json
@@ -1,0 +1,14 @@
+{
+  "title": "Elgato Avea",
+  "config": {
+    "step": {
+      "confirm": {
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -21,6 +21,7 @@ FLOWS = [
     "arcam_fmj",
     "atag",
     "august",
+    "avea",
     "avri",
     "awair",
     "axis",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -300,7 +300,7 @@ aurorapy==0.2.6
 av==8.0.2
 
 # homeassistant.components.avea
-# avea==1.4
+avea==1.4
 
 # homeassistant.components.avion
 # avion==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -300,7 +300,7 @@ aurorapy==0.2.6
 av==8.0.2
 
 # homeassistant.components.avea
-avea==1.4
+# avea==1.4
 
 # homeassistant.components.avion
 # avion==0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -177,7 +177,7 @@ async-upnp-client==0.14.13
 av==8.0.2
 
 # homeassistant.components.avea
-# avea==1.4
+avea==1.4
 
 # homeassistant.components.avri
 avri-api==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -177,7 +177,7 @@ async-upnp-client==0.14.13
 av==8.0.2
 
 # homeassistant.components.avea
-avea==1.4
+# avea==1.4
 
 # homeassistant.components.avri
 avri-api==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -176,6 +176,9 @@ async-upnp-client==0.14.13
 # homeassistant.components.stream
 av==8.0.2
 
+# homeassistant.components.avea
+# avea==1.4
+
 # homeassistant.components.avri
 avri-api==0.1.7
 

--- a/tests/components/avea/__init__.py
+++ b/tests/components/avea/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Elgato Avea integration."""

--- a/tests/components/avea/test_config_flow.py
+++ b/tests/components/avea/test_config_flow.py
@@ -1,0 +1,33 @@
+"""Test the Elgato Avea config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.avea.const import DOMAIN
+
+from tests.async_mock import patch
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.xxxxx.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.xxxxxx.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "avea"
+    assert result2["data"] == {}
+    await hass.async_block_till_done()
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
This is a new try for #34468
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If you have previously configured this integration using configuration.yaml, you should delete this entry and reconfigure it via the Home Assistant frontend.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Added config flow to avea via frontent
- Removed yaml configuration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13098/

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
