### PR TITLE
Fix block till done in create entry config flow tests

### DIFF
--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -32,6 +32,7 @@ async def test_form(hass):
                 "password": "test-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Name of the device"
@@ -40,7 +41,6 @@ async def test_form(hass):
         "username": "test-username",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/alarmdecoder/test_config_flow.py
+++ b/tests/components/alarmdecoder/test_config_flow.py
@@ -89,8 +89,8 @@ async def test_setups(hass: HomeAssistant, protocol, connection, title):
             **connection,
             CONF_PROTOCOL: protocol,
         }
+        await hass.async_block_till_done()
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/august/test_config_flow.py
+++ b/tests/components/august/test_config_flow.py
@@ -46,6 +46,7 @@ async def test_form(hass):
                 CONF_PASSWORD: "test-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "my@email.tld"
@@ -57,7 +58,6 @@ async def test_form(hass):
         CONF_TIMEOUT: 10,
         CONF_ACCESS_TOKEN_CACHE_FILE: ".my@email.tld.august.conf",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -205,6 +205,7 @@ async def test_form_needs_validate(hass):
             result["flow_id"],
             {VERIFICATION_CODE_KEY: "correct"},
         )
+        await hass.async_block_till_done()
 
     assert len(mock_send_verification_code.mock_calls) == 0
     assert len(mock_validate_verification_code.mock_calls) == 1
@@ -218,7 +219,6 @@ async def test_form_needs_validate(hass):
         CONF_TIMEOUT: 10,
         CONF_ACCESS_TOKEN_CACHE_FILE: ".my@email.tld.august.conf",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -261,9 +261,9 @@ async def test_form_reauth(hass):
                 CONF_PASSWORD: "new-test-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "reauth_successful"
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -31,6 +31,7 @@ async def test_form(hass):
             result["flow_id"],
             {"username": "blink@example.com", "password": "example"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "blink"
@@ -45,7 +46,6 @@ async def test_form(hass):
         "client_id": None,
         "region_id": None,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -88,11 +88,11 @@ async def test_form_2fa(hass):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], {"pin": "1234"}
         )
+        await hass.async_block_till_done()
 
     assert result3["type"] == "create_entry"
     assert result3["title"] == "blink"
     assert result3["result"].unique_id == "blink@example.com"
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -29,6 +29,7 @@ async def test_user_form(hass: core.HomeAssistant):
             result["flow_id"],
             {CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-bond-id"
@@ -36,7 +37,6 @@ async def test_user_form(hass: core.HomeAssistant):
         CONF_HOST: "some host",
         CONF_ACCESS_TOKEN: "test-token",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -165,6 +165,7 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
             result["flow_id"],
             {CONF_ACCESS_TOKEN: "test-token"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-bond-id"
@@ -172,7 +173,6 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
         CONF_HOST: "test-host",
         CONF_ACCESS_TOKEN: "test-token",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/control4/test_config_flow.py
+++ b/tests/components/control4/test_config_flow.py
@@ -75,6 +75,7 @@ async def test_form(hass):
                 CONF_PASSWORD: "test-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "control4_model_00AA00AA00AA"
@@ -84,7 +85,6 @@ async def test_form(hass):
         CONF_PASSWORD: "test-password",
         "controller_unique_id": "control4_model_00AA00AA00AA",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/coolmaster/test_config_flow.py
+++ b/tests/components/coolmaster/test_config_flow.py
@@ -32,6 +32,7 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], _flow_data()
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "1.1.1.1"
@@ -40,7 +41,6 @@ async def test_form(hass):
         "port": 10102,
         "supported_modes": AVAILABLE_MODES,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -33,6 +33,7 @@ async def test_form(hass):
             result["flow_id"],
             {"username": "test-username", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "devolo Home Control"
@@ -43,7 +44,6 @@ async def test_form(hass):
         "mydevolo_url": "https://www.mydevolo.com",
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -118,6 +118,7 @@ async def test_form_advanced_options(hass):
                 "mydevolo_url": "https://test_mydevolo_url.test",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "devolo Home Control"
@@ -128,6 +129,5 @@ async def test_form_advanced_options(hass):
         "mydevolo_url": "https://test_mydevolo_url.test",
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/dexcom/test_config_flow.py
+++ b/tests/components/dexcom/test_config_flow.py
@@ -32,11 +32,11 @@ async def test_form(hass):
             result["flow_id"],
             CONFIG,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == CONFIG[CONF_USERNAME]
     assert result2["data"] == CONFIG
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -62,6 +62,7 @@ async def test_user_form(hass):
             result["flow_id"],
             VALID_CONFIG,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "1.2.3.4"
@@ -71,7 +72,6 @@ async def test_user_form(hass):
         "password": "password",
         "username": "friend",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -108,6 +108,7 @@ async def test_form_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data=import_config,
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "1.2.3.4"
@@ -124,7 +125,6 @@ async def test_form_import(hass):
     # It is not possible to import options at this time
     # so they end up in the config entry data and are
     # used a fallback when they are not in options
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -176,6 +176,7 @@ async def test_form_import_with_zeroconf_already_discovered(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data=import_config,
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "1.2.3.4"
@@ -192,7 +193,6 @@ async def test_form_import_with_zeroconf_already_discovered(hass):
     # It is not possible to import options at this time
     # so they end up in the config entry data and are
     # used a fallback when they are not in options
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -274,6 +274,7 @@ async def test_form_zeroconf_correct_oui(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], VALID_CONFIG
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "1.2.3.4"
@@ -283,7 +284,6 @@ async def test_form_zeroconf_correct_oui(hass):
         "password": "password",
         "username": "friend",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -45,6 +45,7 @@ async def test_form_user_with_secure_elk(hass):
                 "prefix": "",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "ElkM1"
@@ -56,7 +57,6 @@ async def test_form_user_with_secure_elk(hass):
         "temperature_unit": "°F",
         "username": "test-username",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -90,6 +90,7 @@ async def test_form_user_with_non_secure_elk(hass):
                 "prefix": "guest_house",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "guest_house"
@@ -101,7 +102,6 @@ async def test_form_user_with_non_secure_elk(hass):
         "password": "",
         "temperature_unit": "°F",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -135,6 +135,7 @@ async def test_form_user_with_serial_elk(hass):
                 "prefix": "",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "ElkM1"
@@ -146,7 +147,6 @@ async def test_form_user_with_serial_elk(hass):
         "password": "",
         "temperature_unit": "°C",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -253,6 +253,7 @@ async def test_form_import(hass):
                 },
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "ohana"
@@ -274,6 +275,5 @@ async def test_form_import(hass):
         "username": "friend",
         "zone": {"enabled": True, "exclude": [[15, 15], [28, 208]], "include": []},
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/flick_electric/test_config_flow.py
+++ b/tests/components/flick_electric/test_config_flow.py
@@ -43,11 +43,11 @@ async def test_form(hass):
             result["flow_id"],
             CONF,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "Flick Electric: test-username"
     assert result2["data"] == CONF
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/flume/test_config_flow.py
+++ b/tests/components/flume/test_config_flow.py
@@ -51,6 +51,7 @@ async def test_form(hass):
                 CONF_CLIENT_SECRET: "client_secret",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-username"
@@ -60,7 +61,6 @@ async def test_form(hass):
         CONF_CLIENT_ID: "client_id",
         CONF_CLIENT_SECRET: "client_secret",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -92,6 +92,7 @@ async def test_form_import(hass):
                 CONF_CLIENT_SECRET: "client_secret",
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "test-username"
@@ -101,7 +102,6 @@ async def test_form_import(hass):
         CONF_CLIENT_ID: "client_id",
         CONF_CLIENT_SECRET: "client_secret",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/griddy/test_config_flow.py
+++ b/tests/components/griddy/test_config_flow.py
@@ -29,11 +29,11 @@ async def test_form(hass):
             result["flow_id"],
             {"loadzone": "LZ_HOUSTON"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Load Zone LZ_HOUSTON"
     assert result2["data"] == {"loadzone": "LZ_HOUSTON"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -56,11 +56,11 @@ async def test_user_form(hass):
             result["flow_id"],
             {"host": "1.2.3.4", "name": "friend"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "friend"
     assert result2["data"] == {"host": "1.2.3.4", "name": "friend"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -90,6 +90,7 @@ async def test_form_import(hass):
                 "unique_id": "555234534543",
             },
         )
+        await hass.async_block_till_done()
 
     assert result["result"].unique_id == "555234534543"
     assert result["type"] == "create_entry"
@@ -103,7 +104,6 @@ async def test_form_import(hass):
     # It is not possible to import options at this time
     # so they end up in the config entry data and are
     # used a fallback when they are not in options
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -147,11 +147,11 @@ async def test_form_ssdp(hass):
             result["flow_id"],
             {},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Harmony Hub"
     assert result2["data"] == {"host": "192.168.1.12", "name": "Harmony Hub"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/hlk_sw16/test_config_flow.py
+++ b/tests/components/hlk_sw16/test_config_flow.py
@@ -77,6 +77,7 @@ async def test_form(hass):
             result["flow_id"],
             conf,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "127.0.0.1:8080"
@@ -84,7 +85,6 @@ async def test_form(hass):
         "host": "127.0.0.1",
         "port": 8080,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -139,6 +139,7 @@ async def test_import(hass):
             result["flow_id"],
             conf,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "127.0.0.1:8080"
@@ -146,7 +147,6 @@ async def test_import(hass):
         "host": "127.0.0.1",
         "port": 8080,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -62,6 +62,7 @@ async def test_user_form(hass):
             result["flow_id"],
             {},
         )
+        await hass.async_block_till_done()
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result3["title"][:11] == "HASS Bridge"
@@ -77,7 +78,6 @@ async def test_user_form(hass):
         "name": bridge_name,
         "port": 12345,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -111,6 +111,7 @@ async def test_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_NAME: "othername", CONF_PORT: 56789},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "othername:56789"
@@ -118,7 +119,6 @@ async def test_import(hass):
         "name": "othername",
         "port": 56789,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 2
 

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -46,13 +46,13 @@ async def test_user_form(hass):
             result["flow_id"],
             {"host": "1.2.3.4"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "AlexanderHD"
     assert result2["data"] == {
         "host": "1.2.3.4",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -89,13 +89,13 @@ async def test_form_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={"host": "1.2.3.4"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "AlexanderHD"
     assert result["data"] == {
         "host": "1.2.3.4",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -141,13 +141,13 @@ async def test_form_homekit(hass):
         return_value=True,
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "PowerViewHub"
     assert result2["data"] == {"host": "1.2.3.4"}
     assert result2["result"].unique_id == "ABC123"
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -88,6 +88,7 @@ async def _device_form(hass, flow_id, connection, user_input):
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(flow_id, user_input)
+        await hass.async_block_till_done()
     return result, mock_setup, mock_setup_entry
 
 
@@ -130,7 +131,6 @@ async def test_form_select_plm(hass: HomeAssistantType):
     assert result2["type"] == "create_entry"
     assert result2["data"] == MOCK_USER_INPUT_PLM
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -149,7 +149,6 @@ async def test_form_select_hub_v1(hass: HomeAssistantType):
         CONF_HUB_VERSION: 1,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -168,7 +167,6 @@ async def test_form_select_hub_v2(hass: HomeAssistantType):
         CONF_HUB_VERSION: 2,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -93,11 +93,11 @@ async def test_form(hass: HomeAssistantType):
             result["flow_id"],
             MOCK_USER_INPUT,
         )
+        await hass.async_block_till_done()
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -310,11 +310,11 @@ async def test_form_ssdp(hass: HomeAssistantType):
             result["flow_id"],
             MOCK_USER_INPUT,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/juicenet/test_config_flow.py
+++ b/tests/components/juicenet/test_config_flow.py
@@ -35,11 +35,11 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_ACCESS_TOKEN: "access_token"}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "JuiceNet"
     assert result2["data"] == {CONF_ACCESS_TOKEN: "access_token"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -114,10 +114,10 @@ async def test_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_ACCESS_TOKEN: "access_token"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "JuiceNet"
     assert result["data"] == {CONF_ACCESS_TOKEN: "access_token"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -51,6 +51,7 @@ async def test_user_flow(hass, user_flow):
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(user_flow, TEST_HOST)
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == TEST_HOST["host"]
@@ -63,7 +64,6 @@ async def test_user_flow(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -98,6 +98,7 @@ async def test_form_valid_auth(hass, user_flow):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_CREDENTIALS
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == TEST_HOST["host"]
@@ -109,7 +110,6 @@ async def test_form_valid_auth(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -148,6 +148,7 @@ async def test_form_valid_ws_port(hass, user_flow):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_WS_PORT
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == TEST_HOST["host"]
@@ -160,7 +161,6 @@ async def test_form_valid_ws_port(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -193,6 +193,7 @@ async def test_form_empty_ws_port(hass, user_flow):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"ws_port": 0}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == TEST_HOST["host"]
@@ -205,7 +206,6 @@ async def test_form_empty_ws_port(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -436,6 +436,7 @@ async def test_discovery(hass):
         result = await hass.config_entries.flow.async_configure(
             flow_id=result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "hostname"
@@ -448,7 +449,6 @@ async def test_discovery(hass):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -592,12 +592,12 @@ async def test_form_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data=TEST_IMPORT,
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == TEST_IMPORT["name"]
     assert result["data"] == TEST_IMPORT
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -61,6 +61,7 @@ async def test_form(hass, mock_login, mock_get_devices):
             result["flow_id"],
             {"username": "test-email@test-domain.com", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-email@test-domain.com"
@@ -68,7 +69,6 @@ async def test_form(hass, mock_login, mock_get_devices):
         "username": "test-email@test-domain.com",
         "token": "test-token",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -128,6 +128,7 @@ async def test_import_with_token(hass, mock_login, mock_get_devices):
             context={"source": config_entries.SOURCE_IMPORT},
             data={"username": "test-email@test-domain.com", "token": "test-token"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "test-email@test-domain.com"
@@ -135,7 +136,6 @@ async def test_import_with_token(hass, mock_login, mock_get_devices):
         "username": "test-email@test-domain.com",
         "token": "test-token",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/metoffice/test_config_flow.py
+++ b/tests/components/metoffice/test_config_flow.py
@@ -42,6 +42,7 @@ async def test_form(hass, requests_mock):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"api_key": TEST_API_KEY}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == TEST_SITE_NAME_WAVERTREE
@@ -51,7 +52,6 @@ async def test_form(hass, requests_mock):
         "longitude": TEST_LONGITUDE_WAVERTREE,
         "name": TEST_SITE_NAME_WAVERTREE,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -43,6 +43,7 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], CONFIG
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == CONFIG[CONF_PORT]
@@ -50,7 +51,6 @@ async def test_form(hass):
         CONF_PORT: CONFIG[CONF_PORT],
         CONF_SOURCES: {"1": CONFIG[CONF_SOURCE_1], "4": CONFIG[CONF_SOURCE_4]},
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/myq/test_config_flow.py
+++ b/tests/components/myq/test_config_flow.py
@@ -31,6 +31,7 @@ async def test_form_user(hass):
             result["flow_id"],
             {"username": "test-username", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-username"
@@ -38,7 +39,6 @@ async def test_form_user(hass):
         "username": "test-username",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -61,6 +61,7 @@ async def test_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={"username": "test-username", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "test-username"
@@ -68,7 +69,6 @@ async def test_import(hass):
         "username": "test-username",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/nexia/test_config_flow.py
+++ b/tests/components/nexia/test_config_flow.py
@@ -33,6 +33,7 @@ async def test_form(hass):
             result["flow_id"],
             {CONF_USERNAME: "username", CONF_PASSWORD: "password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "myhouse"
@@ -40,7 +41,6 @@ async def test_form(hass):
         CONF_USERNAME: "username",
         CONF_PASSWORD: "password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -162,6 +162,7 @@ async def test_form_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_USERNAME: "username", CONF_PASSWORD: "password"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "myhouse"
@@ -169,7 +170,6 @@ async def test_form_import(hass):
         CONF_USERNAME: "username",
         CONF_PASSWORD: "password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/nuheat/test_config_flow.py
+++ b/tests/components/nuheat/test_config_flow.py
@@ -40,6 +40,7 @@ async def test_form_user(hass):
                 CONF_PASSWORD: "test-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Master bathroom"
@@ -48,7 +49,6 @@ async def test_form_user(hass):
         CONF_USERNAME: "test-username",
         CONF_PASSWORD: "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -79,6 +79,7 @@ async def test_form_import(hass):
                 CONF_PASSWORD: "test-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "Master bathroom"
@@ -87,7 +88,6 @@ async def test_form_import(hass):
         CONF_USERNAME: "test-username",
         CONF_PASSWORD: "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -57,6 +57,7 @@ async def test_form_zeroconf(hass):
             result2["flow_id"],
             {"resources": ["battery.voltage", "ups.status", "ups.status.display"]},
         )
+        await hass.async_block_till_done()
 
     assert result3["type"] == "create_entry"
     assert result3["title"] == "192.168.1.5:1234"
@@ -68,7 +69,6 @@ async def test_form_zeroconf(hass):
         "username": "test-username",
     }
     assert result3["result"].unique_id is None
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -116,6 +116,7 @@ async def test_form_user_one_ups(hass):
             result2["flow_id"],
             {"resources": ["battery.voltage", "ups.status", "ups.status.display"]},
         )
+        await hass.async_block_till_done()
 
     assert result3["type"] == "create_entry"
     assert result3["title"] == "1.1.1.1:2222"
@@ -126,7 +127,6 @@ async def test_form_user_one_ups(hass):
         "resources": ["battery.voltage", "ups.status", "ups.status.display"],
         "username": "test-username",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -195,6 +195,7 @@ async def test_form_user_multiple_ups(hass):
             result3["flow_id"],
             {"resources": ["battery.voltage"]},
         )
+        await hass.async_block_till_done()
 
     assert result4["type"] == "create_entry"
     assert result4["title"] == "ups2@1.1.1.1:2222"
@@ -206,7 +207,6 @@ async def test_form_user_multiple_ups(hass):
         "resources": ["battery.voltage"],
         "username": "test-username",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 2
 
@@ -239,6 +239,7 @@ async def test_form_import(hass):
                 "resources": ["battery.charge"],
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "localhost:123"
@@ -248,7 +249,6 @@ async def test_form_import(hass):
         "name": "name",
         "resources": ["battery.charge"],
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/nws/test_config_flow.py
+++ b/tests/components/nws/test_config_flow.py
@@ -28,6 +28,7 @@ async def test_form(hass, mock_simple_nws_config):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"api_key": "test"}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "ABC"
@@ -37,7 +38,6 @@ async def test_form(hass, mock_simple_nws_config):
         "longitude": -90,
         "station": "ABC",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -94,9 +94,9 @@ async def test_form_already_configured(hass, mock_simple_nws_config):
             result["flow_id"],
             {"api_key": "test"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/omnilogic/test_config_flow.py
+++ b/tests/components/omnilogic/test_config_flow.py
@@ -32,11 +32,11 @@ async def test_form(hass):
             result["flow_id"],
             DATA,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Omnilogic"
     assert result2["data"] == DATA
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -40,6 +40,7 @@ async def test_form_user(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_NAME: "Test Entry 1", CONF_DEVICE: "/dev/ttyUSB0"}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Test Entry 1"
@@ -48,7 +49,6 @@ async def test_form_user(hass):
         CONF_DEVICE: "/dev/ttyUSB0",
         CONF_ID: "test_entry_1",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_pyotgw_connect.mock_calls) == 1

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -24,11 +24,11 @@ async def test_user_create_entry(hass):
         return_value=True,
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == TITLE
     assert result2["data"] == {}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -30,6 +30,7 @@ async def test_form(hass):
             result["flow_id"],
             {"username": "test-plum-username", "password": "test-plum-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-plum-username"
@@ -37,7 +38,6 @@ async def test_form(hass):
         "username": "test-plum-username",
         "password": "test-plum-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/poolsense/test_config_flow.py
+++ b/tests/components/poolsense/test_config_flow.py
@@ -47,10 +47,10 @@ async def test_valid_credentials(hass):
             context={"source": SOURCE_USER},
             data={CONF_EMAIL: "test-email", CONF_PASSWORD: "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "test-email"
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -35,11 +35,11 @@ async def test_form_source_user(hass):
             result["flow_id"],
             {CONF_IP_ADDRESS: "1.2.3.4"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "My site"
     assert result2["data"] == {CONF_IP_ADDRESS: "1.2.3.4"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -63,11 +63,11 @@ async def test_form_source_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_IP_ADDRESS: "1.2.3.4"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "Imported site"
     assert result["data"] == {CONF_IP_ADDRESS: "1.2.3.4"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/profiler/test_config_flow.py
+++ b/tests/components/profiler/test_config_flow.py
@@ -25,11 +25,11 @@ async def test_form_user(hass):
             result["flow_id"],
             {},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Profiler"
     assert result2["data"] == {}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -50,6 +50,7 @@ async def test_form(hass):
                 CONF_MANUAL_RUN_MINS: 5,
             },
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "myusername"
@@ -58,7 +59,6 @@ async def test_form(hass):
         CONF_CUSTOM_URL: "http://custom.url",
         CONF_MANUAL_RUN_MINS: 5,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -30,6 +30,7 @@ async def test_form(hass):
             result["flow_id"],
             {"username": "hello@home-assistant.io", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "hello@home-assistant.io"
@@ -37,7 +38,6 @@ async def test_form(hass):
         "username": "hello@home-assistant.io",
         "token": {"access_token": "mock-token"},
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -66,11 +66,11 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_DATA
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == TEST_SITE_NAME
     assert result2["data"] == TEST_DATA
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     mock_close.assert_awaited_once()

--- a/tests/components/roku/test_config_flow.py
+++ b/tests/components/roku/test_config_flow.py
@@ -76,6 +76,7 @@ async def test_form(
         result = await hass.config_entries.flow.async_configure(
             flow_id=result["flow_id"], user_input=user_input
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == UPNP_FRIENDLY_NAME
@@ -83,7 +84,6 @@ async def test_form(
     assert result["data"]
     assert result["data"][CONF_HOST] == HOST
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -144,6 +144,7 @@ async def test_import(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_IMPORT}, data=user_input
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == UPNP_FRIENDLY_NAME
@@ -151,7 +152,6 @@ async def test_import(
     assert result["data"]
     assert result["data"][CONF_HOST] == HOST
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -216,6 +216,7 @@ async def test_ssdp_discovery(
         result = await hass.config_entries.flow.async_configure(
             flow_id=result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == UPNP_FRIENDLY_NAME
@@ -224,6 +225,5 @@ async def test_ssdp_discovery(
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_NAME] == UPNP_FRIENDLY_NAME
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -62,6 +62,7 @@ async def test_form(hass):
             result["flow_id"],
             VALID_CONFIG,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "myroomba"
@@ -74,7 +75,6 @@ async def test_form(hass):
         CONF_HOST: "1.2.3.4",
         CONF_PASSWORD: "password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -126,6 +126,7 @@ async def test_form_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data=VALID_YAML_CONFIG.copy(),
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == "blid"
@@ -138,7 +139,6 @@ async def test_form_import(hass):
         CONF_PASSWORD: "password",
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -51,11 +51,11 @@ async def test_form_and_auth(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Roon Labs Music Player"
     assert result2["data"] == {"host": "1.1.1.1", "api_key": "good_token"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -136,11 +136,11 @@ async def test_form_host_already_exists(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Roon Labs Music Player"
     assert result2["data"] == {"host": "1.1.1.1", "api_key": "good_token"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 2
 

--- a/tests/components/ruckus_unleashed/test_config_flow.py
+++ b/tests/components/ruckus_unleashed/test_config_flow.py
@@ -39,11 +39,11 @@ async def test_form(hass):
             result["flow_id"],
             CONFIG,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == DEFAULT_TITLE
     assert result2["data"] == CONFIG
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/sense/test_config_flow.py
+++ b/tests/components/sense/test_config_flow.py
@@ -26,6 +26,7 @@ async def test_form(hass):
             result["flow_id"],
             {"timeout": "6", "email": "test-email", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "test-email"
@@ -34,7 +35,6 @@ async def test_form(hass):
         "email": "test-email",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -57,13 +57,13 @@ async def test_form(hass):
             result["flow_id"],
             {"host": "1.1.1.1"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -102,13 +102,13 @@ async def test_title_without_name_and_prefix(hass):
             result["flow_id"],
             {"host": "1.1.1.1"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "shelly1pm-12345"
     assert result2["data"] == {
         "host": "1.1.1.1",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -151,6 +151,7 @@ async def test_form_auth(hass):
             result2["flow_id"],
             {"username": "test username", "password": "test password"},
         )
+        await hass.async_block_till_done()
 
     assert result3["type"] == "create_entry"
     assert result3["title"] == "Test name"
@@ -159,7 +160,6 @@ async def test_form_auth(hass):
         "username": "test username",
         "password": "test password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -323,13 +323,13 @@ async def test_zeroconf(hass):
             result["flow_id"],
             {},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -480,6 +480,7 @@ async def test_zeroconf_require_auth(hass):
             result2["flow_id"],
             {"username": "test username", "password": "test password"},
         )
+        await hass.async_block_till_done()
 
     assert result3["type"] == "create_entry"
     assert result3["title"] == "Test name"
@@ -488,7 +489,6 @@ async def test_zeroconf_require_auth(hass):
         "username": "test username",
         "password": "test password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/smart_meter_texas/test_config_flow.py
+++ b/tests/components/smart_meter_texas/test_config_flow.py
@@ -36,11 +36,11 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], TEST_LOGIN
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == TEST_LOGIN[CONF_USERNAME]
     assert result2["data"] == TEST_LOGIN
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/smarthab/test_config_flow.py
+++ b/tests/components/smarthab/test_config_flow.py
@@ -28,6 +28,7 @@ async def test_form(hass):
             result["flow_id"],
             {CONF_EMAIL: "mock@example.com", CONF_PASSWORD: "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "mock@example.com"
@@ -35,7 +36,6 @@ async def test_form(hass):
         CONF_EMAIL: "mock@example.com",
         CONF_PASSWORD: "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -115,6 +115,7 @@ async def test_import(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=imported_conf
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "mock@example.com"
@@ -122,6 +123,5 @@ async def test_import(hass):
         CONF_EMAIL: "mock@example.com",
         CONF_PASSWORD: "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/solarlog/test_config_flow.py
+++ b/tests/components/solarlog/test_config_flow.py
@@ -34,11 +34,11 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": HOST, "name": NAME}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "solarlog_test_1_2_3"
     assert result2["data"] == {"host": "http://1.1.1.1"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/spider/test_config_flow.py
+++ b/tests/components/spider/test_config_flow.py
@@ -42,6 +42,7 @@ async def test_user(hass, spider):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=SPIDER_USER_DATA
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == DOMAIN
@@ -49,7 +50,6 @@ async def test_user(hass, spider):
     assert result["data"][CONF_PASSWORD] == PASSWORD
     assert not result["result"].unique_id
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -69,6 +69,7 @@ async def test_import(hass, spider):
             context={"source": config_entries.SOURCE_IMPORT},
             data=SPIDER_USER_DATA,
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == DOMAIN
@@ -76,7 +77,6 @@ async def test_import(hass, spider):
     assert result["data"][CONF_PASSWORD] == PASSWORD
     assert not result["result"].unique_id
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/tado/test_config_flow.py
+++ b/tests/components/tado/test_config_flow.py
@@ -42,6 +42,7 @@ async def test_form(hass):
             result["flow_id"],
             {"username": "test-username", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "myhome"
@@ -49,7 +50,6 @@ async def test_form(hass):
         "username": "test-username",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -74,6 +74,7 @@ async def test_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={"username": "test-username", "password": "test-password"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "myhome"
@@ -81,7 +82,6 @@ async def test_import(hass):
         "username": "test-username",
         "password": "test-password",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/tesla/test_config_flow.py
+++ b/tests/components/tesla/test_config_flow.py
@@ -42,6 +42,7 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_PASSWORD: "test", CONF_USERNAME: "test@email.com"}
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "test@email.com"
@@ -49,7 +50,6 @@ async def test_form(hass):
         CONF_TOKEN: "test-refresh-token",
         CONF_ACCESS_TOKEN: "test-access-token",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -47,6 +47,7 @@ async def test_user(hass, tuya):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=TUYA_USER_DATA
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == USERNAME
@@ -56,7 +57,6 @@ async def test_user(hass, tuya):
     assert result["data"][CONF_PLATFORM] == TUYA_PLATFORM
     assert not result["result"].unique_id
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -76,6 +76,7 @@ async def test_import(hass, tuya):
             context={"source": config_entries.SOURCE_IMPORT},
             data=TUYA_USER_DATA,
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == USERNAME
@@ -85,7 +86,6 @@ async def test_import(hass, tuya):
     assert result["data"][CONF_PLATFORM] == TUYA_PLATFORM
     assert not result["result"].unique_id
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -59,6 +59,7 @@ async def test_full_upb_flow_with_serial_port(hass):
                 "file_path": "upb.upe",
             },
         )
+        await hass.async_block_till_done()
 
     assert flow["type"] == "form"
     assert flow["errors"] == {}
@@ -68,7 +69,6 @@ async def test_full_upb_flow_with_serial_port(hass):
         "host": "serial:///dev/ttyS0:115200",
         "file_path": "upb.upe",
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -125,12 +125,12 @@ async def test_form_import(hass):
             context={"source": config_entries.SOURCE_IMPORT},
             data={"host": "tcp://42.4.2.42", "file_path": "upb.upe"},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == "UPB"
 
     assert result["data"] == {"host": "tcp://42.4.2.42", "file_path": "upb.upe"}
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -38,7 +38,6 @@ async def test_form(hass):
         "access_token": "test-token",
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/volumio/test_config_flow.py
+++ b/tests/components/volumio/test_config_flow.py
@@ -50,12 +50,12 @@ async def test_form(hass):
             result["flow_id"],
             TEST_CONNECTION,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "TestVolumio"
     assert result2["data"] == {**TEST_SYSTEM_INFO, **TEST_CONNECTION}
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -118,6 +118,7 @@ async def test_empty_system_info(hass):
             result["flow_id"],
             TEST_CONNECTION,
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == TEST_CONNECTION["host"]
@@ -128,7 +129,6 @@ async def test_empty_system_info(hass):
         "id": None,
     }
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -191,6 +191,7 @@ async def test_discovery(hass):
             result["flow_id"],
             user_input={},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == TEST_DISCOVERY_RESULT["name"]
@@ -199,7 +200,6 @@ async def test_discovery(hass):
     assert result2["result"]
     assert result2["result"].unique_id == TEST_DISCOVERY_RESULT["id"]
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/zerproc/test_config_flow.py
+++ b/tests/components/zerproc/test_config_flow.py
@@ -29,12 +29,12 @@ async def test_flow_success(hass):
             result["flow_id"],
             {},
         )
+        await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Zerproc"
     assert result2["data"] == {}
 
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The call to async_block_till_done in config entry tests was incorrectly placed outside of while the mocks were active. Fixed in the scaffold and in every test that was based off it 🙈 

Triggered this fix by a flaky Shelly test. Digged deeper and realized that we are relying on a race condition to make sure that we call async_setup_entry to be called while the mock is active. With this PR it will always be 👍 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
