### PR TITLE
Remove relative time sensor from cert_expiry

### DIFF
--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -10,13 +10,11 @@ from homeassistant.const import (
     CONF_PORT,
     DEVICE_CLASS_TIMESTAMP,
     EVENT_HOMEASSISTANT_START,
-    TIME_DAYS,
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt
 
 from .const import DEFAULT_PORT, DOMAIN
 
@@ -55,7 +53,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
     sensors = [
-        SSLCertificateDays(coordinator),
         SSLCertificateTimestamp(coordinator),
     ]
 
@@ -77,34 +74,6 @@ class CertExpiryEntity(CoordinatorEntity):
             "is_valid": self.coordinator.is_cert_valid,
             "error": str(self.coordinator.cert_error),
         }
-
-
-class SSLCertificateDays(CertExpiryEntity):
-    """Implementation of the Cert Expiry days sensor."""
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"Cert Expiry ({self.coordinator.name})"
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        if not self.coordinator.is_cert_valid:
-            return 0
-
-        expiry = self.coordinator.data - dt.utcnow()
-        return expiry.days
-
-    @property
-    def unique_id(self):
-        """Return a unique id for the sensor."""
-        return f"{self.coordinator.host}:{self.coordinator.port}"
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit this state is expressed in."""
-        return TIME_DAYS
 
 
 class SSLCertificateTimestamp(CertExpiryEntity):

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -76,21 +76,22 @@ async def test_unload_config_entry(mock_now, hass):
     assert len(config_entries) == 1
     assert entry is config_entries[0]
 
+    timestamp = future_timestamp(100)
     with patch(
         "homeassistant.components.cert_expiry.get_cert_expiry_timestamp",
-        return_value=future_timestamp(100),
+        return_value=timestamp,
     ):
         assert await async_setup_component(hass, DOMAIN, {}) is True
         await hass.async_block_till_done()
 
     assert entry.state == ENTRY_STATE_LOADED
-    state = hass.states.get("sensor.cert_expiry_example_com")
-    assert state.state == "100"
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
+    assert state.state == timestamp.isoformat()
     assert state.attributes.get("error") == "None"
     assert state.attributes.get("is_valid")
 
     await hass.config_entries.async_unload(entry.entry_id)
 
     assert entry.state == ENTRY_STATE_NOT_LOADED
-    state = hass.states.get("sensor.cert_expiry_example_com")
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is None

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -34,13 +34,6 @@ async def test_async_setup_entry(mock_now, hass):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "100"
-    assert state.attributes.get("error") == "None"
-    assert state.attributes.get("is_valid")
-
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
@@ -57,6 +50,7 @@ async def test_async_setup_entry_bad_cert(hass):
         unique_id=f"{HOST}:{PORT}",
     )
 
+
     with patch(
         "homeassistant.components.cert_expiry.helper.get_cert",
         side_effect=ssl.SSLError("some error"),
@@ -65,10 +59,9 @@ async def test_async_setup_entry_bad_cert(hass):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
-    assert state.state == "0"
     assert state.attributes.get("error") == "some error"
     assert not state.attributes.get("is_valid")
 
@@ -99,7 +92,7 @@ async def test_async_setup_entry_host_unavailable(hass):
     ):
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is None
 
 
@@ -122,13 +115,6 @@ async def test_update_sensor(hass):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "100"
-    assert state.attributes.get("error") == "None"
-    assert state.attributes.get("is_valid")
-
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
@@ -143,13 +129,6 @@ async def test_update_sensor(hass):
     ):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=24))
         await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.cert_expiry_example_com")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "99"
-    assert state.attributes.get("error") == "None"
-    assert state.attributes.get("is_valid")
 
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is not None
@@ -178,13 +157,6 @@ async def test_update_sensor_network_errors(hass):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "100"
-    assert state.attributes.get("error") == "None"
-    assert state.attributes.get("is_valid")
-
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
@@ -203,7 +175,7 @@ async def test_update_sensor_network_errors(hass):
 
     next_update = starting_time + timedelta(hours=48)
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state.state == STATE_UNAVAILABLE
 
     with patch("homeassistant.util.dt.utcnow", return_value=next_update), patch(
@@ -213,12 +185,12 @@ async def test_update_sensor_network_errors(hass):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=48))
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "98"
-    assert state.attributes.get("error") == "None"
-    assert state.attributes.get("is_valid")
+        state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
+        assert state is not None
+        assert state.state != STATE_UNAVAILABLE
+        assert state.state == timestamp.isoformat()
+        assert state.attributes.get("error") == "None"
+        assert state.attributes.get("is_valid")
 
     next_update = starting_time + timedelta(hours=72)
 
@@ -228,13 +200,6 @@ async def test_update_sensor_network_errors(hass):
     ):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=72))
         await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.cert_expiry_example_com")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "0"
-    assert state.attributes.get("error") == "something bad"
-    assert not state.attributes.get("is_valid")
 
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is not None
@@ -250,5 +215,5 @@ async def test_update_sensor_network_errors(hass):
         async_fire_time_changed(hass, utcnow() + timedelta(hours=96))
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.cert_expiry_example_com")
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -50,7 +50,6 @@ async def test_async_setup_entry_bad_cert(hass):
         unique_id=f"{HOST}:{PORT}",
     )
 
-
     with patch(
         "homeassistant.components.cert_expiry.helper.get_cert",
         side_effect=ssl.SSLError("some error"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
In order to optimize stability and performance of HomeAssistant, sensors should use only absolute time values (store the date of the event) and not relative time values (seconds from event) so the db value doesn't change each seconds.
"cert_expiry" integration has both of them, so to adhere to HomeAssistant development rules, the offending sensor is now removed.
If your config was based on it, please switch to the other one.


Removed relative time sensor from cert_expiry

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removed relative time sensor from cert_expiry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40120
- This PR is related to issue: 
- Link to documentation pull request: [Removed relative time sensor from description](https://github.com/home-assistant/home-assistant.io/pull/15632)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
