### PR TITLE
Rewrite mochad unittest to pytest style

### DIFF
--- a/tests/components/mochad/test_light.py
+++ b/tests/components/mochad/test_light.py
@@ -1,14 +1,12 @@
 """The tests for the mochad light platform."""
-import unittest
 
 import pytest
 
 from homeassistant.components import light
 from homeassistant.components.mochad import light as mochad
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 import tests.async_mock as mock
-from tests.common import get_test_home_assistant
 
 
 @pytest.fixture(autouse=True)
@@ -18,122 +16,57 @@ def pymochad_mock():
         yield device
 
 
-class TestMochadSwitchSetup(unittest.TestCase):
-    """Test the mochad light."""
-
-    PLATFORM = mochad
-    COMPONENT = light
-    THING = "light"
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
-
-    @mock.patch("homeassistant.components.mochad.light.MochadLight")
-    def test_setup_adds_proper_devices(self, mock_light):
-        """Test if setup adds devices."""
-        good_config = {
-            "mochad": {},
-            "light": {
-                "platform": "mochad",
-                "devices": [{"name": "Light1", "address": "a1"}],
-            },
-        }
-        assert setup_component(self.hass, light.DOMAIN, good_config)
+@pytest.fixture
+def light_mock(hass, brightness):
+    """Mock light."""
+    controller_mock = mock.MagicMock()
+    dev_dict = {"address": "a1", "name": "fake_light", "brightness_levels": brightness}
+    return mochad.MochadLight(hass, controller_mock, dev_dict)
 
 
-class TestMochadLight(unittest.TestCase):
-    """Test for mochad light platform."""
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        controller_mock = mock.MagicMock()
-        dev_dict = {"address": "a1", "name": "fake_light", "brightness_levels": 32}
-        self.light = mochad.MochadLight(self.hass, controller_mock, dev_dict)
-
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_name(self):
-        """Test the name."""
-        assert "fake_light" == self.light.name
-
-    def test_turn_on_with_no_brightness(self):
-        """Test turn_on."""
-        self.light.turn_on()
-        self.light.light.send_cmd.assert_called_once_with("on")
-
-    def test_turn_on_with_brightness(self):
-        """Test turn_on."""
-        self.light.turn_on(brightness=45)
-        self.light.light.send_cmd.assert_has_calls(
-            [mock.call("on"), mock.call("dim 25")]
-        )
-
-    def test_turn_off(self):
-        """Test turn_off."""
-        self.light.turn_off()
-        self.light.light.send_cmd.assert_called_once_with("off")
+async def test_setup_adds_proper_devices(hass):
+    """Test if setup adds devices."""
+    good_config = {
+        "mochad": {},
+        "light": {
+            "platform": "mochad",
+            "devices": [{"name": "Light1", "address": "a1"}],
+        },
+    }
+    assert await async_setup_component(hass, light.DOMAIN, good_config)
 
 
-class TestMochadLight256Levels(unittest.TestCase):
-    """Test for mochad light platform."""
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        controller_mock = mock.MagicMock()
-        dev_dict = {"address": "a1", "name": "fake_light", "brightness_levels": 256}
-        self.light = mochad.MochadLight(self.hass, controller_mock, dev_dict)
-
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_turn_on_with_no_brightness(self):
-        """Test turn_on."""
-        self.light.turn_on()
-        self.light.light.send_cmd.assert_called_once_with("xdim 255")
-
-    def test_turn_on_with_brightness(self):
-        """Test turn_on."""
-        self.light.turn_on(brightness=45)
-        self.light.light.send_cmd.assert_called_once_with("xdim 45")
-
-    def test_turn_off(self):
-        """Test turn_off."""
-        self.light.turn_off()
-        self.light.light.send_cmd.assert_called_once_with("off")
+@pytest.mark.parametrize("brightness", [32, 256, 64])
+async def test_name(light_mock):
+    """Test the name."""
+    assert "fake_light" == light_mock.name
 
 
-class TestMochadLight64Levels(unittest.TestCase):
-    """Test for mochad light platform."""
+@pytest.mark.parametrize(
+    "brightness,expected", [(32, "on"), (256, "xdim 255"), (64, "xdim 63")]
+)
+async def test_turn_on_with_no_brightness(light_mock, expected):
+    """Test turn_on."""
+    light_mock.turn_on()
+    light_mock.light.send_cmd.assert_called_once_with(expected)
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        controller_mock = mock.MagicMock()
-        dev_dict = {"address": "a1", "name": "fake_light", "brightness_levels": 64}
-        self.light = mochad.MochadLight(self.hass, controller_mock, dev_dict)
 
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
+@pytest.mark.parametrize(
+    "brightness,expected",
+    [
+        (32, [mock.call("on"), mock.call("dim 25")]),
+        (256, [mock.call("xdim 45")]),
+        (64, [mock.call("xdim 11")]),
+    ],
+)
+async def test_turn_on_with_brightness(light_mock, expected):
+    """Test turn_on."""
+    light_mock.turn_on(brightness=45)
+    light_mock.light.send_cmd.assert_has_calls(expected)
 
-    def test_turn_on_with_no_brightness(self):
-        """Test turn_on."""
-        self.light.turn_on()
-        self.light.light.send_cmd.assert_called_once_with("xdim 63")
 
-    def test_turn_on_with_brightness(self):
-        """Test turn_on."""
-        self.light.turn_on(brightness=45)
-        self.light.light.send_cmd.assert_called_once_with("xdim 11")
-
-    def test_turn_off(self):
-        """Test turn_off."""
-        self.light.turn_off()
-        self.light.light.send_cmd.assert_called_once_with("off")
+@pytest.mark.parametrize("brightness", [32, 256, 64])
+async def test_turn_off(light_mock):
+    """Test turn_off."""
+    light_mock.turn_off()
+    light_mock.light.send_cmd.assert_called_once_with("off")

--- a/tests/components/mochad/test_light.py
+++ b/tests/components/mochad/test_light.py
@@ -36,12 +36,6 @@ async def test_setup_adds_proper_devices(hass):
     assert await async_setup_component(hass, light.DOMAIN, good_config)
 
 
-@pytest.mark.parametrize("brightness", [32, 256, 64])
-async def test_name(light_mock):
-    """Test the name."""
-    assert "fake_light" == light_mock.name
-
-
 @pytest.mark.parametrize(
     "brightness,expected", [(32, "on"), (256, "xdim 255"), (64, "xdim 63")]
 )
@@ -65,7 +59,7 @@ async def test_turn_on_with_brightness(light_mock, expected):
     light_mock.light.send_cmd.assert_has_calls(expected)
 
 
-@pytest.mark.parametrize("brightness", [32, 256, 64])
+@pytest.mark.parametrize("brightness", [32])
 async def test_turn_off(light_mock):
     """Test turn_off."""
     light_mock.turn_off()

--- a/tests/components/mochad/test_switch.py
+++ b/tests/components/mochad/test_switch.py
@@ -1,14 +1,11 @@
 """The tests for the mochad switch platform."""
-import unittest
-
 import pytest
 
 from homeassistant.components import switch
 from homeassistant.components.mochad import switch as mochad
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 import tests.async_mock as mock
-from tests.common import get_test_home_assistant
 
 
 @pytest.fixture(autouse=True)
@@ -20,55 +17,38 @@ def pymochad_mock():
         yield
 
 
-class TestMochadSwitchSetup(unittest.TestCase):
-    """Test the mochad switch."""
-
-    PLATFORM = mochad
-    COMPONENT = switch
-    THING = "switch"
-
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
-
-    @mock.patch("homeassistant.components.mochad.switch.MochadSwitch")
-    def test_setup_adds_proper_devices(self, mock_switch):
-        """Test if setup adds devices."""
-        good_config = {
-            "mochad": {},
-            "switch": {
-                "platform": "mochad",
-                "devices": [{"name": "Switch1", "address": "a1"}],
-            },
-        }
-        assert setup_component(self.hass, switch.DOMAIN, good_config)
+@pytest.fixture
+def switch_mock(hass):
+    """Mock switch."""
+    controller_mock = mock.MagicMock()
+    dev_dict = {"address": "a1", "name": "fake_switch"}
+    return mochad.MochadSwitch(hass, controller_mock, dev_dict)
 
 
-class TestMochadSwitch(unittest.TestCase):
-    """Test for mochad switch platform."""
+async def test_setup_adds_proper_devices(hass):
+    """Test if setup adds devices."""
+    good_config = {
+        "mochad": {},
+        "switch": {
+            "platform": "mochad",
+            "devices": [{"name": "Switch1", "address": "a1"}],
+        },
+    }
+    assert await async_setup_component(hass, switch.DOMAIN, good_config)
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        controller_mock = mock.MagicMock()
-        dev_dict = {"address": "a1", "name": "fake_switch"}
-        self.switch = mochad.MochadSwitch(self.hass, controller_mock, dev_dict)
 
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
+async def test_name(switch_mock):
+    """Test the name."""
+    assert "fake_switch" == switch_mock.name
 
-    def test_name(self):
-        """Test the name."""
-        assert "fake_switch" == self.switch.name
 
-    def test_turn_on(self):
-        """Test turn_on."""
-        self.switch.turn_on()
-        self.switch.switch.send_cmd.assert_called_once_with("on")
+async def test_turn_on(switch_mock):
+    """Test turn_on."""
+    switch_mock.turn_on()
+    switch_mock.switch.send_cmd.assert_called_once_with("on")
 
-    def test_turn_off(self):
-        """Test turn_off."""
-        self.switch.turn_off()
-        self.switch.switch.send_cmd.assert_called_once_with("off")
+
+async def test_turn_off(switch_mock):
+    """Test turn_off."""
+    switch_mock.turn_off()
+    switch_mock.switch.send_cmd.assert_called_once_with("off")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40867
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
