### PR TITLE
Fix AVError and allow more missing DTS packets in stream

### DIFF
--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -20,3 +20,5 @@ MIN_SEGMENT_DURATION = 1.5  # Each segment is at least this many seconds
 
 PACKETS_TO_WAIT_FOR_AUDIO = 20  # Some streams have an audio stream with no audio
 MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably reasonable
+
+MAX_MISSING_DTS_PEEK = 10  # Number of missing DTS packets to allow in peek_first_pts

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -22,3 +22,4 @@ PACKETS_TO_WAIT_FOR_AUDIO = 20  # Some streams have an audio stream with no audi
 MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably reasonable
 
 MAX_MISSING_DTS = 6  # Number of packets missing DTS to allow
+STREAM_TIMEOUT = 5  # Timeout for reading stream

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -21,4 +21,4 @@ MIN_SEGMENT_DURATION = 1.5  # Each segment is at least this many seconds
 PACKETS_TO_WAIT_FOR_AUDIO = 20  # Some streams have an audio stream with no audio
 MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably reasonable
 
-MAX_MISSING_DTS_PEEK = 10  # Number of missing DTS packets to allow in peek_first_pts
+MAX_MISSING_DTS = 6  # Number of packets missing DTS to allow

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -22,4 +22,4 @@ PACKETS_TO_WAIT_FOR_AUDIO = 20  # Some streams have an audio stream with no audi
 MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably reasonable
 
 MAX_MISSING_DTS = 6  # Number of packets missing DTS to allow
-STREAM_TIMEOUT = 5  # Timeout for reading stream
+STREAM_TIMEOUT = 30  # Timeout for reading stream

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -237,7 +237,7 @@ def _stream_worker_internal(hass, stream, quit_event):
             else:
                 packet = next(container_packets)
             if packet.dts is None:
-                # Allow MAX_MISSING_DTS consective packets without dts before terminating the stream.
+                # Allow MAX_MISSING_DTS consecutive packets without dts before terminating the stream.
                 if missing_dts >= MAX_MISSING_DTS:
                     raise StopIteration(
                         f"No dts in {MAX_MISSING_DTS} consecutive packets"

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -127,10 +127,10 @@ def _stream_worker_internal(hass, stream, quit_event):
                 packet = next(container_packets)
                 if (
                     packet.dts is None
-                ):  # Allow single packet with no dts, raise error on second
+                ):  # Allow MAX_MISSING_DTS packets with no dts, raise error on the next one
                     if missing_dts >= MAX_MISSING_DTS:
                         raise StopIteration(
-                            f"Invalid data - got {MAX_MISSING_DTS} packets with missing DTS while initializing"
+                            f"Invalid data - got {MAX_MISSING_DTS+1} packets with missing DTS while initializing"
                         )
                     missing_dts += 1
                     continue
@@ -144,10 +144,10 @@ def _stream_worker_internal(hass, stream, quit_event):
                 packet = next(container_packets)
                 if (
                     packet.dts is None
-                ):  # Allow single packet with no dts, raise error on second
+                ):  # Allow MAX_MISSING_DTS packet with no dts, raise error on the next one
                     if missing_dts >= MAX_MISSING_DTS:
                         raise StopIteration(
-                            f"Invalid data - got {MAX_MISSING_DTS} packets with missing DTS while initializing"
+                            f"Invalid data - got {MAX_MISSING_DTS+1} packets with missing DTS while initializing"
                         )
                     missing_dts += 1
                     continue
@@ -237,10 +237,10 @@ def _stream_worker_internal(hass, stream, quit_event):
             else:
                 packet = next(container_packets)
             if packet.dts is None:
-                # Allow MAX_MISSING_DTS consecutive packets without dts before terminating the stream.
+                # Allow MAX_MISSING_DTS consecutive packets without dts. Terminate the stream on the next one.
                 if missing_dts >= MAX_MISSING_DTS:
                     raise StopIteration(
-                        f"No dts in {MAX_MISSING_DTS} consecutive packets"
+                        f"No dts in {MAX_MISSING_DTS+1} consecutive packets"
                     )
                 missing_dts += 1
                 continue

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -11,6 +11,7 @@ from .const import (
     MAX_TIMESTAMP_GAP,
     MIN_SEGMENT_DURATION,
     PACKETS_TO_WAIT_FOR_AUDIO,
+    STREAM_TIMEOUT,
 )
 from .core import Segment, StreamBuffer
 
@@ -67,7 +68,7 @@ def stream_worker(hass, stream, quit_event):
 def _stream_worker_internal(hass, stream, quit_event):
     """Handle consuming streams."""
 
-    container = av.open(stream.source, options=stream.options)
+    container = av.open(stream.source, options=stream.options, timeout=STREAM_TIMEOUT)
     try:
         video_stream = container.streams.video[0]
     except (KeyError, IndexError):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The existing code did not properly raise an AVError. As the AVError class contains actual errors from ffmpeg, it's probably better to use a different error class for our own errors. Changed the code to raise a StopIteration error. Also increased the number of "bad" (missing DTS) packets allowed during initialization.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42254
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
