### PR TITLE
Remove split devices from HMIPC

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -43,7 +43,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericEntity
-from .generic_entity import async_add_base_multi_area_device
 from .hap import HomematicipHAP
 
 ATTR_ACCELERATION_SENSOR_MODE = "acceleration_sensor_mode"
@@ -88,12 +87,9 @@ async def async_setup_entry(
         if isinstance(device, AsyncTiltVibrationSensor):
             entities.append(HomematicipTiltVibrationSensor(hap, device))
         if isinstance(device, AsyncWiredInput32):
-            await async_add_base_multi_area_device(hass, config_entry, device)
             for channel in range(1, 33):
                 entities.append(
-                    HomematicipMultiContactInterface(
-                        hap, device, channel=channel, is_multi_area=True
-                    )
+                    HomematicipMultiContactInterface(hap, device, channel=channel)
                 )
         elif isinstance(
             device, (AsyncContactInterface, AsyncFullFlushContactInterface)
@@ -220,11 +216,9 @@ class HomematicipTiltVibrationSensor(HomematicipBaseActionSensor):
 class HomematicipMultiContactInterface(HomematicipGenericEntity, BinarySensorEntity):
     """Representation of the HomematicIP multi room/area contact interface."""
 
-    def __init__(
-        self, hap: HomematicipHAP, device, channel: int, is_multi_area: bool = False
-    ) -> None:
+    def __init__(self, hap: HomematicipHAP, device, channel: int) -> None:
         """Initialize the multi contact entity."""
-        super().__init__(hap, device, channel=channel, is_multi_area=is_multi_area)
+        super().__init__(hap, device, channel=channel)
 
     @property
     def device_class(self) -> str:

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -21,10 +21,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as HMIPC_DOMAIN, HomematicipGenericEntity
-from .generic_entity import (
-    ATTR_GROUP_MEMBER_UNREACHABLE,
-    async_add_base_multi_area_device,
-)
+from .generic_entity import ATTR_GROUP_MEMBER_UNREACHABLE
 from .hap import HomematicipHAP
 
 
@@ -45,13 +42,8 @@ async def async_setup_entry(
         ):
             entities.append(HomematicipSwitchMeasuring(hap, device))
         elif isinstance(device, AsyncWiredSwitch8):
-            await async_add_base_multi_area_device(hass, config_entry, device)
             for channel in range(1, 9):
-                entities.append(
-                    HomematicipMultiSwitch(
-                        hap, device, channel=channel, is_multi_area=True
-                    )
-                )
+                entities.append(HomematicipMultiSwitch(hap, device, channel=channel))
         elif isinstance(
             device,
             (
@@ -85,11 +77,9 @@ async def async_setup_entry(
 class HomematicipMultiSwitch(HomematicipGenericEntity, SwitchEntity):
     """Representation of the HomematicIP multi switch."""
 
-    def __init__(
-        self, hap: HomematicipHAP, device, channel: int, is_multi_area: bool = False
-    ) -> None:
+    def __init__(self, hap: HomematicipHAP, device, channel: int) -> None:
         """Initialize the multi switch device."""
-        super().__init__(hap, device, channel=channel, is_multi_area=is_multi_area)
+        super().__init__(hap, device, channel=channel)
 
     @property
     def is_on(self) -> bool:

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -264,12 +264,8 @@ async def test_hmip_multi_area_device(hass, default_mock_hap_factory):
     # get the device
     device_registry = await dr.async_get_registry(hass)
     device = device_registry.async_get(entity.device_id)
-    assert device.name == entity_name
-
-    # get the base device
-    via_device = device_registry.async_get(device.via_device_id)
-    assert via_device.name == "Wired Eingangsmodul – 32-fach"
+    assert device.name == "Wired Eingangsmodul – 32-fach"
 
     # get the hap
-    hap_device = device_registry.async_get(via_device.via_device_id)
+    hap_device = device_registry.async_get(device.via_device_id)
     assert hap_device.name == "Access Point"


### PR DESCRIPTION

## Proposed change
This PR partially reverts PR #41232.
Since PR #42221 adds area_id to the entity registry, it is no longer required to split devices to be able assign different areas.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
