### PR TITLE
Add unique_id and device_info to DSMR entities

### DIFF
--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -18,6 +18,9 @@ DEFAULT_RECONNECT_INTERVAL = 30
 
 DATA_TASK = "task"
 
+DEVICE_NAME_ENERGY = "Energy Meter"
+DEVICE_NAME_GAS = "Gas Meter"
+
 ICON_GAS = "mdi:fire"
 ICON_POWER = "mdi:flash"
 ICON_POWER_FAILURE = "mdi:flash-off"

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -239,7 +239,7 @@ class DSMREntity(Entity):
 
         self._device_name = device_name
         self._device_serial = device_serial
-        self._unique_id = f"{device_serial}_{name}"
+        self._unique_id = f"{device_serial}_{name}".replace(' ', '_')
 
     @callback
     def update_data(self, telegram):

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -3,6 +3,7 @@ import asyncio
 from asyncio import CancelledError
 from functools import partial
 import logging
+from typing import Dict
 
 from dsmr_parser import obis_references as obis_ref
 from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
@@ -26,11 +27,15 @@ from .const import (
     CONF_DSMR_VERSION,
     CONF_PRECISION,
     CONF_RECONNECT_INTERVAL,
+    CONF_SERIAL_ID,
+    CONF_SERIAL_ID_GAS,
     DATA_TASK,
     DEFAULT_DSMR_VERSION,
     DEFAULT_PORT,
     DEFAULT_PRECISION,
     DEFAULT_RECONNECT_INTERVAL,
+    DEVICE_NAME_ENERGY,
+    DEVICE_NAME_GAS,
     DOMAIN,
     ICON_GAS,
     ICON_POWER,
@@ -106,21 +111,37 @@ async def async_setup_entry(
     ]
 
     # Generate device entities
-    devices = [DSMREntity(name, obis, config) for name, obis in obis_mapping]
+    devices = [
+        DSMREntity(name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config)
+        for name, obis in obis_mapping
+    ]
 
     # Protocol version specific obis
-    if dsmr_version in ("4", "5"):
-        gas_obis = obis_ref.HOURLY_GAS_METER_READING
-    elif dsmr_version in ("5B",):
-        gas_obis = obis_ref.BELGIUM_HOURLY_GAS_METER_READING
-    else:
-        gas_obis = obis_ref.GAS_METER_READING
+    if CONF_SERIAL_ID_GAS in config:
+        if dsmr_version in ("4", "5"):
+            gas_obis = obis_ref.HOURLY_GAS_METER_READING
+        elif dsmr_version in ("5B",):
+            gas_obis = obis_ref.BELGIUM_HOURLY_GAS_METER_READING
+        else:
+            gas_obis = obis_ref.GAS_METER_READING
 
-    # Add gas meter reading and derivative for usage
-    devices += [
-        DSMREntity("Gas Consumption", gas_obis, config),
-        DerivativeDSMREntity("Hourly Gas Consumption", gas_obis, config),
-    ]
+        # Add gas meter reading and derivative for usage
+        devices += [
+            DSMREntity(
+                "Gas Consumption",
+                DEVICE_NAME_GAS,
+                config[CONF_SERIAL_ID_GAS],
+                gas_obis,
+                config,
+            ),
+            DerivativeDSMREntity(
+                "Hourly Gas Consumption",
+                DEVICE_NAME_GAS,
+                config[CONF_SERIAL_ID_GAS],
+                gas_obis,
+                config,
+            ),
+        ]
 
     async_add_entities(devices)
 
@@ -209,12 +230,16 @@ async def async_setup_entry(
 class DSMREntity(Entity):
     """Entity reading values from DSMR telegram."""
 
-    def __init__(self, name, obis, config):
+    def __init__(self, name, device_name, device_serial, obis, config):
         """Initialize entity."""
         self._name = name
         self._obis = obis
         self._config = config
         self.telegram = {}
+
+        self._device_name = device_name
+        self._device_serial = device_serial
+        self._unique_id = f"{device_serial}_{name}"
 
     @callback
     def update_data(self, telegram):
@@ -272,6 +297,19 @@ class DSMREntity(Entity):
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self.get_dsmr_object_attr("unit")
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def device_info(self) -> Dict[str, any]:
+        """Return the device information."""
+        return {
+            "identifiers": {(DOMAIN, self._device_serial)},
+            "name": self._device_name,
+        }
 
     @property
     def force_update(self):

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -239,7 +239,7 @@ class DSMREntity(Entity):
 
         self._device_name = device_name
         self._device_serial = device_serial
-        self._unique_id = f"{device_serial}_{name}".replace(' ', '_')
+        self._unique_id = f"{device_serial}_{name}".replace(" ", "_")
 
     @callback
     def update_data(self, telegram):

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -100,6 +100,16 @@ async def test_default_setup(hass, dsmr_connection_fixture):
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entry = registry.async_get("sensor.power_consumption")
+    assert entry
+    assert entry.unique_id == "1234_Power Consumption"
+
+    entry = registry.async_get("sensor.gas_consumption")
+    assert entry
+    assert entry.unique_id == "5678_Gas Consumption"
+
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
     # make sure entities have been created and return 'unknown' state
@@ -129,6 +139,35 @@ async def test_default_setup(hass, dsmr_connection_fixture):
     gas_consumption = hass.states.get("sensor.gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
+
+
+async def test_setup_only_energy(hass, dsmr_connection_fixture):
+    """Test the default setup."""
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "precision": 4,
+        "reconnect_interval": 30,
+        "serial_id": "1234",
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entry = registry.async_get("sensor.power_consumption")
+    assert entry
+    assert entry.unique_id == "1234_Power Consumption"
+
+    entry = registry.async_get("sensor.gas_consumption")
+    assert not entry
 
 
 async def test_derivative():

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -104,11 +104,11 @@ async def test_default_setup(hass, dsmr_connection_fixture):
 
     entry = registry.async_get("sensor.power_consumption")
     assert entry
-    assert entry.unique_id == "1234_Power Consumption"
+    assert entry.unique_id == "1234_Power_Consumption"
 
     entry = registry.async_get("sensor.gas_consumption")
     assert entry
-    assert entry.unique_id == "5678_Gas Consumption"
+    assert entry.unique_id == "5678_Gas_Consumption"
 
     telegram_callback = connection_factory.call_args_list[0][0][2]
 
@@ -164,7 +164,7 @@ async def test_setup_only_energy(hass, dsmr_connection_fixture):
 
     entry = registry.async_get("sensor.power_consumption")
     assert entry
-    assert entry.unique_id == "1234_Power Consumption"
+    assert entry.unique_id == "1234_Power_Consumption"
 
     entry = registry.async_get("sensor.gas_consumption")
     assert not entry

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -74,6 +74,8 @@ async def test_default_setup(hass, dsmr_connection_fixture):
         "dsmr_version": "2.2",
         "precision": 4,
         "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     telegram = {
@@ -135,7 +137,7 @@ async def test_derivative():
 
     config = {"platform": "dsmr"}
 
-    entity = DerivativeDSMREntity("test", "1.0.0", config)
+    entity = DerivativeDSMREntity("test", "test_device", "5678", "1.0.0", config)
     await entity.async_update()
 
     assert entity.state is None, "initial state not unknown"
@@ -184,6 +186,8 @@ async def test_v4_meter(hass, dsmr_connection_fixture):
         "dsmr_version": "4",
         "precision": 4,
         "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     telegram = {
@@ -239,6 +243,8 @@ async def test_v5_meter(hass, dsmr_connection_fixture):
         "dsmr_version": "5",
         "precision": 4,
         "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     telegram = {
@@ -294,6 +300,8 @@ async def test_belgian_meter(hass, dsmr_connection_fixture):
         "dsmr_version": "5B",
         "precision": 4,
         "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     telegram = {
@@ -346,6 +354,8 @@ async def test_belgian_meter_low(hass, dsmr_connection_fixture):
         "dsmr_version": "5B",
         "precision": 4,
         "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     telegram = {ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0002", "unit": ""}])}
@@ -383,6 +393,8 @@ async def test_tcp(hass, dsmr_connection_fixture):
         "dsmr_version": "2.2",
         "precision": 4,
         "reconnect_interval": 30,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     mock_entry = MockConfigEntry(
@@ -407,6 +419,8 @@ async def test_connection_errors_retry(hass, dsmr_connection_fixture):
         "dsmr_version": "2.2",
         "precision": 4,
         "reconnect_interval": 0,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     # override the mock to have it fail the first time and succeed after
@@ -442,6 +456,8 @@ async def test_reconnect(hass, dsmr_connection_fixture):
         "dsmr_version": "2.2",
         "precision": 4,
         "reconnect_interval": 0,
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
     }
 
     # mock waiting coroutine while connection lasts


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds unique ids and device info to the entities based on the serial id that is read from the energy/gas meter. Additionally, if a gas serial id is missing, don't create the gas meter entities because no gas meter is connected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
