### PR TITLE
Fix for Fibaro HC3 support, climate temp sensor and target temp

### DIFF
--- a/homeassistant/components/fibaro/climate.py
+++ b/homeassistant/components/fibaro/climate.py
@@ -132,7 +132,10 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
             elif (
                 self._temp_sensor_device is None
                 and "unit" in device.properties
-                and "value" in device.properties
+                and (
+                    "value" in device.properties
+                    or "heatingThermostatSetpoint" in device.properties
+                )
                 and (device.properties.unit == "C" or device.properties.unit == "F")
             ):
                 self._temp_sensor_device = FibaroDevice(device)
@@ -141,6 +144,7 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
             if (
                 "setTargetLevel" in device.actions
                 or "setThermostatSetpoint" in device.actions
+                or "setHeatingThermostatSetpoint" in device.actions
             ):
                 self._target_temp_device = FibaroDevice(device)
                 self._support_flags |= SUPPORT_TARGET_TEMPERATURE
@@ -317,6 +321,8 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
         """Return the current temperature."""
         if self._temp_sensor_device:
             device = self._temp_sensor_device.fibaro_device
+            if device.properties.heatingThermostatSetpoint:
+                return float(device.properties.heatingThermostatSetpoint)
             return float(device.properties.value)
         return None
 
@@ -325,6 +331,8 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
         """Return the temperature we try to reach."""
         if self._target_temp_device:
             device = self._target_temp_device.fibaro_device
+            if device.properties.heatingThermostatSetpointFuture:
+                return float(device.properties.heatingThermostatSetpointFuture)
             return float(device.properties.targetLevel)
         return None
 
@@ -335,5 +343,7 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
         if temperature is not None:
             if "setThermostatSetpoint" in target.fibaro_device.actions:
                 target.action("setThermostatSetpoint", self.fibaro_op_mode, temperature)
+            elif "setHeatingThermostatSetpoint" in target.fibaro_device.actions:
+                target.action("setHeatingThermostatSetpoint", temperature)
             else:
                 target.action("setTargetLevel", temperature)


### PR DESCRIPTION
Fix for Fibaro HC3 support, climate temp sensor and target temp
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The REST Api of the new Fibaro Home Center 3 differs slightly from the previous generation HC2.

Some climate device actions and properties have been renamed. 
Getting current temperature and setting target temperature was no longer possible for the following device: **Danfoss Thermostats LC-13 (014G0013)**.

This will improve Fibaro HC3 support. 

These new actions and properties are now supported for climate devices:
- **Action**: _setHeatingThermostatSetpoint_
- **Property**: _heatingThermostatSetpoint_
- **Property**: _heatingThermostatSetpointFuture_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
