### PR TITLE
Add Openplantbook integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -621,6 +621,7 @@ omit =
     homeassistant/components/openhome/__init__.py
     homeassistant/components/openhome/media_player.py
     homeassistant/components/openhome/const.py
+    homeassistant/components/openplantbook/__init__.py
     homeassistant/components/opensensemap/air_quality.py
     homeassistant/components/opensky/sensor.py
     homeassistant/components/opentherm_gw/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -309,6 +309,7 @@ homeassistant/components/onewire/* @garbled1 @epenet
 homeassistant/components/onvif/* @hunterjm
 homeassistant/components/openerz/* @misialq
 homeassistant/components/opengarage/* @danielhiversen
+homeassistant/components/openplantbook/* @Olen
 homeassistant/components/opentherm_gw/* @mvn23
 homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff @freekode

--- a/homeassistant/components/openplantbook/__init__.py
+++ b/homeassistant/components/openplantbook/__init__.py
@@ -1,0 +1,76 @@
+"""The OpenPlantBook integration."""
+import logging
+
+from pyopenplantbook import OpenPlantBookApi
+import voluptuous as vol
+
+from homeassistant import exceptions
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import async_generate_entity_id
+
+from .const import ATTR_ALIAS, ATTR_SPECIES, DOMAIN
+
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the OpenPlantBook component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up OpenPlantBook from a config entry."""
+
+    if DOMAIN not in hass.data:
+        _LOGGER.debug("Creating domain in init")
+        hass.data[DOMAIN] = {}
+    if "API" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["API"] = OpenPlantBookApi(
+            entry.data.get("client_id"), entry.data.get("secret")
+        )
+
+    async def get_plant(call):
+        species = call.data.get(ATTR_SPECIES)
+        if species:
+            plant_data = await hass.data[DOMAIN]["API"].get_plantbook_data(species)
+            attrs = {}
+            for var, val in plant_data.items():
+                attrs[var] = val
+            entity_id = async_generate_entity_id(
+                f"{DOMAIN}" + ".{}", plant_data["pid"], hass=hass
+            )
+            hass.states.async_set(entity_id, plant_data["display_pid"], attrs)
+
+    async def search_plantbook(call):
+        alias = call.data.get(ATTR_ALIAS)
+        if alias:
+            plant_data = await hass.data[DOMAIN]["API"].search_plantbook(alias)
+            state = len(plant_data["results"])
+            attrs = {}
+            for plant in plant_data["results"]:
+                pid = plant["pid"]
+                attrs[pid] = plant["display_pid"]
+            hass.states.async_set(f"{DOMAIN}.search_result", state, attrs)
+
+    hass.services.async_register(DOMAIN, "search", search_plantbook)
+    hass.services.async_register(DOMAIN, "get", get_plant)
+    hass.states.async_set(f"{DOMAIN}.search_result", 0)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    hass.data.pop(DOMAIN)
+
+    return True
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/openplantbook/__init__.py
+++ b/homeassistant/components/openplantbook/__init__.py
@@ -24,7 +24,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up OpenPlantBook from a config entry."""
 
     if DOMAIN not in hass.data:
-        _LOGGER.debug("Creating domain in init")
         hass.data[DOMAIN] = {}
     if "API" not in hass.data[DOMAIN]:
         hass.data[DOMAIN]["API"] = OpenPlantBookApi(

--- a/homeassistant/components/openplantbook/__init__.py
+++ b/homeassistant/components/openplantbook/__init__.py
@@ -31,16 +31,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
     async def get_plant(call):
+        if "SPECIES" not in hass.data[DOMAIN]:
+            hass.data[DOMAIN]["SPECIES"] = {}
         species = call.data.get(ATTR_SPECIES)
-        if species:
+        if species and species not in hass.data[DOMAIN]["SPECIES"]:
             plant_data = await hass.data[DOMAIN]["API"].get_plantbook_data(species)
-            attrs = {}
-            for var, val in plant_data.items():
-                attrs[var] = val
-            entity_id = async_generate_entity_id(
-                f"{DOMAIN}" + ".{}", plant_data["pid"], hass=hass
-            )
-            hass.states.async_set(entity_id, plant_data["display_pid"], attrs)
+            if plant_data:
+                hass.data[DOMAIN]["SPECIES"][species] = plant_data
+                attrs = {}
+                for var, val in plant_data.items():
+                    attrs[var] = val
+                entity_id = async_generate_entity_id(
+                    f"{DOMAIN}" + ".{}", plant_data["pid"], hass=hass
+                )
+                hass.states.async_set(entity_id, plant_data["display_pid"], attrs)
 
     async def search_plantbook(call):
         alias = call.data.get(ATTR_ALIAS)

--- a/homeassistant/components/openplantbook/__init__.py
+++ b/homeassistant/components/openplantbook/__init__.py
@@ -30,10 +30,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN]["API"] = OpenPlantBookApi(
             entry.data.get("client_id"), entry.data.get("secret")
         )
+    if "SPECIES" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["SPECIES"] = {}
 
     async def get_plant(call):
-        if "SPECIES" not in hass.data[DOMAIN]:
-            hass.data[DOMAIN]["SPECIES"] = {}
         species = call.data.get(ATTR_SPECIES)
         if species:
             # Here we try to ensure that we only run one API request for each species

--- a/homeassistant/components/openplantbook/__init__.py
+++ b/homeassistant/components/openplantbook/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import async_generate_entity_id
 
-from .const import ATTR_ALIAS, ATTR_API, ATTR_SPECIES, CACHE_TIME, DOMAIN
+from .const import ATTR_ALIAS, ATTR_API, ATTR_HOURS, ATTR_SPECIES, CACHE_TIME, DOMAIN
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 _LOGGER = logging.getLogger(__name__)
@@ -96,12 +96,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.states.async_set(f"{DOMAIN}.search_result", state, attrs)
 
     async def clean_cache(call):
+        hours = call.data.get(ATTR_HOURS)
+        if not hours:
+            hours = CACHE_TIME
         if ATTR_SPECIES in hass.data[DOMAIN]:
             for species in list(hass.data[DOMAIN][ATTR_SPECIES]):
                 value = hass.data[DOMAIN][ATTR_SPECIES][species]
                 if datetime.now() > datetime.fromisoformat(
                     value["timestamp"]
-                ) + timedelta(hours=CACHE_TIME):
+                ) + timedelta(hours=hours):
                     _LOGGER.debug("Removing %s from cache", species)
                     entity_id = async_generate_entity_id(
                         f"{DOMAIN}" + ".{}", value["pid"], current_ids={}

--- a/homeassistant/components/openplantbook/__init__.py
+++ b/homeassistant/components/openplantbook/__init__.py
@@ -40,7 +40,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             # The first process creates an empty dict, and access the API
             # Later requests for the same species either wait for the first one to complete
             # or they returns immediately if we already have the data we need
-            # TODO: Cache invalidation...
             _LOGGER.debug("get_plant %s", species)
             if species not in hass.data[DOMAIN]["SPECIES"]:
                 _LOGGER.debug("I am the first process %s", species)

--- a/homeassistant/components/openplantbook/config_flow.py
+++ b/homeassistant/components/openplantbook/config_flow.py
@@ -20,7 +20,6 @@ async def validate_input(hass: core.HomeAssistant, data):
     """
 
     if DOMAIN not in hass.data:
-        _LOGGER.debug("Creating domain in config flow")
         hass.data[DOMAIN] = {}
     hass.data[DOMAIN]["API"] = OpenPlantBookApi(data["client_id"], data["secret"])
 

--- a/homeassistant/components/openplantbook/config_flow.py
+++ b/homeassistant/components/openplantbook/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core
 
 from . import CannotConnect, InvalidAuth, OpenPlantBookApi
-from .const import DOMAIN
+from .const import ATTR_API, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
-    hass.data[DOMAIN]["API"] = OpenPlantBookApi(data["client_id"], data["secret"])
+    hass.data[DOMAIN][ATTR_API] = OpenPlantBookApi(data["client_id"], data["secret"])
 
     return {"title": "Openplantbook API"}
 

--- a/homeassistant/components/openplantbook/config_flow.py
+++ b/homeassistant/components/openplantbook/config_flow.py
@@ -1,0 +1,55 @@
+"""Config flow for OpenPlantBook integration."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries, core
+
+from . import CannotConnect, InvalidAuth, OpenPlantBookApi
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema({"client_id": str, "secret": str})
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+
+    if DOMAIN not in hass.data:
+        _LOGGER.debug("Creating domain in config flow")
+        hass.data[DOMAIN] = {}
+    hass.data[DOMAIN]["API"] = OpenPlantBookApi(data["client_id"], data["secret"])
+
+    return {"title": "Openplantbook API"}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for OpenPlantBook."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_UNKNOWN
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+                if info:
+                    return self.async_create_entry(title=info["title"], data=user_input)
+                raise CannotConnect
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )

--- a/homeassistant/components/openplantbook/const.py
+++ b/homeassistant/components/openplantbook/const.py
@@ -3,3 +3,5 @@ DOMAIN = "openplantbook"
 PLANTBOOK_BASEURL = "https://open.plantbook.io/api/v1"
 ATTR_ALIAS = "alias"
 ATTR_SPECIES = "species"
+ATTR_API = "api"
+CACHE_TIME = 24

--- a/homeassistant/components/openplantbook/const.py
+++ b/homeassistant/components/openplantbook/const.py
@@ -1,0 +1,5 @@
+"""Constants for the openplantbook integration."""
+DOMAIN = "openplantbook"
+PLANTBOOK_BASEURL = "https://open.plantbook.io/api/v1"
+ATTR_ALIAS = "alias"
+ATTR_SPECIES = "species"

--- a/homeassistant/components/openplantbook/const.py
+++ b/homeassistant/components/openplantbook/const.py
@@ -4,5 +4,5 @@ PLANTBOOK_BASEURL = "https://open.plantbook.io/api/v1"
 ATTR_ALIAS = "alias"
 ATTR_SPECIES = "species"
 ATTR_API = "api"
-ATTR_DAYS = "days"
+ATTR_HOURS = "hours"
 CACHE_TIME = 24

--- a/homeassistant/components/openplantbook/const.py
+++ b/homeassistant/components/openplantbook/const.py
@@ -4,4 +4,5 @@ PLANTBOOK_BASEURL = "https://open.plantbook.io/api/v1"
 ATTR_ALIAS = "alias"
 ATTR_SPECIES = "species"
 ATTR_API = "api"
+ATTR_DAYS = "days"
 CACHE_TIME = 24

--- a/homeassistant/components/openplantbook/manifest.json
+++ b/homeassistant/components/openplantbook/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "openplantbook",
+  "name": "OpenPlantBook",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/openplantbook",
+  "requirements": ["pyopenplantbook==0.0.4"],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@Olen"
+  ]
+}

--- a/homeassistant/components/openplantbook/services.yaml
+++ b/homeassistant/components/openplantbook/services.yaml
@@ -1,0 +1,13 @@
+search:
+  description: Searches Openplantbook for a plant
+  fields:
+    alias:
+      description: The string to search for
+      example: Capsicum
+
+get:
+  description: Fetches data for a single species
+  fields:
+    species:
+      description: The name of the species as written in "pid" in Openplantbook
+      example: coleus 'marble'

--- a/homeassistant/components/openplantbook/strings.json
+++ b/homeassistant/components/openplantbook/strings.json
@@ -1,0 +1,22 @@
+{
+  "title": "OpenPlantBook",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "client_id": "Client ID",
+          "secret": "Secret"
+        },
+        "description": "Log in to https://open.plantbook.io/apikey/show/ and get you API client id and secret."
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/openplantbook/translations/en.json
+++ b/homeassistant/components/openplantbook/translations/en.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "client_id": "Client ID",
+                    "secret": "Secret"
+                },
+                "description": "Log in to https://open.plantbook.io/apikey/show/ and get you API client id and secret."
+            }
+        }
+    },
+    "title": "OpenPlantBook"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -134,6 +134,7 @@ FLOWS = [
     "omnilogic",
     "onewire",
     "onvif",
+    "openplantbook",
     "opentherm_gw",
     "openuv",
     "openweathermap",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1562,6 +1562,9 @@ pyobihai==1.2.3
 # homeassistant.components.ombi
 pyombi==0.1.10
 
+# homeassistant.components.openplantbook
+pyopenplantbook==0.0.4
+
 # homeassistant.components.openuv
 pyopenuv==1.0.9
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -769,6 +769,9 @@ pynx584==0.5
 # homeassistant.components.nzbget
 pynzbgetapi==0.2.0
 
+# homeassistant.components.openplantbook
+pyopenplantbook==0.0.4
+
 # homeassistant.components.openuv
 pyopenuv==1.0.9
 

--- a/tests/components/openplantbook/__init__.py
+++ b/tests/components/openplantbook/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the OpenPlantBook integration."""

--- a/tests/components/openplantbook/test_config_flow.py
+++ b/tests/components/openplantbook/test_config_flow.py
@@ -1,0 +1,94 @@
+"""Test the OpenPlantbook config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.openplantbook.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+)
+from homeassistant.components.openplantbook.const import DOMAIN
+
+from tests.async_mock import patch
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.openplantbook.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.openplantbook.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.openplantbook.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.openplantbook.config_flow.PlaceholderHub.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.openplantbook.config_flow.PlaceholderHub.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/openplantbook/test_init.py
+++ b/tests/components/openplantbook/test_init.py
@@ -1,6 +1,6 @@
 """Test the __init__.py functions."""
 from homeassistant import setup
-from homeassistant.components.openplantbook.const import DOMAIN
+from homeassistant.components.openplantbook.const import ATTR_API, ATTR_SPECIES, DOMAIN
 
 # from tests.async_mock import patch
 from tests.common import MockConfigEntry
@@ -19,8 +19,8 @@ async def test_async_setup_entry(hass):
     assert await setup.async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
-    assert "API" in hass.data[DOMAIN]
-    assert "SPECIES" in hass.data[DOMAIN]
+    assert ATTR_API in hass.data[DOMAIN]
+    assert ATTR_SPECIES in hass.data[DOMAIN]
 
     state = hass.states.get(f"{DOMAIN}.search_result")
     assert state is not None

--- a/tests/components/openplantbook/test_init.py
+++ b/tests/components/openplantbook/test_init.py
@@ -1,0 +1,27 @@
+"""Test the __init__.py functions."""
+from homeassistant import setup
+from homeassistant.components.openplantbook.const import DOMAIN
+
+# from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_async_setup_entry(hass):
+    """Test async_setup_entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "client_id": "xxxx",
+            "secret": "xxxx",
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await setup.async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert "API" in hass.data[DOMAIN]
+    assert "SPECIES" in hass.data[DOMAIN]
+
+    state = hass.states.get(f"{DOMAIN}.search_result")
+    assert state is not None
+    assert int(state.state) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

This PR adds access to the OpenPlantbook API, and is mostly a preparation for a later PR to the Plant component.
The Openplantbook component itself does not do much, except providing a way for Home Assistant to communicate with the OpenPlantbook API and online DB to fetch data.
There are two service calls which allows you to search for plant species, and get data for a specific species.
https://open.plantbook.io/

This PR is a replacement for PR#42200 where the git history was problematic after a bad rebase.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
The component requires the user to get a client id and secret to the OpenPlantbook API. It is configured using a config flow.
The Openplantbook API is the exposed to HA as a class where other components (e.g. the Plant component) can fetch data.
A PR for the Plant component where it can take advantage of the OpenPlantbook API will be submitted once this component is accepted.



<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  PR#42200
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15445
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
