### PR TITLE
Fix state overwrite race condition where two platforms request the same entity_id

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -358,9 +358,6 @@ ATTR_OPTION = "option"
 # The entity has been restored with restore state
 ATTR_RESTORED = "restored"
 
-# The entity is in the process of being created
-ATTR_RESERVED = "__reserved"
-
 # Bitfield of supported component features for the entity
 ATTR_SUPPORTED_FEATURES = "supported_features"
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -355,6 +355,12 @@ ATTR_STATE = "state"
 ATTR_EDITABLE = "editable"
 ATTR_OPTION = "option"
 
+# The entity has been restored with restore state
+ATTR_RESTORED = "restored"
+
+# The entity is in the process of being created
+ATTR_RESERVED = "__reserved"
+
 # Bitfield of supported component features for the entity
 ATTR_SUPPORTED_FEATURES = "supported_features"
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -970,8 +970,6 @@ class State:
 class StateMachine:
     """Helper class that tracks the state of different entities."""
 
-    __slots__ = ("_states", "_reservations", "_bus", "_loop")
-
     def __init__(self, bus: EventBus, loop: asyncio.events.AbstractEventLoop) -> None:
         """Initialize state machine."""
         self._states: Dict[str, State] = {}

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -43,6 +43,7 @@ from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_FRIENDLY_NAME,
     ATTR_NOW,
+    ATTR_RESERVED,
     ATTR_SECONDS,
     ATTR_SERVICE,
     ATTR_SERVICE_DATA,
@@ -61,6 +62,7 @@ from homeassistant.const import (
     EVENT_TIMER_OUT_OF_SYNC,
     LENGTH_METERS,
     MATCH_ALL,
+    STATE_UNAVAILABLE,
     __version__,
 )
 from homeassistant.exceptions import (
@@ -1117,6 +1119,28 @@ class StateMachine:
         ).result()
 
     @callback
+    def async_reserve(self, entity_id: str) -> None:
+        """Reserve a state in the state machine for an entity being added.
+
+        This must not fire an event when the state is reserved.
+
+        This avoids a race condition where multiple entities with the same
+        entity_id are added.
+        """
+        entity_id = entity_id.lower()
+
+        if entity_id in self._states:
+            raise HomeAssistantError(
+                "async_reserve must not be called once the state is in the state machine."
+            )
+
+        self._states[entity_id] = State(
+            entity_id,
+            STATE_UNAVAILABLE,
+            {ATTR_RESERVED: True},
+        )
+
+    @callback
     def async_set(
         self,
         entity_id: str,
@@ -1138,7 +1162,8 @@ class StateMachine:
         new_state = str(new_state)
         attributes = attributes or {}
         old_state = self._states.get(entity_id)
-        if old_state is None:
+        if old_state is None or ATTR_RESERVED in old_state.attributes:
+            old_state = None
             same_state = False
             same_attr = False
             last_changed = None
@@ -1146,6 +1171,10 @@ class StateMachine:
             same_state = old_state.state == new_state and not force_update
             same_attr = old_state.attributes == MappingProxyType(attributes)
             last_changed = old_state.last_changed if same_state else None
+            if ATTR_RESERVED in attributes:
+                raise HomeAssistantError(
+                    f"{ATTR_RESERVED} is a reserved name for attributes"
+                )
 
         if same_state and same_attr:
             return

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -77,7 +77,7 @@ def async_generate_entity_id(
 
     test_string = preferred_string
     tries = 1
-    while hass.states.get(test_string):
+    while not hass.states.async_available(test_string):
         tries += 1
         test_string = f"{preferred_string}_{tries}"
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -463,12 +463,14 @@ class EntityPlatform:
         already_exists = entity.entity_id in self.entities
         restored = False
 
-        if not already_exists:
+        if not already_exists and not self.hass.states.async_available(
+            entity.entity_id
+        ):
             existing = self.hass.states.get(entity.entity_id)
-
-            if existing:
-                restored = ATTR_RESTORED in existing.attributes
-                already_exists = not restored
+            if existing is not None and ATTR_RESTORED in existing.attributes:
+                restored = True
+            else:
+                already_exists = True
 
         if already_exists:
             if entity.unique_id is not None:

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
+    ATTR_RESTORED,
     ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT,
     EVENT_HOMEASSISTANT_START,
@@ -55,8 +56,6 @@ DISABLED_CONFIG_ENTRY = "config_entry"
 DISABLED_HASS = "hass"
 DISABLED_USER = "user"
 DISABLED_INTEGRATION = "integration"
-
-ATTR_RESTORED = "restored"
 
 STORAGE_VERSION = 1
 STORAGE_KEY = "core.entity_registry"

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -182,7 +182,7 @@ class EntityRegistry:
         while (
             test_string in self.entities
             or test_string in known_object_ids
-            or self.hass.states.get(test_string)
+            or not self.hass.states.async_available(test_string)
         ):
             tries += 1
             test_string = f"{preferred_string}_{tries}"

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1,6 +1,5 @@
 """The test for the Template sensor platform."""
 from asyncio import Event
-from datetime import timedelta
 
 from homeassistant.bootstrap import async_from_config_dict
 from homeassistant.components import sensor
@@ -19,7 +18,7 @@ from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.async_mock import patch
-from tests.common import assert_setup_component, async_fire_time_changed
+from tests.common import assert_setup_component
 
 
 async def test_template(hass):
@@ -832,7 +831,6 @@ async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(hass, c
 
 async def test_self_referencing_entity_picture_loop(hass, caplog):
     """Test a self referencing sensor does not loop forever with a looping self referencing entity picture."""
-
     await async_setup_component(
         hass,
         sensor.DOMAIN,
@@ -855,19 +853,10 @@ async def test_self_referencing_entity_picture_loop(hass, caplog):
 
     assert len(hass.states.async_all()) == 1
 
-    next_time = dt_util.utcnow() + timedelta(seconds=1.2)
-    with patch(
-        "homeassistant.helpers.ratelimit.dt_util.utcnow", return_value=next_time
-    ):
-        async_fire_time_changed(hass, next_time)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-
-    assert "Template loop detected" in caplog.text
-
     state = hass.states.get("sensor.test")
     assert int(state.state) == 1
-    assert state.attributes[ATTR_ENTITY_PICTURE] == 2
+    assert state.attributes[ATTR_ENTITY_PICTURE] == 3
+    assert "Template loop detected" in caplog.text
 
     await hass.async_block_till_done()
     assert int(state.state) == 1

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -969,9 +969,55 @@ async def test_setup_entry_with_entities_that_block_forever(hass, caplog):
         await hass.async_block_till_done()
     full_name = f"{mock_entity_platform.domain}.{config_entry.domain}"
     assert full_name in hass.config.components
-    assert len(hass.states.async_entity_ids()) == 0
+    assert len(hass.states.async_entity_ids()) == 1
     assert len(registry.entities) == 1
     assert "Timed out adding entities" in caplog.text
     assert "test_domain.test1" in caplog.text
     assert "test_domain" in caplog.text
     assert "test" in caplog.text
+
+
+async def test_two_platforms_add_same_entity(hass):
+    """Test two platforms in the same domain adding an entity with the same name."""
+    entity_platform1 = MockEntityPlatform(
+        hass, domain="mock_integration", platform_name="mock_platform", platform=None
+    )
+    entity1 = SlowEntity(name="entity_1")
+
+    entity_platform2 = MockEntityPlatform(
+        hass, domain="mock_integration", platform_name="mock_platform", platform=None
+    )
+    entity2 = SlowEntity(name="entity_1")
+
+    await asyncio.gather(
+        entity_platform1.async_add_entities([entity1]),
+        entity_platform2.async_add_entities([entity2]),
+    )
+
+    entities = []
+
+    @callback
+    def handle_service(entity, *_):
+        entities.append(entity)
+
+    entity_platform1.async_register_entity_service("hello", {}, handle_service)
+    await hass.services.async_call(
+        "mock_platform", "hello", {"entity_id": "all"}, blocking=True
+    )
+
+    assert len(entities) == 2
+    assert {entity1.entity_id, entity2.entity_id} == {
+        "mock_integration.entity_1",
+        "mock_integration.entity_1_2",
+    }
+    assert entity1 in entities
+    assert entity2 in entities
+
+
+class SlowEntity(MockEntity):
+    """An entity that will sleep during add."""
+
+    async def async_added_to_hass(self):
+        """Make sure control is returned to the event loop on add."""
+        await asyncio.sleep(0.1)
+        await super().async_added_to_hass()

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -969,7 +969,7 @@ async def test_setup_entry_with_entities_that_block_forever(hass, caplog):
         await hass.async_block_till_done()
     full_name = f"{mock_entity_platform.domain}.{config_entry.domain}"
     assert full_name in hass.config.components
-    assert len(hass.states.async_entity_ids()) == 1
+    assert len(hass.states.async_entity_ids()) == 0
     assert len(registry.entities) == 1
     assert "Timed out adding entities" in caplog.text
     assert "test_domain.test1" in caplog.text

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1537,3 +1537,13 @@ async def test_hassjob_forbid_coroutine():
 
     # To avoid warning about unawaited coro
     await coro
+
+
+async def test_reserving_states(hass):
+    """Test we can reserve a state in the state machine."""
+
+    hass.states.async_reserve("light.bedroom")
+    hass.states.async_set("light.bedroom", "on")
+
+    with pytest.raises(ha.HomeAssistantError):
+        hass.states.async_reserve("light.bedroom")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1543,7 +1543,20 @@ async def test_reserving_states(hass):
     """Test we can reserve a state in the state machine."""
 
     hass.states.async_reserve("light.bedroom")
+    assert hass.states.async_available("light.bedroom") is False
+    hass.states.async_set("light.bedroom", "on")
+    assert hass.states.async_available("light.bedroom") is False
+
+    with pytest.raises(ha.HomeAssistantError):
+        hass.states.async_reserve("light.bedroom")
+
+    hass.states.async_remove("light.bedroom")
+    assert hass.states.async_available("light.bedroom") is True
     hass.states.async_set("light.bedroom", "on")
 
     with pytest.raises(ha.HomeAssistantError):
         hass.states.async_reserve("light.bedroom")
+
+    assert hass.states.async_available("light.bedroom") is False
+    hass.states.async_remove("light.bedroom")
+    assert hass.states.async_available("light.bedroom") is True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix state overwrite race condition where two platforms request the same entity_id.

`entity_platform._async_add_entity` is the gate that ensures that `entity_id`s are unique. It was subject to a race condition where it returned control to the event loop between checking the state machine and adding the state via `await entity.add_to_platform_finish()` which allowed another execution of `_async_add_entity` to run before the state was added to the state machine and add the same `entity_id`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40586
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
