### PR TITLE
Avoid overloading the executor with service.yaml loads

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -38,7 +38,7 @@ from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType, TemplateVarsType
-from homeassistant.loader import async_get_integration, bind_hass
+from homeassistant.loader import Integration, async_get_integration, bind_hass
 from homeassistant.util.yaml import load_yaml
 from homeassistant.util.yaml.loader import JSON_TYPE
 
@@ -252,19 +252,27 @@ async def async_extract_entity_ids(
     return extracted
 
 
-async def _load_services_file(hass: HomeAssistantType, domain: str) -> JSON_TYPE:
+def _load_services_file(hass: HomeAssistantType, integration: Integration) -> JSON_TYPE:
     """Load services file for an integration."""
-    integration = await async_get_integration(hass, domain)
     try:
-        return await hass.async_add_executor_job(
-            load_yaml, str(integration.file_path / "services.yaml")
-        )
+        return load_yaml(str(integration.file_path / "services.yaml"))
     except FileNotFoundError:
-        _LOGGER.warning("Unable to find services.yaml for the %s integration", domain)
+        _LOGGER.warning(
+            "Unable to find services.yaml for the %s integration", integration.domain
+        )
         return {}
     except HomeAssistantError:
-        _LOGGER.warning("Unable to parse services.yaml for the %s integration", domain)
+        _LOGGER.warning(
+            "Unable to parse services.yaml for the %s integration", integration.domain
+        )
         return {}
+
+
+def _load_services_files(
+    hass: HomeAssistantType, integrations: Iterable[Integration]
+) -> List[JSON_TYPE]:
+    """Load service files for multiple intergrations."""
+    return [_load_services_file(hass, integration) for integration in integrations]
 
 
 @bind_hass
@@ -289,8 +297,12 @@ async def async_get_all_descriptions(
     loaded = {}
 
     if missing:
-        contents = await asyncio.gather(
-            *(_load_services_file(hass, domain) for domain in missing)
+        integrations = await asyncio.gather(
+            *(async_get_integration(hass, domain) for domain in missing)
+        )
+
+        contents = await hass.async_add_executor_job(
+            _load_services_files, hass, integrations
         )
 
         for domain, content in zip(missing, contents):

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -320,7 +320,7 @@ async def async_get_all_descriptions(
             # Cache missing descriptions
             if description is None:
                 domain_yaml = loaded[domain]
-                yaml_description = domain_yaml.get(service, {})
+                yaml_description = domain_yaml.get(service, {})  # type: ignore
 
                 # Don't warn for missing services, because it triggers false
                 # positives for things like scripts, that register as a service


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid overloading the executor with service.yaml loads

If the frontend if open during restart it can spawn many
executor jobs to load the services.yaml files since
each file was being loaded in a separate
executor job.  Grouping these avoids the overload.

`load_translations_files` does something similar already.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
