### PR TITLE
Improve custom datatype parsing in Modbus sensor and climate

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -541,6 +541,7 @@ omit =
     homeassistant/components/modbus/climate.py
     homeassistant/components/modbus/cover.py
     homeassistant/components/modbus/switch.py
+    homeassistant/components/modbus/sensor.py
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/mpchc/media_player.py
     homeassistant/components/mpd/media_player.py

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -256,7 +256,7 @@ class ModbusThermostat(ClimateEntity):
             [x.to_bytes(2, byteorder="big") for x in result.registers]
         )
         val = struct.unpack(self._structure, byte_string)
-        if len(val) > 1 or not isinstance(val[0], (float, int)):
+        if len(val) != 1 or not isinstance(val[0], (float, int)):
             _LOGGER.error(
                 "Unable to parse result as a single int or float value; adjust your configuration. Result: %s",
                 str(val),

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -256,7 +256,7 @@ class ModbusThermostat(ClimateEntity):
             [x.to_bytes(2, byteorder="big") for x in result.registers]
         )
         val = struct.unpack(self._structure, byte_string)
-        if len(val) > 1 or not (isinstance(val[0], int) or isinstance(val[0], float)):
+        if len(val) > 1 or not isinstance(val[0], (float, int)):
             _LOGGER.error(
                 "Unable to parse result as a single int or float value; adjust your configuration. Result: %s",
                 str(val),

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -255,7 +255,15 @@ class ModbusThermostat(ClimateEntity):
         byte_string = b"".join(
             [x.to_bytes(2, byteorder="big") for x in result.registers]
         )
-        val = struct.unpack(self._structure, byte_string)[0]
+        val = struct.unpack(self._structure, byte_string)
+        if len(val) > 1 or not (isinstance(val[0], int) or isinstance(val[0], float)):
+            _LOGGER.error(
+                "Unable to parse result as a single int or float value; adjust your configuration. Result: %s",
+                str(val),
+            )
+            return -1
+
+        val = val[0]
         register_value = format(
             (self._scale * val) + self._offset, f".{self._precision}f"
         )

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -250,16 +250,25 @@ class ModbusRegisterSensor(RestoreEntity):
             registers.reverse()
 
         byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
-        if self._data_type != DATA_TYPE_STRING:
-            val = struct.unpack(self._structure, byte_string)[0]
-            val = self._scale * val + self._offset
-            if isinstance(val, int):
-                self._value = str(val)
-                if self._precision > 0:
-                    self._value += "." + "0" * self._precision
-            else:
-                self._value = f"{val:.{self._precision}f}"
-        else:
+        if self._data_type == DATA_TYPE_STRING:
             self._value = byte_string.decode()
+        else:
+            val = struct.unpack(self._structure, byte_string)
+
+            # Issue: https://github.com/home-assistant/core/issues/41944
+            # If unpack() returns a tuple greater than 1, don't try to process the value.
+            # Instead, return the values of unpack(...) separated by commas.
+            if len(val) > 1:
+                self._value = ",".join(map(str, val))
+            else:
+                val = val[0]
+
+                # Apply scale and precision to floats and ints
+                if isinstance(val, int) or isinstance(val, float):
+                    val = self._scale * val + self._offset
+                    self._value = f"{float(val):.{self._precision}f}"
+                else:
+                    # Don't process remaining datatypes (bytes and booleans)
+                    self._value = str(val)
 
         self._available = True

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -264,7 +264,7 @@ class ModbusRegisterSensor(RestoreEntity):
                 val = val[0]
 
                 # Apply scale and precision to floats and ints
-                if isinstance(val, int) or isinstance(val, float):
+                if isinstance(val, (float, int)):
                     val = self._scale * val + self._offset
                     if isinstance(val, int) and self._precision == 0:
                         self._value = str(val)

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -266,6 +266,10 @@ class ModbusRegisterSensor(RestoreEntity):
                 # Apply scale and precision to floats and ints
                 if isinstance(val, (float, int)):
                     val = self._scale * val + self._offset
+
+                    # We could convert int to float, and the code would still work; however
+                    # we lose some precision, and unit tests will fail. Therefore, we do
+                    # the conversion only when it's absolutely necessary.
                     if isinstance(val, int) and self._precision == 0:
                         self._value = str(val)
                     else:

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -266,7 +266,10 @@ class ModbusRegisterSensor(RestoreEntity):
                 # Apply scale and precision to floats and ints
                 if isinstance(val, int) or isinstance(val, float):
                     val = self._scale * val + self._offset
-                    self._value = f"{float(val):.{self._precision}f}"
+                    if isinstance(val, int) and self._precision == 0:
+                        self._value = str(val)
+                    else:
+                        self._value = f"{float(val):.{self._precision}f}"
                 else:
                     # Don't process remaining datatypes (bytes and booleans)
                     self._value = str(val)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
## Breaking change
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR improves parsing of input data in Modbus Sensor or Climate when using `custom` data type.
Because each component has a little bit different behavior, my implementation takes that into account.

### Modbus Sensor
- If a user defined a custom data type, and the call to `struct.unpack(...)` returns more than one number, all data is printed as a list separated by commas. For example: the structure `>3H` gives us a tuple of 3 integers. We print them as `val1, val2, val3` (visible also in the UI)
- If `struct.unpack(...)` returns a value other than `int` or `float`, the value is not processed, and it's printed as a string
- If `struct.unpack(...)` returns `int` or `float`, we apply scaling factor and precision (also current behavior)

### Modbus Climate
Unlike `Modbus sensor`, which can store pretty much any value,  the `Modbus climate` requires either `int` or `float`, because this value is used to control the component. Instead of implementing the same behavior as in `Modbus sensor`, I decided to print a warning if the value is not `int`, `float`, or the `struct.unpack()` returned more than a single value.

```bash
2020-10-25 16:57:43 ERROR (SyncWorker_4) [homeassistant.components.modbus.climate] Unable to parse result as a single int or float value; adjust your configuration. Result: (200, 200, 200)
```

In both cases, existing behavior is **NOT AFFECTED**.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

<!--
## Example entry for `configuration.yaml`:
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.

```yaml
# Example configuration.yaml

```
-->
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41944
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
