### PR TITLE
Expose more Websocket API constants

### DIFF
--- a/homeassistant/components/websocket_api/__init__.py
+++ b/homeassistant/components/websocket_api/__init__.py
@@ -6,24 +6,37 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.loader import bind_hass
 
-from . import commands, connection, const, decorators, http, messages
+from . import commands, connection, const, decorators, http, messages  # noqa
+from .connection import ActiveConnection  # noqa
+from .const import (  # noqa
+    ERR_HOME_ASSISTANT_ERROR,
+    ERR_INVALID_FORMAT,
+    ERR_NOT_FOUND,
+    ERR_NOT_SUPPORTED,
+    ERR_TEMPLATE_ERROR,
+    ERR_TIMEOUT,
+    ERR_UNAUTHORIZED,
+    ERR_UNKNOWN_COMMAND,
+    ERR_UNKNOWN_ERROR,
+)
+from .decorators import (  # noqa
+    async_response,
+    require_admin,
+    websocket_command,
+    ws_require_user,
+)
+from .messages import (  # noqa
+    BASE_COMMAND_MESSAGE_SCHEMA,
+    error_message,
+    event_message,
+    result_message,
+)
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 
 DOMAIN = const.DOMAIN
 
 DEPENDENCIES = ("http",)
-
-# Backwards compat / Make it easier to integrate
-ActiveConnection = connection.ActiveConnection
-BASE_COMMAND_MESSAGE_SCHEMA = messages.BASE_COMMAND_MESSAGE_SCHEMA
-error_message = messages.error_message
-result_message = messages.result_message
-event_message = messages.event_message
-async_response = decorators.async_response
-require_admin = decorators.require_admin
-ws_require_user = decorators.ws_require_user
-websocket_command = decorators.websocket_command
 
 
 @bind_hass

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Hashable, Optional
 import voluptuous as vol
 
 from homeassistant.core import Context, callback
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 
 from . import const, messages
 
@@ -118,6 +118,9 @@ class ActiveConnection:
         elif isinstance(err, asyncio.TimeoutError):
             code = const.ERR_TIMEOUT
             err_message = "Timeout"
+        elif isinstance(err, HomeAssistantError):
+            code = const.ERR_UNKNOWN_ERROR
+            err_message = str(err)
         else:
             code = const.ERR_UNKNOWN_ERROR
             err_message = "Unknown error"

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -1,4 +1,10 @@
 """Test WebSocket Connection class."""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant import exceptions
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api import const
 
@@ -20,3 +26,32 @@ async def test_send_big_result(hass, websocket_client):
     assert msg["type"] == const.TYPE_RESULT
     assert msg["success"]
     assert msg["result"] == {"big": "result"}
+
+
+async def test_exception_handling():
+    """Test handling of exceptions."""
+    send_messages = []
+    conn = websocket_api.ActiveConnection(
+        logging.getLogger(__name__), None, send_messages.append, None, None
+    )
+
+    for (exc, code, err) in (
+        (exceptions.Unauthorized(), websocket_api.ERR_UNAUTHORIZED, "Unauthorized"),
+        (
+            vol.Invalid("Invalid something"),
+            websocket_api.ERR_INVALID_FORMAT,
+            "Invalid something. Got {'id': 5}",
+        ),
+        (asyncio.TimeoutError(), websocket_api.ERR_TIMEOUT, "Timeout"),
+        (
+            exceptions.HomeAssistantError("Failed to do X"),
+            websocket_api.ERR_UNKNOWN_ERROR,
+            "Failed to do X",
+        ),
+        (ValueError("Really bad"), websocket_api.ERR_UNKNOWN_ERROR, "Unknown error"),
+    ):
+        send_messages.clear()
+        conn.async_handle_exception({"id": 5}, exc)
+        assert len(send_messages) == 1
+        assert send_messages[0]["error"]["code"] == code
+        assert send_messages[0]["error"]["message"] == err


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I noticed in a recent PR that it is cumbersome to work with the websocket API. This PR exposes all the errors and decorators at the top level.

Also includes supported handling of the `HomeAssistantError`. It will not log as an exception anymore, but it will still treat it as an error. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
