### PR TITLE
Refresh now() templates on second=0

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -798,6 +798,9 @@ class _TrackTemplateResultInfo:
                 self._time_listeners.pop(template)()
             return
 
+        if template in self._time_listeners:
+            return
+
         track_templates = [
             track_template_
             for track_template_ in self._track_templates
@@ -808,10 +811,9 @@ class _TrackTemplateResultInfo:
         def _refresh_from_time(now: datetime) -> None:
             self._refresh(None, track_templates=track_templates)
 
-        if template not in self._time_listeners:
-            self._time_listeners[template] = async_track_utc_time_change(
-                self.hass, _refresh_from_time, second=0
-            )
+        self._time_listeners[template] = async_track_utc_time_change(
+            self.hass, _refresh_from_time, second=0
+        )
 
     @callback
     def _update_time_listeners(self) -> None:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -792,11 +792,10 @@ class _TrackTemplateResultInfo:
 
     @callback
     def _setup_time_listener(self, template: Template, has_time: bool) -> None:
-        if template in self._time_listeners:
-            self._time_listeners.pop(template)()
-
-        # now() or utcnow() has left the scope of the template
         if not has_time:
+            if template in self._time_listeners:
+                # now() or utcnow() has left the scope of the template
+                self._time_listeners.pop(template)()
             return
 
         track_templates = [
@@ -809,9 +808,10 @@ class _TrackTemplateResultInfo:
         def _refresh_from_time(now: datetime) -> None:
             self._refresh(None, track_templates=track_templates)
 
-        self._time_listeners[template] = async_call_later(
-            self.hass, 60.45, _refresh_from_time
-        )
+        if template not in self._time_listeners:
+            self._time_listeners[template] = async_track_utc_time_change(
+                self.hass, _refresh_from_time, second=0
+            )
 
     @callback
     def _update_time_listeners(self) -> None:

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -2172,15 +2172,17 @@ async def test_track_template_with_time_that_leaves_scope(hass):
         "time": True,
     }
 
-    # Verify we do not update a second time
-    # if the state change happens
+    # Verify we do not update before the minute rolls over
     callback_count_before_time_change = len(specific_runs)
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=59))
+    test_time = dt_util.utcnow().replace(second=1)
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, test_time + timedelta(seconds=58))
     await hass.async_block_till_done()
     assert len(specific_runs) == callback_count_before_time_change
 
-    # Verify we do update on the next time change
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=61))
+    # Verify we do update on the next change of minute
+    async_fire_time_changed(hass, test_time + timedelta(seconds=59))
     await hass.async_block_till_done()
     assert len(specific_runs) == callback_count_before_time_change + 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Beta feedback on #41147 is that it would be better if `now()` causes templates to refresh when the minute changes. This will be more useful for example for comparisons with input_datetime and it is also easier to debug things when you know when to expect the change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15360

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
