### PR TITLE
Clean up ElkM1 lib

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -326,14 +326,14 @@ async def async_wait_for_elk_to_sync(elk, timeout, conf_host):
     try:
         with async_timeout.timeout(timeout):
             await event.wait()
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         _LOGGER.error(
             "Timed out after %d seconds while trying to sync with ElkM1 at %s",
             SYNC_TIMEOUT,
             conf_host,
         )
         elk.disconnect()
-        raise ConfigEntryNotReady
+        raise ConfigEntryNotReady from exc
 
     return success
 

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
@@ -326,14 +326,14 @@ async def async_wait_for_elk_to_sync(elk, timeout, conf_host):
     try:
         with async_timeout.timeout(timeout):
             await event.wait()
-    except asyncio.TimeoutError as exc:
+    except asyncio.TimeoutError:
         _LOGGER.error(
             "Timed out after %d seconds while trying to sync with ElkM1 at %s",
             SYNC_TIMEOUT,
             conf_host,
         )
         elk.disconnect()
-        raise ConfigEntryNotReady from exc
+        raise
 
     return success
 

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -249,17 +249,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for keypad in elk.keypads:  # pylint: disable=no-member
         keypad.add_callback(_element_changed)
 
-    if not await async_wait_for_elk_to_sync(elk, SYNC_TIMEOUT):
-        _LOGGER.error(
-            "Timed out after %d seconds while trying to sync with ElkM1 at %s",
-            SYNC_TIMEOUT,
-            conf[CONF_HOST],
-        )
-        elk.disconnect()
-        raise ConfigEntryNotReady
-
-    if elk.invalid_auth:
-        _LOGGER.error("Authentication failed for ElkM1")
+    if not await async_wait_for_elk_to_sync(elk, SYNC_TIMEOUT, conf[CONF_HOST]):
         return False
 
     hass.data[DOMAIN][entry.entry_id] = {
@@ -312,16 +302,40 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     return unload_ok
 
 
-async def async_wait_for_elk_to_sync(elk, timeout):
-    """Wait until the elk system has finished sync."""
+async def async_wait_for_elk_to_sync(elk, timeout, conf_host):
+    """Wait until the elk has finished sync. Can fail login or timeout."""
+
+    def login_status(succeeded):
+        nonlocal success
+
+        success = succeeded
+        if succeeded:
+            _LOGGER.info("ElkM1 login succeeded.")
+        else:
+            elk.disconnect()
+            _LOGGER.error("ElkM1 login failed; invalid username or password.")
+            event.set()
+
+    def sync_complete():
+        event.set()
+
+    success = True
+    event = asyncio.Event()
+    elk.add_handler("login", login_status)
+    elk.add_handler("sync_complete", sync_complete)
     try:
         with async_timeout.timeout(timeout):
-            await elk.sync_complete()
-            return True
+            await event.wait()
     except asyncio.TimeoutError:
+        _LOGGER.error(
+            "Timed out after %d seconds while trying to sync with ElkM1 at %s",
+            SYNC_TIMEOUT,
+            conf_host,
+        )
         elk.disconnect()
+        raise ConfigEntryNotReady
 
-    return False
+    return success
 
 
 def _create_elk_services(hass):

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Elk-M1 Control integration."""
+import asyncio
 import logging
 from urllib.parse import urlparse
 
@@ -103,7 +104,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 info = await validate_input(user_input)
 
-            except exceptions.ConfigEntryNotReady:
+            except asyncio.TimeoutError:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -65,20 +65,7 @@ async def validate_input(data):
     )
     elk.connect()
 
-    timed_out = False
-    if not await async_wait_for_elk_to_sync(elk, VALIDATE_TIMEOUT):
-        _LOGGER.error(
-            "Timed out after %d seconds while trying to sync with ElkM1 at %s",
-            VALIDATE_TIMEOUT,
-            url,
-        )
-        timed_out = True
-
-    elk.disconnect()
-
-    if timed_out:
-        raise CannotConnect
-    if elk.invalid_auth:
+    if not await async_wait_for_elk_to_sync(elk, VALIDATE_TIMEOUT, url):
         raise InvalidAuth
 
     device_name = data[CONF_PREFIX] if data[CONF_PREFIX] else "ElkM1"
@@ -116,7 +103,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 info = await validate_input(user_input)
 
-            except CannotConnect:
+            except exceptions.ConfigEntryNotReady:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
@@ -159,10 +146,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             for entry in self._async_current_entries()
         }
         return urlparse(url).hostname in existing_hosts
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
 
 
 class InvalidAuth(exceptions.HomeAssistantError):

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -2,7 +2,7 @@
   "domain": "elkm1",
   "name": "Elk-M1 Control",
   "documentation": "https://www.home-assistant.io/integrations/elkm1",
-  "requirements": ["elkm1-lib==0.8.4"],
+  "requirements": ["elkm1-lib==0.8.5"],
   "codeowners": ["@gwww", "@bdraco"],
   "config_flow": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -535,7 +535,7 @@ elgato==0.2.0
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==0.8.4
+elkm1-lib==0.8.5
 
 # homeassistant.components.mobile_app
 emoji==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -278,7 +278,7 @@ eebrightbox==0.0.4
 elgato==0.2.0
 
 # homeassistant.components.elkm1
-elkm1-lib==0.8.4
+elkm1-lib==0.8.5
 
 # homeassistant.components.mobile_app
 emoji==0.5.4

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -3,14 +3,24 @@
 from homeassistant import config_entries, setup
 from homeassistant.components.elkm1.const import DOMAIN
 
-from tests.async_mock import AsyncMock, MagicMock, PropertyMock, patch
+from tests.async_mock import MagicMock, patch
 
 
 def mock_elk(invalid_auth=None, sync_complete=None):
     """Mock m1lib Elk."""
+
+    def handler_callbacks(type_, callback):
+        nonlocal invalid_auth, sync_complete
+
+        if type_ == "login":
+            if invalid_auth is not None:
+                callback(not invalid_auth)
+        elif type_ == "sync_complete":
+            if sync_complete:
+                callback()
+
     mocked_elk = MagicMock()
-    type(mocked_elk).invalid_auth = PropertyMock(return_value=invalid_auth)
-    type(mocked_elk).sync_complete = AsyncMock()
+    mocked_elk.add_handler.side_effect = handler_callbacks
     return mocked_elk
 
 
@@ -23,7 +33,7 @@ async def test_form_user_with_secure_elk(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    mocked_elk = mock_elk(invalid_auth=False)
+    mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
 
     with patch(
         "homeassistant.components.elkm1.config_flow.elkm1.Elk",
@@ -70,7 +80,7 @@ async def test_form_user_with_non_secure_elk(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    mocked_elk = mock_elk(invalid_auth=False)
+    mocked_elk = mock_elk(invalid_auth=None, sync_complete=True)
 
     with patch(
         "homeassistant.components.elkm1.config_flow.elkm1.Elk",
@@ -115,7 +125,7 @@ async def test_form_user_with_serial_elk(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    mocked_elk = mock_elk(invalid_auth=False)
+    mocked_elk = mock_elk(invalid_auth=None, sync_complete=True)
 
     with patch(
         "homeassistant.components.elkm1.config_flow.elkm1.Elk",
@@ -153,19 +163,21 @@ async def test_form_user_with_serial_elk(hass):
 
 async def test_form_cannot_connect(hass):
     """Test we handle cannot connect error."""
+    from asyncio import TimeoutError
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mocked_elk = mock_elk(invalid_auth=False)
+    mocked_elk = mock_elk(invalid_auth=None, sync_complete=None)
 
     with patch(
         "homeassistant.components.elkm1.config_flow.elkm1.Elk",
         return_value=mocked_elk,
     ), patch(
-        "homeassistant.components.elkm1.config_flow.async_wait_for_elk_to_sync",
-        return_value=False,
-    ):  # async_wait_for_elk_to_sync is being patched to avoid making the test wait 45s
+        "homeassistant.components.elkm1.async_timeout.timeout",
+        side_effect=TimeoutError,
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -188,7 +200,7 @@ async def test_form_invalid_auth(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mocked_elk = mock_elk(invalid_auth=True)
+    mocked_elk = mock_elk(invalid_auth=True, sync_complete=True)
 
     with patch(
         "homeassistant.components.elkm1.config_flow.elkm1.Elk",
@@ -214,7 +226,7 @@ async def test_form_import(hass):
     """Test we get the form with import source."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    mocked_elk = mock_elk(invalid_auth=False)
+    mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
     with patch(
         "homeassistant.components.elkm1.config_flow.elkm1.Elk",
         return_value=mocked_elk,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Because of some improvements/changes/cleanup in the ElkM1 library a change to how configuration is done on HA is required. Details...

The ElkM1 library has been cleaned up fairly significantly as there are some crufty bits that were starting to be bothersome. The primary reason for this change is that consistency around callbacks was introduced in library. Specifically, callbacks are supported for all significant events, such as timeout, login (success and fail), sync complete, and others.

This change uses the new callbacks.

The existing code in the library that marks sync complete and login success/fail will be deleted in a future (likely next) library release.

There are other library changes around simplifying heartbeat, getting descriptions of elements, and not leaking out the transport connection out of the `proto.py` module. These have all been well tested.

The library also switched to use f-strings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
N/A
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
