### PR TITLE
Refactor august to use self.async_on_remove

### DIFF
--- a/homeassistant/components/august/entity.py
+++ b/homeassistant/components/august/entity.py
@@ -46,18 +46,13 @@ class AugustEntityMixin(Entity):
 
     async def async_added_to_hass(self):
         """Subscribe to updates."""
-        self._data.async_subscribe_device_id(
-            self._device_id, self._update_from_data_and_write_state
+        self.async_on_remove(
+            self._data.async_subscribe_device_id(
+                self._device_id, self._update_from_data_and_write_state
+            )
         )
-        self._data.activity_stream.async_subscribe_device_id(
-            self._device_id, self._update_from_data_and_write_state
-        )
-
-    async def async_will_remove_from_hass(self):
-        """Undo subscription."""
-        self._data.async_unsubscribe_device_id(
-            self._device_id, self._update_from_data_and_write_state
-        )
-        self._data.activity_stream.async_unsubscribe_device_id(
-            self._device_id, self._update_from_data_and_write_state
+        self.async_on_remove(
+            self._data.activity_stream.async_subscribe_device_id(
+                self._device_id, self._update_from_data_and_write_state
+            )
         )

--- a/homeassistant/components/august/subscriber.py
+++ b/homeassistant/components/august/subscriber.py
@@ -18,12 +18,20 @@ class AugustSubscriberMixin:
 
     @callback
     def async_subscribe_device_id(self, device_id, update_callback):
-        """Add an callback subscriber."""
+        """Add an callback subscriber.
+
+        Returns a callable that can be used to unsubscribe.
+        """
         if not self._subscriptions:
             self._unsub_interval = async_track_time_interval(
                 self._hass, self._async_refresh, self._update_interval
             )
         self._subscriptions.setdefault(device_id, []).append(update_callback)
+
+        def _unsubscribe():
+            self.async_unsubscribe_device_id(device_id, update_callback)
+
+        return _unsubscribe
 
     @callback
     def async_unsubscribe_device_id(self, device_id, update_callback):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor august to use self.async_on_remove

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
