### PR TITLE
Add discovery for MQTT device tracker

### DIFF
--- a/homeassistant/components/mqtt/device_tracker.py
+++ b/homeassistant/components/mqtt/device_tracker.py
@@ -3,13 +3,36 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import mqtt
+from homeassistant.components import device_tracker, mqtt
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SOURCE_TYPES
-from homeassistant.const import CONF_DEVICES, STATE_HOME, STATE_NOT_HOME
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.const import (
+    ATTR_GPS_ACCURACY,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_DEVICE,
+    CONF_DEVICES,
+    CONF_ICON,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    CONF_VALUE_TEMPLATE,
+    STATE_HOME,
+    STATE_NOT_HOME,
+)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import CONF_QOS
+from . import (
+    MqttAttributes,
+    MqttAvailability,
+    MqttDiscoveryUpdate,
+    MqttEntityDeviceInfo,
+    subscription,
+)
+from .const import ATTR_DISCOVERY_HASH, CONF_QOS, CONF_STATE_TOPIC
+from .debug_info import log_messages
+from .discovery import MQTT_DISCOVERY_NEW, clear_discovery_hash
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +48,194 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(mqtt.SCHEMA_BASE).extend(
         vol.Optional(CONF_SOURCE_TYPE): vol.In(SOURCE_TYPES),
     }
 )
+DISCOVERY_PLATFORM_SCHEMA = (
+    mqtt.MQTT_RO_PLATFORM_SCHEMA.extend(
+        {
+            vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
+            vol.Optional(CONF_ICON): cv.icon,
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.string,
+            vol.Optional(CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME): cv.string,
+            vol.Optional(CONF_SOURCE_TYPE): vol.In(SOURCE_TYPES),
+            vol.Optional(CONF_UNIQUE_ID): cv.string,
+        }
+    )
+    .extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
+    .extend(mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
+)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up MQTT device tracker dynamically through MQTT discovery."""
+
+    async def async_discover(discovery_payload):
+        """Discover and add an MQTT device tracker."""
+        discovery_data = discovery_payload.discovery_data
+        try:
+            config = DISCOVERY_PLATFORM_SCHEMA(discovery_payload)
+            await _async_setup_entity(
+                hass, config, async_add_entities, config_entry, discovery_data
+            )
+        except Exception:
+            clear_discovery_hash(hass, discovery_data[ATTR_DISCOVERY_HASH])
+            raise
+
+    async_dispatcher_connect(
+        hass, MQTT_DISCOVERY_NEW.format(device_tracker.DOMAIN, "mqtt"), async_discover
+    )
+
+
+async def _async_setup_entity(
+    hass, config, async_add_entities, config_entry=None, discovery_data=None
+):
+    """Set up the MQTT Device Tracker entity."""
+    async_add_entities([MqttDeviceTracker(hass, config, config_entry, discovery_data)])
+
+
+class MqttDeviceTracker(
+    MqttAttributes,
+    MqttAvailability,
+    MqttDiscoveryUpdate,
+    MqttEntityDeviceInfo,
+    TrackerEntity,
+):
+    """Representation of a device tracker using MQTT."""
+
+    def __init__(self, hass, config, config_entry, discovery_data):
+        """Initialize the tracker."""
+        self.hass = hass
+        self._location_name = None
+        self._sub_state = None
+        self._unique_id = config.get(CONF_UNIQUE_ID)
+
+        # Load config
+        self._setup_from_config(config)
+
+        device_config = config.get(CONF_DEVICE)
+
+        MqttAttributes.__init__(self, config)
+        MqttAvailability.__init__(self, config)
+        MqttDiscoveryUpdate.__init__(self, discovery_data, self.discovery_update)
+        MqttEntityDeviceInfo.__init__(self, device_config, config_entry)
+
+    async def async_added_to_hass(self):
+        """Subscribe to MQTT events."""
+        await super().async_added_to_hass()
+        await self._subscribe_topics()
+
+    async def discovery_update(self, discovery_payload):
+        """Handle updated discovery message."""
+        config = DISCOVERY_PLATFORM_SCHEMA(discovery_payload)
+        self._setup_from_config(config)
+        await self.attributes_discovery_update(config)
+        await self.availability_discovery_update(config)
+        await self.device_info_discovery_update(config)
+        await self._subscribe_topics()
+        self.async_write_ha_state()
+
+    def _setup_from_config(self, config):
+        """(Re)Setup the entity."""
+        self._config = config
+
+        value_template = self._config.get(CONF_VALUE_TEMPLATE)
+        if value_template is not None:
+            value_template.hass = self.hass
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+
+        @callback
+        @log_messages(self.hass, self.entity_id)
+        def message_received(msg):
+            """Handle new MQTT messages."""
+            payload = msg.payload
+            value_template = self._config.get(CONF_VALUE_TEMPLATE)
+            if value_template is not None:
+                payload = value_template.async_render_with_possible_json_value(payload)
+            if payload == self._config[CONF_PAYLOAD_HOME]:
+                self._location_name = STATE_HOME
+            elif payload == self._config[CONF_PAYLOAD_NOT_HOME]:
+                self._location_name = STATE_NOT_HOME
+            else:
+                self._location_name = msg.payload
+
+            self.async_write_ha_state()
+
+        self._sub_state = await subscription.async_subscribe_topics(
+            self.hass,
+            self._sub_state,
+            {
+                "state_topic": {
+                    "topic": self._config[CONF_STATE_TOPIC],
+                    "msg_callback": message_received,
+                    "qos": self._config[CONF_QOS],
+                }
+            },
+        )
+
+    async def async_will_remove_from_hass(self):
+        """Unsubscribe when removed."""
+        self._sub_state = await subscription.async_unsubscribe_topics(
+            self.hass, self._sub_state
+        )
+        await MqttAttributes.async_will_remove_from_hass(self)
+        await MqttAvailability.async_will_remove_from_hass(self)
+        await MqttDiscoveryUpdate.async_will_remove_from_hass(self)
+
+    @property
+    def icon(self):
+        """Return the icon of the device."""
+        return self._config.get(CONF_ICON)
+
+    @property
+    def latitude(self):
+        """Return latitude if provided in device_state_attributes or None."""
+        if (
+            self.device_state_attributes is not None
+            and ATTR_LATITUDE in self.device_state_attributes
+        ):
+            return self.device_state_attributes[ATTR_LATITUDE]
+        return None
+
+    @property
+    def location_accuracy(self):
+        """Return location accuracy if provided in device_state_attributes or None."""
+        if (
+            self.device_state_attributes is not None
+            and ATTR_GPS_ACCURACY in self.device_state_attributes
+        ):
+            return self.device_state_attributes[ATTR_GPS_ACCURACY]
+        return None
+
+    @property
+    def longitude(self):
+        """Return longitude if provided in device_state_attributes or None."""
+        if (
+            self.device_state_attributes is not None
+            and ATTR_LONGITUDE in self.device_state_attributes
+        ):
+            return self.device_state_attributes[ATTR_LONGITUDE]
+        return None
+
+    @property
+    def location_name(self):
+        """Return a location name for the current location of the device."""
+        return self._location_name
+
+    @property
+    def name(self):
+        """Return the name of the device tracker."""
+        return self._config.get(CONF_NAME)
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return self._config.get(CONF_SOURCE_TYPE)
 
 
 async def async_setup_scanner(hass, config, async_see, discovery_info=None):

--- a/homeassistant/components/mqtt/device_tracker/__init__.py
+++ b/homeassistant/components/mqtt/device_tracker/__init__.py
@@ -1,0 +1,7 @@
+"""Support for tracking MQTT enabled devices."""
+from .schema_discovery import async_setup_entry_from_discovery
+from .schema_yaml import PLATFORM_SCHEMA_YAML, async_setup_scanner_from_yaml
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA_YAML
+async_setup_scanner = async_setup_scanner_from_yaml
+async_setup_entry = async_setup_entry_from_discovery

--- a/homeassistant/components/mqtt/device_tracker/schema_yaml.py
+++ b/homeassistant/components/mqtt/device_tracker/schema_yaml.py
@@ -1,0 +1,55 @@
+"""Support for tracking MQTT enabled devices defined in YAML."""
+
+import voluptuous as vol
+
+from homeassistant.components import mqtt
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SOURCE_TYPES
+from homeassistant.const import CONF_DEVICES, STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+
+from ..const import CONF_QOS
+
+CONF_PAYLOAD_HOME = "payload_home"
+CONF_PAYLOAD_NOT_HOME = "payload_not_home"
+CONF_SOURCE_TYPE = "source_type"
+
+PLATFORM_SCHEMA_YAML = PLATFORM_SCHEMA.extend(mqtt.SCHEMA_BASE).extend(
+    {
+        vol.Required(CONF_DEVICES): {cv.string: mqtt.valid_subscribe_topic},
+        vol.Optional(CONF_PAYLOAD_HOME, default=STATE_HOME): cv.string,
+        vol.Optional(CONF_PAYLOAD_NOT_HOME, default=STATE_NOT_HOME): cv.string,
+        vol.Optional(CONF_SOURCE_TYPE): vol.In(SOURCE_TYPES),
+    }
+)
+
+
+async def async_setup_scanner_from_yaml(hass, config, async_see, discovery_info=None):
+    """Set up the MQTT tracker."""
+    devices = config[CONF_DEVICES]
+    qos = config[CONF_QOS]
+    payload_home = config[CONF_PAYLOAD_HOME]
+    payload_not_home = config[CONF_PAYLOAD_NOT_HOME]
+    source_type = config.get(CONF_SOURCE_TYPE)
+
+    for dev_id, topic in devices.items():
+
+        @callback
+        def async_message_received(msg, dev_id=dev_id):
+            """Handle received MQTT message."""
+            if msg.payload == payload_home:
+                location_name = STATE_HOME
+            elif msg.payload == payload_not_home:
+                location_name = STATE_NOT_HOME
+            else:
+                location_name = msg.payload
+
+            see_args = {"dev_id": dev_id, "location_name": location_name}
+            if source_type:
+                see_args["source_type"] = source_type
+
+            hass.async_create_task(async_see(**see_args))
+
+        await mqtt.async_subscribe(hass, topic, async_message_received, qos)
+
+    return True

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -34,6 +34,7 @@ SUPPORTED_COMPONENTS = [
     "climate",
     "cover",
     "device_automation",
+    "device_tracker",
     "fan",
     "light",
     "lock",

--- a/tests/components/mqtt/test_device_tracker_discovery.py
+++ b/tests/components/mqtt/test_device_tracker_discovery.py
@@ -1,0 +1,306 @@
+"""The tests for the  MQTT device_tracker discovery platform."""
+
+import pytest
+
+from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNKNOWN
+
+from tests.common import async_fire_mqtt_message, mock_device_registry, mock_registry
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_discover_device_tracker(hass, mqtt_mock, caplog):
+    """Test discovering an MQTT device tracker component."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "test", "state_topic": "test_topic" }',
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test")
+
+    assert state is not None
+    assert state.name == "test"
+    assert ("device_tracker", "bla") in hass.data[ALREADY_DISCOVERED]
+
+
+async def test_non_duplicate_device_tracker_discovery(hass, mqtt_mock, caplog):
+    """Test for a non duplicate component."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "Beer", "state_topic": "test-topic" }',
+    )
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "Beer", "state_topic": "test-topic" }',
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.beer")
+    state_duplicate = hass.states.get("device_tracker.beer1")
+
+    assert state is not None
+    assert state.name == "Beer"
+    assert state_duplicate is None
+    assert "Component has already been discovered: device_tracker bla" in caplog.text
+
+
+async def test_device_tracker_removal(hass, mqtt_mock, caplog):
+    """Test removal of component through empty discovery message."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "Beer", "state_topic": "test-topic" }',
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("device_tracker.beer")
+    assert state is not None
+
+    async_fire_mqtt_message(hass, "homeassistant/device_tracker/bla/config", "")
+    await hass.async_block_till_done()
+    state = hass.states.get("device_tracker.beer")
+    assert state is None
+
+
+async def test_device_tracker_rediscover(hass, mqtt_mock, caplog):
+    """Test rediscover of removed component."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "Beer", "state_topic": "test-topic" }',
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("device_tracker.beer")
+    assert state is not None
+
+    async_fire_mqtt_message(hass, "homeassistant/device_tracker/bla/config", "")
+    await hass.async_block_till_done()
+    state = hass.states.get("device_tracker.beer")
+    assert state is None
+
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "Beer", "state_topic": "test-topic" }',
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("device_tracker.beer")
+    assert state is not None
+
+
+async def test_duplicate_device_tracker_removal(hass, mqtt_mock, caplog):
+    """Test for a non duplicate component."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "Beer", "state_topic": "test-topic" }',
+    )
+    await hass.async_block_till_done()
+    async_fire_mqtt_message(hass, "homeassistant/device_tracker/bla/config", "")
+    await hass.async_block_till_done()
+    assert "Component has already been discovered: device_tracker bla" in caplog.text
+    caplog.clear()
+    async_fire_mqtt_message(hass, "homeassistant/device_tracker/bla/config", "")
+    await hass.async_block_till_done()
+
+    assert (
+        "Component has already been discovered: device_tracker bla" not in caplog.text
+    )
+
+
+async def test_cleanup_device_tracker(hass, device_reg, entity_reg, mqtt_mock):
+    """Test discvered device is cleaned up when removed from registry."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "device":{"identifiers":["0AFFD2"]},'
+        '  "state_topic": "foobar/tracker",'
+        '  "unique_id": "unique" }',
+    )
+    await hass.async_block_till_done()
+
+    # Verify device and registry entries are created
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    assert device_entry is not None
+    entity_entry = entity_reg.async_get("device_tracker.mqtt_unique")
+    assert entity_entry is not None
+
+    state = hass.states.get("device_tracker.mqtt_unique")
+    assert state is not None
+
+    device_reg.async_remove_device(device_entry.id)
+    await hass.async_block_till_done()
+
+    # Verify device and registry entries are cleared
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    assert device_entry is None
+    entity_entry = entity_reg.async_get("device_tracker.mqtt_unique")
+    assert entity_entry is None
+
+    # Verify state is removed
+    state = hass.states.get("device_tracker.mqtt_unique")
+    assert state is None
+    await hass.async_block_till_done()
+
+    # Verify retained discovery topic has been cleared
+    mqtt_mock.async_publish.assert_called_once_with(
+        "homeassistant/device_tracker/bla/config", "", 0, True
+    )
+
+
+async def test_setting_device_tracker_value_via_mqtt_message(hass, mqtt_mock, caplog):
+    """Test the setting of the value via MQTT."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "test", "state_topic": "test-topic" }',
+    )
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test")
+
+    assert state.state == STATE_UNKNOWN
+
+    async_fire_mqtt_message(hass, "test-topic", "home")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_HOME
+
+    async_fire_mqtt_message(hass, "test-topic", "not_home")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_NOT_HOME
+
+
+async def test_setting_device_tracker_value_via_mqtt_message_and_template(
+    hass, mqtt_mock, caplog
+):
+    """Test the setting of the value via MQTT."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        "{"
+        '"name": "test", '
+        '"state_topic": "test-topic", '
+        '"value_template": "{% if value is equalto \\"proxy_for_home\\" %}home{% else %}not_home{% endif %}" '
+        "}",
+    )
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, "test-topic", "proxy_for_home")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_HOME
+
+    async_fire_mqtt_message(hass, "test-topic", "anything_for_not_home")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_NOT_HOME
+
+
+async def test_setting_device_tracker_value_via_mqtt_message_and_template2(
+    hass, mqtt_mock, caplog
+):
+    """Test the setting of the value via MQTT."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        "{"
+        '"name": "test", '
+        '"state_topic": "test-topic", '
+        '"value_template": "{{ value | lower }}" '
+        "}",
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_UNKNOWN
+
+    async_fire_mqtt_message(hass, "test-topic", "HOME")
+    state = hass.states.get("device_Tracker.test")
+    assert state.state == STATE_HOME
+
+    async_fire_mqtt_message(hass, "test-topic", "NOT_HOME")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_NOT_HOME
+
+
+async def test_setting_device_tracker_location_via_mqtt_message(
+    hass, mqtt_mock, caplog
+):
+    """Test the setting of the location via MQTT."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        '{ "name": "test", "state_topic": "test-topic" }',
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test")
+
+    assert state.state == STATE_UNKNOWN
+
+    async_fire_mqtt_message(hass, "test-topic", "test-location")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == "test-location"
+
+
+async def test_setting_device_tracker_location_via_lat_lon_message(
+    hass, mqtt_mock, caplog
+):
+    """Test the setting of the latitude and longitude via MQTT."""
+    async_fire_mqtt_message(
+        hass,
+        "homeassistant/device_tracker/bla/config",
+        "{ "
+        '"name": "test", '
+        '"state_topic": "test-topic", '
+        '"json_attributes_topic": "attributes-topic" '
+        "}",
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("device_tracker.test")
+
+    assert state.state == STATE_UNKNOWN
+
+    hass.config.latitude = 32.87336
+    hass.config.longitude = -117.22743
+
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude":32.87336,"longitude": -117.22743, "gps_accuracy":1.5}',
+    )
+    state = hass.states.get("device_tracker.test")
+    assert state.attributes["latitude"] == 32.87336
+    assert state.attributes["longitude"] == -117.22743
+    assert state.attributes["gps_accuracy"] == 1.5
+    assert state.state == STATE_HOME
+
+    async_fire_mqtt_message(
+        hass,
+        "attributes-topic",
+        '{"latitude":50.1,"longitude": -2.1, "gps_accuracy":1.5}',
+    )
+    state = hass.states.get("device_tracker.test")
+    assert state.attributes["latitude"] == 50.1
+    assert state.attributes["longitude"] == -2.1
+    assert state.attributes["gps_accuracy"] == 1.5
+    assert state.state == STATE_NOT_HOME
+
+    async_fire_mqtt_message(hass, "attributes-topic", '{"longitude": -117.22743}')
+    state = hass.states.get("device_tracker.test")
+    assert state.attributes["longitude"] == -117.22743
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding discovery for mqtt device tracker following the same pattern as other domains. I have left the legacy yaml configuration (uses `see` rather than `TrackerEntity`) unaltered to avoid impacting existing setups. Tests and documentation have been added.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15427

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
