### PR TITLE
Add retry for unavailable static tplink devices after HA starts

### DIFF
--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -23,6 +23,8 @@ CONF_LIGHT = "light"
 CONF_STRIP = "strip"
 CONF_SWITCH = "switch"
 
+UNAVAILABLE_RETRY_DELAY = 60
+
 
 class SmartDevices:
     """Hold different kinds of devices."""
@@ -127,3 +129,22 @@ def get_static_devices(config_data) -> SmartDevices:
                     "Failed to setup device %s due to %s; not retrying", host, sde
                 )
     return SmartDevices(lights, switches)
+
+
+def get_devices_sysinfo(devices, device_class):
+    """Get sysinfo for all devices."""
+    entities_ready = []
+    entities_unavailable = []
+    for device in devices:
+        try:
+            device.get_sysinfo()
+            entities_ready.append(device_class(device))
+        except SmartDeviceException as ex:
+            entities_unavailable.append(device)
+            _LOGGER.warning(
+                "Unable to communicate with device %s: %s",
+                device.host,
+                ex,
+            )
+
+    return entities_ready, entities_unavailable

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -78,8 +78,10 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_ent
             get_devices_sysinfo, entities_unavailable, TPLinkSmartBulb
         )
         if entities_ready:
+            _LOGGER.debug("Adding additional entries")
             async_add_entities(entities_ready, update_before_add=True)
         if entities_unavailable:
+            _LOGGER.debug("Rescheduling retry for unavailable devices")
             hass.helpers.event.async_call_later(
                 UNAVAILABLE_RETRY_DELAY, async_retry_setup_entry
             )

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -73,7 +73,15 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_ent
 def get_devices_sysinfo(devices):
     """Get sysinfo for all devices."""
     for device in devices:
-        device.get_sysinfo()
+        try:
+            device.get_sysinfo()
+        except SmartDeviceException as ex:
+            _LOGGER.warning(
+                "Unable to communicate with device %s due to: %s",
+                device.host,
+                ex,
+            )
+            devices.remove(device)
 
 
 def brightness_to_percentage(byt):

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -69,7 +69,8 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_ent
     entities_ready, entities_unavailable = await hass.async_add_executor_job(
         get_devices_sysinfo, devices, TPLinkSmartBulb
     )
-    async_add_entities(entities_ready, update_before_add=True)
+    if entities_ready:
+        async_add_entities(entities_ready, update_before_add=True)
 
     async def async_retry_setup_entry(_):
         entities_unavailable = hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_remaining"]

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -46,8 +46,10 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_ent
             get_devices_sysinfo, entities_unavailable, SmartPlugSwitch
         )
         if entities_ready:
+            _LOGGER.debug("Adding additional entries")
             async_add_entities(entities_ready, update_before_add=True)
         if entities_unavailable:
+            _LOGGER.debug("Rescheduling retry for unavailable devices")
             hass.helpers.event.async_call_later(
                 UNAVAILABLE_RETRY_DELAY, async_retry_setup_entry
             )

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -37,7 +37,8 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_ent
     entities_ready, entities_unavailable = await hass.async_add_executor_job(
         get_devices_sysinfo, devices, SmartPlugSwitch
     )
-    async_add_entities(entities_ready, update_before_add=True)
+    if entities_ready:
+        async_add_entities(entities_ready, update_before_add=True)
 
     async def async_retry_setup_entry(_):
         entities_unavailable = hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_remaining"]

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -42,7 +42,15 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_ent
 def get_devices_sysinfo(devices):
     """Get sysinfo for all devices."""
     for device in devices:
-        device.get_sysinfo()
+        try:
+            device.get_sysinfo()
+        except SmartDeviceException as ex:
+            _LOGGER.warning(
+                "Unable to communicate with device %s due to: %s",
+                device.host,
+                ex,
+            )
+            devices.remove(device)
 
 
 class SmartPlugSwitch(SwitchEntity):

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -10,11 +10,12 @@ from homeassistant.components.switch import (
     ATTR_TODAY_ENERGY_KWH,
     SwitchEntity,
 )
-from homeassistant.const import ATTR_VOLTAGE
+from homeassistant.const import ATTR_VOLTAGE, EVENT_HOMEASSISTANT_STARTED
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import CONF_SWITCH, DOMAIN as TPLINK_DOMAIN
+from .common import UNAVAILABLE_RETRY_DELAY, get_devices_sysinfo
 
 PARALLEL_UPDATES = 0
 
@@ -30,27 +31,31 @@ SLEEP_TIME = 2
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up switches."""
     devices = hass.data[TPLINK_DOMAIN][CONF_SWITCH]
-    entities = []
+    entities_ready = []
+    entities_unavailable = []
 
-    await hass.async_add_executor_job(get_devices_sysinfo, devices)
-    for device in devices:
-        entities.append(SmartPlugSwitch(device))
+    entities_ready, entities_unavailable = await hass.async_add_executor_job(
+        get_devices_sysinfo, devices, SmartPlugSwitch
+    )
+    async_add_entities(entities_ready, update_before_add=True)
 
-    async_add_entities(entities, update_before_add=True)
-
-
-def get_devices_sysinfo(devices):
-    """Get sysinfo for all devices."""
-    for device in devices:
-        try:
-            device.get_sysinfo()
-        except SmartDeviceException as ex:
-            _LOGGER.warning(
-                "Unable to communicate with device %s due to: %s",
-                device.host,
-                ex,
+    async def async_retry_setup_entry(_):
+        entities_unavailable = hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_remaining"]
+        entities_ready, entities_unavailable = await hass.async_add_executor_job(
+            get_devices_sysinfo, entities_unavailable, SmartPlugSwitch
+        )
+        if entities_ready:
+            async_add_entities(entities_ready, update_before_add=True)
+        if entities_unavailable:
+            hass.helpers.event.async_call_later(
+                UNAVAILABLE_RETRY_DELAY, async_retry_setup_entry
             )
-            devices.remove(device)
+
+    if entities_unavailable:
+        hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_remaining"] = entities_unavailable
+
+        _LOGGER.warning("Scheduling a retry for unavailable devices")
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, async_retry_setup_entry)
 
 
 class SmartPlugSwitch(SwitchEntity):

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -1,5 +1,4 @@
 """Tests for the TP-Link component."""
-import logging
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -17,7 +16,6 @@ from homeassistant.components.tplink.common import (
 from homeassistant.const import CONF_HOST
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import Mock
 from tests.common import MockConfigEntry, mock_coro
 
 
@@ -221,29 +219,6 @@ async def test_platforms_are_initialized(hass):
     assert discover.call_count == 0
     assert light_setup.call_count == 1
     assert switch_setup.call_count == 1
-
-
-async def test_async_setup_entry_unavailable(hass, caplog):
-    """Test async_setup_entry."""
-    config = {
-        tplink.DOMAIN: {
-            CONF_DISCOVERY: False,
-            CONF_LIGHT: [{CONF_HOST: "123.123.123.123"}],
-        }
-    }
-
-    caplog.clear()
-    caplog.set_level(logging.WARNING)
-    await async_setup_component(hass, tplink.DOMAIN, config)
-    await hass.async_block_till_done()
-
-    await tplink.light.async_setup_entry(hass, Mock(), MagicMock())
-    assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1
-    assert (
-        "Unable to communicate with device 123.123.123.123: Communication error"
-        in caplog.text
-    )
-    assert "Scheduling a retry for unavailable devices" in caplog.text
 
 
 async def test_no_config_creates_no_entry(hass):

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -223,7 +223,7 @@ async def test_platforms_are_initialized(hass):
     assert switch_setup.call_count == 1
 
 
-async def test_async_setup_entry_default(hass, caplog):
+async def test_async_setup_entry_unavailable(hass, caplog):
     """Test async_setup_entry."""
     config = {
         tplink.DOMAIN: {
@@ -244,9 +244,6 @@ async def test_async_setup_entry_default(hass, caplog):
         in caplog.text
     )
     assert "Scheduling a retry for unavailable devices" in caplog.text
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    await hass.async_block_till_done()
 
 
 async def test_no_config_creates_no_entry(hass):

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.components.tplink.common import (
     CONF_LIGHT,
     CONF_SWITCH,
 )
-from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import CONF_HOST
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import Mock

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the TP-Link component."""
+import logging
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -13,9 +14,10 @@ from homeassistant.components.tplink.common import (
     CONF_LIGHT,
     CONF_SWITCH,
 )
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.setup import async_setup_component
 
+from tests.async_mock import Mock
 from tests.common import MockConfigEntry, mock_coro
 
 
@@ -219,6 +221,28 @@ async def test_platforms_are_initialized(hass):
     assert discover.call_count == 0
     assert light_setup.call_count == 1
     assert switch_setup.call_count == 1
+
+
+async def test_async_setup_entry_default(hass, caplog):
+    """Test async_setup_entry."""
+    config = {
+        tplink.DOMAIN: {
+            CONF_DISCOVERY: False,
+            CONF_LIGHT: [{CONF_HOST: "123.123.123.123"}],
+        }
+    }
+
+    caplog.clear()
+    caplog.set_level(logging.WARNING)
+    await async_setup_component(hass, tplink.DOMAIN, config)
+    await hass.async_block_till_done()
+
+    await tplink.light.async_setup_entry(hass, Mock(), MagicMock())
+    assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1
+    assert "Scheduling a retry for unavailable devices" in caplog.text
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
 
 
 async def test_no_config_creates_no_entry(hass):

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -239,6 +239,7 @@ async def test_async_setup_entry_default(hass, caplog):
 
     await tplink.light.async_setup_entry(hass, Mock(), MagicMock())
     assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1
+    assert "Unable to communicate with device 123.123.123.123: Communication error"
     assert "Scheduling a retry for unavailable devices" in caplog.text
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -239,7 +239,10 @@ async def test_async_setup_entry_default(hass, caplog):
 
     await tplink.light.async_setup_entry(hass, Mock(), MagicMock())
     assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1
-    assert "Unable to communicate with device 123.123.123.123: Communication error"
+    assert (
+        "Unable to communicate with device 123.123.123.123: Communication error"
+        in caplog.text
+    )
     assert "Scheduling a retry for unavailable devices" in caplog.text
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -25,7 +25,6 @@ from homeassistant.components.tplink.light import SLEEP_TIME
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,
-    EVENT_HOMEASSISTANT_STARTED,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
@@ -606,48 +605,5 @@ async def test_async_setup_entry_unavailable(
         )
 
         await hass.async_block_till_done()
-        assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1
         assert "Unable to communicate with device 123.123.123.123" in caplog.text
-        assert "Scheduling a retry for unavailable devices" in caplog.text
-        caplog.clear()
-        caplog.set_level(logging.DEBUG)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-        with patch("homeassistant.components.tplink.common", UNAVAILABLE_RETRY_DELAY=0):
-            assert "Rescheduling retry for unavailable devices" in caplog.text
-
-
-async def test_async_setup_entry_rescheduled(
-    hass: HomeAssistant, light_mock_data: LightMockData, caplog
-):
-    """Test async_setup_entry is rescheduled."""
-
-    with patch(
-        "homeassistant.components.tplink.common.SmartDevice.get_sysinfo",
-        side_effect=SmartDeviceException,
-    ):
-        await async_setup_component(hass, HA_DOMAIN, {})
-        await hass.async_block_till_done()
-
-        await async_setup_component(
-            hass,
-            tplink.DOMAIN,
-            {
-                tplink.DOMAIN: {
-                    CONF_DISCOVERY: False,
-                    CONF_LIGHT: [{CONF_HOST: "123.123.123.124"}],
-                }
-            },
-        )
-
-        await hass.async_block_till_done()
-
-    caplog.clear()
-    caplog.set_level(logging.DEBUG)
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    await hass.async_block_till_done()
-
-    with patch("homeassistant.components.tplink.common", UNAVAILABLE_RETRY_DELAY=0):
-
-        assert "Adding additional entries" in caplog.text
+        assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import MagicMock, Mock, PropertyMock, patch
+from tests.async_mock import Mock, PropertyMock, patch
 
 
 class LightMockData(NamedTuple):

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -455,6 +455,75 @@ async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> Non
     assert state.attributes["brightness"] == 232
 
 
+async def test_get_light_state_retry(
+    hass: HomeAssistant, light_mock_data: LightMockData
+) -> None:
+    """Test function."""
+    # Setup test for retries for sysinfo.
+    get_sysinfo_call_count = 0
+
+    def get_sysinfo_side_effect():
+        nonlocal get_sysinfo_call_count
+        get_sysinfo_call_count += 1
+
+        # Need to fail on the 2nd call because the first call is used to
+        # determine if the device is online during the light platform's
+        # setup hook.
+        if get_sysinfo_call_count == 2:
+            raise SmartDeviceException()
+
+        return light_mock_data.sys_info
+
+    light_mock_data.get_sysinfo_mock.side_effect = get_sysinfo_side_effect
+
+    # Setup test for retries of setting state information.
+    set_state_call_count = 0
+
+    def set_light_state_side_effect(state_data: dict):
+        nonlocal set_state_call_count, light_mock_data
+        set_state_call_count += 1
+
+        if set_state_call_count == 1:
+            raise SmartDeviceException()
+
+        return light_mock_data.set_light_state(state_data)
+
+    light_mock_data.set_light_state_mock.side_effect = set_light_state_side_effect
+
+    # Setup component.
+    await async_setup_component(hass, HA_DOMAIN, {})
+    await hass.async_block_till_done()
+
+    await async_setup_component(
+        hass,
+        tplink.DOMAIN,
+        {
+            tplink.DOMAIN: {
+                CONF_DISCOVERY: False,
+                CONF_LIGHT: [{CONF_HOST: "123.123.123.123"}],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "light.light1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    await update_entity(hass, "light.light1")
+
+    assert light_mock_data.get_sysinfo_mock.call_count > 1
+    assert light_mock_data.get_light_state_mock.call_count > 1
+    assert light_mock_data.set_light_state_mock.call_count > 1
+
+    assert light_mock_data.get_sysinfo_mock.call_count < 40
+    assert light_mock_data.get_light_state_mock.call_count < 40
+    assert light_mock_data.set_light_state_mock.call_count < 10
+
+
 async def test_update_failure(
     hass: HomeAssistant, light_mock_data: LightMockData, caplog
 ):
@@ -523,7 +592,6 @@ async def test_async_setup_entry_unavailable(hass, caplog):
     caplog.set_level(logging.WARNING)
     await async_setup_component(hass, tplink.DOMAIN, config)
     await hass.async_block_till_done()
-    await tplink.light.async_setup_entry(hass, Mock(), MagicMock())
 
     assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1
     assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current tplink component will fail if a device is not available during startup. This change adds a try during the initial device setup and removes the device to prevent component from failing completely.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42222
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
