### PR TITLE
Ensure event listener integrations do the queue insert as a callback

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import event as event_helper, state as state_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_values import EntityValues
@@ -500,6 +501,7 @@ class InfluxThread(threading.Thread):
         self.shutdown = False
         hass.bus.listen(EVENT_STATE_CHANGED, self._event_listener)
 
+    @callback
     def _event_listener(self, event):
         """Listen for new messages on the bus and queue them for Influx."""
         item = (time.monotonic(), event)

--- a/homeassistant/components/watson_iot/__init__.py
+++ b/homeassistant/components/watson_iot/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
 
@@ -165,6 +166,7 @@ class WatsonIOTThread(threading.Thread):
         self.shutdown = False
         hass.bus.listen(EVENT_STATE_CHANGED, self._event_listener)
 
+    @callback
     def _event_listener(self, event):
         """Listen for new messages on the bus and queue them for Watson IoT."""
         item = (time.monotonic(), event)

--- a/homeassistant/components/zabbix/__init__.py
+++ b/homeassistant/components/zabbix/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import callback
 from homeassistant.helpers import event as event_helper, state as state_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import (
@@ -186,6 +187,7 @@ class ZabbixThread(threading.Thread):
         self.queue.put(None)
         self.join()
 
+    @callback
     def _event_listener(self, event):
         """Listen for new messages on the bus and queue them for Zabbix."""
         item = (time.monotonic(), event)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

At least three of the integrations that insert into queue that is
read in another thread were missing the callback decorator which
resulted in each state changed event jumping into the executor to
do the queue insert which is going to be processed by another thread. 

Matches recorder behavior:
https://github.com/home-assistant/core/blob/dev/homeassistant/components/recorder/__init__.py#L529

The following integrations have this issue.  This fix only takes
care of three since they used the same copied code:
- [ ] datadog (opened https://github.com/home-assistant/core/issues/42267)
- [ ] google_pubsub (opened https://github.com/home-assistant/core/issues/42268)
- [ ] graphite (opened https://github.com/home-assistant/core/issues/42269)
- [x] influxdb
- [ ] logentries (opened https://github.com/home-assistant/core/issues/42270)
- [ ] prometheus (opened https://github.com/home-assistant/core/issues/42271)
- [ ] shiftr (https://github.com/home-assistant/core/issues/42273)
- [ ] statsd (https://github.com/home-assistant/core/issues/42274)
- [x] watson_iot
- [x] zabbix

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
