### PR TITLE
Add remote control platform to Panasonic Viera

### DIFF
--- a/homeassistant/components/panasonic_viera/__init__.py
+++ b/homeassistant/components/panasonic_viera/__init__.py
@@ -8,6 +8,7 @@ from panasonic_viera import EncryptionRequired, Keys, RemoteControl, SOAPError
 import voluptuous as vol
 
 from homeassistant.components.media_player.const import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_ON
 import homeassistant.helpers.config_validation as cv
@@ -46,7 +47,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS = [MEDIA_PLAYER_DOMAIN]
+PLATFORMS = [MEDIA_PLAYER_DOMAIN, REMOTE_DOMAIN]
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/panasonic_viera/__init__.py
+++ b/homeassistant/components/panasonic_viera/__init__.py
@@ -246,7 +246,9 @@ class Remote:
         """Return device info."""
         if self._control is None:
             return None
-        return await self._handle_errors(self._control.get_device_info)
+        device_info = await self._handle_errors(self._control.get_device_info)
+        _LOGGER.debug("Fetched device info: %s", str(device_info))
+        return device_info
 
     async def _handle_errors(self, func, *args):
         """Handle errors from func, set available and reconnect if needed."""

--- a/homeassistant/components/panasonic_viera/const.py
+++ b/homeassistant/components/panasonic_viera/const.py
@@ -18,4 +18,7 @@ ATTR_MANUFACTURER = "manufacturer"
 ATTR_MODEL_NUMBER = "modelNumber"
 ATTR_UDN = "UDN"
 
+DEFAULT_MANUFACTURER = "Panasonic"
+DEFAULT_MODEL_NUMBER = "Panasonic Viera"
+
 ERROR_INVALID_PIN_CODE = "invalid_pin_code"

--- a/homeassistant/components/panasonic_viera/const.py
+++ b/homeassistant/components/panasonic_viera/const.py
@@ -19,6 +19,6 @@ ATTR_MODEL_NUMBER = "modelNumber"
 ATTR_UDN = "UDN"
 
 DEFAULT_MANUFACTURER = "Panasonic"
-DEFAULT_MODEL_NUMBER = "Panasonic Viera"
+DEFAULT_MODEL_NUMBER = "Viera"
 
 ERROR_INVALID_PIN_CODE = "invalid_pin_code"

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -71,9 +71,9 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
     @property
     def unique_id(self) -> str:
         """Return the unique ID of the device."""
-        if self._device_info is not None:
-            return self._device_info[ATTR_UDN]
-        return None
+        if self._device_info is None:
+            return None
+        return self._device_info[ATTR_UDN]
 
     @property
     def device_info(self):

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -26,6 +26,8 @@ from .const import (
     ATTR_MODEL_NUMBER,
     ATTR_REMOTE,
     ATTR_UDN,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
     DOMAIN,
 )
 
@@ -83,8 +85,10 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
         return {
             "name": self._name,
             "identifiers": {(DOMAIN, self._device_info[ATTR_UDN])},
-            "manufacturer": self._device_info[ATTR_MANUFACTURER],
-            "model": self._device_info[ATTR_MODEL_NUMBER],
+            "manufacturer": self._device_info.get(
+                ATTR_MANUFACTURER, DEFAULT_MANUFACTURER
+            ),
+            "model": self._device_info.get(ATTR_MODEL_NUMBER, DEFAULT_MODEL_NUMBER),
         }
 
     @property

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -71,7 +71,7 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
         self._device_info = device_info
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self):
         """Return the unique ID of the device."""
         if self._device_info is None:
             return None

--- a/homeassistant/components/panasonic_viera/remote.py
+++ b/homeassistant/components/panasonic_viera/remote.py
@@ -46,7 +46,7 @@ class PanasonicVieraRemoteEntity(RemoteEntity):
         """Return the unique ID of the device."""
         if self._device_info is None:
             return None
-        return self._device_info.get(ATTR_UDN)
+        return self._device_info[ATTR_UDN]
 
     @property
     def device_info(self):

--- a/homeassistant/components/panasonic_viera/remote.py
+++ b/homeassistant/components/panasonic_viera/remote.py
@@ -1,0 +1,87 @@
+"""Remote control support for Panasonic Viera TV."""
+import logging
+
+from homeassistant.components.remote import RemoteEntity
+from homeassistant.const import CONF_NAME, STATE_ON
+
+from .const import (
+    ATTR_DEVICE_INFO,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL_NUMBER,
+    ATTR_REMOTE,
+    ATTR_UDN,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Panasonic Viera TV Remote from a config entry."""
+
+    config = config_entry.data
+
+    remote = hass.data[DOMAIN][config_entry.entry_id][ATTR_REMOTE]
+    name = config[CONF_NAME]
+    device_info = config[ATTR_DEVICE_INFO]
+
+    remote_device = PanasonicVieraRemoteEntity(remote, name, device_info)
+    async_add_entities([remote_device])
+
+
+class PanasonicVieraRemoteEntity(RemoteEntity):
+    """Representation of a Panasonic Viera TV Remote."""
+
+    def __init__(self, remote, name, device_info):
+        """Initialize the entity."""
+        # Save a reference to the imported class
+        self._remote = remote
+        self._name = name
+        self._device_info = device_info
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the device."""
+        if self._device_info is None:
+            return None
+        return self._device_info[ATTR_UDN]
+
+    @property
+    def device_info(self):
+        """Return device specific attributes."""
+        if self._device_info is None:
+            return None
+        return {
+            "name": self._name,
+            "identifiers": {(DOMAIN, self._device_info[ATTR_UDN])},
+            "manufacturer": self._device_info[ATTR_MANUFACTURER],
+            "model": self._device_info[ATTR_MODEL_NUMBER],
+        }
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def available(self):
+        """Return True if the device is available."""
+        return self._remote.available
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._remote.state == STATE_ON
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        await self._remote.async_turn_on()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        await self._remote.async_turn_off()
+
+    async def async_send_command(self, command, **kwargs):
+        """Send a command to one device."""
+        for cmd in command:
+            await self._remote.async_send_key(cmd)

--- a/homeassistant/components/panasonic_viera/remote.py
+++ b/homeassistant/components/panasonic_viera/remote.py
@@ -10,6 +10,8 @@ from .const import (
     ATTR_MODEL_NUMBER,
     ATTR_REMOTE,
     ATTR_UDN,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
     DOMAIN,
 )
 
@@ -44,7 +46,7 @@ class PanasonicVieraRemoteEntity(RemoteEntity):
         """Return the unique ID of the device."""
         if self._device_info is None:
             return None
-        return self._device_info[ATTR_UDN]
+        return self._device_info.get(ATTR_UDN)
 
     @property
     def device_info(self):
@@ -54,8 +56,10 @@ class PanasonicVieraRemoteEntity(RemoteEntity):
         return {
             "name": self._name,
             "identifiers": {(DOMAIN, self._device_info[ATTR_UDN])},
-            "manufacturer": self._device_info[ATTR_MANUFACTURER],
-            "model": self._device_info[ATTR_MODEL_NUMBER],
+            "manufacturer": self._device_info.get(
+                ATTR_MANUFACTURER, DEFAULT_MANUFACTURER
+            ),
+            "model": self._device_info.get(ATTR_MODEL_NUMBER, DEFAULT_MODEL_NUMBER),
         }
 
     @property

--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -12,6 +12,8 @@ from homeassistant.components.panasonic_viera.const import (
     CONF_APP_ID,
     CONF_ENCRYPTION_KEY,
     CONF_ON_ACTION,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DOMAIN,
@@ -42,8 +44,8 @@ def get_mock_remote(
     app_id=None,
     encryption_key=None,
     name=DEFAULT_NAME,
-    manufacturer="mock-manufacturer",
-    model_number="mock-model-number",
+    manufacturer=DEFAULT_MANUFACTURER,
+    model_number=DEFAULT_MODEL_NUMBER,
     unique_id="mock-unique-id",
 ):
     """Return a mock remote."""
@@ -110,8 +112,8 @@ async def test_flow_non_encrypted(hass):
         CONF_ON_ACTION: None,
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }
@@ -208,8 +210,8 @@ async def test_flow_encrypted_valid_pin_code(hass):
         CONF_ENCRYPTION_KEY: "test-encryption-key",
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }
@@ -392,8 +394,8 @@ async def test_imported_flow_non_encrypted(hass):
         CONF_ON_ACTION: "test-on-action",
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }
@@ -442,8 +444,8 @@ async def test_imported_flow_encrypted_valid_pin_code(hass):
         CONF_ENCRYPTION_KEY: "test-encryption-key",
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }

--- a/tests/components/panasonic_viera/test_init.py
+++ b/tests/components/panasonic_viera/test_init.py
@@ -8,6 +8,8 @@ from homeassistant.components.panasonic_viera.const import (
     CONF_APP_ID,
     CONF_ENCRYPTION_KEY,
     CONF_ON_ACTION,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DOMAIN,
@@ -33,8 +35,8 @@ MOCK_ENCRYPTION_DATA = {
 
 MOCK_DEVICE_INFO = {
     ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-    ATTR_MANUFACTURER: "mock-manufacturer",
-    ATTR_MODEL_NUMBER: "mock-model-number",
+    ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+    ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
     ATTR_UDN: "mock-unique-id",
 }
 

--- a/tests/components/panasonic_viera/test_init.py
+++ b/tests/components/panasonic_viera/test_init.py
@@ -78,7 +78,7 @@ async def test_setup_entry_encrypted(hass):
         await hass.async_block_till_done()
 
         state_tv = hass.states.get("media_player.panasonic_viera_tv")
-        state_remote = hass.states.get("media_player.panasonic_viera_remote")
+        state_remote = hass.states.get("remote.panasonic_viera_tv")
 
         assert state_tv
         assert state_tv.name == DEFAULT_NAME
@@ -110,7 +110,7 @@ async def test_setup_entry_encrypted_missing_device_info(hass):
         assert mock_entry.unique_id == MOCK_DEVICE_INFO[ATTR_UDN]
 
         state_tv = hass.states.get("media_player.panasonic_viera_tv")
-        state_remote = hass.states.get("media_player.panasonic_viera_remote")
+        state_remote = hass.states.get("remote.panasonic_viera_tv")
 
         assert state_tv
         assert state_tv.name == DEFAULT_NAME
@@ -142,7 +142,7 @@ async def test_setup_entry_encrypted_missing_device_info_none(hass):
         assert mock_entry.unique_id == MOCK_CONFIG_DATA[CONF_HOST]
 
         state_tv = hass.states.get("media_player.panasonic_viera_tv")
-        state_remote = hass.states.get("media_player.panasonic_viera_remote")
+        state_remote = hass.states.get("remote.panasonic_viera_tv")
 
         assert state_tv
         assert state_tv.name == DEFAULT_NAME
@@ -171,7 +171,7 @@ async def test_setup_entry_unencrypted(hass):
         await hass.async_block_till_done()
 
         state_tv = hass.states.get("media_player.panasonic_viera_tv")
-        state_remote = hass.states.get("media_player.panasonic_viera_remote")
+        state_remote = hass.states.get("remote.panasonic_viera_tv")
 
         assert state_tv
         assert state_tv.name == DEFAULT_NAME
@@ -203,7 +203,7 @@ async def test_setup_entry_unencrypted_missing_device_info(hass):
         assert mock_entry.unique_id == MOCK_DEVICE_INFO[ATTR_UDN]
 
         state_tv = hass.states.get("media_player.panasonic_viera_tv")
-        state_remote = hass.states.get("media_player.panasonic_viera_remote")
+        state_remote = hass.states.get("remote.panasonic_viera_tv")
 
         assert state_tv
         assert state_tv.name == DEFAULT_NAME
@@ -235,7 +235,7 @@ async def test_setup_entry_unencrypted_missing_device_info_none(hass):
         assert mock_entry.unique_id == MOCK_CONFIG_DATA[CONF_HOST]
 
         state_tv = hass.states.get("media_player.panasonic_viera_tv")
-        state_remote = hass.states.get("media_player.panasonic_viera_remote")
+        state_remote = hass.states.get("remote.panasonic_viera_tv")
 
         assert state_tv
         assert state_tv.name == DEFAULT_NAME
@@ -280,7 +280,7 @@ async def test_setup_unload_entry(hass):
     assert mock_entry.state == ENTRY_STATE_NOT_LOADED
 
     state_tv = hass.states.get("media_player.panasonic_viera_tv")
-    state_remote = hass.states.get("media_player.panasonic_viera_remote")
+    state_remote = hass.states.get("remote.panasonic_viera_tv")
 
     assert state_tv is None
     assert state_remote is None

--- a/tests/components/panasonic_viera/test_init.py
+++ b/tests/components/panasonic_viera/test_init.py
@@ -75,10 +75,14 @@ async def test_setup_entry_encrypted(hass):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-        state = hass.states.get("media_player.panasonic_viera_tv")
+        state_tv = hass.states.get("media_player.panasonic_viera_tv")
+        state_remote = hass.states.get("media_player.panasonic_viera_remote")
 
-        assert state
-        assert state.name == DEFAULT_NAME
+        assert state_tv
+        assert state_tv.name == DEFAULT_NAME
+
+        assert state_remote
+        assert state_remote.name == DEFAULT_NAME
 
 
 async def test_setup_entry_encrypted_missing_device_info(hass):
@@ -103,10 +107,14 @@ async def test_setup_entry_encrypted_missing_device_info(hass):
         assert mock_entry.data[ATTR_DEVICE_INFO] == MOCK_DEVICE_INFO
         assert mock_entry.unique_id == MOCK_DEVICE_INFO[ATTR_UDN]
 
-        state = hass.states.get("media_player.panasonic_viera_tv")
+        state_tv = hass.states.get("media_player.panasonic_viera_tv")
+        state_remote = hass.states.get("media_player.panasonic_viera_remote")
 
-        assert state
-        assert state.name == DEFAULT_NAME
+        assert state_tv
+        assert state_tv.name == DEFAULT_NAME
+
+        assert state_remote
+        assert state_remote.name == DEFAULT_NAME
 
 
 async def test_setup_entry_encrypted_missing_device_info_none(hass):
@@ -131,10 +139,14 @@ async def test_setup_entry_encrypted_missing_device_info_none(hass):
         assert mock_entry.data[ATTR_DEVICE_INFO] is None
         assert mock_entry.unique_id == MOCK_CONFIG_DATA[CONF_HOST]
 
-        state = hass.states.get("media_player.panasonic_viera_tv")
+        state_tv = hass.states.get("media_player.panasonic_viera_tv")
+        state_remote = hass.states.get("media_player.panasonic_viera_remote")
 
-        assert state
-        assert state.name == DEFAULT_NAME
+        assert state_tv
+        assert state_tv.name == DEFAULT_NAME
+
+        assert state_remote
+        assert state_remote.name == DEFAULT_NAME
 
 
 async def test_setup_entry_unencrypted(hass):
@@ -156,10 +168,14 @@ async def test_setup_entry_unencrypted(hass):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-        state = hass.states.get("media_player.panasonic_viera_tv")
+        state_tv = hass.states.get("media_player.panasonic_viera_tv")
+        state_remote = hass.states.get("media_player.panasonic_viera_remote")
 
-        assert state
-        assert state.name == DEFAULT_NAME
+        assert state_tv
+        assert state_tv.name == DEFAULT_NAME
+
+        assert state_remote
+        assert state_remote.name == DEFAULT_NAME
 
 
 async def test_setup_entry_unencrypted_missing_device_info(hass):
@@ -184,10 +200,14 @@ async def test_setup_entry_unencrypted_missing_device_info(hass):
         assert mock_entry.data[ATTR_DEVICE_INFO] == MOCK_DEVICE_INFO
         assert mock_entry.unique_id == MOCK_DEVICE_INFO[ATTR_UDN]
 
-        state = hass.states.get("media_player.panasonic_viera_tv")
+        state_tv = hass.states.get("media_player.panasonic_viera_tv")
+        state_remote = hass.states.get("media_player.panasonic_viera_remote")
 
-        assert state
-        assert state.name == DEFAULT_NAME
+        assert state_tv
+        assert state_tv.name == DEFAULT_NAME
+
+        assert state_remote
+        assert state_remote.name == DEFAULT_NAME
 
 
 async def test_setup_entry_unencrypted_missing_device_info_none(hass):
@@ -212,10 +232,14 @@ async def test_setup_entry_unencrypted_missing_device_info_none(hass):
         assert mock_entry.data[ATTR_DEVICE_INFO] is None
         assert mock_entry.unique_id == MOCK_CONFIG_DATA[CONF_HOST]
 
-        state = hass.states.get("media_player.panasonic_viera_tv")
+        state_tv = hass.states.get("media_player.panasonic_viera_tv")
+        state_remote = hass.states.get("media_player.panasonic_viera_remote")
 
-        assert state
-        assert state.name == DEFAULT_NAME
+        assert state_tv
+        assert state_tv.name == DEFAULT_NAME
+
+        assert state_remote
+        assert state_remote.name == DEFAULT_NAME
 
 
 async def test_setup_config_flow_initiated(hass):
@@ -253,6 +277,8 @@ async def test_setup_unload_entry(hass):
 
     assert mock_entry.state == ENTRY_STATE_NOT_LOADED
 
-    state = hass.states.get("media_player.panasonic_viera_tv")
+    state_tv = hass.states.get("media_player.panasonic_viera_tv")
+    state_remote = hass.states.get("media_player.panasonic_viera_remote")
 
-    assert state is None
+    assert state_tv is None
+    assert state_remote is None

--- a/tests/components/panasonic_viera/test_remote.py
+++ b/tests/components/panasonic_viera/test_remote.py
@@ -1,0 +1,84 @@
+"""Test the Panasonic Viera remote entity."""
+
+from homeassistant.components.panasonic_viera.const import ATTR_UDN, DOMAIN
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+
+from .test_init import (
+    MOCK_CONFIG_DATA,
+    MOCK_DEVICE_INFO,
+    MOCK_ENCRYPTION_DATA,
+    get_mock_remote,
+)
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def setup_panasonic_viera(hass):
+    """Initialize integration for tests."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_DEVICE_INFO[ATTR_UDN],
+        data={**MOCK_CONFIG_DATA, **MOCK_ENCRYPTION_DATA, **MOCK_DEVICE_INFO},
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    mock_remote = get_mock_remote()
+
+    with patch(
+        "homeassistant.components.panasonic_viera.Remote",
+        return_value=mock_remote,
+    ):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_turn_on(hass):
+    """Test turn on service call."""
+    mock_remote = get_mock_remote()
+
+    with patch(
+        "homeassistant.components.panasonic_viera.Remote",
+        return_value=mock_remote,
+    ):
+        await setup_panasonic_viera(hass)
+
+        data = {ATTR_ENTITY_ID: "remote.panasonic_viera_tv"}
+        await hass.services.async_call(REMOTE_DOMAIN, SERVICE_TURN_ON, data)
+        await hass.async_block_till_done()
+
+
+async def test_turn_off(hass):
+    """Test turn off service call."""
+    mock_remote = get_mock_remote()
+
+    with patch(
+        "homeassistant.components.panasonic_viera.Remote",
+        return_value=mock_remote,
+    ):
+        await setup_panasonic_viera(hass)
+
+        data = {ATTR_ENTITY_ID: "remote.panasonic_viera_tv"}
+        await hass.services.async_call(REMOTE_DOMAIN, SERVICE_TURN_OFF, data)
+        await hass.async_block_till_done()
+
+
+async def test_send_command(hass):
+    """Test send command service call."""
+    mock_remote = get_mock_remote()
+
+    with patch(
+        "homeassistant.components.panasonic_viera.Remote",
+        return_value=mock_remote,
+    ):
+        await setup_panasonic_viera(hass)
+
+        data = {ATTR_ENTITY_ID: "remote.panasonic_viera_tv", ATTR_COMMAND: "power"}
+        await hass.services.async_call(REMOTE_DOMAIN, SERVICE_SEND_COMMAND, data)
+        await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request adds the `remote` entity to the Panasonic Viera integration (with `send_command` support, for both default and custom keys) and defines default manufacturer and model number values, fixing possible future issues with TVs that (for some reason) don't return all `device_info` properties (as seen here #42205, thanks @tomlut!). I'm also adding remote tests and two new config flow cases to increase code coverage (maybe I should make separate PRs? 🤔) (that happened)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #42205
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15377

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
