### PR TITLE
Add device trigger support for device trackers

### DIFF
--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -5,8 +5,7 @@ import voluptuous as vol
 
 from homeassistant.components.automation import AutomationActionType
 from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
-from homeassistant.components.zone import DOMAIN as DOMAIN_ZONE
-from homeassistant.components.zone import trigger as zone
+from homeassistant.components.zone import DOMAIN as DOMAIN_ZONE, trigger as zone
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DOMAIN,

--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -1,0 +1,90 @@
+"""Provides device automations for Device Tracker."""
+from typing import List
+
+import voluptuous as vol
+
+from homeassistant.components.automation import AutomationActionType
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.components.zone import trigger as zone
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_EVENT,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    CONF_ZONE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+
+TRIGGER_TYPES = {"enters", "leaves"}
+
+TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Required(CONF_ZONE): cv.entity_id,
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device triggers for Device Tracker devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    triggers = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "enters",
+            }
+        )
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+                CONF_TYPE: "leaves",
+            }
+        )
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+
+    if config[CONF_TYPE] == "enters":
+        event = zone.EVENT_ENTER
+    else:
+        event = zone.EVENT_LEAVE
+
+    zone_config = {
+        CONF_PLATFORM: "zone",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        CONF_ZONE: config[CONF_ZONE],
+        CONF_EVENT: event,
+    }
+    zone_config = zone.TRIGGER_SCHEMA(zone_config)
+    return await zone.async_attach_trigger(
+        hass, zone_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -5,6 +5,7 @@ import voluptuous as vol
 
 from homeassistant.components.automation import AutomationActionType
 from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.components.zone import DOMAIN as DOMAIN_ZONE
 from homeassistant.components.zone import trigger as zone
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -27,7 +28,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
-        vol.Required(CONF_ZONE): cv.entity_id,
+        vol.Required(CONF_ZONE): cv.entity_domain(DOMAIN_ZONE),
     }
 )
 
@@ -79,7 +80,7 @@ async def async_attach_trigger(
         event = zone.EVENT_LEAVE
 
     zone_config = {
-        CONF_PLATFORM: "zone",
+        CONF_PLATFORM: DOMAIN_ZONE,
         CONF_ENTITY_ID: config[CONF_ENTITY_ID],
         CONF_ZONE: config[CONF_ZONE],
         CONF_EVENT: event,
@@ -88,3 +89,15 @@ async def async_attach_trigger(
     return await zone.async_attach_trigger(
         hass, zone_config, action, automation_info, platform_type="device"
     )
+
+
+async def async_get_trigger_capabilities(hass: HomeAssistant, config: ConfigType):
+    """List trigger capabilities."""
+    zones = hass.states.async_entity_ids(DOMAIN_ZONE)
+    return {
+        "extra_fields": vol.Schema(
+            {
+                vol.Required(CONF_ZONE): vol.In(zones),
+            }
+        )
+    }

--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -92,7 +92,7 @@ async def async_attach_trigger(
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, config: ConfigType):
     """List trigger capabilities."""
-    zones = hass.states.async_entity_ids(DOMAIN_ZONE)
+    zones = {ent.entity_id: ent.name for ent in hass.states.async_all(DOMAIN_ZONE)}
     return {
         "extra_fields": vol.Schema(
             {

--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -92,7 +92,10 @@ async def async_attach_trigger(
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, config: ConfigType):
     """List trigger capabilities."""
-    zones = {ent.entity_id: ent.name for ent in hass.states.async_all(DOMAIN_ZONE)}
+    zones = {
+        ent.entity_id: ent.name
+        for ent in sorted(hass.states.async_all(DOMAIN_ZONE), key=lambda ent: ent.name)
+    }
     return {
         "extra_fields": vol.Schema(
             {

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -6,8 +6,8 @@
       "is_not_home": "{entity_name} is not home"
     },
     "trigger_type": {
-      "enters": "{entity_name} enters {zone_name}",
-      "leaves": "{entity_name} leaves {zone_name}"
+      "enters": "{entity_name} enters a zone",
+      "leaves": "{entity_name} leaves a zone"
     }
   },
   "state": {

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -4,6 +4,10 @@
     "condition_type": {
       "is_home": "{entity_name} is home",
       "is_not_home": "{entity_name} is not home"
+    },
+    "trigger_type": {
+      "enters": "{entity_name} enters {zone_name}",
+      "leaves": "{entity_name} leaves {zone_name}"
     }
   },
   "state": {

--- a/homeassistant/components/device_tracker/translations/en.json
+++ b/homeassistant/components/device_tracker/translations/en.json
@@ -3,6 +3,10 @@
         "condition_type": {
             "is_home": "{entity_name} is home",
             "is_not_home": "{entity_name} is not home"
+        },
+        "trigger_type": {
+            "enters": "{entity_name} enters {zone_name}",
+            "leaves": "{entity_name} leaves {zone_name}"
         }
     },
     "state": {

--- a/homeassistant/components/device_tracker/translations/en.json
+++ b/homeassistant/components/device_tracker/translations/en.json
@@ -5,8 +5,8 @@
             "is_not_home": "{entity_name} is not home"
         },
         "trigger_type": {
-            "enters": "{entity_name} enters {zone_name}",
-            "leaves": "{entity_name} leaves {zone_name}"
+            "enters": "{entity_name} enters a zone",
+            "leaves": "{entity_name} leaves a zone"
         }
     },
     "state": {

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -8,11 +8,12 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_ZONE,
 )
-from homeassistant.core import HassJob, callback
+from homeassistant.core import CALLBACK_TYPE, HassJob, callback
 from homeassistant.helpers import condition, config_validation as cv, location
 from homeassistant.helpers.event import async_track_state_change_event
 
-# mypy: allow-untyped-defs, no-check-untyped-defs
+# mypy: allow-incomplete-defs, allow-untyped-defs
+# mypy: no-check-untyped-defs
 
 EVENT_ENTER = "enter"
 EVENT_LEAVE = "leave"
@@ -34,7 +35,7 @@ TRIGGER_SCHEMA = vol.Schema(
 
 async def async_attach_trigger(
     hass, config, action, automation_info, *, platform_type: str = "zone"
-):
+) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     entity_id = config.get(CONF_ENTITY_ID)
     zone_entity_id = config.get(CONF_ZONE)

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -32,7 +32,9 @@ TRIGGER_SCHEMA = vol.Schema(
 )
 
 
-async def async_attach_trigger(hass, config, action, automation_info):
+async def async_attach_trigger(
+    hass, config, action, automation_info, *, platform_type: str = "zone"
+):
     """Listen for state changes based on configuration."""
     entity_id = config.get(CONF_ENTITY_ID)
     zone_entity_id = config.get(CONF_ZONE)
@@ -70,7 +72,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 job,
                 {
                     "trigger": {
-                        "platform": "zone",
+                        "platform": platform_type,
                         "entity_id": entity,
                         "from_state": from_s,
                         "to_state": to_s,

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -1,0 +1,171 @@
+"""The tests for Device Tracker device triggers."""
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.device_tracker import DOMAIN
+import homeassistant.components.zone as zone
+from homeassistant.helpers import device_registry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+
+AWAY_LATITUDE = 32.881011
+AWAY_LONGITUDE = -117.234758
+
+HOME_LATITUDE = 32.880837
+HOME_LONGITUDE = -117.237561
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+@pytest.fixture(autouse=True)
+def setup_zone(hass):
+    """Create test zone."""
+    hass.loop.run_until_complete(
+        async_setup_component(
+            hass,
+            zone.DOMAIN,
+            {
+                "zone": {
+                    "name": "test",
+                    "latitude": HOME_LATITUDE,
+                    "longitude": HOME_LONGITUDE,
+                    "radius": 250,
+                }
+            },
+        )
+    )
+
+
+async def test_get_triggers(hass, device_reg, entity_reg):
+    """Test we get the expected triggers from a device_tracker."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "leaves",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "enters",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        },
+    ]
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_if_fires_on_zone_change(hass, calls):
+    """Test for enter and leave triggers firing."""
+    hass.states.async_set(
+        "device_tracker.entity",
+        "state",
+        {"latitude": AWAY_LATITUDE, "longitude": AWAY_LONGITUDE},
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "device_tracker.entity",
+                        "type": "enters",
+                        "zone": "zone.test",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "enter - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.attributes.longitude|round(3)}} - "
+                                "{{ trigger.to_state.attributes.longitude|round(3)}}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "device_tracker.entity",
+                        "type": "leaves",
+                        "zone": "zone.test",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "leave - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.attributes.longitude|round(3)}} - "
+                                "{{ trigger.to_state.attributes.longitude|round(3)}}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is entering.
+    hass.states.async_set(
+        "device_tracker.entity",
+        "state",
+        {"latitude": HOME_LATITUDE, "longitude": HOME_LONGITUDE},
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "enter - device - {} - -117.235 - -117.238".format(
+        "device_tracker.entity"
+    )
+
+    # Fake that the entity is leaving.
+    hass.states.async_set(
+        "device_tracker.entity",
+        "state",
+        {"latitude": AWAY_LATITUDE, "longitude": AWAY_LONGITUDE},
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "leave - device - {} - -117.238 - -117.235".format(
+        "device_tracker.entity"
+    )

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -200,6 +200,6 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
             "name": "zone",
             "required": True,
             "type": "select",
-            "options": [("zone.test", "zone.test"), ("zone.home", "zone.home")],
+            "options": [("zone.test", "test"), ("zone.home", "test home")],
         }
     ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds device trigger support for device trackers entering and exiting zones.

emontnemery on the issue ticket suggested generating zone triggers, which seems like a good idea to me, but is inconsistent with the existing device condition support which only understands home vs not home. Should device condition be extended to support other zones? Should the existing conditions be migrated on load to use zone.home or should it keep the is_home condition available? If there is a condition for is_home, should the trigger have special enters_home support?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# within an automation
trigger:
  platform: device
  domain: device_tracker
  device_id: 123
  entity_id: device_tracker.entity
  type: enters
  zone: zone.test
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27016
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
