### PR TITLE
Add WLED preset service

### DIFF
--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -29,3 +29,4 @@ CURRENT_MA = "mA"
 
 # Services
 SERVICE_EFFECT = "effect"
+SERVICE_PRESET = "preset"

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -42,6 +42,7 @@ from .const import (
     ATTR_SPEED,
     DOMAIN,
     SERVICE_EFFECT,
+    SERVICE_PRESET,
 )
 
 PARALLEL_UPDATES = 1
@@ -71,6 +72,16 @@ async def async_setup_entry(
             ),
         },
         "async_effect",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_PRESET,
+        {
+            vol.Required(ATTR_PRESET): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=16)
+            ),
+        },
+        "async_preset",
     )
 
     update_segments = partial(
@@ -371,6 +382,16 @@ class WLEDSegmentLight(LightEntity, WLEDDeviceEntity):
             data[ATTR_SPEED] = speed
 
         await self.coordinator.wled.segment(**data)
+
+    @wled_exception_handler
+    async def async_preset(
+        self,
+        preset: int,
+    ) -> None:
+        """Set a WLED light to a saved preset."""
+        data = {ATTR_PRESET: preset}
+
+        await self.coordinator.wled.preset(**data)
 
 
 @callback

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -78,7 +78,7 @@ async def async_setup_entry(
         SERVICE_PRESET,
         {
             vol.Required(ATTR_PRESET): vol.All(
-                vol.Coerce(int), vol.Range(min=1, max=16)
+                vol.Coerce(int), vol.Range(min=-1, max=65535)
             ),
         },
         "async_preset",

--- a/homeassistant/components/wled/services.yaml
+++ b/homeassistant/components/wled/services.yaml
@@ -19,3 +19,12 @@ effect:
     reverse:
       description: Reverse the effect. Either true to reverse or false otherwise.
       example: false
+preset:
+  description: Calls a preset on the WLED device
+  fields:
+    entity_id:
+      description: Name of the WLED light entity.
+      example: "light.wled"
+    preset:
+      description: ID of the WLED preset
+      example: 6

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -23,6 +23,7 @@ from homeassistant.components.wled.const import (
     ATTR_SPEED,
     DOMAIN,
     SERVICE_EFFECT,
+    SERVICE_PRESET,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -580,6 +581,49 @@ async def test_effect_service_error(
             DOMAIN,
             SERVICE_EFFECT,
             {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_EFFECT: 9},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("light.wled_rgb_light_segment_0")
+        assert state.state == STATE_ON
+        assert "Invalid response from API" in caplog.text
+
+
+async def test_preset_service(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the prest service of a WLED light."""
+    await init_integration(hass, aioclient_mock)
+
+    with patch("wled.WLED.preset") as light_mock:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PRESET,
+            {
+                ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+                ATTR_PRESET: 1,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        light_mock.assert_called_once_with(
+            preset=1,
+        )
+
+
+async def test_preset_service_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+) -> None:
+    """Test error handling of the WLED preset service."""
+    aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
+    await init_integration(hass, aioclient_mock)
+
+    with patch("homeassistant.components.wled.WLED.update"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PRESET,
+            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_PRESET: 1},
             blocking=True,
         )
         await hass.async_block_till_done()

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -593,7 +593,7 @@ async def test_effect_service_error(
 async def test_preset_service(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test the prest service of a WLED light."""
+    """Test the preset service of a WLED light."""
     await init_integration(hass, aioclient_mock)
 
     with patch("wled.WLED.preset") as light_mock:


### PR DESCRIPTION
## Proposed change
Add a service enabling users to call stored WLED presets from Home Assistant.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15358

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
