### PR TITLE
Set Vizio unique ID for discovery flow early and abort if configured to prevent duplicate discovery flows

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -206,29 +206,30 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: Dict[str, Any] = None
     ) -> Dict[str, Any]:
         """Handle a flow initialized by the user."""
+        assert self.hass
         errors = {}
 
         if user_input is not None:
             # Store current values in case setup fails and user needs to edit
             self._user_schema = _get_config_schema(user_input)
-            unique_id = await VizioAsync.get_unique_id(
-                user_input[CONF_HOST],
-                user_input[CONF_DEVICE_CLASS],
-                session=async_get_clientsession(self.hass, False),
-            )
-
-            if not unique_id:
-                errors[CONF_HOST] = "cannot_connect"
-            else:
-                # Set unique ID and abort if a flow with the same unique ID is already in progress
-                existing_entry = await self.async_set_unique_id(
-                    unique_id=unique_id, raise_on_progress=True
+            if self.unique_id is None:
+                unique_id = await VizioAsync.get_unique_id(
+                    user_input[CONF_HOST],
+                    user_input[CONF_DEVICE_CLASS],
+                    session=async_get_clientsession(self.hass, False),
                 )
-                # If device was discovered, abort if existing entry found, otherwise display an error
-                # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-                if self.context["source"] == SOURCE_ZEROCONF:
-                    self._abort_if_unique_id_configured()
-                elif existing_entry:
+
+                if not unique_id:
+                    errors[CONF_HOST] = "cannot_connect"
+                # Set unique ID and abort if a flow with the same unique ID is already in progress
+                elif (
+                    await self.async_set_unique_id(
+                        unique_id=unique_id, raise_on_progress=True
+                    )
+                    is not None
+                ):
+                    # If device was discovered, abort if existing entry found, otherwise display an error
+                    # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
                     errors[CONF_HOST] = "existing_config_entry_found"
 
             if not errors:
@@ -346,6 +347,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: Optional[DiscoveryInfoType] = None
     ) -> Dict[str, Any]:
         """Handle zeroconf discovery."""
+        assert self.hass
 
         discovery_info[
             CONF_HOST
@@ -359,6 +361,15 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         discovery_info[CONF_DEVICE_CLASS] = await async_guess_device_type(
             discovery_info[CONF_HOST]
         )
+
+        # Set unique ID early for discovery flow so we can abort if needed
+        unique_id = await VizioAsync.get_unique_id(
+            discovery_info[CONF_HOST],
+            discovery_info[CONF_DEVICE_CLASS],
+            session=async_get_clientsession(self.hass, False),
+        )
+        await self.async_set_unique_id(unique_id=unique_id, raise_on_progress=True)
+        self._abort_if_unique_id_configured()
 
         # Form must be shown after discovery so user can confirm/update configuration
         # before ConfigEntry creation.

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -219,17 +219,16 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     session=async_get_clientsession(self.hass, False),
                 )
 
+                # Check if unique ID was found, set unique ID, and abort if a flow with
+                # the same unique ID is already in progress
                 if not unique_id:
                     errors[CONF_HOST] = "cannot_connect"
-                # Set unique ID and abort if a flow with the same unique ID is already in progress
                 elif (
                     await self.async_set_unique_id(
                         unique_id=unique_id, raise_on_progress=True
                     )
                     is not None
                 ):
-                    # If device was discovered, abort if existing entry found, otherwise display an error
-                    # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
                     errors[CONF_HOST] = "existing_config_entry_found"
 
             if not errors:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Users are reporting that discovery flows are sticking around in the UI for either already in progress flows or for entries that have already been configured. This appears to have been introduced with https://github.com/home-assistant/core/pull/37692. As far as I can tell, the config flow *should* abort immediately due to the initial logic in `async_step_user`, but because it's a discovery flow, the flow is "paused" until the user actually opens the form and submits, which then aborts the flow. This new change sets the unique ID in the discovery steps and aborts immediately on progress or if it already exists, which should prevent this issue.

I can't figure out how to test for this one scenario because I already have a test that should cover this: https://github.com/home-assistant/core/blob/dev/tests/components/vizio/test_config_flow.py#L780 I am open to suggestions on how to improve the tests to catch this. I am unable to reproduce this error locally which I suspect is because I don't have the right device type.

I added this to the 0.117.0 milestone because this has been an ongoing bug that would be great to fix sooner rather than later


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/issues/31642

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
