### PR TITLE
Stub light profiles

### DIFF
--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -199,11 +199,11 @@ def lifx_features(bulb):
     ) or aiolifx().products.features_map.get(1)
 
 
-def find_hsbk(**kwargs):
+def find_hsbk(hass, **kwargs):
     """Find the desired color from a number of possible inputs."""
     hue, saturation, brightness, kelvin = [None] * 4
 
-    preprocess_turn_on_alternatives(kwargs)
+    preprocess_turn_on_alternatives(hass, kwargs)
 
     if ATTR_HS_COLOR in kwargs:
         hue, saturation = kwargs[ATTR_HS_COLOR]
@@ -330,11 +330,11 @@ class LIFXManager:
                 period=kwargs.get(ATTR_PERIOD),
                 cycles=kwargs.get(ATTR_CYCLES),
                 mode=kwargs.get(ATTR_MODE),
-                hsbk=find_hsbk(**kwargs),
+                hsbk=find_hsbk(self.hass, **kwargs),
             )
             await self.effects_conductor.start(effect, bulbs)
         elif service == SERVICE_EFFECT_COLORLOOP:
-            preprocess_turn_on_alternatives(kwargs)
+            preprocess_turn_on_alternatives(self.hass, kwargs)
 
             brightness = None
             if ATTR_BRIGHTNESS in kwargs:
@@ -600,7 +600,7 @@ class LIFXLight(LightEntity):
             power_on = kwargs.get(ATTR_POWER, False)
             power_off = not kwargs.get(ATTR_POWER, True)
 
-            hsbk = find_hsbk(**kwargs)
+            hsbk = find_hsbk(self.hass, **kwargs)
 
             # Send messages, waiting for ACK each time
             ack = AwaitAioLIFX().wait

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -344,7 +344,6 @@ class Profiles:
         name = "group.all_lights.default"
         if name in self.data:
             self.apply_profile(name, params)
-            return
 
     @callback
     def apply_profile(self, name, params):

--- a/tests/components/abode/conftest.py
+++ b/tests/components/abode/conftest.py
@@ -3,7 +3,7 @@ import abodepy.helpers.constants as CONST
 import pytest
 
 from tests.common import load_fixture
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/abode/conftest.py
+++ b/tests/components/abode/conftest.py
@@ -3,6 +3,7 @@ import abodepy.helpers.constants as CONST
 import pytest
 
 from tests.common import load_fixture
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""axis conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -1,2 +1,2 @@
 """axis conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -1,5 +1,4 @@
 """PyTest fixtures and test helpers."""
-
 from unittest import mock
 
 import blebox_uniapi
@@ -11,6 +10,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.async_mock import AsyncMock, PropertyMock, patch
 from tests.common import MockConfigEntry
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 def patch_product_identify(path=None, **kwargs):

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -10,7 +10,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.async_mock import AsyncMock, PropertyMock, patch
 from tests.common import MockConfigEntry
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 def patch_product_identify(path=None, **kwargs):

--- a/tests/components/bond/conftest.py
+++ b/tests/components/bond/conftest.py
@@ -1,2 +1,2 @@
 """bond conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/bond/conftest.py
+++ b/tests/components/bond/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""bond conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""deconz conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -1,2 +1,2 @@
 """deconz conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/demo/conftest.py
+++ b/tests/components/demo/conftest.py
@@ -1,2 +1,2 @@
 """demo conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/demo/conftest.py
+++ b/tests/components/demo/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""demo conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/dynalite/conftest.py
+++ b/tests/components/dynalite/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""dynalite conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/dynalite/conftest.py
+++ b/tests/components/dynalite/conftest.py
@@ -1,2 +1,2 @@
 """dynalite conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/elgato/conftest.py
+++ b/tests/components/elgato/conftest.py
@@ -1,2 +1,2 @@
 """elgato conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/elgato/conftest.py
+++ b/tests/components/elgato/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""elgato conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/everlights/conftest.py
+++ b/tests/components/everlights/conftest.py
@@ -1,2 +1,2 @@
 """everlights conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/everlights/conftest.py
+++ b/tests/components/everlights/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""everlights conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/group/conftest.py
+++ b/tests/components/group/conftest.py
@@ -1,2 +1,2 @@
 """group conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/group/conftest.py
+++ b/tests/components/group/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""group conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import homeassistant.util.dt as dt_util
 
 import tests.async_mock
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import homeassistant.util.dt as dt_util
 
 import tests.async_mock
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -24,6 +24,7 @@ from .helper import AUTH_TOKEN, HAPID, HAPPIN, HomeFactory
 
 from tests.async_mock import AsyncMock, MagicMock, Mock, patch
 from tests.common import MockConfigEntry
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture(name="mock_connection")

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -24,7 +24,7 @@ from .helper import AUTH_TOKEN, HAPID, HAPPIN, HomeFactory
 
 from tests.async_mock import AsyncMock, MagicMock, Mock, patch
 from tests.common import MockConfigEntry
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture(name="mock_connection")

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -12,7 +12,7 @@ from homeassistant.components import hue
 from homeassistant.components.hue import sensor_base as hue_sensor_base
 
 from tests.async_mock import AsyncMock, Mock, patch
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -12,6 +12,7 @@ from homeassistant.components import hue
 from homeassistant.components.hue import sensor_base as hue_sensor_base
 
 from tests.async_mock import AsyncMock, Mock, patch
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/hyperion/conftest.py
+++ b/tests/components/hyperion/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""hyperion conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/hyperion/conftest.py
+++ b/tests/components/hyperion/conftest.py
@@ -1,2 +1,2 @@
 """hyperion conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/light/conftest.py
+++ b/tests/components/light/conftest.py
@@ -1,0 +1,29 @@
+"""Light conftest."""
+
+import pytest
+
+from homeassistant.components import light
+
+from tests.async_mock import patch
+
+orig_load_profiles = light.Profiles.load_profiles
+
+
+@pytest.fixture(autouse=True)
+def mock_profile_loading():
+    """Mock loading of profiles."""
+
+    async def fake_load(hass):
+        hass.data[light.DATA_PROFILES] = {}
+        return True
+
+    with patch(
+        "homeassistant.components.light.Profiles.load_profiles", side_effect=fake_load
+    ) as mock_load_profiles:
+        yield mock_load_profiles
+
+
+@pytest.fixture()
+def not_mock_profile_loading(mock_profile_loading):
+    """Do not mock the profile loading."""
+    mock_profile_loading.side_effect = orig_load_profiles

--- a/tests/components/light/conftest.py
+++ b/tests/components/light/conftest.py
@@ -2,28 +2,22 @@
 
 import pytest
 
-from homeassistant.components import light
+from homeassistant.components.light import Profiles
 
 from tests.async_mock import patch
 
-orig_load_profiles = light.Profiles.load_profiles
-
 
 @pytest.fixture(autouse=True)
-def mock_profile_loading():
+def mock_profiles():
     """Mock loading of profiles."""
+    data = {}
 
-    async def fake_load(hass):
-        hass.data[light.DATA_PROFILES] = {}
-        return True
+    def mock_profiles_class(hass):
+        profiles = Profiles(hass)
+        profiles.data = data
+        return profiles
 
     with patch(
-        "homeassistant.components.light.Profiles.load_profiles", side_effect=fake_load
-    ) as mock_load_profiles:
-        yield mock_load_profiles
-
-
-@pytest.fixture()
-def not_mock_profile_loading(mock_profile_loading):
-    """Do not mock the profile loading."""
-    mock_profile_loading.side_effect = orig_load_profiles
+        "homeassistant.components.light.Profiles", side_effect=mock_profiles_class
+    ):
+        yield data

--- a/tests/components/light/conftest.py
+++ b/tests/components/light/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from homeassistant.components.light import Profiles
 
-from tests.async_mock import patch
+from tests.async_mock import AsyncMock, patch
 
 
 @pytest.fixture(autouse=True)
@@ -15,9 +15,12 @@ def mock_profiles():
     def mock_profiles_class(hass):
         profiles = Profiles(hass)
         profiles.data = data
+        profiles.async_initialize = AsyncMock()
         return profiles
 
     with patch(
-        "homeassistant.components.light.Profiles", side_effect=mock_profiles_class
+        "homeassistant.components.light.Profiles",
+        SCHEMA=Profiles.SCHEMA,
+        side_effect=mock_profiles_class,
     ):
         yield data

--- a/tests/components/light/conftest.py
+++ b/tests/components/light/conftest.py
@@ -8,7 +8,7 @@ from tests.async_mock import AsyncMock, patch
 
 
 @pytest.fixture(autouse=True)
-def mock_profiles():
+def mock_light_profiles():
     """Mock loading of profiles."""
     data = {}
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,6 +1,4 @@
 """The tests for the Light component."""
-import os
-
 import pytest
 import voluptuous as vol
 
@@ -18,18 +16,11 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import Unauthorized
 from homeassistant.setup import async_setup_component
+from homeassistant.util import color
 
 from tests.common import async_mock_service
 
-
-@pytest.fixture
-def mock_storage(hass, hass_storage):
-    """Clean up user light files at the end."""
-    yield
-    user_light_file = hass.config.path(light.LIGHT_PROFILES_FILE)
-
-    if os.path.isfile(user_light_file):
-        os.remove(user_light_file)
+orig_Profiles = light.Profiles
 
 
 async def test_methods(hass):
@@ -416,17 +407,13 @@ async def test_services(hass, mock_profiles):
     assert data == {}
 
 
-async def test_light_profiles(hass, mock_storage):
+async def test_light_profiles(hass, mock_profiles):
     """Test light profiles."""
     platform = getattr(hass.components, "test.light")
     platform.init()
 
-    user_light_file = hass.config.path(light.LIGHT_PROFILES_FILE)
-
-    with open(user_light_file, "w") as user_file:
-        user_file.write("id,x,y,brightness\n")
-        user_file.write("test,.4,.6,100\n")
-        user_file.write("test_off,0,0,0\n")
+    mock_profiles["test"] = color.color_xy_to_hs(0.4, 0.6) + (100, 0)
+    mock_profiles["test_off"] = 0, 0, 0, 0
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -465,52 +452,6 @@ async def test_light_profiles(hass, mock_storage):
     assert data == {light.ATTR_TRANSITION: 0}
 
 
-async def test_light_profiles_with_transition(hass, mock_storage):
-    """Test light profiles with transition."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
-
-    user_light_file = hass.config.path(light.LIGHT_PROFILES_FILE)
-
-    with open(user_light_file, "w") as user_file:
-        user_file.write("id,x,y,brightness,transition\n")
-        user_file.write("test,.4,.6,100,2\n")
-        user_file.write("test_off,0,0,0,0\n")
-
-    assert await async_setup_component(
-        hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
-    )
-    await hass.async_block_till_done()
-
-    ent1, _, _ = platform.ENTITIES
-
-    await hass.services.async_call(
-        light.DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ent1.entity_id, light.ATTR_PROFILE: "test"},
-        blocking=True,
-    )
-
-    _, data = ent1.last_call("turn_on")
-    assert light.is_on(hass, ent1.entity_id)
-    assert data == {
-        light.ATTR_HS_COLOR: (71.059, 100),
-        light.ATTR_BRIGHTNESS: 100,
-        light.ATTR_TRANSITION: 2,
-    }
-
-    await hass.services.async_call(
-        light.DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ent1.entity_id, light.ATTR_PROFILE: "test_off"},
-        blocking=True,
-    )
-
-    _, data = ent1.last_call("turn_off")
-    assert not light.is_on(hass, ent1.entity_id)
-    assert data == {light.ATTR_TRANSITION: 0}
-
-
 async def test_default_profiles_group(hass, mock_profiles):
     """Test default turn-on light profile for all lights."""
     platform = getattr(hass.components, "test.light")
@@ -521,7 +462,7 @@ async def test_default_profiles_group(hass, mock_profiles):
     )
     await hass.async_block_till_done()
 
-    mock_profiles["group.all_lights.default"] = (0.4, 0.6, 99, 2)
+    mock_profiles["group.all_lights.default"] = color.color_xy_to_hs(0.4, 0.6) + (99, 2)
 
     ent, _, _ = platform.ENTITIES
     await hass.services.async_call(
@@ -546,8 +487,11 @@ async def test_default_profiles_light(hass, mock_profiles):
     )
     await hass.async_block_till_done()
 
-    mock_profiles["group.all_lights.default"] = (0.3, 0.5, 200, 0)
-    mock_profiles["light.ceiling_2.default"] = (0.6, 0.6, 100, 3)
+    mock_profiles["group.all_lights.default"] = color.color_xy_to_hs(0.3, 0.5) + (
+        200,
+        0,
+    )
+    mock_profiles["light.ceiling_2.default"] = color.color_xy_to_hs(0.6, 0.6) + (100, 3)
 
     dev = next(filter(lambda x: x.entity_id == "light.ceiling_2", platform.ENTITIES))
     await hass.services.async_call(
@@ -721,3 +665,15 @@ def test_deprecated_base_class(caplog):
 
     CustomLight()
     assert "Light is deprecated, modify CustomLight" in caplog.text
+
+
+async def test_profiles(hass):
+    """Test profiles loading."""
+    profiles = orig_Profiles(hass)
+    await profiles.async_initialize()
+    assert profiles.data == {
+        "concentrate": (35.932, 69.412, 219, 0),
+        "energize": (43.333, 21.176, 203, 0),
+        "reading": (38.88, 49.02, 240, 0),
+        "relax": (35.932, 69.412, 144, 0),
+    }

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -117,7 +117,7 @@ async def test_methods(hass):
     assert call.data[light.ATTR_TRANSITION] == "transition_val"
 
 
-async def test_services(hass):
+async def test_services(hass, not_mock_profile_loading):
     """Test the provided services."""
     platform = getattr(hass.components, "test.light")
 
@@ -418,7 +418,7 @@ async def test_services(hass):
     assert data == {}
 
 
-async def test_broken_light_profiles(hass, mock_storage):
+async def test_broken_light_profiles(hass, mock_storage, not_mock_profile_loading):
     """Test light profiles."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -435,7 +435,7 @@ async def test_broken_light_profiles(hass, mock_storage):
     )
 
 
-async def test_light_profiles(hass, mock_storage):
+async def test_light_profiles(hass, mock_storage, not_mock_profile_loading):
     """Test light profiles."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -484,7 +484,9 @@ async def test_light_profiles(hass, mock_storage):
     assert data == {light.ATTR_TRANSITION: 0}
 
 
-async def test_light_profiles_with_transition(hass, mock_storage):
+async def test_light_profiles_with_transition(
+    hass, mock_storage, not_mock_profile_loading
+):
     """Test light profiles with transition."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -530,7 +532,7 @@ async def test_light_profiles_with_transition(hass, mock_storage):
     assert data == {light.ATTR_TRANSITION: 0}
 
 
-async def test_default_profiles_group(hass, mock_storage):
+async def test_default_profiles_group(hass, mock_storage, not_mock_profile_loading):
     """Test default turn-on light profile for all lights."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -571,7 +573,7 @@ async def test_default_profiles_group(hass, mock_storage):
     }
 
 
-async def test_default_profiles_light(hass, mock_storage):
+async def test_default_profiles_light(hass, mock_storage, not_mock_profile_loading):
     """Test default turn-on light profile for a specific light."""
     platform = getattr(hass.components, "test.light")
     platform.init()

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -105,7 +105,7 @@ async def test_methods(hass):
     assert call.data[light.ATTR_TRANSITION] == "transition_val"
 
 
-async def test_services(hass, mock_profiles):
+async def test_services(hass, mock_light_profiles):
     """Test the provided services."""
     platform = getattr(hass.components, "test.light")
 
@@ -280,7 +280,7 @@ async def test_services(hass, mock_profiles):
     assert data == {}
 
     # One of the light profiles
-    mock_profiles["relax"] = (35.932, 69.412, 144, 0)
+    mock_light_profiles["relax"] = (35.932, 69.412, 144, 0)
     prof_name, prof_h, prof_s, prof_bri, prof_t = "relax", 35.932, 69.412, 144, 0
 
     # Test light profiles
@@ -407,13 +407,13 @@ async def test_services(hass, mock_profiles):
     assert data == {}
 
 
-async def test_light_profiles(hass, mock_profiles):
+async def test_light_profiles(hass, mock_light_profiles):
     """Test light profiles."""
     platform = getattr(hass.components, "test.light")
     platform.init()
 
-    mock_profiles["test"] = color.color_xy_to_hs(0.4, 0.6) + (100, 0)
-    mock_profiles["test_off"] = 0, 0, 0, 0
+    mock_light_profiles["test"] = color.color_xy_to_hs(0.4, 0.6) + (100, 0)
+    mock_light_profiles["test_off"] = 0, 0, 0, 0
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -452,7 +452,7 @@ async def test_light_profiles(hass, mock_profiles):
     assert data == {light.ATTR_TRANSITION: 0}
 
 
-async def test_default_profiles_group(hass, mock_profiles):
+async def test_default_profiles_group(hass, mock_light_profiles):
     """Test default turn-on light profile for all lights."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -462,7 +462,10 @@ async def test_default_profiles_group(hass, mock_profiles):
     )
     await hass.async_block_till_done()
 
-    mock_profiles["group.all_lights.default"] = color.color_xy_to_hs(0.4, 0.6) + (99, 2)
+    mock_light_profiles["group.all_lights.default"] = color.color_xy_to_hs(0.4, 0.6) + (
+        99,
+        2,
+    )
 
     ent, _, _ = platform.ENTITIES
     await hass.services.async_call(
@@ -477,7 +480,7 @@ async def test_default_profiles_group(hass, mock_profiles):
     }
 
 
-async def test_default_profiles_light(hass, mock_profiles):
+async def test_default_profiles_light(hass, mock_light_profiles):
     """Test default turn-on light profile for a specific light."""
     platform = getattr(hass.components, "test.light")
     platform.init()
@@ -487,11 +490,14 @@ async def test_default_profiles_light(hass, mock_profiles):
     )
     await hass.async_block_till_done()
 
-    mock_profiles["group.all_lights.default"] = color.color_xy_to_hs(0.3, 0.5) + (
+    mock_light_profiles["group.all_lights.default"] = color.color_xy_to_hs(0.3, 0.5) + (
         200,
         0,
     )
-    mock_profiles["light.ceiling_2.default"] = color.color_xy_to_hs(0.6, 0.6) + (100, 3)
+    mock_light_profiles["light.ceiling_2.default"] = color.color_xy_to_hs(0.6, 0.6) + (
+        100,
+        3,
+    )
 
     dev = next(filter(lambda x: x.entity_id == "light.ceiling_2", platform.ENTITIES))
     await hass.services.async_call(

--- a/tests/components/litejet/conftest.py
+++ b/tests/components/litejet/conftest.py
@@ -1,2 +1,2 @@
 """litejet conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/litejet/conftest.py
+++ b/tests/components/litejet/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""litejet conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/mochad/conftest.py
+++ b/tests/components/mochad/conftest.py
@@ -1,2 +1,2 @@
 """mochad conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/mochad/conftest.py
+++ b/tests/components/mochad/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""mochad conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/mqtt/conftest.py
+++ b/tests/components/mqtt/conftest.py
@@ -1,2 +1,2 @@
 """Test fixtures for mqtt component."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/ozw/conftest.py
+++ b/tests/components/ozw/conftest.py
@@ -7,7 +7,7 @@ from .common import MQTTMessage
 
 from tests.async_mock import patch
 from tests.common import load_fixture
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture(name="generic_data", scope="session")

--- a/tests/components/ozw/conftest.py
+++ b/tests/components/ozw/conftest.py
@@ -7,6 +7,7 @@ from .common import MQTTMessage
 
 from tests.async_mock import patch
 from tests.common import load_fixture
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture(name="generic_data", scope="session")

--- a/tests/components/rflink/conftest.py
+++ b/tests/components/rflink/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""rflink conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/rflink/conftest.py
+++ b/tests/components/rflink/conftest.py
@@ -1,2 +1,2 @@
 """rflink conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -9,6 +9,7 @@ from homeassistant.util.dt import utcnow
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 def create_rfx_test_cfg(device="abcd", automatic_add=False, devices=None):

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -9,7 +9,7 @@ from homeassistant.util.dt import utcnow
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 def create_rfx_test_cfg(device="abcd", automatic_add=False, devices=None):

--- a/tests/components/ring/conftest.py
+++ b/tests/components/ring/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import requests_mock
 
 from tests.common import load_fixture
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture(name="requests_mock")

--- a/tests/components/ring/conftest.py
+++ b/tests/components/ring/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import requests_mock
 
 from tests.common import load_fixture
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture(name="requests_mock")

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -47,7 +47,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 COMPONENT_PREFIX = "homeassistant.components.smartthings."
 

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -47,6 +47,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.async_mock import Mock, patch
 from tests.common import MockConfigEntry
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 COMPONENT_PREFIX = "homeassistant.components.smartthings."
 

--- a/tests/components/switch/conftest.py
+++ b/tests/components/switch/conftest.py
@@ -1,2 +1,2 @@
 """switch conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/switch/conftest.py
+++ b/tests/components/switch/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""switch conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -1,5 +1,4 @@
 """Test fixtures for Tasmota component."""
-
 from hatasmota.discovery import get_status_sensor_entities
 import pytest
 
@@ -17,6 +16,7 @@ from tests.common import (
     mock_device_registry,
     mock_registry,
 )
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture

--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -16,7 +16,7 @@ from tests.common import (
     mock_device_registry,
     mock_registry,
 )
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""template conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -1,2 +1,2 @@
 """template conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/tplink/conftest.py
+++ b/tests/components/tplink/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""tplink conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/tplink/conftest.py
+++ b/tests/components/tplink/conftest.py
@@ -1,2 +1,2 @@
 """tplink conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from . import MOCK_GATEWAY_ID
 
 from tests.async_mock import Mock, patch
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 # pylint: disable=protected-access
 

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from . import MOCK_GATEWAY_ID
 
 from tests.async_mock import Mock, patch
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 # pylint: disable=protected-access
 

--- a/tests/components/vera/conftest.py
+++ b/tests/components/vera/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from .common import ComponentFactory
 
 from tests.async_mock import patch
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture()

--- a/tests/components/vera/conftest.py
+++ b/tests/components/vera/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for tests."""
-
 import pytest
 
 from .common import ComponentFactory
 
 from tests.async_mock import patch
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 
 @pytest.fixture()

--- a/tests/components/wilight/conftest.py
+++ b/tests/components/wilight/conftest.py
@@ -1,2 +1,2 @@
 """wilight conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/wilight/conftest.py
+++ b/tests/components/wilight/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""wilight conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,2 +1,2 @@
 """wled conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""wled conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/yeelight/conftest.py
+++ b/tests/components/yeelight/conftest.py
@@ -1,2 +1,2 @@
 """yeelight conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/yeelight/conftest.py
+++ b/tests/components/yeelight/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""yeelight conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/zerproc/conftest.py
+++ b/tests/components/zerproc/conftest.py
@@ -1,2 +1,2 @@
 """zerproc conftest."""
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa

--- a/tests/components/zerproc/conftest.py
+++ b/tests/components/zerproc/conftest.py
@@ -1,2 +1,2 @@
-"""Test fixtures for mqtt component."""
+"""zerproc conftest."""
 from tests.components.light.conftest import mock_profile_loading  # noqa

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -15,7 +15,7 @@ from .common import FakeDevice, FakeEndpoint, get_zha_gateway
 
 from tests.async_mock import AsyncMock, MagicMock, PropertyMock, patch
 from tests.common import MockConfigEntry
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -1,5 +1,4 @@
 """Test configuration for the ZHA component."""
-
 import pytest
 import zigpy
 from zigpy.application import ControllerApplication
@@ -16,6 +15,7 @@ from .common import FakeDevice, FakeEndpoint, get_zha_gateway
 
 from tests.async_mock import AsyncMock, MagicMock, PropertyMock, patch
 from tests.common import MockConfigEntry
+from tests.components.light.conftest import mock_profile_loading  # noqa
 
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"

--- a/tests/components/zwave/conftest.py
+++ b/tests/components/zwave/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from homeassistant.components.zwave import const
 
 from tests.async_mock import AsyncMock, MagicMock, patch
+from tests.components.light.conftest import mock_profile_loading  # noqa
 from tests.mock.zwave import MockNetwork, MockNode, MockOption, MockValue
 
 

--- a/tests/components/zwave/conftest.py
+++ b/tests/components/zwave/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.components.zwave import const
 
 from tests.async_mock import AsyncMock, MagicMock, patch
-from tests.components.light.conftest import mock_profile_loading  # noqa
+from tests.components.light.conftest import mock_light_profiles  # noqa
 from tests.mock.zwave import MockNetwork, MockNode, MockOption, MockValue
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We've seen a flaky test. This is happening because a bad profile data is written for a test, and that is loaded by another test.

This PR changes:
 - Profiles are now stored in `hass` instead of in a static class variable
 - Light tests automatically stub out profile loading
 - New test added to verify profile class works
 - All integrations that have light tests will also stub out the profile loading.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41069
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
