### PR TITLE
Generate switches for harmony activities automatically

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -359,6 +359,8 @@ omit =
     homeassistant/components/hangouts/hangups_utils.py
     homeassistant/components/harman_kardon_avr/media_player.py
     homeassistant/components/harmony/const.py
+    homeassistant/components/harmony/data.py
+    homeassistant/components/harmony/remote.py
     homeassistant/components/harmony/util.py
     homeassistant/components/haveibeenpwned/sensor.py
     homeassistant/components/hdmi_cec/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -358,7 +358,8 @@ omit =
     homeassistant/components/hangouts/hangouts_bot.py
     homeassistant/components/hangouts/hangups_utils.py
     homeassistant/components/harman_kardon_avr/media_player.py
-    homeassistant/components/harmony/*
+    homeassistant/components/harmony/const.py
+    homeassistant/components/harmony/util.py
     homeassistant/components/haveibeenpwned/sensor.py
     homeassistant/components/hdmi_cec/*
     homeassistant/components/heatmiser/climate.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -180,7 +180,7 @@ homeassistant/components/griddy/* @bdraco
 homeassistant/components/group/* @home-assistant/core
 homeassistant/components/growatt_server/* @indykoning
 homeassistant/components/guardian/* @bachya
-homeassistant/components/harmony/* @ehendrix23 @bramkragten @bdraco
+homeassistant/components/harmony/* @ehendrix23 @bramkragten @bdraco @mkeesey
 homeassistant/components/hassio/* @home-assistant/supervisor
 homeassistant/components/hdmi_cec/* @newAM
 homeassistant/components/heatmiser/* @andylockran

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -1,11 +1,7 @@
 """The Logitech Harmony Hub integration."""
 import asyncio
 
-from homeassistant.components.remote import (
-    ATTR_ACTIVITY,
-    ATTR_DELAY_SECS,
-    DEFAULT_DELAY_SECS,
-)
+from homeassistant.components.remote import ATTR_ACTIVITY, ATTR_DELAY_SECS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
@@ -13,7 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DOMAIN, HARMONY_OPTIONS_UPDATE, PLATFORMS
-from .remote import HarmonyRemote
+from .data import HarmonyData
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -33,22 +29,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     address = entry.data[CONF_HOST]
     name = entry.data[CONF_NAME]
-    activity = entry.options.get(ATTR_ACTIVITY)
-    delay_secs = entry.options.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
-
-    harmony_conf_file = hass.config.path(f"harmony_{entry.unique_id}.conf")
+    data = HarmonyData(address, name, entry.unique_id)
     try:
-        device = HarmonyRemote(
-            name, entry.unique_id, address, activity, harmony_conf_file, delay_secs
-        )
-        connected_ok = await device.connect()
+        connected_ok = await data.connect()
     except (asyncio.TimeoutError, ValueError, AttributeError) as err:
         raise ConfigEntryNotReady from err
 
     if not connected_ok:
         raise ConfigEntryNotReady
 
-    hass.data[DOMAIN][entry.entry_id] = device
+    hass.data[DOMAIN][entry.entry_id] = data
 
     entry.add_update_listener(_update_listener)
 
@@ -92,8 +82,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     # Shutdown a harmony remote for removal
-    device = hass.data[DOMAIN][entry.entry_id]
-    await device.shutdown()
+    data = hass.data[DOMAIN][entry.entry_id]
+    await data.shutdown()
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     address = entry.data[CONF_HOST]
     name = entry.data[CONF_NAME]
-    data = HarmonyData(address, name, entry.unique_id)
+    data = HarmonyData(hass, address, name, entry.unique_id)
     try:
         connected_ok = await data.connect()
     except (asyncio.TimeoutError, ValueError, AttributeError) as err:

--- a/homeassistant/components/harmony/connection_state.py
+++ b/homeassistant/components/harmony/connection_state.py
@@ -1,0 +1,43 @@
+"""Mixin class for handling connection state changes."""
+import logging
+
+from homeassistant.helpers.event import async_call_later
+
+_LOGGER = logging.getLogger(__name__)
+
+TIME_MARK_DISCONNECTED = 10
+
+
+class ConnectionStateMixin:
+    """Base implementation for connection state handling."""
+
+    def __init__(self):
+        """Initialize this mixin instance."""
+        self._unsub_mark_disconnected = None
+
+    async def got_connected(self, _=None):
+        """Notification that we're connected to the HUB."""
+        _LOGGER.debug("%s: connected to the HUB", self._name)
+        self.async_write_ha_state()
+
+        self._clear_disconnection_delay()
+
+    async def got_disconnected(self, _=None):
+        """Notification that we're disconnected from the HUB."""
+        _LOGGER.debug("%s: disconnected from the HUB", self._name)
+        # We're going to wait for 10 seconds before announcing we're
+        # unavailable, this to allow a reconnection to happen.
+        self._unsub_mark_disconnected = async_call_later(
+            self.hass, TIME_MARK_DISCONNECTED, self._mark_disconnected_if_unavailable
+        )
+
+    def _clear_disconnection_delay(self):
+        if self._unsub_mark_disconnected:
+            self._unsub_mark_disconnected()
+            self._unsub_mark_disconnected = None
+
+    def _mark_disconnected_if_unavailable(self, _):
+        self._unsub_mark_disconnected = None
+        if not self.available:
+            # Still disconnected. Let the state engine know.
+            self.async_write_ha_state()

--- a/homeassistant/components/harmony/connection_state.py
+++ b/homeassistant/components/harmony/connection_state.py
@@ -13,6 +13,7 @@ class ConnectionStateMixin:
 
     def __init__(self):
         """Initialize this mixin instance."""
+        super().__init__()
         self._unsub_mark_disconnected = None
 
     async def got_connected(self, _=None):

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -2,7 +2,7 @@
 DOMAIN = "harmony"
 SERVICE_SYNC = "sync"
 SERVICE_CHANGE_CHANNEL = "change_channel"
-PLATFORMS = ["remote"]
+PLATFORMS = ["remote", "switch"]
 UNIQUE_ID = "unique_id"
 ACTIVITY_POWER_OFF = "PowerOff"
 HARMONY_OPTIONS_UPDATE = "harmony_options_update"

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -12,3 +12,5 @@ ATTR_LAST_ACTIVITY = "last_activity"
 ATTR_CURRENT_ACTIVITY = "current_activity"
 ATTR_ACTIVITY_STARTING = "activity_starting"
 PREVIOUS_ACTIVE_ACTIVITY = "Previous Active Activity"
+
+SIGNAL_UPDATE_ACTIVITY = DOMAIN + "_activity_update"

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -14,3 +14,4 @@ ATTR_ACTIVITY_STARTING = "activity_starting"
 PREVIOUS_ACTIVE_ACTIVITY = "Previous Active Activity"
 
 SIGNAL_UPDATE_ACTIVITY = DOMAIN + "_activity_update"
+CONNECTION_UPDATE_ACTIVITY = DOMAIN + "_connection_update"

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -12,6 +12,3 @@ ATTR_LAST_ACTIVITY = "last_activity"
 ATTR_CURRENT_ACTIVITY = "current_activity"
 ATTR_ACTIVITY_STARTING = "activity_starting"
 PREVIOUS_ACTIVE_ACTIVITY = "Previous Active Activity"
-
-SIGNAL_UPDATE_ACTIVITY = DOMAIN + "_activity_update"
-CONNECTION_UPDATE_ACTIVITY = DOMAIN + "_connection_update"

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -285,7 +285,10 @@ class HarmonyData:
         for subscription in self._subscriptions:
             current_callback = subscription.config_updated
             if current_callback:
-                current_callback(self._client.hub_config)
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback(self._client.hub_config))
+                else:
+                    current_callback(self._client.hub_config)
 
     def _connected(self, _=None) -> None:
         _LOGGER.debug("connected")
@@ -314,11 +317,17 @@ class HarmonyData:
         for subscription in self._subscriptions:
             current_callback = subscription.activity_starting
             if current_callback:
-                current_callback(activity_info)
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback(activity_info))
+                else:
+                    current_callback(activity_info)
 
     def _activity_started(self, activity_info: tuple) -> None:
         _LOGGER.debug("activity %s started", activity_info)
         for subscription in self._subscriptions:
             current_callback = subscription.activity_started
             if current_callback:
-                current_callback(activity_info)
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback(activity_info))
+                else:
+                    current_callback(activity_info)

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -1,5 +1,6 @@
 """Harmony data object which contains the Harmony Client."""
 
+import asyncio
 import logging
 from typing import Any, Callable, Iterable, NamedTuple, Optional
 
@@ -292,7 +293,10 @@ class HarmonyData:
         for subscription in self._subscriptions:
             current_callback = subscription.connected
             if current_callback:
-                current_callback()
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback())
+                else:
+                    current_callback()
 
     def _disconnected(self, _=None) -> None:
         _LOGGER.debug("disconnected")
@@ -300,7 +304,10 @@ class HarmonyData:
         for subscription in self._subscriptions:
             current_callback = subscription.disconnected
             if current_callback:
-                current_callback()
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback())
+                else:
+                    current_callback()
 
     def _activity_starting(self, activity_info: tuple) -> None:
         _LOGGER.debug("activity %s starting", activity_info)

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -1,4 +1,4 @@
-"""Harmony callback subscriber."""
+"""Harmony data object which contains the Harmony Client."""
 
 import logging
 from typing import Any, Callable, NamedTuple, Optional
@@ -25,8 +25,8 @@ class HarmonyCallback(NamedTuple):
     activity_started: ActivityCallback
 
 
-class HarmonySubscriber:
-    """Subscriber for Harmony hub updates."""
+class HarmonyData:
+    """HarmonyData registers for Harmony hub updates."""
 
     def __init__(self, client: HarmonyClient, name: str):
         """Initialize a subscriber."""

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -1,18 +1,21 @@
 """Harmony data object which contains the Harmony Client."""
 
 import logging
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, Iterable, NamedTuple, Optional
 
-from aioharmony.const import ClientCallbackType
+from aioharmony.const import ClientCallbackType, ClientConfigType, SendCommandDevice
 import aioharmony.exceptions as aioexc
 from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
 
 from homeassistant.core import callback
 
+from .const import ACTIVITY_POWER_OFF
+
 _LOGGER = logging.getLogger(__name__)
 
 NoParamCallback = Optional[Callable[[object], Any]]
 ActivityCallback = Optional[Callable[[object, tuple], Any]]
+ConfigCallback = Optional[Callable[[object, ClientConfigType], Any]]
 
 
 class HarmonyCallback(NamedTuple):
@@ -20,7 +23,7 @@ class HarmonyCallback(NamedTuple):
 
     connected: NoParamCallback
     disconnected: NoParamCallback
-    config_updated: NoParamCallback
+    config_updated: ConfigCallback
     activity_starting: ActivityCallback
     activity_started: ActivityCallback
 
@@ -28,11 +31,12 @@ class HarmonyCallback(NamedTuple):
 class HarmonyData:
     """HarmonyData registers for Harmony hub updates."""
 
-    def __init__(self, client: HarmonyClient, name: str):
+    def __init__(self, address: str, name: str, unique_id: str):
         """Initialize a subscriber."""
-        self._client = client
         self._name = name
+        self._unique_id = unique_id
         self._subscriptions = []
+        self._available = False
 
         callbacks = {
             "config_updated": self._config_updated,
@@ -41,7 +45,73 @@ class HarmonyData:
             "new_activity_starting": self._activity_starting,
             "new_activity": self._activity_started,
         }
-        self._client.callbacks = ClientCallbackType(**callbacks)
+        self._client = HarmonyClient(
+            ip_address=address, callbacks=ClientCallbackType(**callbacks)
+        )
+
+    @property
+    def activity_names(self):
+        """Names of all the remotes activities."""
+        activity_infos = self._client.config.get("activity", [])
+        activities = [activity["label"] for activity in activity_infos]
+
+        # Remove both ways of representing PowerOff
+        if None in activities:
+            activities.remove(None)
+        if ACTIVITY_POWER_OFF in activities:
+            activities.remove(ACTIVITY_POWER_OFF)
+
+        return activities
+
+    @property
+    def device_names(self):
+        """Names of all of the devices connected to the hub."""
+        device_infos = self._client.config.get("device", [])
+        devices = [device["label"] for device in device_infos]
+
+        return devices
+
+    @property
+    def name(self):
+        """Return the Harmony device's name."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return the Harmony device's unique_id."""
+        return self._unique_id
+
+    @property
+    def available(self) -> bool:
+        """Return if connected to the hub."""
+        return self._available
+
+    @property
+    def current_activity(self) -> tuple:
+        """Return the current activity tuple."""
+        return self._client.current_activity
+
+    @property
+    def json_config(self) -> dict:
+        """Return the hub config as json."""
+        if self._client.config is None:
+            return None
+        return self._client.json_config
+
+    def device_info(self, domain: str):
+        """Return hub device info."""
+        model = "Harmony Hub"
+        if "ethernetStatus" in self._client.hub_config.info:
+            model = "Harmony Hub Pro 2400"
+        return {
+            "identifiers": {(domain, self.unique_id)},
+            "manufacturer": "Logitech",
+            "sw_version": self._client.hub_config.info.get(
+                "hubSwVersion", self._client.fw_version
+            ),
+            "name": self.name,
+            "model": model,
+        }
 
     async def connect(self) -> bool:
         """Connect to the Harmony Hub."""
@@ -64,47 +134,184 @@ class HarmonyData:
         except aioexc.TimeOut:
             _LOGGER.warning("%s: Disconnect timed-out", self._name)
 
+    async def async_start_activity(self, activity: str):
+        """Start an activity from the Harmony device."""
+
+        if activity:
+            activity_id = None
+            activity_name = None
+
+            if activity.isdigit() or activity == "-1":
+                _LOGGER.debug("%s: Activity is numeric", self.name)
+                activity_name = self._client.get_activity_name(int(activity))
+                if activity_name:
+                    activity_id = activity
+
+            if activity_id is None:
+                _LOGGER.debug("%s: Find activity ID based on name", self.name)
+                activity_name = str(activity)
+                activity_id = self._client.get_activity_id(activity_name)
+
+            if activity_id is None:
+                _LOGGER.error("%s: Activity %s is invalid", self.name, activity)
+                return
+
+            current_activity_id, current_activity_name = self.current_activity
+            if current_activity_name == activity_name:
+                # Automations or HomeKit may turn the device on multiple times
+                # when the current activity is already active which will cause
+                # harmony to loose state.  This behavior is unexpected as turning
+                # the device on when its already on isn't expected to reset state.
+                _LOGGER.debug(
+                    "%s: Current activity is already %s", self.name, activity_name
+                )
+                return
+
+            try:
+                await self._client.start_activity(activity_id)
+            except aioexc.TimeOut:
+                _LOGGER.error("%s: Starting activity %s timed-out", self.name, activity)
+        else:
+            _LOGGER.error("%s: No activity specified with turn_on service", self.name)
+
+    async def async_power_off(self):
+        """Start the PowerOff activity."""
+        _LOGGER.debug("%s: Turn Off", self.name)
+        try:
+            await self._client.power_off()
+        except aioexc.TimeOut:
+            _LOGGER.error("%s: Powering off timed-out", self.name)
+
+    async def async_send_command(
+        self,
+        commands: Iterable[str],
+        device: str,
+        num_repeats: int,
+        delay_secs: float,
+        hold_secs: float,
+    ):
+        """Send a list of commands to one device."""
+        device_id = None
+        if device.isdigit():
+            _LOGGER.debug("%s: Device %s is numeric", self.name, device)
+            if self._client.get_device_name(int(device)):
+                device_id = device
+
+        if device_id is None:
+            _LOGGER.debug(
+                "%s: Find device ID %s based on device name", self.name, device
+            )
+            device_id = self._client.get_device_id(str(device).strip())
+
+        if device_id is None:
+            _LOGGER.error("%s: Device %s is invalid", self.name, device)
+            return
+
+        _LOGGER.debug(
+            "Sending commands to device %s holding for %s seconds "
+            "with a delay of %s seconds",
+            device,
+            hold_secs,
+            delay_secs,
+        )
+
+        # Creating list of commands to send.
+        snd_cmnd_list = []
+        for _ in range(num_repeats):
+            for single_command in commands:
+                send_command = SendCommandDevice(
+                    device=device_id, command=single_command, delay=hold_secs
+                )
+                snd_cmnd_list.append(send_command)
+                if delay_secs > 0:
+                    snd_cmnd_list.append(float(delay_secs))
+
+        _LOGGER.debug("%s: Sending commands", self.name)
+        try:
+            result_list = await self._client.send_commands(snd_cmnd_list)
+        except aioexc.TimeOut:
+            _LOGGER.error("%s: Sending commands timed-out", self.name)
+            return
+
+        for result in result_list:
+            _LOGGER.error(
+                "Sending command %s to device %s failed with code %s: %s",
+                result.command.command,
+                result.command.device,
+                result.code,
+                result.msg,
+            )
+
+    async def change_channel(self, channel: int):
+        """Change the channel using Harmony remote."""
+        _LOGGER.debug("%s: Changing channel to %s", self.name, channel)
+        try:
+            await self._client.change_channel(channel)
+        except aioexc.TimeOut:
+            _LOGGER.error("%s: Changing channel to %s timed-out", self.name, channel)
+
+    async def sync(self) -> bool:
+        """Sync the Harmony device with the web service.
+
+        Returns True if the sync was successful.
+        """
+        _LOGGER.debug("%s: Syncing hub with Harmony cloud", self.name)
+        try:
+            await self._client.sync()
+        except aioexc.TimeOut:
+            _LOGGER.error("%s: Syncing hub with Harmony cloud timed-out", self.name)
+            return False
+        else:
+            return True
+
     @callback
-    def async_subscribe(self, update_callback: HarmonyCallback):
+    def async_subscribe(self, update_callback: HarmonyCallback) -> Callable:
         """Add a callback subscriber."""
         self._subscriptions.append(update_callback)
 
         def _unsubscribe():
             self.async_unsubscribe(update_callback)
 
-        return _unsubscribe()
+        return _unsubscribe
 
     @callback
-    def async_unsubscribe_hub_id(self, update_callback: HarmonyCallback):
+    def async_unsubscribe(self, update_callback: HarmonyCallback):
         """Remove a callback subscriber."""
         self._subscriptions.remove(update_callback)
 
     def _config_updated(self, _=None) -> None:
+        _LOGGER.debug("config_updated")
         for subscription in self._subscriptions:
-            callback = subscription.config_updated
-            if callback:
-                callback()
+            current_callback = subscription.config_updated
+            if current_callback:
+                current_callback(self._client.hub_config)
 
     def _connected(self, _=None) -> None:
+        _LOGGER.debug("connected")
+        self._available = True
         for subscription in self._subscriptions:
-            callback = subscription.connected
-            if callback:
-                callback()
+            current_callback = subscription.connected
+            if current_callback:
+                current_callback()
 
     def _disconnected(self, _=None) -> None:
+        _LOGGER.debug("disconnected")
+        self._available = False
         for subscription in self._subscriptions:
-            callback = subscription.disconnected
-            if callback:
-                callback()
+            current_callback = subscription.disconnected
+            if current_callback:
+                current_callback()
 
     def _activity_starting(self, activity_info: tuple) -> None:
+        _LOGGER.debug("activity %s starting", activity_info)
         for subscription in self._subscriptions:
-            callback = subscription.activity_starting
-            if callback:
-                callback(activity_info)
+            current_callback = subscription.activity_starting
+            if current_callback:
+                current_callback(activity_info)
 
     def _activity_started(self, activity_info: tuple) -> None:
+        _LOGGER.debug("activity %s started", activity_info)
         for subscription in self._subscriptions:
-            callback = subscription.activity_started
-            if callback:
-                callback(activity_info)
+            current_callback = subscription.activity_started
+            if current_callback:
+                current_callback(activity_info)

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -67,6 +67,13 @@ class HarmonyData(HarmonySubscriberMixin):
         return self._unique_id
 
     @property
+    def json_config(self):
+        """Return the hub config as json."""
+        if self._client.config is None:
+            return None
+        return self._client.json_config
+
+    @property
     def available(self) -> bool:
         """Return if connected to the hub."""
         return self._available

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -16,9 +16,9 @@ _LOGGER = logging.getLogger(__name__)
 class HarmonyData(HarmonySubscriberMixin):
     """HarmonyData registers for Harmony hub updates."""
 
-    def __init__(self, address: str, name: str, unique_id: str):
+    def __init__(self, hass, address: str, name: str, unique_id: str):
         """Initialize a data object."""
-        super().__init__()
+        super().__init__(hass)
         self._name = name
         self._unique_id = unique_id
         self._available = False

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -92,13 +92,6 @@ class HarmonyData:
         """Return the current activity tuple."""
         return self._client.current_activity
 
-    @property
-    def json_config(self) -> dict:
-        """Return the hub config as json."""
-        if self._client.config is None:
-            return None
-        return self._client.json_config
-
     def device_info(self, domain: str):
         """Return hub device info."""
         model = "Harmony Hub"

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -122,42 +122,43 @@ class HarmonyData(HarmonySubscriberMixin):
     async def async_start_activity(self, activity: str):
         """Start an activity from the Harmony device."""
 
-        if activity:
-            activity_id = None
-            activity_name = None
-
-            if activity.isdigit() or activity == "-1":
-                _LOGGER.debug("%s: Activity is numeric", self.name)
-                activity_name = self._client.get_activity_name(int(activity))
-                if activity_name:
-                    activity_id = activity
-
-            if activity_id is None:
-                _LOGGER.debug("%s: Find activity ID based on name", self.name)
-                activity_name = str(activity)
-                activity_id = self._client.get_activity_id(activity_name)
-
-            if activity_id is None:
-                _LOGGER.error("%s: Activity %s is invalid", self.name, activity)
-                return
-
-            _, current_activity_name = self.current_activity
-            if current_activity_name == activity_name:
-                # Automations or HomeKit may turn the device on multiple times
-                # when the current activity is already active which will cause
-                # harmony to loose state.  This behavior is unexpected as turning
-                # the device on when its already on isn't expected to reset state.
-                _LOGGER.debug(
-                    "%s: Current activity is already %s", self.name, activity_name
-                )
-                return
-
-            try:
-                await self._client.start_activity(activity_id)
-            except aioexc.TimeOut:
-                _LOGGER.error("%s: Starting activity %s timed-out", self.name, activity)
-        else:
+        if not activity:
             _LOGGER.error("%s: No activity specified with turn_on service", self.name)
+            return
+
+        activity_id = None
+        activity_name = None
+
+        if activity.isdigit() or activity == "-1":
+            _LOGGER.debug("%s: Activity is numeric", self.name)
+            activity_name = self._client.get_activity_name(int(activity))
+            if activity_name:
+                activity_id = activity
+
+        if activity_id is None:
+            _LOGGER.debug("%s: Find activity ID based on name", self.name)
+            activity_name = str(activity)
+            activity_id = self._client.get_activity_id(activity_name)
+
+        if activity_id is None:
+            _LOGGER.error("%s: Activity %s is invalid", self.name, activity)
+            return
+
+        _, current_activity_name = self.current_activity
+        if current_activity_name == activity_name:
+            # Automations or HomeKit may turn the device on multiple times
+            # when the current activity is already active which will cause
+            # harmony to loose state.  This behavior is unexpected as turning
+            # the device on when its already on isn't expected to reset state.
+            _LOGGER.debug(
+                "%s: Current activity is already %s", self.name, activity_name
+            )
+            return
+
+        try:
+            await self._client.start_activity(activity_id)
+        except aioexc.TimeOut:
+            _LOGGER.error("%s: Starting activity %s timed-out", self.name, activity)
 
     async def async_power_off(self):
         """Start the PowerOff activity."""

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -157,7 +157,7 @@ class HarmonyData:
                 _LOGGER.error("%s: Activity %s is invalid", self.name, activity)
                 return
 
-            current_activity_id, current_activity_name = self.current_activity
+            _, current_activity_name = self.current_activity
             if current_activity_name == activity_name:
                 # Automations or HomeKit may turn the device on multiple times
                 # when the current activity is already active which will cause

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -10,5 +10,6 @@
       "deviceType": "urn:myharmony-com:device:harmony:1"
     }
   ],
+  "dependencies": ["remote", "switch"],
   "config_flow": true
 }

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -3,7 +3,7 @@
   "name": "Logitech Harmony Hub",
   "documentation": "https://www.home-assistant.io/integrations/harmony",
   "requirements": ["aioharmony==0.2.6"],
-  "codeowners": ["@ehendrix23", "@bramkragten", "@bdraco"],
+  "codeowners": ["@ehendrix23", "@bramkragten", "@bdraco", "@mkeesey"],
   "ssdp": [
     {
       "manufacturer": "Logitech",

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -24,7 +24,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -39,6 +42,7 @@ from .const import (
     PREVIOUS_ACTIVE_ACTIVITY,
     SERVICE_CHANGE_CHANNEL,
     SERVICE_SYNC,
+    SIGNAL_UPDATE_ACTIVITY,
     UNIQUE_ID,
 )
 from .util import (
@@ -311,6 +315,7 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         self._state = bool(activity_id != -1)
         self._available = True
         self.async_write_ha_state()
+        async_dispatcher_send(self.hass, SIGNAL_UPDATE_ACTIVITY)
 
     async def new_config(self, _=None):
         """Call for updating the current activity."""

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -315,7 +315,9 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         self._state = bool(activity_id != -1)
         self._available = True
         self.async_write_ha_state()
-        async_dispatcher_send(self.hass, SIGNAL_UPDATE_ACTIVITY)
+        async_dispatcher_send(
+            self.hass, SIGNAL_UPDATE_ACTIVITY, {"current_activity": activity_name}
+        )
 
     async def new_config(self, _=None):
         """Call for updating the current activity."""

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -3,9 +3,6 @@ import asyncio
 import json
 import logging
 
-from aioharmony.const import ClientCallbackType
-import aioharmony.exceptions as aioexc
-from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient, SendCommandDevice
 import voluptuous as vol
 
 from homeassistant.components import remote
@@ -24,10 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -37,21 +31,19 @@ from .const import (
     ATTR_CURRENT_ACTIVITY,
     ATTR_DEVICES_LIST,
     ATTR_LAST_ACTIVITY,
-    CONNECTION_UPDATE_ACTIVITY,
     DOMAIN,
     HARMONY_OPTIONS_UPDATE,
     PREVIOUS_ACTIVE_ACTIVITY,
     SERVICE_CHANGE_CHANNEL,
     SERVICE_SYNC,
-    SIGNAL_UPDATE_ACTIVITY,
     UNIQUE_ID,
 )
+from .data import HarmonyCallback
 from .util import (
     find_best_name_for_remote,
     find_matching_config_entries_for_host,
     find_unique_id_for_remote,
     get_harmony_client_if_available,
-    list_names_from_hublist,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,10 +110,15 @@ async def async_setup_entry(
 ):
     """Set up the Harmony config entry."""
 
-    device = hass.data[DOMAIN][entry.entry_id]
+    data = hass.data[DOMAIN][entry.entry_id]
 
-    _LOGGER.debug("Harmony Remote: %s", device)
+    _LOGGER.debug("HarmonyData : %s", data)
 
+    default_activity = entry.options.get(ATTR_ACTIVITY)
+    delay_secs = entry.options.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
+
+    harmony_conf_file = hass.config.path(f"harmony_{entry.unique_id}.conf")
+    device = HarmonyRemote(data, default_activity, harmony_conf_file, delay_secs)
     async_add_entities([device])
 
     platform = entity_platform.current_platform.get()
@@ -139,34 +136,20 @@ async def async_setup_entry(
 class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
     """Remote representation used to control a Harmony device."""
 
-    def __init__(self, name, unique_id, host, activity, out_path, delay_secs):
+    def __init__(self, data, activity, out_path, delay_secs):
         """Initialize HarmonyRemote class."""
-        self._name = name
-        self.host = host
+        self._data = data
+        self._name = data.name
         self._state = None
         self._current_activity = ACTIVITY_POWER_OFF
         self.default_activity = activity
         self._activity_starting = None
         self._is_initial_update = True
-        self._client = HarmonyClient(ip_address=host)
         self._config_path = out_path
         self.delay_secs = delay_secs
         self._available = False
-        self._unique_id = unique_id
+        self._unique_id = data.unique_id
         self._last_activity = None
-
-    @property
-    def activity_names(self):
-        """Names of all the remotes activities."""
-        activities = [activity["label"] for activity in self._client.config["activity"]]
-
-        # Remove both ways of representing PowerOff
-        if None in activities:
-            activities.remove(None)
-        if ACTIVITY_POWER_OFF in activities:
-            activities.remove(ACTIVITY_POWER_OFF)
-
-        return activities
 
     async def _async_update_options(self, data):
         """Change options when the options flow does."""
@@ -176,15 +159,16 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         if ATTR_ACTIVITY in data:
             self.default_activity = data[ATTR_ACTIVITY]
 
-    def _update_callbacks(self):
+    def _setup_callbacks(self):
         callbacks = {
+            "connected": self.got_connected,
+            "disconnected": self.got_disconnected,
             "config_updated": self.new_config,
-            "connect": self.got_connected,
-            "disconnect": self.got_disconnected,
-            "new_activity_starting": self.new_activity,
-            "new_activity": self._new_activity_finished,
+            "activity_starting": self.new_activity,
+            "activity_started": self._new_activity_finished,
         }
-        self._client.callbacks = ClientCallbackType(**callbacks)
+
+        self.async_on_remove(self._data.async_subscribe(HarmonyCallback(**callbacks)))
 
     def _new_activity_finished(self, activity_info: tuple) -> None:
         """Call for finished updated current activity."""
@@ -197,8 +181,9 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
 
         _LOGGER.debug("%s: Harmony Hub added", self._name)
         # Register the callbacks
-        self._update_callbacks()
+        self._setup_callbacks()
 
+        # TODO
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
@@ -224,29 +209,10 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
 
         self._last_activity = last_state.attributes[ATTR_LAST_ACTIVITY]
 
-    async def shutdown(self):
-        """Close connection on shutdown."""
-        _LOGGER.debug("%s: Closing Harmony Hub", self._name)
-        try:
-            await self._client.close()
-        except aioexc.TimeOut:
-            _LOGGER.warning("%s: Disconnect timed-out", self._name)
-
     @property
     def device_info(self):
         """Return device info."""
-        model = "Harmony Hub"
-        if "ethernetStatus" in self._client.hub_config.info:
-            model = "Harmony Hub Pro 2400"
-        return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "manufacturer": "Logitech",
-            "sw_version": self._client.hub_config.info.get(
-                "hubSwVersion", self._client.fw_version
-            ),
-            "name": self.name,
-            "model": model,
-        }
+        self._data.device_info(DOMAIN)
 
     @property
     def unique_id(self):
@@ -269,10 +235,8 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         return {
             ATTR_ACTIVITY_STARTING: self._activity_starting,
             ATTR_CURRENT_ACTIVITY: self._current_activity,
-            ATTR_ACTIVITY_LIST: list_names_from_hublist(
-                self._client.hub_config.activities
-            ),
-            ATTR_DEVICES_LIST: list_names_from_hublist(self._client.hub_config.devices),
+            ATTR_ACTIVITY_LIST: self._data.activity_names,
+            ATTR_DEVICES_LIST: self._data.device_names,
             ATTR_LAST_ACTIVITY: self._last_activity,
         }
 
@@ -285,19 +249,6 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
     def available(self):
         """Return True if connected to Hub, otherwise False."""
         return self._available
-
-    async def connect(self):
-        """Connect to the Harmony HUB."""
-        _LOGGER.debug("%s: Connecting", self._name)
-        try:
-            if not await self._client.connect():
-                _LOGGER.warning("%s: Unable to connect to HUB", self._name)
-                await self._client.close()
-                return False
-        except aioexc.TimeOut:
-            _LOGGER.warning("%s: Connection timed-out", self._name)
-            return False
-        return True
 
     def new_activity(self, activity_info: tuple) -> None:
         """Call for updating the current activity."""
@@ -316,21 +267,11 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         self._state = bool(activity_id != -1)
         self._available = True
         self.async_write_ha_state()
-        async_dispatcher_send(
-            self.hass,
-            f"{SIGNAL_UPDATE_ACTIVITY}-{self.unique_id}",
-            {"current_activity": activity_name},
-        )
-        async_dispatcher_send(
-            self.hass,
-            f"{CONNECTION_UPDATE_ACTIVITY}-{self.unique_id}",
-            {"available": self._available},
-        )
 
     async def new_config(self, _=None):
         """Call for updating the current activity."""
         _LOGGER.debug("%s: configuration has been updated", self._name)
-        self.new_activity(self._client.current_activity)
+        self.new_activity(self._data.current_activity)
         await self.hass.async_add_executor_job(self.write_config_file)
 
     async def got_connected(self, _=None):
@@ -351,11 +292,6 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         if not self._available:
             # Still disconnected. Let the state engine know.
             self.async_write_ha_state()
-            async_dispatcher_send(
-                self.hass,
-                f"{CONNECTION_UPDATE_ACTIVITY}-{self.unique_id}",
-                {"available": self._available},
-            )
 
     async def async_turn_on(self, **kwargs):
         """Start an activity from the Harmony device."""
@@ -367,55 +303,18 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
             if self._last_activity:
                 activity = self._last_activity
             else:
-                all_activities = list_names_from_hublist(
-                    self._client.hub_config.activities
-                )
+                all_activities = self._data.activity_names
                 if all_activities:
                     activity = all_activities[0]
 
         if activity:
-            activity_id = None
-            activity_name = None
-
-            if activity.isdigit() or activity == "-1":
-                _LOGGER.debug("%s: Activity is numeric", self.name)
-                activity_name = self._client.get_activity_name(int(activity))
-                if activity_name:
-                    activity_id = activity
-
-            if activity_id is None:
-                _LOGGER.debug("%s: Find activity ID based on name", self.name)
-                activity_name = str(activity)
-                activity_id = self._client.get_activity_id(activity_name)
-
-            if activity_id is None:
-                _LOGGER.error("%s: Activity %s is invalid", self.name, activity)
-                return
-
-            if self._current_activity == activity_name:
-                # Automations or HomeKit may turn the device on multiple times
-                # when the current activity is already active which will cause
-                # harmony to loose state.  This behavior is unexpected as turning
-                # the device on when its already on isn't expected to reset state.
-                _LOGGER.debug(
-                    "%s: Current activity is already %s", self.name, activity_name
-                )
-                return
-
-            try:
-                await self._client.start_activity(activity_id)
-            except aioexc.TimeOut:
-                _LOGGER.error("%s: Starting activity %s timed-out", self.name, activity)
+            await self._data.async_start_activity(activity)
         else:
             _LOGGER.error("%s: No activity specified with turn_on service", self.name)
 
     async def async_turn_off(self, **kwargs):
         """Start the PowerOff activity."""
-        _LOGGER.debug("%s: Turn Off", self.name)
-        try:
-            await self._client.power_off()
-        except aioexc.TimeOut:
-            _LOGGER.error("%s: Powering off timed-out", self.name)
+        await self._data.async_power_off()
 
     async def async_send_command(self, command, **kwargs):
         """Send a list of commands to one device."""
@@ -425,76 +324,20 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
             _LOGGER.error("%s: Missing required argument: device", self.name)
             return
 
-        device_id = None
-        if device.isdigit():
-            _LOGGER.debug("%s: Device %s is numeric", self.name, device)
-            if self._client.get_device_name(int(device)):
-                device_id = device
-
-        if device_id is None:
-            _LOGGER.debug(
-                "%s: Find device ID %s based on device name", self.name, device
-            )
-            device_id = self._client.get_device_id(str(device).strip())
-
-        if device_id is None:
-            _LOGGER.error("%s: Device %s is invalid", self.name, device)
-            return
-
         num_repeats = kwargs[ATTR_NUM_REPEATS]
         delay_secs = kwargs.get(ATTR_DELAY_SECS, self.delay_secs)
         hold_secs = kwargs[ATTR_HOLD_SECS]
-        _LOGGER.debug(
-            "Sending commands to device %s holding for %s seconds "
-            "with a delay of %s seconds",
-            device,
-            hold_secs,
-            delay_secs,
+        await self._data.async_send_command(
+            command, device, num_repeats, delay_secs, hold_secs
         )
-
-        # Creating list of commands to send.
-        snd_cmnd_list = []
-        for _ in range(num_repeats):
-            for single_command in command:
-                send_command = SendCommandDevice(
-                    device=device_id, command=single_command, delay=hold_secs
-                )
-                snd_cmnd_list.append(send_command)
-                if delay_secs > 0:
-                    snd_cmnd_list.append(float(delay_secs))
-
-        _LOGGER.debug("%s: Sending commands", self.name)
-        try:
-            result_list = await self._client.send_commands(snd_cmnd_list)
-        except aioexc.TimeOut:
-            _LOGGER.error("%s: Sending commands timed-out", self.name)
-            return
-
-        for result in result_list:
-            _LOGGER.error(
-                "Sending command %s to device %s failed with code %s: %s",
-                result.command.command,
-                result.command.device,
-                result.code,
-                result.msg,
-            )
 
     async def change_channel(self, channel):
         """Change the channel using Harmony remote."""
-        _LOGGER.debug("%s: Changing channel to %s", self.name, channel)
-        try:
-            await self._client.change_channel(channel)
-        except aioexc.TimeOut:
-            _LOGGER.error("%s: Changing channel to %s timed-out", self.name, channel)
+        self._data.change_channel(channel)
 
     async def sync(self):
         """Sync the Harmony device with the web service."""
-        _LOGGER.debug("%s: Syncing hub with Harmony cloud", self.name)
-        try:
-            await self._client.sync()
-        except aioexc.TimeOut:
-            _LOGGER.error("%s: Syncing hub with Harmony cloud timed-out", self.name)
-        else:
+        if await self._data.sync():
             await self.hass.async_add_executor_job(self.write_config_file)
 
     def write_config_file(self):
@@ -502,13 +345,14 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         _LOGGER.debug(
             "%s: Writing hub configuration to file: %s", self.name, self._config_path
         )
-        if self._client.config is None:
+        json_config = self._data.json_config
+        if json_config is None:
             _LOGGER.warning("%s: No configuration received from hub", self.name)
             return
 
         try:
             with open(self._config_path, "w+", encoding="utf-8") as file_out:
-                json.dump(self._client.json_config, file_out, sort_keys=True, indent=4)
+                json.dump(json_config, file_out, sort_keys=True, indent=4)
         except OSError as exc:
             _LOGGER.error(
                 "%s: Unable to write HUB configuration to %s: %s",

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -180,7 +180,6 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         # Register the callbacks
         self._setup_callbacks()
 
-        # TODO
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
@@ -283,9 +282,7 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         self._available = False
         # We're going to wait for 10 seconds before announcing we're
         # unavailable, this to allow a reconnection to happen.
-        _LOGGER.debug("pre sleep")
         await self.sleep(10)
-        _LOGGER.debug("past sleep")
 
         if not self._available:
             # Still disconnected. Let the state engine know.

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -37,6 +37,7 @@ from .const import (
     ATTR_CURRENT_ACTIVITY,
     ATTR_DEVICES_LIST,
     ATTR_LAST_ACTIVITY,
+    CONNECTION_UPDATE_ACTIVITY,
     DOMAIN,
     HARMONY_OPTIONS_UPDATE,
     PREVIOUS_ACTIVE_ACTIVITY,
@@ -318,6 +319,9 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         async_dispatcher_send(
             self.hass, SIGNAL_UPDATE_ACTIVITY, {"current_activity": activity_name}
         )
+        async_dispatcher_send(
+            self.hass, CONNECTION_UPDATE_ACTIVITY, {"available": self._available}
+        )
 
     async def new_config(self, _=None):
         """Call for updating the current activity."""
@@ -343,6 +347,9 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         if not self._available:
             # Still disconnected. Let the state engine know.
             self.async_write_ha_state()
+            async_dispatcher_send(
+                self.hass, CONNECTION_UPDATE_ACTIVITY, {"available": self._available}
+            )
 
     async def async_turn_on(self, **kwargs):
         """Start an activity from the Harmony device."""

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -317,10 +317,14 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         self._available = True
         self.async_write_ha_state()
         async_dispatcher_send(
-            self.hass, SIGNAL_UPDATE_ACTIVITY, {"current_activity": activity_name}
+            self.hass,
+            f"{SIGNAL_UPDATE_ACTIVITY}-{self.unique_id}",
+            {"current_activity": activity_name},
         )
         async_dispatcher_send(
-            self.hass, CONNECTION_UPDATE_ACTIVITY, {"available": self._available}
+            self.hass,
+            f"{CONNECTION_UPDATE_ACTIVITY}-{self.unique_id}",
+            {"available": self._available},
         )
 
     async def new_config(self, _=None):
@@ -348,7 +352,9 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
             # Still disconnected. Let the state engine know.
             self.async_write_ha_state()
             async_dispatcher_send(
-                self.hass, CONNECTION_UPDATE_ACTIVITY, {"available": self._available}
+                self.hass,
+                f"{CONNECTION_UPDATE_ACTIVITY}-{self.unique_id}",
+                {"available": self._available},
             )
 
     async def async_turn_on(self, **kwargs):

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -283,7 +283,9 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
         self._available = False
         # We're going to wait for 10 seconds before announcing we're
         # unavailable, this to allow a reconnection to happen.
-        await asyncio.sleep(10)
+        _LOGGER.debug("pre sleep")
+        await self.sleep(10)
+        _LOGGER.debug("past sleep")
 
         if not self._available:
             # Still disconnected. Let the state engine know.
@@ -334,3 +336,7 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
     async def sync(self):
         """Sync the Harmony device with the web service."""
         await self._data.sync()
+
+    async def sleep(self, time):
+        """Sleep for the given time."""
+        await asyncio.sleep(time)

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -328,7 +328,7 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
 
     async def change_channel(self, channel):
         """Change the channel using Harmony remote."""
-        self._data.change_channel(channel)
+        await self._data.change_channel(channel)
 
     async def sync(self):
         """Sync the Harmony device with the web service."""

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -372,7 +372,7 @@ class HarmonyRemote(remote.RemoteEntity, RestoreEntity):
                 exc,
             )
 
-    def _mark_disconnected_if_unavailable(self):
+    def _mark_disconnected_if_unavailable(self, _):
         self._unsub_mark_disconnected = None
         if not self._available:
             # Still disconnected. Let the state engine know.

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -37,7 +37,7 @@ from .const import (
     SERVICE_SYNC,
     UNIQUE_ID,
 )
-from .data import HarmonyCallback
+from .subscriber import HarmonyCallback
 from .util import (
     find_best_name_for_remote,
     find_matching_config_entries_for_host,

--- a/homeassistant/components/harmony/subscriber.py
+++ b/homeassistant/components/harmony/subscriber.py
@@ -1,0 +1,110 @@
+"""Harmony callback subscriber."""
+
+import logging
+from typing import Any, Callable, NamedTuple, Optional
+
+from aioharmony.const import ClientCallbackType
+import aioharmony.exceptions as aioexc
+from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
+
+from homeassistant.core import callback
+
+_LOGGER = logging.getLogger(__name__)
+
+NoParamCallback = Optional[Callable[[object], Any]]
+ActivityCallback = Optional[Callable[[object, tuple], Any]]
+
+
+class HarmonyCallback(NamedTuple):
+    """Callback type for Harmony Hub notifications."""
+
+    connected: NoParamCallback
+    disconnected: NoParamCallback
+    config_updated: NoParamCallback
+    activity_starting: ActivityCallback
+    activity_started: ActivityCallback
+
+
+class HarmonySubscriber:
+    """Subscriber for Harmony hub updates."""
+
+    def __init__(self, client: HarmonyClient, name: str):
+        """Initialize a subscriber."""
+        self._client = client
+        self._name = name
+        self._subscriptions = []
+
+        callbacks = {
+            "config_updated": self._config_updated,
+            "connect": self._connected,
+            "disconnect": self._disconnected,
+            "new_activity_starting": self._activity_starting,
+            "new_activity": self._activity_started,
+        }
+        self._client.callbacks = ClientCallbackType(**callbacks)
+
+    async def connect(self) -> bool:
+        """Connect to the Harmony Hub."""
+        _LOGGER.debug("%s: Connecting", self._name)
+        try:
+            if not await self._client.connect():
+                _LOGGER.warning("%s: Unable to connect to HUB", self._name)
+                await self._client.close()
+                return False
+        except aioexc.TimeOut:
+            _LOGGER.warning("%s: Connection timed-out", self._name)
+            return False
+        return True
+
+    async def shutdown(self):
+        """Close connection on shutdown."""
+        _LOGGER.debug("%s: Closing Harmony Hub", self._name)
+        try:
+            await self._client.close()
+        except aioexc.TimeOut:
+            _LOGGER.warning("%s: Disconnect timed-out", self._name)
+
+    @callback
+    def async_subscribe(self, update_callback: HarmonyCallback):
+        """Add a callback subscriber."""
+        self._subscriptions.append(update_callback)
+
+        def _unsubscribe():
+            self.async_unsubscribe(update_callback)
+
+        return _unsubscribe()
+
+    @callback
+    def async_unsubscribe_hub_id(self, update_callback: HarmonyCallback):
+        """Remove a callback subscriber."""
+        self._subscriptions.remove(update_callback)
+
+    def _config_updated(self, _=None) -> None:
+        for subscription in self._subscriptions:
+            callback = subscription.config_updated
+            if callback:
+                callback()
+
+    def _connected(self, _=None) -> None:
+        for subscription in self._subscriptions:
+            callback = subscription.connected
+            if callback:
+                callback()
+
+    def _disconnected(self, _=None) -> None:
+        for subscription in self._subscriptions:
+            callback = subscription.disconnected
+            if callback:
+                callback()
+
+    def _activity_starting(self, activity_info: tuple) -> None:
+        for subscription in self._subscriptions:
+            callback = subscription.activity_starting
+            if callback:
+                callback(activity_info)
+
+    def _activity_started(self, activity_info: tuple) -> None:
+        for subscription in self._subscriptions:
+            callback = subscription.activity_started
+            if callback:
+                callback(activity_info)

--- a/homeassistant/components/harmony/subscriber.py
+++ b/homeassistant/components/harmony/subscriber.py
@@ -1,0 +1,98 @@
+"""Mixin class for handling harmony callback subscriptions."""
+
+import asyncio
+import logging
+from typing import Any, Callable, NamedTuple, Optional
+
+from homeassistant.core import callback
+
+_LOGGER = logging.getLogger(__name__)
+
+NoParamCallback = Optional[Callable[[object], Any]]
+ActivityCallback = Optional[Callable[[object, tuple], Any]]
+
+
+class HarmonyCallback(NamedTuple):
+    """Callback type for Harmony Hub notifications."""
+
+    connected: NoParamCallback
+    disconnected: NoParamCallback
+    config_updated: NoParamCallback
+    activity_starting: ActivityCallback
+    activity_started: ActivityCallback
+
+
+class HarmonySubscriberMixin:
+    """Base implementation for a subscriber."""
+
+    def __init__(self):
+        """Initialize an subscriber."""
+        super().__init__()
+        self._subscriptions = []
+
+    @callback
+    def async_subscribe(self, update_callback: HarmonyCallback) -> Callable:
+        """Add a callback subscriber."""
+        self._subscriptions.append(update_callback)
+
+        def _unsubscribe():
+            self.async_unsubscribe(update_callback)
+
+        return _unsubscribe
+
+    @callback
+    def async_unsubscribe(self, update_callback: HarmonyCallback):
+        """Remove a callback subscriber."""
+        self._subscriptions.remove(update_callback)
+
+    def _config_updated(self, _=None) -> None:
+        _LOGGER.debug("config_updated")
+        for subscription in self._subscriptions:
+            current_callback = subscription.config_updated
+            if current_callback:
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback())
+                else:
+                    current_callback()
+
+    def _connected(self, _=None) -> None:
+        _LOGGER.debug("connected")
+        self._available = True
+        for subscription in self._subscriptions:
+            current_callback = subscription.connected
+            if current_callback:
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback())
+                else:
+                    current_callback()
+
+    def _disconnected(self, _=None) -> None:
+        _LOGGER.debug("disconnected")
+        self._available = False
+        for subscription in self._subscriptions:
+            current_callback = subscription.disconnected
+            if current_callback:
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback())
+                else:
+                    current_callback()
+
+    def _activity_starting(self, activity_info: tuple) -> None:
+        _LOGGER.debug("activity %s starting", activity_info)
+        for subscription in self._subscriptions:
+            current_callback = subscription.activity_starting
+            if current_callback:
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback(activity_info))
+                else:
+                    current_callback(activity_info)
+
+    def _activity_started(self, activity_info: tuple) -> None:
+        _LOGGER.debug("activity %s started", activity_info)
+        for subscription in self._subscriptions:
+            current_callback = subscription.activity_started
+            if current_callback:
+                if asyncio.iscoroutinefunction(current_callback):
+                    asyncio.create_task(current_callback(activity_info))
+                else:
+                    current_callback(activity_info)

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -1,26 +1,25 @@
 """Support for Harmony Hub activities."""
 import logging
 
-from homeassistant.components.remote import ATTR_ACTIVITY
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_NAME
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import CONNECTION_UPDATE_ACTIVITY, DOMAIN, SIGNAL_UPDATE_ACTIVITY
+from .const import DOMAIN
+from .data import HarmonyCallback, HarmonyData
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up harmony activity switches."""
-    device = hass.data[DOMAIN][entry.entry_id]
-    activities = device.activity_names
+    data = hass.data[DOMAIN][entry.entry_id]
+    activities = data.activity_names
 
     switches = []
     for activity in activities:
         _LOGGER.debug("creating switch for activity: %s", activity)
         name = f"{entry.data[CONF_NAME]} {activity}"
-        switches.append(HarmonyActivitySwitch(name, activity, device))
+        switches.append(HarmonyActivitySwitch(name, activity, data))
 
     async_add_entities(switches, True)
 
@@ -28,14 +27,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class HarmonyActivitySwitch(SwitchEntity):
     """Switch representation of a Harmony activity."""
 
-    def __init__(self, name, activity, device):
+    def __init__(self, name: str, activity: str, data: HarmonyData):
         """Initialize HarmonyActivitySwitch class."""
         self._name = name
         self._activity = activity
-        self._device = device
-        self._state = False
-        self._available = False
-        self._dispatcher_disconnectors = []
+        self._data = data
 
     @property
     def name(self):
@@ -45,12 +41,13 @@ class HarmonyActivitySwitch(SwitchEntity):
     @property
     def unique_id(self):
         """Return the unique id."""
-        return f"{self._device.unique_id}-{self._activity}"
+        return f"{self._data.unique_id}-{self._activity}"
 
     @property
     def is_on(self):
         """Return if the current activity is the one for this switch."""
-        return self._state
+        activity_id, activity_name = self._data.current_activity
+        return activity_name == self._activity
 
     @property
     def should_poll(self):
@@ -60,51 +57,34 @@ class HarmonyActivitySwitch(SwitchEntity):
     @property
     def available(self):
         """Return True if we're connected to the Hub, otherwise False."""
-        return self._available
+        return self._data.available
 
     async def async_turn_on(self, **kwargs):
         """Start this activity."""
-        await self._device.async_turn_on(**{ATTR_ACTIVITY: self._activity})
+        await self._data.async_start_activity(self._activity)
 
     async def async_turn_off(self, **kwargs):
         """Stop this activity."""
-        await self._device.async_turn_off()
+        await self._data.async_power_off()
 
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
-        self._dispatcher_disconnectors.append(
-            async_dispatcher_connect(
-                self.hass,
-                f"{SIGNAL_UPDATE_ACTIVITY}-{self._device.unique_id}",
-                self._update_activity_callback,
-            )
-        )
 
-        self._dispatcher_disconnectors.append(
-            async_dispatcher_connect(
-                self.hass,
-                f"{CONNECTION_UPDATE_ACTIVITY}-{self._device.unique_id}",
-                self._update_connection_callback,
-            )
-        )
+        callbacks = {
+            "connected": self._connected,
+            "disconnected": self._disconnected,
+            "activity_starting": self._activity_update,
+            "activity_started": self._activity_update,
+            "config_updated": None,
+        }
 
-    async def async_will_remove_from_hass(self):
-        """Call when entity is removed from hass."""
-        for disconnector in self._dispatcher_disconnectors:
-            disconnector()
+        self.async_on_remove(self._data.async_subscribe(HarmonyCallback(**callbacks)))
 
-    def _update_activity_callback(self, data):
-        old_state = self._state
-        if data["current_activity"] == self._activity:
-            self._state = True
-        else:
-            self._state = False
+    def _connected(self):
+        self.async_write_ha_state()
 
-        if self._state != old_state:
-            self.async_write_ha_state()
+    def _disconnected(self):
+        self.async_write_ha_state()
 
-    def _update_connection_callback(self, data):
-        old_state = self._available
-        self._available = data["available"]
-        if self._available != old_state:
-            self.async_write_ha_state()
+    def _activity_update(self, activity_info: tuple):
+        self.async_write_ha_state()

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -74,13 +74,17 @@ class HarmonyActivitySwitch(SwitchEntity):
         """Call when entity is added to hass."""
         self._dispatcher_disconnectors.append(
             async_dispatcher_connect(
-                self.hass, SIGNAL_UPDATE_ACTIVITY, self._update_activity_callback
+                self.hass,
+                f"{SIGNAL_UPDATE_ACTIVITY}-{self._device.unique_id}",
+                self._update_activity_callback,
             )
         )
 
         self._dispatcher_disconnectors.append(
             async_dispatcher_connect(
-                self.hass, CONNECTION_UPDATE_ACTIVITY, self._update_connection_callback
+                self.hass,
+                f"{CONNECTION_UPDATE_ACTIVITY}-{self._device.unique_id}",
+                self._update_connection_callback,
             )
         )
 

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -3,8 +3,9 @@ import logging
 
 from homeassistant.components.remote import ATTR_ACTIVITY
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_UPDATE_ACTIVITY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ class HarmonyActivitySwitch(SwitchEntity):
         self._name = name
         self._activity = activity
         self._device = device
+        self._remove_signal_update = None
 
     @property
     def name(self):
@@ -62,3 +64,17 @@ class HarmonyActivitySwitch(SwitchEntity):
     async def async_turn_off(self, **kwargs):
         """Stop this activity."""
         await self._device.async_turn_off()
+
+    async def async_added_to_hass(self):
+        """Call when entity is added to hass."""
+        self._remove_signal_update = async_dispatcher_connect(
+            self.hass, SIGNAL_UPDATE_ACTIVITY, self._update_callback
+        )
+
+    async def async_will_remove_from_hass(self):
+        """Call when entity is removed from hass."""
+        self._remove_signal_update()
+
+    def _update_callback(self):
+        # TODO was it just us
+        self.async_write_ha_state()

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -44,12 +44,6 @@ class HarmonyActivitySwitch(SwitchEntity):
         """Return the unique id."""
         return f"{self._device.unique_id}-{self._activity}"
 
-    @property
-    def should_poll(self):
-        """Return the fact that we should not be polled."""
-        # TODO
-        return True
-
     # TODO private variables
     @property
     def is_on(self):

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -1,0 +1,54 @@
+"""Support for Harmony Hub activities."""
+import logging
+
+from homeassistant.components.remote import ATTR_ACTIVITY
+from homeassistant.components.switch import SwitchEntity
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up harmony activity switches."""
+    # TODO
+    _LOGGER.warn("Loading the switch for harmony")
+
+    device = hass.data[DOMAIN][entry.entry_id]
+    activities = device.activity_names
+
+    switches = []
+    for activity in activities:
+        switches.append(
+            HarmonyActivitySwitch(
+                activity + "-switch", "TODO" + activity, activity, device
+            )
+        )
+
+    async_add_entities(switches, True)
+
+
+class HarmonyActivitySwitch(SwitchEntity):
+    """Switch representation of a Harmony activity."""
+
+    # TODO do we have all params
+    def __init__(self, name, unique_id, activity, remote):
+        """Initialize HarmonyActivitySwitch class."""
+        self._name = name
+        self._unique_id = unique_id
+        self._activity = activity
+        self._remote = remote
+
+    # TODO private variables
+    @property
+    def is_on(self):
+        """Return if the current activity is the one for this switch."""
+        return self._remote._current_activity == self._activity
+
+    async def async_turn_on(self, **kwargs):
+        """Start this activity."""
+        self._remote.async_turn_on(**{ATTR_ACTIVITY: self.activity})
+
+    async def async_turn_off(self, **kwargs):
+        """Stop this activity."""
+        self._remote.async_turn_off()

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -12,15 +12,12 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up harmony activity switches."""
-    # TODO
-    _LOGGER.warn("Loading the switch for harmony")
-
     device = hass.data[DOMAIN][entry.entry_id]
     activities = device.activity_names
 
     switches = []
     for activity in activities:
-        switches.append(HarmonyActivitySwitch(activity, activity, device))
+        switches.append(HarmonyActivitySwitch(activity, device))
 
     async_add_entities(switches, True)
 
@@ -28,9 +25,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class HarmonyActivitySwitch(SwitchEntity):
     """Switch representation of a Harmony activity."""
 
-    def __init__(self, name, activity, device):
+    def __init__(self, activity, device):
         """Initialize HarmonyActivitySwitch class."""
-        self._name = name
         self._activity = activity
         self._device = device
         self._state = False
@@ -40,7 +36,7 @@ class HarmonyActivitySwitch(SwitchEntity):
     @property
     def name(self):
         """Return the Harmony activity's name."""
-        return self._name
+        return self._activity
 
     @property
     def unique_id(self):

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -3,6 +3,7 @@ import logging
 
 from homeassistant.components.remote import ATTR_ACTIVITY
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_NAME
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import CONNECTION_UPDATE_ACTIVITY, DOMAIN, SIGNAL_UPDATE_ACTIVITY
@@ -17,7 +18,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     switches = []
     for activity in activities:
-        switches.append(HarmonyActivitySwitch(activity, device))
+        _LOGGER.debug("creating switch for activity: %s", activity)
+        name = f"{entry.data[CONF_NAME]} {activity}"
+        switches.append(HarmonyActivitySwitch(name, activity, device))
 
     async_add_entities(switches, True)
 
@@ -25,8 +28,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class HarmonyActivitySwitch(SwitchEntity):
     """Switch representation of a Harmony activity."""
 
-    def __init__(self, activity, device):
+    def __init__(self, name, activity, device):
         """Initialize HarmonyActivitySwitch class."""
+        self._name = name
         self._activity = activity
         self._device = device
         self._state = False
@@ -36,7 +40,7 @@ class HarmonyActivitySwitch(SwitchEntity):
     @property
     def name(self):
         """Return the Harmony activity's name."""
-        return self._activity
+        return self._name
 
     @property
     def unique_id(self):

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -19,11 +19,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     switches = []
     for activity in activities:
-        switches.append(
-            HarmonyActivitySwitch(
-                activity + "-switch", "TODO" + activity, activity, device
-            )
-        )
+        switches.append(HarmonyActivitySwitch(activity, activity, device))
 
     async_add_entities(switches, True)
 
@@ -32,23 +28,43 @@ class HarmonyActivitySwitch(SwitchEntity):
     """Switch representation of a Harmony activity."""
 
     # TODO do we have all params
-    def __init__(self, name, unique_id, activity, remote):
+    def __init__(self, name, activity, device):
         """Initialize HarmonyActivitySwitch class."""
         self._name = name
-        self._unique_id = unique_id
         self._activity = activity
-        self._remote = remote
+        self._device = device
+
+    @property
+    def name(self):
+        """Return the Harmony activity's name."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return f"{self._device.unique_id}-{self._activity}"
+
+    @property
+    def should_poll(self):
+        """Return the fact that we should not be polled."""
+        # TODO
+        return True
 
     # TODO private variables
     @property
     def is_on(self):
         """Return if the current activity is the one for this switch."""
-        return self._remote._current_activity == self._activity
+        return self._device._current_activity == self._activity
+
+    # @property
+    # def available(self):
+    # """Return True if we're connected to the Hub, otherwise False."""
+    # return self._device.available
 
     async def async_turn_on(self, **kwargs):
         """Start this activity."""
-        self._remote.async_turn_on(**{ATTR_ACTIVITY: self.activity})
+        await self._device.async_turn_on(**{ATTR_ACTIVITY: self._activity})
 
     async def async_turn_off(self, **kwargs):
         """Stop this activity."""
-        self._remote.async_turn_off()
+        await self._device.async_turn_off()

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -46,7 +46,7 @@ class HarmonyActivitySwitch(SwitchEntity):
     @property
     def is_on(self):
         """Return if the current activity is the one for this switch."""
-        activity_id, activity_name = self._data.current_activity
+        _, activity_name = self._data.current_activity
         return activity_name == self._activity
 
     @property

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -5,7 +5,8 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_NAME
 
 from .const import DOMAIN
-from .data import HarmonyCallback, HarmonyData
+from .data import HarmonyData
+from .subscriber import HarmonyCallback
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_NAME
 
+from .connection_state import ConnectionStateMixin
 from .const import DOMAIN
 from .data import HarmonyData
 from .subscriber import HarmonyCallback
@@ -25,11 +26,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(switches, True)
 
 
-class HarmonyActivitySwitch(SwitchEntity):
+class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
     """Switch representation of a Harmony activity."""
 
     def __init__(self, name: str, activity: str, data: HarmonyData):
         """Initialize HarmonyActivitySwitch class."""
+        super().__init__()
         self._name = name
         self._activity = activity
         self._data = data
@@ -72,20 +74,14 @@ class HarmonyActivitySwitch(SwitchEntity):
         """Call when entity is added to hass."""
 
         callbacks = {
-            "connected": self._connected,
-            "disconnected": self._disconnected,
+            "connected": self.got_connected,
+            "disconnected": self.got_disconnected,
             "activity_starting": self._activity_update,
             "activity_started": self._activity_update,
             "config_updated": None,
         }
 
         self.async_on_remove(self._data.async_subscribe(HarmonyCallback(**callbacks)))
-
-    def _connected(self):
-        self.async_write_ha_state()
-
-    def _disconnected(self):
-        self.async_write_ha_state()
 
     def _activity_update(self, activity_info: tuple):
         self.async_write_ha_state()

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -37,7 +37,7 @@ class FakeHarmonyStates:
         self._client_mock.callbacks.new_activity_starting(activity_tuple)
         self._client_mock.callbacks.new_activity(activity_tuple)
 
-        return AsyncMock(return_value=True)
+        return AsyncMock(return_value=(True, "unused message"))
 
     def get_activity_id(self, activity_name):
         """Return the mapping of an activity name to the internal id."""

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -76,6 +76,11 @@ class FakeHarmonyClient:
         return self.hub_config.config
 
     @property
+    def json_config(self):
+        """Return the json config as a dict."""
+        return {}
+
+    @property
     def hub_config(self):
         """Return the client_config type."""
         config = MagicMock()

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -47,6 +47,7 @@ class FakeHarmonyClient:
         self.close = AsyncMock()
         self.send_commands = AsyncMock()
         self.change_channel = AsyncMock()
+        self.sync = AsyncMock()
         self._callbacks = callbacks
 
     async def connect(self):

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for harmony tests."""
 import logging
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from aioharmony.const import ClientCallbackType
 import pytest
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from homeassistant.components.harmony.const import ACTIVITY_POWER_OFF
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -4,7 +4,7 @@ import logging
 from aioharmony.const import ClientCallbackType
 import pytest
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from homeassistant.components.harmony.const import ACTIVITY_POWER_OFF
 
 _LOGGER = logging.getLogger(__name__)
@@ -134,3 +134,14 @@ def mock_harmonyclient():
     fake = FakeHarmonyClient()
 
     yield fake
+
+
+@pytest.fixture()
+def patched_remote():
+    """Create a patched remote that removes side effects."""
+    with patch.multiple(
+        "homeassistant.components.harmony.remote.HarmonyRemote",
+        sleep=AsyncMock(),
+        write_config_file=MagicMock(),
+    ) as mocks:
+        yield mocks

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -4,7 +4,7 @@ import logging
 from aioharmony.const import ClientCallbackType
 import pytest
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import DEFAULT, AsyncMock, MagicMock, PropertyMock, patch
 from homeassistant.components.harmony.const import ACTIVITY_POWER_OFF
 
 _LOGGER = logging.getLogger(__name__)
@@ -129,11 +129,13 @@ class FakeHarmonyClient:
 
 
 @pytest.fixture()
-def mock_harmonyclient():
+def mock_hc():
     """Create a mock HarmonyClient."""
-    fake = FakeHarmonyClient()
-
-    yield fake
+    with patch(
+        "homeassistant.components.harmony.data.HarmonyClient",
+        side_effect=FakeHarmonyClient,
+    ) as fake:
+        yield fake
 
 
 @pytest.fixture()
@@ -141,7 +143,7 @@ def patched_remote():
     """Create a patched remote that removes side effects."""
     with patch.multiple(
         "homeassistant.components.harmony.remote.HarmonyRemote",
-        sleep=AsyncMock(),
-        write_config_file=MagicMock(),
+        sleep=DEFAULT,
+        write_config_file=DEFAULT,
     ) as mocks:
         yield mocks

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -4,7 +4,7 @@ import logging
 from aioharmony.const import ClientCallbackType
 import pytest
 
-from unittest.mock import DEFAULT, AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from homeassistant.components.harmony.const import ACTIVITY_POWER_OFF
 
 _LOGGER = logging.getLogger(__name__)
@@ -139,11 +139,9 @@ def mock_hc():
 
 
 @pytest.fixture()
-def patched_remote():
-    """Create a patched remote that removes side effects."""
-    with patch.multiple(
-        "homeassistant.components.harmony.remote.HarmonyRemote",
-        sleep=DEFAULT,
-        write_config_file=DEFAULT,
-    ) as mocks:
-        yield mocks
+def mock_write_config():
+    """Patches write_config_file to remove side effects."""
+    with patch(
+        "homeassistant.components.harmony.remote.HarmonyRemote.write_config_file",
+    ) as mock:
+        yield mock

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -1,0 +1,34 @@
+"""Fixtures for harmony tests."""
+import pytest
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+
+@pytest.fixture()
+def mock_harmonyclient():
+    """Create a mock HarmonyClient."""
+    harmonyclient_mock = MagicMock()
+    type(harmonyclient_mock).connect = AsyncMock()
+    type(harmonyclient_mock).close = AsyncMock()
+    type(harmonyclient_mock).get_activity_name = MagicMock(return_value="Watch TV")
+    type(harmonyclient_mock.hub_config).activities = PropertyMock(
+        return_value=[
+            {"name": "Watch TV", "id": 123},
+            {"name": "Play Music", "id": 456},
+        ]
+    )
+    type(harmonyclient_mock.hub_config).devices = PropertyMock(
+        return_value=[{"name": "My TV", "id": 1234}]
+    )
+    type(harmonyclient_mock.hub_config).info = PropertyMock(return_value={})
+    type(harmonyclient_mock.hub_config).hub_state = PropertyMock(return_value={})
+    type(harmonyclient_mock.hub_config).config = PropertyMock(
+        return_value={
+            "activity": [
+                {"id": 123, "label": "Watch TV"},
+                {"id": 456, "label": "Play Music"},
+            ]
+        }
+    )
+
+    yield harmonyclient_mock

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -3,18 +3,45 @@ import pytest
 
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
+WATCH_TV_ACTIVITY_ID = 123
+PLAY_MUSIC_ACTIVITY_ID = 456
+
+ACTIVITIES_TO_IDS = {
+    "Watch TV": WATCH_TV_ACTIVITY_ID,
+    "Play Music": PLAY_MUSIC_ACTIVITY_ID,
+}
+
+# class FakeHarmonyStates:
+# def __init__(self):
+# self._activity_name = "Watch TV"
+
+# def get_activity_name(self, *args):
+# return self._activity_name
+
+# async def start_activity(self, *args, **kwargs):
+# print(args)
+# print(kwargs)
+# fut = asyncio.Future()
+# fut.return_value=True
+# return await fut
+
 
 @pytest.fixture()
 def mock_harmonyclient():
     """Create a mock HarmonyClient."""
+    # stateHandler = FakeHarmonyStates()
     harmonyclient_mock = MagicMock()
     type(harmonyclient_mock).connect = AsyncMock()
     type(harmonyclient_mock).close = AsyncMock()
+    # type(harmonyclient_mock).get_activity_name = MagicMock(side_effect=stateHandler.get_activity_name)
     type(harmonyclient_mock).get_activity_name = MagicMock(return_value="Watch TV")
+    type(harmonyclient_mock).get_activity_id = _get_activity_id
+    # type(harmonyclient_mock).start_activity = AsyncMock(side_effect=stateHandler.start_activity, return_value=True)
+    type(harmonyclient_mock).start_activity = AsyncMock()
     type(harmonyclient_mock.hub_config).activities = PropertyMock(
         return_value=[
-            {"name": "Watch TV", "id": 123},
-            {"name": "Play Music", "id": 456},
+            {"name": "Watch TV", "id": WATCH_TV_ACTIVITY_ID},
+            {"name": "Play Music", "id": PLAY_MUSIC_ACTIVITY_ID},
         ]
     )
     type(harmonyclient_mock.hub_config).devices = PropertyMock(
@@ -25,10 +52,14 @@ def mock_harmonyclient():
     type(harmonyclient_mock.hub_config).config = PropertyMock(
         return_value={
             "activity": [
-                {"id": 123, "label": "Watch TV"},
-                {"id": 456, "label": "Play Music"},
+                {"id": WATCH_TV_ACTIVITY_ID, "label": "Watch TV"},
+                {"id": PLAY_MUSIC_ACTIVITY_ID, "label": "Play Music"},
             ]
         }
     )
 
     yield harmonyclient_mock
+
+
+def _get_activity_id(_, activity_name):
+    return ACTIVITIES_TO_IDS.get(activity_name)

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -41,13 +41,13 @@ class FakeHarmonyClient:
         self._callbacks.connect(None)
         return AsyncMock(return_value=(True))
 
-    def get_activity_name(self, *args):
-        """Return the current activity."""
-        return self._activity_name
+    def get_activity_name(self, activity_id):
+        """Return the activity name with the given activity_id."""
+        return IDS_TO_ACTIVITIES.get(activity_id)
 
     async def start_activity(self, activity_id):
         """Update the current activity and call the appropriate callbacks."""
-        self._activity_name = IDS_TO_ACTIVITIES.get(activity_id)
+        self._activity_name = IDS_TO_ACTIVITIES.get(int(activity_id))
         activity_tuple = (activity_id, self._activity_name)
         self._callbacks.new_activity_starting(activity_tuple)
         self._callbacks.new_activity(activity_tuple)
@@ -66,8 +66,8 @@ class FakeHarmonyClient:
     def current_activity(self):
         """Return the current activity tuple."""
         return (
-            self.get_activity_id(self.get_activity_name()),
-            self.get_activity_name(),
+            self.get_activity_id(self._activity_name),
+            self._activity_name,
         )
 
     @property

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -1,81 +1,109 @@
 """Fixtures for harmony tests."""
+import logging
+
+from aioharmony.const import ClientCallbackType
 import pytest
 
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
+from homeassistant.components.harmony.const import ACTIVITY_POWER_OFF
+
+_LOGGER = logging.getLogger(__name__)
 
 WATCH_TV_ACTIVITY_ID = 123
 PLAY_MUSIC_ACTIVITY_ID = 456
 
 ACTIVITIES_TO_IDS = {
+    ACTIVITY_POWER_OFF: -1,
     "Watch TV": WATCH_TV_ACTIVITY_ID,
     "Play Music": PLAY_MUSIC_ACTIVITY_ID,
 }
 
 IDS_TO_ACTIVITIES = {
+    -1: ACTIVITY_POWER_OFF,
     WATCH_TV_ACTIVITY_ID: "Watch TV",
     PLAY_MUSIC_ACTIVITY_ID: "Play Music",
 }
 
 
-class FakeHarmonyStates:
-    """Class to keep track of activity states based on calls to the client mock."""
+class FakeHarmonyClient:
+    """FakeHarmonyClient to mock away network calls."""
 
-    def __init__(self, client_mock):
-        """Initialize FakeHarmonyStates class."""
+    def __init__(
+        self, ip_address: str = "", callbacks: ClientCallbackType = MagicMock()
+    ):
+        """Initialize FakeHarmonyClient class."""
         self._activity_name = "Watch TV"
-        self._client_mock = client_mock
+        self.close = AsyncMock()
+        self._callbacks = callbacks
+
+    async def connect(self):
+        """Connect and call the appropriate callbacks."""
+        self._callbacks.connect(None)
+        return AsyncMock(return_value=(True))
 
     def get_activity_name(self, *args):
         """Return the current activity."""
         return self._activity_name
 
-    def start_activity(self, *args, **kwargs):
+    async def start_activity(self, activity_id):
         """Update the current activity and call the appropriate callbacks."""
-        activity_id = kwargs["activity_id"]
         self._activity_name = IDS_TO_ACTIVITIES.get(activity_id)
         activity_tuple = (activity_id, self._activity_name)
-        self._client_mock.callbacks.new_activity_starting(activity_tuple)
-        self._client_mock.callbacks.new_activity(activity_tuple)
+        self._callbacks.new_activity_starting(activity_tuple)
+        self._callbacks.new_activity(activity_tuple)
 
         return AsyncMock(return_value=(True, "unused message"))
+
+    async def power_off(self):
+        """Power off all activities."""
+        await self.start_activity(-1)
 
     def get_activity_id(self, activity_name):
         """Return the mapping of an activity name to the internal id."""
         return ACTIVITIES_TO_IDS.get(activity_name)
 
+    @property
+    def current_activity(self):
+        """Return the current activity tuple."""
+        return (
+            self.get_activity_id(self.get_activity_name()),
+            self.get_activity_name(),
+        )
+
+    @property
+    def config(self):
+        """Return the config object."""
+        return self.hub_config.config
+
+    @property
+    def hub_config(self):
+        """Return the client_config type."""
+        config = MagicMock()
+        type(config).activities = PropertyMock(
+            return_value=[
+                {"name": "Watch TV", "id": WATCH_TV_ACTIVITY_ID},
+                {"name": "Play Music", "id": PLAY_MUSIC_ACTIVITY_ID},
+            ]
+        )
+        type(config).devices = PropertyMock(
+            return_value=[{"name": "My TV", "id": 1234}]
+        )
+        type(config).info = PropertyMock(return_value={})
+        type(config).hub_state = PropertyMock(return_value={})
+        type(config).config = PropertyMock(
+            return_value={
+                "activity": [
+                    {"id": WATCH_TV_ACTIVITY_ID, "label": "Watch TV"},
+                    {"id": PLAY_MUSIC_ACTIVITY_ID, "label": "Play Music"},
+                ]
+            }
+        )
+        return config
+
 
 @pytest.fixture()
 def mock_harmonyclient():
     """Create a mock HarmonyClient."""
-    harmonyclient_mock = MagicMock()
-    stateHandler = FakeHarmonyStates(harmonyclient_mock)
-    type(harmonyclient_mock).connect = AsyncMock()
-    type(harmonyclient_mock).close = AsyncMock()
-    type(harmonyclient_mock).get_activity_name = MagicMock(
-        side_effect=stateHandler.get_activity_name
-    )
-    type(harmonyclient_mock).get_activity_id = stateHandler.get_activity_id
-    type(harmonyclient_mock).start_activity = AsyncMock(
-        side_effect=stateHandler.start_activity
-    )
-    type(harmonyclient_mock.hub_config).activities = PropertyMock(
-        return_value=[
-            {"name": "Watch TV", "id": WATCH_TV_ACTIVITY_ID},
-            {"name": "Play Music", "id": PLAY_MUSIC_ACTIVITY_ID},
-        ]
-    )
-    type(harmonyclient_mock.hub_config).devices = PropertyMock(
-        return_value=[{"name": "My TV", "id": 1234}]
-    )
-    type(harmonyclient_mock.hub_config).info = PropertyMock(return_value={})
-    type(harmonyclient_mock.hub_config).hub_state = PropertyMock(return_value={})
-    type(harmonyclient_mock.hub_config).config = PropertyMock(
-        return_value={
-            "activity": [
-                {"id": WATCH_TV_ACTIVITY_ID, "label": "Watch TV"},
-                {"id": PLAY_MUSIC_ACTIVITY_ID, "label": "Play Music"},
-            ]
-        }
-    )
+    fake = FakeHarmonyClient()
 
-    yield harmonyclient_mock
+    yield fake

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -24,6 +24,17 @@ IDS_TO_ACTIVITIES = {
     PLAY_MUSIC_ACTIVITY_ID: "Play Music",
 }
 
+TV_DEVICE_ID = 1234
+TV_DEVICE_NAME = "My TV"
+
+DEVICES_TO_IDS = {
+    TV_DEVICE_NAME: TV_DEVICE_ID,
+}
+
+IDS_TO_DEVICES = {
+    TV_DEVICE_ID: TV_DEVICE_NAME,
+}
+
 
 class FakeHarmonyClient:
     """FakeHarmonyClient to mock away network calls."""
@@ -34,6 +45,8 @@ class FakeHarmonyClient:
         """Initialize FakeHarmonyClient class."""
         self._activity_name = "Watch TV"
         self.close = AsyncMock()
+        self.send_commands = AsyncMock()
+        self.change_channel = AsyncMock()
         self._callbacks = callbacks
 
     async def connect(self):
@@ -44,6 +57,18 @@ class FakeHarmonyClient:
     def get_activity_name(self, activity_id):
         """Return the activity name with the given activity_id."""
         return IDS_TO_ACTIVITIES.get(activity_id)
+
+    def get_activity_id(self, activity_name):
+        """Return the mapping of an activity name to the internal id."""
+        return ACTIVITIES_TO_IDS.get(activity_name)
+
+    def get_device_name(self, device_id):
+        """Return the device name with the given device_id."""
+        return IDS_TO_DEVICES.get(device_id)
+
+    def get_device_id(self, device_name):
+        """Return the device id with the given device_name."""
+        return DEVICES_TO_IDS.get(device_name)
 
     async def start_activity(self, activity_id):
         """Update the current activity and call the appropriate callbacks."""
@@ -57,10 +82,6 @@ class FakeHarmonyClient:
     async def power_off(self):
         """Power off all activities."""
         await self.start_activity(-1)
-
-    def get_activity_id(self, activity_name):
-        """Return the mapping of an activity name to the internal id."""
-        return ACTIVITIES_TO_IDS.get(activity_name)
 
     @property
     def current_activity(self):
@@ -91,7 +112,7 @@ class FakeHarmonyClient:
             ]
         )
         type(config).devices = PropertyMock(
-            return_value=[{"name": "My TV", "id": 1234}]
+            return_value=[{"name": TV_DEVICE_NAME, "id": TV_DEVICE_ID}]
         )
         type(config).info = PropertyMock(return_value={})
         type(config).hub_state = PropertyMock(return_value={})

--- a/tests/components/harmony/const.py
+++ b/tests/components/harmony/const.py
@@ -1,0 +1,6 @@
+"""Constants for Logitch Harmony Hub tests."""
+
+HUB_NAME = "Guest Room"
+ENTITY_REMOTE = "remote.guest_room"
+ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
+ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"

--- a/tests/components/harmony/test_activity_changes.py
+++ b/tests/components/harmony/test_activity_changes.py
@@ -25,7 +25,7 @@ from tests.common import MockConfigEntry
 _LOGGER = logging.getLogger(__name__)
 
 
-async def test_switch_toggles(mock_hc, hass, patched_remote):
+async def test_switch_toggles(mock_hc, hass, mock_write_config):
     """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -59,7 +59,7 @@ async def test_switch_toggles(mock_hc, hass, patched_remote):
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
-async def test_remote_toggles(mock_hc, hass, patched_remote):
+async def test_remote_toggles(mock_hc, hass, mock_write_config):
     """Ensure calls to the remote also updates the switches."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_activity_changes.py
+++ b/tests/components/harmony/test_activity_changes.py
@@ -17,19 +17,15 @@ from homeassistant.const import (
     STATE_ON,
 )
 
-from .conftest import ACTIVITIES_TO_IDS, FakeHarmonyClient
+from .conftest import ACTIVITIES_TO_IDS
 from .const import ENTITY_PLAY_MUSIC, ENTITY_REMOTE, ENTITY_WATCH_TV, HUB_NAME
 
-from unittest.mock import patch
 from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
-async def test_switch_toggles(_, hass, patched_remote):
+async def test_switch_toggles(mock_hc, hass, patched_remote):
     """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -63,10 +59,7 @@ async def test_switch_toggles(_, hass, patched_remote):
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
-async def test_remote_toggles(_, hass, patched_remote):
+async def test_remote_toggles(mock_hc, hass, patched_remote):
     """Ensure calls to the remote also updates the switches."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_activity_changes.py
+++ b/tests/components/harmony/test_activity_changes.py
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 @patch(
     "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
 )
-async def test_switch_toggles(_, hass):
+async def test_switch_toggles(_, hass, patched_remote):
     """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -66,7 +66,7 @@ async def test_switch_toggles(_, hass):
 @patch(
     "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
 )
-async def test_remote_toggles(_, hass):
+async def test_remote_toggles(_, hass, patched_remote):
     """Ensure calls to the remote also updates the switches."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_activity_changes.py
+++ b/tests/components/harmony/test_activity_changes.py
@@ -15,20 +15,15 @@ from homeassistant.const import (
     CONF_NAME,
     STATE_OFF,
     STATE_ON,
-    STATE_UNAVAILABLE,
 )
 
 from .conftest import FakeHarmonyClient
+from .const import ENTITY_PLAY_MUSIC, ENTITY_REMOTE, ENTITY_WATCH_TV, HUB_NAME
 
 from unittest.mock import patch
 from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
-
-HUB_NAME = "Guest Room"
-ENTITY_REMOTE = "remote.guest_room"
-ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
-ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"
 
 
 @patch(
@@ -130,35 +125,5 @@ async def test_remote_toggles(_, hass):
     await hass.async_block_till_done()
 
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-
-
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
-async def test_connection_state_changes(_, hass):
-    """Ensure connection changes are reflected in the switch states."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
-    )
-
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    data = hass.data[DOMAIN][entry.entry_id]
-
-    # mocks start with current activity == Watch TV
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-
-    data._disconnected()
-
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
-
-    data._connected()
-
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)

--- a/tests/components/harmony/test_activity_changes.py
+++ b/tests/components/harmony/test_activity_changes.py
@@ -45,40 +45,19 @@ async def test_switch_toggles(_, hass):
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
     # turn off watch tv switch
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: ENTITY_WATCH_TV},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
+    await _toggle_switch_and_wait(hass, SERVICE_TURN_OFF, ENTITY_WATCH_TV)
     assert hass.states.is_state(ENTITY_REMOTE, STATE_OFF)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
     # turn on play music switch
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ENTITY_PLAY_MUSIC},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
+    await _toggle_switch_and_wait(hass, SERVICE_TURN_ON, ENTITY_PLAY_MUSIC)
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_ON)
 
     # turn on watch tv switch
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ENTITY_WATCH_TV},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
+    await _toggle_switch_and_wait(hass, SERVICE_TURN_ON, ENTITY_WATCH_TV)
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
@@ -153,3 +132,13 @@ async def test_remote_toggles(_, hass):
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
+
+
+async def _toggle_switch_and_wait(hass, service_name, entity):
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service_name,
+        {ATTR_ENTITY_ID: entity},
+        blocking=True,
+    )
+    await hass.async_block_till_done()

--- a/tests/components/harmony/test_commands.py
+++ b/tests/components/harmony/test_commands.py
@@ -19,19 +19,15 @@ from homeassistant.components.remote import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME
 
-from .conftest import TV_DEVICE_ID, TV_DEVICE_NAME, FakeHarmonyClient
+from .conftest import TV_DEVICE_ID, TV_DEVICE_NAME
 from .const import ENTITY_REMOTE, HUB_NAME
 
-from unittest.mock import MagicMock, patch
 from tests.common import MockConfigEntry
 
 PLAY_COMMAND = "Play"
 STOP_COMMAND = "Stop"
 
 
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
 async def test_async_send_command(mock_hc, hass, patched_remote):
     """Ensure calls to send remote commands properly propagate to devices."""
     entry = MockConfigEntry(
@@ -165,9 +161,6 @@ async def test_async_send_command(mock_hc, hass, patched_remote):
     send_commands_mock.reset_mock()
 
 
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
 async def test_async_send_command_custom_delay(mock_hc, hass, patched_remote):
     """Ensure calls to send remote commands properly propagate to devices with custom delays."""
     entry = MockConfigEntry(
@@ -209,9 +202,6 @@ async def test_async_send_command_custom_delay(mock_hc, hass, patched_remote):
     send_commands_mock.reset_mock()
 
 
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
 async def test_change_channel(mock_hc, hass, patched_remote):
     """Test change channel commands."""
     entry = MockConfigEntry(
@@ -237,14 +227,7 @@ async def test_change_channel(mock_hc, hass, patched_remote):
     change_channel_mock.assert_awaited_once_with(100)
 
 
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
-@patch(
-    "homeassistant.components.harmony.remote.HarmonyRemote.write_config_file",
-    new_callable=MagicMock,
-)
-async def test_sync(mock_hc, harmony_remote, hass):
+async def test_sync(mock_hc, patched_remote, hass):
     """Test the sync command."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -267,6 +250,7 @@ async def test_sync(mock_hc, harmony_remote, hass):
     await hass.async_block_till_done()
 
     sync_mock.assert_awaited_once()
+    assert patched_remote["write_config_file"].called
 
 
 async def _send_commands_and_wait(hass, service_data):

--- a/tests/components/harmony/test_commands.py
+++ b/tests/components/harmony/test_commands.py
@@ -22,7 +22,7 @@ from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME
 from .conftest import TV_DEVICE_ID, TV_DEVICE_NAME, FakeHarmonyClient
 from .const import ENTITY_REMOTE, HUB_NAME
 
-from tests.async_mock import patch
+from unittest.mock import MagicMock, patch
 from tests.common import MockConfigEntry
 
 PLAY_COMMAND = "Play"
@@ -32,7 +32,7 @@ STOP_COMMAND = "Stop"
 @patch(
     "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
 )
-async def test_async_send_command(mock_hc, hass):
+async def test_async_send_command(mock_hc, hass, patched_remote):
     """Ensure calls to send remote commands properly propagate to devices."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -168,7 +168,7 @@ async def test_async_send_command(mock_hc, hass):
 @patch(
     "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
 )
-async def test_async_send_command_custom_delay(mock_hc, hass):
+async def test_async_send_command_custom_delay(mock_hc, hass, patched_remote):
     """Ensure calls to send remote commands properly propagate to devices with custom delays."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -212,7 +212,7 @@ async def test_async_send_command_custom_delay(mock_hc, hass):
 @patch(
     "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
 )
-async def test_change_channel(mock_hc, hass):
+async def test_change_channel(mock_hc, hass, patched_remote):
     """Test change channel commands."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -240,7 +240,11 @@ async def test_change_channel(mock_hc, hass):
 @patch(
     "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
 )
-async def test_sync(mock_hc, hass):
+@patch(
+    "homeassistant.components.harmony.remote.HarmonyRemote.write_config_file",
+    new_callable=MagicMock,
+)
+async def test_sync(mock_hc, harmony_remote, hass):
     """Test the sync command."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_commands.py
+++ b/tests/components/harmony/test_commands.py
@@ -1,0 +1,210 @@
+"""Test sending commands to the Harmony Hub remote."""
+
+from aioharmony.const import SendCommandDevice
+
+from homeassistant.components.harmony.const import DOMAIN, SERVICE_CHANGE_CHANNEL
+from homeassistant.components.harmony.remote import ATTR_CHANNEL
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    ATTR_DEVICE,
+    ATTR_NUM_REPEATS,
+    DEFAULT_DELAY_SECS,
+    DEFAULT_HOLD_SECS,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME
+
+from .conftest import TV_DEVICE_ID, TV_DEVICE_NAME, FakeHarmonyClient
+from .const import ENTITY_REMOTE, HUB_NAME
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+PLAY_COMMAND = "Play"
+STOP_COMMAND = "Stop"
+
+
+@patch(
+    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
+)
+async def test_async_send_command(mock_hc, hass):
+    """Ensure calls to send remote commands properly propagate to devices."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
+    )
+
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = hass.data[DOMAIN][entry.entry_id]
+    send_commands_mock = data._client.send_commands
+
+    # No device provided
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_REMOTE, ATTR_COMMAND: PLAY_COMMAND},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    send_commands_mock.assert_not_awaited()
+
+    # Tell the TV to play by id
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {
+            ATTR_ENTITY_ID: ENTITY_REMOTE,
+            ATTR_COMMAND: PLAY_COMMAND,
+            ATTR_DEVICE: TV_DEVICE_ID,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    send_commands_mock.assert_awaited_once_with(
+        [
+            SendCommandDevice(
+                device=str(TV_DEVICE_ID),
+                command=PLAY_COMMAND,
+                delay=float(DEFAULT_HOLD_SECS),
+            ),
+            DEFAULT_DELAY_SECS,
+        ]
+    )
+    send_commands_mock.reset_mock()
+
+    # Tell the TV to play by name
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {
+            ATTR_ENTITY_ID: ENTITY_REMOTE,
+            ATTR_COMMAND: PLAY_COMMAND,
+            ATTR_DEVICE: TV_DEVICE_NAME,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    send_commands_mock.assert_awaited_once_with(
+        [
+            SendCommandDevice(
+                device=TV_DEVICE_ID,
+                command=PLAY_COMMAND,
+                delay=float(DEFAULT_HOLD_SECS),
+            ),
+            DEFAULT_DELAY_SECS,
+        ]
+    )
+    send_commands_mock.reset_mock()
+
+    # Tell the TV to play and stop by name
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {
+            ATTR_ENTITY_ID: ENTITY_REMOTE,
+            ATTR_COMMAND: [PLAY_COMMAND, STOP_COMMAND],
+            ATTR_DEVICE: TV_DEVICE_NAME,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    send_commands_mock.assert_awaited_once_with(
+        [
+            SendCommandDevice(
+                device=TV_DEVICE_ID,
+                command=PLAY_COMMAND,
+                delay=float(DEFAULT_HOLD_SECS),
+            ),
+            DEFAULT_DELAY_SECS,
+            SendCommandDevice(
+                device=TV_DEVICE_ID,
+                command=STOP_COMMAND,
+                delay=float(DEFAULT_HOLD_SECS),
+            ),
+            DEFAULT_DELAY_SECS,
+        ]
+    )
+    send_commands_mock.reset_mock()
+
+    # Tell the TV to play by name multiple times
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {
+            ATTR_ENTITY_ID: ENTITY_REMOTE,
+            ATTR_COMMAND: PLAY_COMMAND,
+            ATTR_DEVICE: TV_DEVICE_NAME,
+            ATTR_NUM_REPEATS: 2,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    send_commands_mock.assert_awaited_once_with(
+        [
+            SendCommandDevice(
+                device=TV_DEVICE_ID,
+                command=PLAY_COMMAND,
+                delay=float(DEFAULT_HOLD_SECS),
+            ),
+            DEFAULT_DELAY_SECS,
+            SendCommandDevice(
+                device=TV_DEVICE_ID,
+                command=PLAY_COMMAND,
+                delay=float(DEFAULT_HOLD_SECS),
+            ),
+            DEFAULT_DELAY_SECS,
+        ]
+    )
+    send_commands_mock.reset_mock()
+
+    # Send commands to an unknown device
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {
+            ATTR_ENTITY_ID: ENTITY_REMOTE,
+            ATTR_COMMAND: PLAY_COMMAND,
+            ATTR_DEVICE: "no-such-device",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    send_commands_mock.assert_not_awaited()
+    send_commands_mock.reset_mock()
+
+
+@patch(
+    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
+)
+async def test_change_channel(mock_hc, hass):
+    """Test change channel commands."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
+    )
+
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = hass.data[DOMAIN][entry.entry_id]
+    change_channel_mock = data._client.change_channel
+
+    # Tell the remote to change channels
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CHANGE_CHANNEL,
+        {ATTR_ENTITY_ID: ENTITY_REMOTE, ATTR_CHANNEL: 100},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    change_channel_mock.assert_awaited_once_with(100)

--- a/tests/components/harmony/test_commands.py
+++ b/tests/components/harmony/test_commands.py
@@ -46,28 +46,20 @@ async def test_async_send_command(mock_hc, hass):
     send_commands_mock = data._client.send_commands
 
     # No device provided
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
-        {ATTR_ENTITY_ID: ENTITY_REMOTE, ATTR_COMMAND: PLAY_COMMAND},
-        blocking=True,
+    await _send_commands_and_wait(
+        hass, {ATTR_ENTITY_ID: ENTITY_REMOTE, ATTR_COMMAND: PLAY_COMMAND}
     )
-    await hass.async_block_till_done()
-
     send_commands_mock.assert_not_awaited()
 
     # Tell the TV to play by id
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
+    await _send_commands_and_wait(
+        hass,
         {
             ATTR_ENTITY_ID: ENTITY_REMOTE,
             ATTR_COMMAND: PLAY_COMMAND,
             ATTR_DEVICE: TV_DEVICE_ID,
         },
-        blocking=True,
     )
-    await hass.async_block_till_done()
 
     send_commands_mock.assert_awaited_once_with(
         [
@@ -82,17 +74,14 @@ async def test_async_send_command(mock_hc, hass):
     send_commands_mock.reset_mock()
 
     # Tell the TV to play by name
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
+    await _send_commands_and_wait(
+        hass,
         {
             ATTR_ENTITY_ID: ENTITY_REMOTE,
             ATTR_COMMAND: PLAY_COMMAND,
             ATTR_DEVICE: TV_DEVICE_NAME,
         },
-        blocking=True,
     )
-    await hass.async_block_till_done()
 
     send_commands_mock.assert_awaited_once_with(
         [
@@ -107,17 +96,14 @@ async def test_async_send_command(mock_hc, hass):
     send_commands_mock.reset_mock()
 
     # Tell the TV to play and stop by name
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
+    await _send_commands_and_wait(
+        hass,
         {
             ATTR_ENTITY_ID: ENTITY_REMOTE,
             ATTR_COMMAND: [PLAY_COMMAND, STOP_COMMAND],
             ATTR_DEVICE: TV_DEVICE_NAME,
         },
-        blocking=True,
     )
-    await hass.async_block_till_done()
 
     send_commands_mock.assert_awaited_once_with(
         [
@@ -138,18 +124,15 @@ async def test_async_send_command(mock_hc, hass):
     send_commands_mock.reset_mock()
 
     # Tell the TV to play by name multiple times
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
+    await _send_commands_and_wait(
+        hass,
         {
             ATTR_ENTITY_ID: ENTITY_REMOTE,
             ATTR_COMMAND: PLAY_COMMAND,
             ATTR_DEVICE: TV_DEVICE_NAME,
             ATTR_NUM_REPEATS: 2,
         },
-        blocking=True,
     )
-    await hass.async_block_till_done()
 
     send_commands_mock.assert_awaited_once_with(
         [
@@ -170,18 +153,14 @@ async def test_async_send_command(mock_hc, hass):
     send_commands_mock.reset_mock()
 
     # Send commands to an unknown device
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
+    await _send_commands_and_wait(
+        hass,
         {
             ATTR_ENTITY_ID: ENTITY_REMOTE,
             ATTR_COMMAND: PLAY_COMMAND,
             ATTR_DEVICE: "no-such-device",
         },
-        blocking=True,
     )
-    await hass.async_block_till_done()
-
     send_commands_mock.assert_not_awaited()
     send_commands_mock.reset_mock()
 
@@ -208,17 +187,14 @@ async def test_async_send_command_custom_delay(mock_hc, hass):
     send_commands_mock = data._client.send_commands
 
     # Tell the TV to play by id
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
+    await _send_commands_and_wait(
+        hass,
         {
             ATTR_ENTITY_ID: ENTITY_REMOTE,
             ATTR_COMMAND: PLAY_COMMAND,
             ATTR_DEVICE: TV_DEVICE_ID,
         },
-        blocking=True,
     )
-    await hass.async_block_till_done()
 
     send_commands_mock.assert_awaited_once_with(
         [
@@ -287,3 +263,13 @@ async def test_sync(mock_hc, hass):
     await hass.async_block_till_done()
 
     sync_mock.assert_awaited_once()
+
+
+async def _send_commands_and_wait(hass, service_data):
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        service_data,
+        blocking=True,
+    )
+    await hass.async_block_till_done()

--- a/tests/components/harmony/test_commands.py
+++ b/tests/components/harmony/test_commands.py
@@ -28,7 +28,7 @@ PLAY_COMMAND = "Play"
 STOP_COMMAND = "Stop"
 
 
-async def test_async_send_command(mock_hc, hass, patched_remote):
+async def test_async_send_command(mock_hc, hass, mock_write_config):
     """Ensure calls to send remote commands properly propagate to devices."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -161,7 +161,7 @@ async def test_async_send_command(mock_hc, hass, patched_remote):
     send_commands_mock.reset_mock()
 
 
-async def test_async_send_command_custom_delay(mock_hc, hass, patched_remote):
+async def test_async_send_command_custom_delay(mock_hc, hass, mock_write_config):
     """Ensure calls to send remote commands properly propagate to devices with custom delays."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -202,7 +202,7 @@ async def test_async_send_command_custom_delay(mock_hc, hass, patched_remote):
     send_commands_mock.reset_mock()
 
 
-async def test_change_channel(mock_hc, hass, patched_remote):
+async def test_change_channel(mock_hc, hass, mock_write_config):
     """Test change channel commands."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -227,7 +227,7 @@ async def test_change_channel(mock_hc, hass, patched_remote):
     change_channel_mock.assert_awaited_once_with(100)
 
 
-async def test_sync(mock_hc, patched_remote, hass):
+async def test_sync(mock_hc, mock_write_config, hass):
     """Test the sync command."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -250,7 +250,7 @@ async def test_sync(mock_hc, patched_remote, hass):
     await hass.async_block_till_done()
 
     sync_mock.assert_awaited_once()
-    assert patched_remote["write_config_file"].called
+    mock_write_config.assert_called()
 
 
 async def _send_commands_and_wait(hass, service_data):

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -23,13 +23,24 @@ def _get_mock_harmonyclient():
     type(harmonyclient_mock).close = AsyncMock()
     type(harmonyclient_mock).get_activity_name = MagicMock(return_value="Watch TV")
     type(harmonyclient_mock.hub_config).activities = PropertyMock(
-        return_value=[{"name": "Watch TV", "id": 123}]
+        return_value=[
+            {"name": "Watch TV", "id": 123},
+            {"name": "Play Music", "id": 456},
+        ]
     )
     type(harmonyclient_mock.hub_config).devices = PropertyMock(
         return_value=[{"name": "My TV", "id": 1234}]
     )
     type(harmonyclient_mock.hub_config).info = PropertyMock(return_value={})
     type(harmonyclient_mock.hub_config).hub_state = PropertyMock(return_value={})
+    type(harmonyclient_mock.hub_config).config = PropertyMock(
+        return_value={
+            "activity": [
+                {"id": 123, "label": "Watch TV"},
+                {"id": 456, "label": "Play Music"},
+            ]
+        }
+    )
 
     return harmonyclient_mock
 
@@ -215,7 +226,6 @@ async def test_form_cannot_connect(hass):
 
 async def test_options_flow(hass):
     """Test config flow options."""
-
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="abcde12345",

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Logitech Harmony Hub config flow."""
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.harmony.config_flow import CannotConnect

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -208,7 +208,7 @@ async def test_options_flow(hass, mock_harmonyclient):
     with patch(
         "aioharmony.harmonyapi.HarmonyClient",
         return_value=mock_harmonyclient,
-    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
+    ):
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -196,7 +196,7 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_options_flow(hass, mock_harmonyclient):
+async def test_options_flow(hass, mock_hc):
     """Test config flow options."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -205,17 +205,13 @@ async def test_options_flow(hass, mock_harmonyclient):
         options={"activity": "Watch TV", "delay_secs": 0.5},
     )
 
-    with patch(
-        "aioharmony.harmonyapi.HarmonyClient",
-        return_value=mock_harmonyclient,
-    ):
-        config_entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        await hass.async_block_till_done()
-        assert await hass.config_entries.async_unload(config_entry.entry_id)
-        await hass.async_block_till_done()
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"

--- a/tests/components/harmony/test_connection_changes.py
+++ b/tests/components/harmony/test_connection_changes.py
@@ -1,0 +1,57 @@
+"""Test the Logitech Harmony Hub entities with connection state changes."""
+
+from homeassistant.components.harmony.const import DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+
+from .conftest import FakeHarmonyClient
+from .const import ENTITY_PLAY_MUSIC, ENTITY_REMOTE, ENTITY_WATCH_TV, HUB_NAME
+
+from tests.async_mock import AsyncMock, patch
+from tests.common import MockConfigEntry
+
+
+@patch(
+    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
+)
+@patch(
+    "homeassistant.components.harmony.remote.HarmonyRemote.sleep",
+    new_callable=AsyncMock,
+)
+async def test_connection_state_changes(sleep, hc_init, hass):
+    """Ensure connection changes are reflected in the switch states."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
+    )
+
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = hass.data[DOMAIN][entry.entry_id]
+
+    # mocks start with current activity == Watch TV
+    assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
+
+    data._disconnected()
+    await hass.async_block_till_done()
+
+    # TODO delay for remote
+
+    assert hass.states.is_state(ENTITY_REMOTE, STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
+
+    data._connected()
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)

--- a/tests/components/harmony/test_connection_changes.py
+++ b/tests/components/harmony/test_connection_changes.py
@@ -43,8 +43,6 @@ async def test_connection_state_changes(sleep, hc_init, hass):
     data._disconnected()
     await hass.async_block_till_done()
 
-    # TODO delay for remote
-
     assert hass.states.is_state(ENTITY_REMOTE, STATE_UNAVAILABLE)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)

--- a/tests/components/harmony/test_connection_changes.py
+++ b/tests/components/harmony/test_connection_changes.py
@@ -14,7 +14,7 @@ from .const import ENTITY_PLAY_MUSIC, ENTITY_REMOTE, ENTITY_WATCH_TV, HUB_NAME
 from tests.common import MockConfigEntry
 
 
-async def test_connection_state_changes(mock_hc, hass, patched_remote):
+async def test_connection_state_changes(mock_hc, hass, mock_write_config):
     """Ensure connection changes are reflected in the switch states."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -34,7 +34,8 @@ async def test_connection_state_changes(mock_hc, hass, patched_remote):
     data._disconnected()
     await hass.async_block_till_done()
 
-    assert hass.states.is_state(ENTITY_REMOTE, STATE_UNAVAILABLE)
+    # Remote does not immediately show as unavailable
+    assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
 

--- a/tests/components/harmony/test_connection_changes.py
+++ b/tests/components/harmony/test_connection_changes.py
@@ -37,15 +37,17 @@ async def test_connection_state_changes(mock_hc, hass, mock_write_config):
     data._disconnected()
     await hass.async_block_till_done()
 
-    # Remote does not immediately show as unavailable
+    # Entities do not immediately show as unavailable
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
     future_time = utcnow() + timedelta(seconds=10)
     async_fire_time_changed(hass, future_time)
     await hass.async_block_till_done()
     assert hass.states.is_state(ENTITY_REMOTE, STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
 
     data._connected()
     await hass.async_block_till_done()
@@ -61,3 +63,5 @@ async def test_connection_state_changes(mock_hc, hass, mock_write_config):
 
     await hass.async_block_till_done()
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)

--- a/tests/components/harmony/test_connection_changes.py
+++ b/tests/components/harmony/test_connection_changes.py
@@ -9,17 +9,12 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 
-from .conftest import FakeHarmonyClient
 from .const import ENTITY_PLAY_MUSIC, ENTITY_REMOTE, ENTITY_WATCH_TV, HUB_NAME
 
-from unittest.mock import patch
 from tests.common import MockConfigEntry
 
 
-@patch(
-    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
-)
-async def test_connection_state_changes(hc_init, hass, patched_remote):
+async def test_connection_state_changes(mock_hc, hass, patched_remote):
     """Ensure connection changes are reflected in the switch states."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_connection_changes.py
+++ b/tests/components/harmony/test_connection_changes.py
@@ -12,18 +12,14 @@ from homeassistant.const import (
 from .conftest import FakeHarmonyClient
 from .const import ENTITY_PLAY_MUSIC, ENTITY_REMOTE, ENTITY_WATCH_TV, HUB_NAME
 
-from tests.async_mock import AsyncMock, patch
+from unittest.mock import patch
 from tests.common import MockConfigEntry
 
 
 @patch(
     "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
 )
-@patch(
-    "homeassistant.components.harmony.remote.HarmonyRemote.sleep",
-    new_callable=AsyncMock,
-)
-async def test_connection_state_changes(sleep, hc_init, hass):
+async def test_connection_state_changes(hc_init, hass, patched_remote):
     """Ensure connection changes are reflected in the switch states."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}

--- a/tests/components/harmony/test_subscriber.py
+++ b/tests/components/harmony/test_subscriber.py
@@ -1,13 +1,12 @@
 """Test the HarmonySubscriberMixin class."""
 
 import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.harmony.subscriber import (
     HarmonyCallback,
     HarmonySubscriberMixin,
 )
-
-from unittest.mock import AsyncMock, MagicMock
 
 _NO_PARAM_CALLBACKS = {
     "connected": "_connected",

--- a/tests/components/harmony/test_subscriber.py
+++ b/tests/components/harmony/test_subscriber.py
@@ -1,0 +1,87 @@
+"""Test the HarmonySubscriberMixin class."""
+
+import asyncio
+
+from homeassistant.components.harmony.subscriber import (
+    HarmonyCallback,
+    HarmonySubscriberMixin,
+)
+
+from tests.async_mock import AsyncMock, MagicMock
+
+_NO_PARAM_CALLBACKS = {
+    "connected": "_connected",
+    "disconnected": "_disconnected",
+    "config_updated": "_config_updated",
+}
+
+_ACTIVITY_CALLBACKS = {
+    "activity_starting": "_activity_starting",
+    "activity_started": "_activity_started",
+}
+
+_ALL_CALLBACK_NAMES = list(_NO_PARAM_CALLBACKS.keys()) + list(
+    _ACTIVITY_CALLBACKS.keys()
+)
+
+_ACTIVITY_TUPLE = ("not", "used")
+
+
+async def test_no_callbacks():
+    """Ensure we handle no subscriptions."""
+    subscriber = HarmonySubscriberMixin()
+    _call_all_callbacks(subscriber)
+
+
+async def test_empty_callbacks():
+    """Ensure we handle a missing callback in a subscription."""
+    subscriber = HarmonySubscriberMixin()
+
+    callbacks = {k: None for k in _ALL_CALLBACK_NAMES}
+    subscriber.async_subscribe(HarmonyCallback(**callbacks))
+    _call_all_callbacks(subscriber)
+
+
+async def test_async_callbacks():
+    """Ensure we handle async callbacks."""
+    subscriber = HarmonySubscriberMixin()
+
+    callbacks = {k: AsyncMock() for k in _ALL_CALLBACK_NAMES}
+    subscriber.async_subscribe(HarmonyCallback(**callbacks))
+    _call_all_callbacks(subscriber)
+    await asyncio.sleep(0)
+
+    for callback_name in _NO_PARAM_CALLBACKS.keys():
+        callback_mock = callbacks[callback_name]
+        callback_mock.assert_awaited_once()
+
+    for callback_name in _ACTIVITY_CALLBACKS.keys():
+        callback_mock = callbacks[callback_name]
+        callback_mock.assert_awaited_once_with(_ACTIVITY_TUPLE)
+
+
+async def test_callbacks():
+    """Ensure we handle non-async callbacks."""
+    subscriber = HarmonySubscriberMixin()
+
+    callbacks = {k: MagicMock() for k in _ALL_CALLBACK_NAMES}
+    subscriber.async_subscribe(HarmonyCallback(**callbacks))
+    _call_all_callbacks(subscriber)
+
+    for callback_name in _NO_PARAM_CALLBACKS.keys():
+        callback_mock = callbacks[callback_name]
+        callback_mock.assert_called_once()
+
+    for callback_name in _ACTIVITY_CALLBACKS.keys():
+        callback_mock = callbacks[callback_name]
+        callback_mock.assert_called_once_with(_ACTIVITY_TUPLE)
+
+
+def _call_all_callbacks(subscriber):
+    for callback_method in _NO_PARAM_CALLBACKS.values():
+        to_call = getattr(subscriber, callback_method)
+        to_call()
+
+    for callback_method in _ACTIVITY_CALLBACKS.values():
+        to_call = getattr(subscriber, callback_method)
+        to_call(_ACTIVITY_TUPLE)

--- a/tests/components/harmony/test_subscriber.py
+++ b/tests/components/harmony/test_subscriber.py
@@ -7,7 +7,7 @@ from homeassistant.components.harmony.subscriber import (
     HarmonySubscriberMixin,
 )
 
-from tests.async_mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 _NO_PARAM_CALLBACKS = {
     "connected": "_connected",

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -1,0 +1,53 @@
+"""Test the Logitech Harmony Hub activity switches."""
+
+import logging
+
+from homeassistant.components.harmony.const import DOMAIN
+
+# from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_OFF
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+# TODO centralize
+from tests.components.harmony.test_config_flow import _get_mock_harmonyclient
+
+# from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def test_switch_state_transitions(hass):
+    """Test state transitions for harmony activity switches."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
+    )
+
+    harmony_client = _get_mock_harmonyclient()
+
+    with patch(
+        "aioharmony.harmonyapi.HarmonyClient",
+        return_value=harmony_client,
+    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # mocks start with current activity == Watch TV
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+
+    # _LOGGER.info("WAFFLES %s", hass.services.async_call)
+    # call = hass.services.async_call(
+    # SWITCH_DOMAIN,
+    # SERVICE_TURN_OFF,
+    # { ATTR_ENTITY_ID: "switch.guest_room_watch_tv"},
+    # blocking=True,
+    # )
+    # _LOGGER.info("WAFFLES %s", call)
+    # await call
+
+    # assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
+    # assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_NAME,
     STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
 )
 
 from .conftest import FakeHarmonyClient
@@ -24,15 +25,16 @@ from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
+HUB_NAME = "Guest Room"
 ENTITY_REMOTE = "remote.guest_room"
 ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
 ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"
 
 
 async def test_switch_toggles(hass):
-    """Ensure calls to the switch call into the harmony client."""
+    """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
     )
 
     with patch(
@@ -89,9 +91,9 @@ async def test_switch_toggles(hass):
 
 
 async def test_remote_toggles(hass):
-    """Ensure calls to the remote updates the switches."""
+    """Ensure calls to the remote also updates the switches."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
     )
 
     with patch(
@@ -130,5 +132,36 @@ async def test_remote_toggles(hass):
     await hass.async_block_till_done()
 
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
+
+
+async def test_connection_state_changes(hass):
+    """Ensure connection changes are reflected in the switch states."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
+    )
+
+    with patch(
+        "homeassistant.components.harmony.data.HarmonyClient",
+        side_effect=FakeHarmonyClient,
+    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    data = hass.data[DOMAIN][entry.entry_id]
+
+    # mocks start with current activity == Watch TV
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
+
+    data._disconnected()
+
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
+
+    data._connected()
+
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -31,19 +31,18 @@ ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
 ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"
 
 
-async def test_switch_toggles(hass):
+@patch(
+    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
+)
+async def test_switch_toggles(_, hass):
     """Ensure calls to the switch modify the harmony state."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
     )
 
-    with patch(
-        "homeassistant.components.harmony.data.HarmonyClient",
-        side_effect=FakeHarmonyClient,
-    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     # mocks start with current activity == Watch TV
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
@@ -90,19 +89,18 @@ async def test_switch_toggles(hass):
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
-async def test_remote_toggles(hass):
+@patch(
+    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
+)
+async def test_remote_toggles(_, hass):
     """Ensure calls to the remote also updates the switches."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
     )
 
-    with patch(
-        "homeassistant.components.harmony.data.HarmonyClient",
-        side_effect=FakeHarmonyClient,
-    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     # mocks start with current activity == Watch TV
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
@@ -136,19 +134,18 @@ async def test_remote_toggles(hass):
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
-async def test_connection_state_changes(hass):
+@patch(
+    "homeassistant.components.harmony.data.HarmonyClient", side_effect=FakeHarmonyClient
+)
+async def test_connection_state_changes(_, hass):
     """Ensure connection changes are reflected in the switch states."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
     )
 
-    with patch(
-        "homeassistant.components.harmony.data.HarmonyClient",
-        side_effect=FakeHarmonyClient,
-    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     data = hass.data[DOMAIN][entry.entry_id]
 

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -2,10 +2,11 @@
 
 import logging
 
-from homeassistant.components.harmony.const import DOMAIN
+from homeassistant.components.harmony.const import DOMAIN, SIGNAL_UPDATE_ACTIVITY
 
 # from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_OFF
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
@@ -13,14 +14,11 @@ from tests.common import MockConfigEntry
 # TODO centralize
 from tests.components.harmony.test_config_flow import _get_mock_harmonyclient
 
-# from homeassistant.helpers.dispatcher import async_dispatcher_send
-
-
 _LOGGER = logging.getLogger(__name__)
 
 
 async def test_switch_state_transitions(hass):
-    """Test state transitions for harmony activity switches."""
+    """Test state transitions for harmony activity switches. These signals are sent by callbacks registered by the remote."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
     )
@@ -39,15 +37,45 @@ async def test_switch_state_transitions(hass):
     assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
     assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
 
-    # _LOGGER.info("WAFFLES %s", hass.services.async_call)
-    # call = hass.services.async_call(
-    # SWITCH_DOMAIN,
-    # SERVICE_TURN_OFF,
-    # { ATTR_ENTITY_ID: "switch.guest_room_watch_tv"},
-    # blocking=True,
-    # )
-    # _LOGGER.info("WAFFLES %s", call)
-    # await call
+    # Harmony Hub is turned off
+    async_dispatcher_send(
+        hass,
+        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
+        {"current_activity": -1},
+    )
+    await hass.async_block_till_done()
 
-    # assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
-    # assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    # Play Music is turned on
+    async_dispatcher_send(
+        hass,
+        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
+        {"current_activity": "Play Music"},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_ON)
+
+    # Watch TV is turned on
+    async_dispatcher_send(
+        hass,
+        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
+        {"current_activity": "Watch TV"},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+
+    # Unknown activity is turned on
+    async_dispatcher_send(
+        hass,
+        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
+        {"current_activity": "Some Other Activity"},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -7,9 +7,13 @@ from homeassistant.components.harmony.const import (
     DOMAIN,
     SIGNAL_UPDATE_ACTIVITY,
 )
-
-# from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_OFF
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_HOST,
     CONF_NAME,
     STATE_OFF,
@@ -20,8 +24,12 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from unittest.mock import patch
 from tests.common import MockConfigEntry
+from tests.components.harmony.conftest import PLAY_MUSIC_ACTIVITY_ID
 
 _LOGGER = logging.getLogger(__name__)
+
+ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
+ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"
 
 
 async def test_state_transitions(hass, mock_harmonyclient):
@@ -39,8 +47,8 @@ async def test_state_transitions(hass, mock_harmonyclient):
         await hass.async_block_till_done()
 
     # mocks start with current activity == Watch TV
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
     # Harmony Hub is turned off
     async_dispatcher_send(
@@ -50,8 +58,8 @@ async def test_state_transitions(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
     # Play Music is turned on
     async_dispatcher_send(
         hass,
@@ -60,8 +68,8 @@ async def test_state_transitions(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_ON)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_ON)
 
     # Watch TV is turned on
     async_dispatcher_send(
@@ -71,8 +79,8 @@ async def test_state_transitions(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
     # Unknown activity is turned on
     async_dispatcher_send(
@@ -82,8 +90,8 @@ async def test_state_transitions(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
 async def test_availability_transitions(hass, mock_harmonyclient):
@@ -101,8 +109,8 @@ async def test_availability_transitions(hass, mock_harmonyclient):
         await hass.async_block_till_done()
 
     # mocks start with current activity == Watch TV
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
     async_dispatcher_send(
         hass,
@@ -111,8 +119,8 @@ async def test_availability_transitions(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_UNAVAILABLE)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
 
     async_dispatcher_send(
         hass,
@@ -121,5 +129,52 @@ async def test_availability_transitions(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
-    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
+    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
+
+
+async def test_switch_toggles(hass, mock_harmonyclient):
+    """Ensure calls to the switch call into the harmony client.
+
+    Note the harmonyclient mock is not currently set up to actually change states.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
+    )
+
+    with patch(
+        "aioharmony.harmonyapi.HarmonyClient",
+        return_value=mock_harmonyclient,
+    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_WATCH_TV},
+        blocking=True,
+    )
+
+    mock_harmonyclient.start_activity.assert_awaited_with(activity_id=-1)
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_PLAY_MUSIC},
+        blocking=True,
+    )
+
+    mock_harmonyclient.start_activity.assert_awaited_with(
+        activity_id=PLAY_MUSIC_ACTIVITY_ID
+    )
+
+    # TODO test turning on and off watch tv
+    # await hass.services.async_call(
+    # SWITCH_DOMAIN,
+    # SERVICE_TURN_OFF,
+    # {ATTR_ENTITY_ID: ENTITY_PLAY_MUSIC},
+    # blocking=True,
+    # )
+
+    # mock_harmonyclient.start_activity.assert_awaited_with(activity_id=PLAY_MUSIC_ACTIVITY_ID)

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -2,32 +2,37 @@
 
 import logging
 
-from homeassistant.components.harmony.const import DOMAIN, SIGNAL_UPDATE_ACTIVITY
+from homeassistant.components.harmony.const import (
+    CONNECTION_UPDATE_ACTIVITY,
+    DOMAIN,
+    SIGNAL_UPDATE_ACTIVITY,
+)
 
 # from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_OFF
-from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from tests.async_mock import patch
+from unittest.mock import patch
 from tests.common import MockConfigEntry
-
-# TODO centralize
-from tests.components.harmony.test_config_flow import _get_mock_harmonyclient
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def test_switch_state_transitions(hass):
+async def test_state_transitions(hass, mock_harmonyclient):
     """Test state transitions for harmony activity switches. These signals are sent by callbacks registered by the remote."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
     )
 
-    harmony_client = _get_mock_harmonyclient()
-
     with patch(
         "aioharmony.harmonyapi.HarmonyClient",
-        return_value=harmony_client,
+        return_value=mock_harmonyclient,
     ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
@@ -78,4 +83,43 @@ async def test_switch_state_transitions(hass):
     await hass.async_block_till_done()
 
     assert hass.states.is_state("switch.guest_room_watch_tv", STATE_OFF)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+
+
+async def test_availability_transitions(hass, mock_harmonyclient):
+    """Test transitions for harmony hub availability."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
+    )
+
+    with patch(
+        "aioharmony.harmonyapi.HarmonyClient",
+        return_value=mock_harmonyclient,
+    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # mocks start with current activity == Watch TV
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)
+
+    async_dispatcher_send(
+        hass,
+        f"{CONNECTION_UPDATE_ACTIVITY}-{entry.unique_id}",
+        {"available": False},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_UNAVAILABLE)
+    assert hass.states.is_state("switch.guest_room_play_music", STATE_UNAVAILABLE)
+
+    async_dispatcher_send(
+        hass,
+        f"{CONNECTION_UPDATE_ACTIVITY}-{entry.unique_id}",
+        {"available": True},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("switch.guest_room_watch_tv", STATE_ON)
     assert hass.states.is_state("switch.guest_room_play_music", STATE_OFF)

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -24,7 +24,10 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from unittest.mock import patch
 from tests.common import MockConfigEntry
-from tests.components.harmony.conftest import PLAY_MUSIC_ACTIVITY_ID
+from tests.components.harmony.conftest import (
+    PLAY_MUSIC_ACTIVITY_ID,
+    WATCH_TV_ACTIVITY_ID,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -170,11 +173,13 @@ async def test_switch_toggles(hass, mock_harmonyclient):
     )
 
     # TODO test turning on and off watch tv
-    # await hass.services.async_call(
-    # SWITCH_DOMAIN,
-    # SERVICE_TURN_OFF,
-    # {ATTR_ENTITY_ID: ENTITY_PLAY_MUSIC},
-    # blocking=True,
-    # )
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_WATCH_TV},
+        blocking=True,
+    )
 
-    # mock_harmonyclient.start_activity.assert_awaited_with(activity_id=PLAY_MUSIC_ACTIVITY_ID)
+    mock_harmonyclient.start_activity.assert_awaited_with(
+        activity_id=WATCH_TV_ACTIVITY_ID
+    )

--- a/tests/components/harmony/test_switch.py
+++ b/tests/components/harmony/test_switch.py
@@ -2,11 +2,7 @@
 
 import logging
 
-from homeassistant.components.harmony.const import (
-    CONNECTION_UPDATE_ACTIVITY,
-    DOMAIN,
-    SIGNAL_UPDATE_ACTIVITY,
-)
+from homeassistant.components.harmony.const import DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
@@ -19,16 +15,12 @@ from homeassistant.const import (
     CONF_NAME,
     STATE_OFF,
     STATE_ON,
-    STATE_UNAVAILABLE,
 )
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .conftest import FakeHarmonyClient
 
 from unittest.mock import patch
 from tests.common import MockConfigEntry
-from tests.components.harmony.conftest import (
-    PLAY_MUSIC_ACTIVITY_ID,
-    WATCH_TV_ACTIVITY_ID,
-)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,116 +29,15 @@ ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
 ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"
 
 
-async def test_state_transitions(hass, mock_harmonyclient):
-    """Test state transitions for harmony activity switches. These signals are sent by callbacks registered by the remote."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
-    )
-
-    with patch(
-        "aioharmony.harmonyapi.HarmonyClient",
-        return_value=mock_harmonyclient,
-    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    # mocks start with current activity == Watch TV
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-
-    # Harmony Hub is turned off
-    async_dispatcher_send(
-        hass,
-        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
-        {"current_activity": -1},
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-    # Play Music is turned on
-    async_dispatcher_send(
-        hass,
-        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
-        {"current_activity": "Play Music"},
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_ON)
-
-    # Watch TV is turned on
-    async_dispatcher_send(
-        hass,
-        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
-        {"current_activity": "Watch TV"},
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-
-    # Unknown activity is turned on
-    async_dispatcher_send(
-        hass,
-        f"{SIGNAL_UPDATE_ACTIVITY}-{entry.unique_id}",
-        {"current_activity": "Some Other Activity"},
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-
-
-async def test_availability_transitions(hass, mock_harmonyclient):
-    """Test transitions for harmony hub availability."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
-    )
-
-    with patch(
-        "aioharmony.harmonyapi.HarmonyClient",
-        return_value=mock_harmonyclient,
-    ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    # mocks start with current activity == Watch TV
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-
-    async_dispatcher_send(
-        hass,
-        f"{CONNECTION_UPDATE_ACTIVITY}-{entry.unique_id}",
-        {"available": False},
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_UNAVAILABLE)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_UNAVAILABLE)
-
-    async_dispatcher_send(
-        hass,
-        f"{CONNECTION_UPDATE_ACTIVITY}-{entry.unique_id}",
-        {"available": True},
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
-    assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
-
-
-async def test_switch_toggles(hass, mock_harmonyclient):
+async def test_switch_toggles(hass):
     """Ensure calls to the switch call into the harmony client."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
     )
 
     with patch(
-        "aioharmony.harmonyapi.HarmonyClient",
-        return_value=mock_harmonyclient,
+        "homeassistant.components.harmony.data.HarmonyClient",
+        side_effect=FakeHarmonyClient,
     ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
@@ -166,8 +57,6 @@ async def test_switch_toggles(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    mock_harmonyclient.start_activity.assert_awaited_with(activity_id=-1)
-
     assert hass.states.is_state(ENTITY_REMOTE, STATE_OFF)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
@@ -180,10 +69,6 @@ async def test_switch_toggles(hass, mock_harmonyclient):
         blocking=True,
     )
     await hass.async_block_till_done()
-
-    mock_harmonyclient.start_activity.assert_awaited_with(
-        activity_id=PLAY_MUSIC_ACTIVITY_ID
-    )
 
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_OFF)
@@ -198,24 +83,20 @@ async def test_switch_toggles(hass, mock_harmonyclient):
     )
     await hass.async_block_till_done()
 
-    mock_harmonyclient.start_activity.assert_awaited_with(
-        activity_id=WATCH_TV_ACTIVITY_ID
-    )
-
     assert hass.states.is_state(ENTITY_REMOTE, STATE_ON)
     assert hass.states.is_state(ENTITY_WATCH_TV, STATE_ON)
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
-async def test_remote_toggles(hass, mock_harmonyclient):
+async def test_remote_toggles(hass):
     """Ensure calls to the remote updates the switches."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: "Guest Room"}
     )
 
     with patch(
-        "aioharmony.harmonyapi.HarmonyClient",
-        return_value=mock_harmonyclient,
+        "homeassistant.components.harmony.data.HarmonyClient",
+        side_effect=FakeHarmonyClient,
     ), patch("homeassistant.components.harmony.remote.HarmonyRemote.write_config_file"):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds switches for each activity associated with a Harmony remote.

Harmony remotes have the concept of "Activities" which represent a set of actions like "Watch Fire TV" which will be configured to turn on your television, turn on your receiver, and turn on the Fire TV stick. Currently the harmony integration supports triggering these activities through a service call to the `remote.turn_on` service with the activity name as a property of the call. To set up switches to control each activity today, the typical advice is to set up template switches to call these services and to extract the current_activity from the remote to populate the value_template.

This PR removes the need to manually set up these template switches, and instead adds a switch per activity. These switches, by default, are named `{hub name} {activity name}` (e.g. "Guest Room Watch TV") to support multiple hubs. To support testing these changes, I also enhanced the mock code in tests to be able to keep state so we can more effectively test state changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

No current documentation update. From integrations I've used before I don't believe they tend to document all of the entities they expose. However, happy to update docs in whatever way makes sense to you folks.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
