### PR TITLE
Rewrite pilight/test_init.py tests to pytest style test functions

### DIFF
--- a/tests/components/pilight/test_init.py
+++ b/tests/components/pilight/test_init.py
@@ -2,20 +2,15 @@
 from datetime import timedelta
 import logging
 import socket
-import unittest
 
-import pytest
+from voluptuous import MultipleInvalid
 
 from homeassistant.components import pilight
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.async_mock import patch
-from tests.common import (
-    assert_setup_component,
-    async_fire_time_changed,
-    get_test_home_assistant,
-)
+from tests.common import assert_setup_component, async_fire_time_changed
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,351 +61,340 @@ class PilightDaemonSim:
         _LOGGER.error("PilightDaemonSim callback: %s", function)
 
 
-@pytest.mark.skip("Flaky")
-class TestPilight(unittest.TestCase):
-    """Test the Pilight component."""
+@patch("homeassistant.components.pilight._LOGGER.error")
+async def test_connection_failed_error(mock_error, hass):
+    """Try to connect at 127.0.0.1:5001 with socket error."""
+    with assert_setup_component(4):
+        with patch("pilight.pilight.Client", side_effect=socket.error) as mock_client:
+            assert not await async_setup_component(
+                hass, pilight.DOMAIN, {pilight.DOMAIN: {}}
+            )
+            mock_client.assert_called_once_with(
+                host=pilight.DEFAULT_HOST, port=pilight.DEFAULT_PORT
+            )
+            assert mock_error.call_count == 1
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.skip_teardown_stop = False
-        self.addCleanup(self.tear_down_cleanup)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        if not self.skip_teardown_stop:
-            self.hass.stop()
+@patch("homeassistant.components.pilight._LOGGER.error")
+async def test_connection_timeout_error(mock_error, hass):
+    """Try to connect at 127.0.0.1:5001 with socket timeout."""
+    with assert_setup_component(4):
+        with patch("pilight.pilight.Client", side_effect=socket.timeout) as mock_client:
+            assert not await async_setup_component(
+                hass, pilight.DOMAIN, {pilight.DOMAIN: {}}
+            )
+            mock_client.assert_called_once_with(
+                host=pilight.DEFAULT_HOST, port=pilight.DEFAULT_PORT
+            )
+            assert mock_error.call_count == 1
 
-    @patch("homeassistant.components.pilight._LOGGER.error")
-    def test_connection_failed_error(self, mock_error):
-        """Try to connect at 127.0.0.1:5001 with socket error."""
-        with assert_setup_component(4):
-            with patch(
-                "pilight.pilight.Client", side_effect=socket.error
-            ) as mock_client:
-                assert not setup_component(
-                    self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}}
-                )
-                mock_client.assert_called_once_with(
-                    host=pilight.DEFAULT_HOST, port=pilight.DEFAULT_PORT
-                )
-                assert mock_error.call_count == 1
 
-    @patch("homeassistant.components.pilight._LOGGER.error")
-    def test_connection_timeout_error(self, mock_error):
-        """Try to connect at 127.0.0.1:5001 with socket timeout."""
-        with assert_setup_component(4):
-            with patch(
-                "pilight.pilight.Client", side_effect=socket.timeout
-            ) as mock_client:
-                assert not setup_component(
-                    self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}}
-                )
-                mock_client.assert_called_once_with(
-                    host=pilight.DEFAULT_HOST, port=pilight.DEFAULT_PORT
-                )
-                assert mock_error.call_count == 1
+@patch("pilight.pilight.Client", PilightDaemonSim)
+async def test_send_code_no_protocol(hass):
+    """Try to send data without protocol information, should give error."""
+    with assert_setup_component(4):
+        assert await async_setup_component(hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
 
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.core._LOGGER.error")
-    @patch("homeassistant.components.pilight._LOGGER.error")
-    def test_send_code_no_protocol(self, mock_pilight_error, mock_error):
-        """Try to send data without protocol information, should give error."""
-        with assert_setup_component(4):
-            assert setup_component(self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
-
-            # Call without protocol info, should be ignored with error
-            self.hass.services.call(
+        # Call without protocol info, should raise an error
+        try:
+            await hass.services.async_call(
                 pilight.DOMAIN,
                 pilight.SERVICE_NAME,
                 service_data={"noprotocol": "test", "value": 42},
                 blocking=True,
             )
-            self.hass.block_till_done()
-            error_log_call = mock_error.call_args_list[-1]
-            assert "required key not provided @ data['protocol']" in str(error_log_call)
+            await hass.async_block_till_done()
+        except MultipleInvalid as error:
+            assert "required key not provided @ data['protocol']" in str(error)
 
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.components.pilight._LOGGER.error")
-    def test_send_code(self, mock_pilight_error):
-        """Try to send proper data."""
-        with assert_setup_component(4):
-            assert setup_component(self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
+
+@patch("homeassistant.components.pilight._LOGGER.error")
+@patch("homeassistant.components.pilight._LOGGER", _LOGGER)
+@patch("pilight.pilight.Client", PilightDaemonSim)
+async def test_send_code(mock_pilight_error, hass):
+    """Try to send proper data."""
+    with assert_setup_component(4):
+        assert await async_setup_component(hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
+
+        # Call with protocol info, should not give error
+        service_data = {"protocol": "test", "value": 42}
+        await hass.services.async_call(
+            pilight.DOMAIN,
+            pilight.SERVICE_NAME,
+            service_data=service_data,
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        error_log_call = mock_pilight_error.call_args_list[-1]
+        service_data["protocol"] = [service_data["protocol"]]
+        assert str(service_data) in str(error_log_call)
+
+
+@patch("pilight.pilight.Client", PilightDaemonSim)
+@patch("homeassistant.components.pilight._LOGGER.error")
+async def test_send_code_fail(mock_pilight_error, hass):
+    """Check IOError exception error message."""
+    with assert_setup_component(4):
+        with patch("pilight.pilight.Client.send_code", side_effect=IOError):
+            assert await async_setup_component(
+                hass, pilight.DOMAIN, {pilight.DOMAIN: {}}
+            )
 
             # Call with protocol info, should not give error
             service_data = {"protocol": "test", "value": 42}
-            self.hass.services.call(
+            await hass.services.async_call(
                 pilight.DOMAIN,
                 pilight.SERVICE_NAME,
                 service_data=service_data,
                 blocking=True,
             )
-            self.hass.block_till_done()
+            await hass.async_block_till_done()
             error_log_call = mock_pilight_error.call_args_list[-1]
-            service_data["protocol"] = [service_data["protocol"]]
-            assert str(service_data) in str(error_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.components.pilight._LOGGER.error")
-    def test_send_code_fail(self, mock_pilight_error):
-        """Check IOError exception error message."""
-        with assert_setup_component(4):
-            with patch("pilight.pilight.Client.send_code", side_effect=IOError):
-                assert setup_component(self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
-
-                # Call with protocol info, should not give error
-                service_data = {"protocol": "test", "value": 42}
-                self.hass.services.call(
-                    pilight.DOMAIN,
-                    pilight.SERVICE_NAME,
-                    service_data=service_data,
-                    blocking=True,
-                )
-                self.hass.block_till_done()
-                error_log_call = mock_pilight_error.call_args_list[-1]
-                assert "Pilight send failed" in str(error_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.components.pilight._LOGGER.error")
-    def test_send_code_delay(self, mock_pilight_error):
-        """Try to send proper data with delay afterwards."""
-        with assert_setup_component(4):
-            assert setup_component(
-                self.hass,
-                pilight.DOMAIN,
-                {pilight.DOMAIN: {pilight.CONF_SEND_DELAY: 5.0}},
-            )
-
-            # Call with protocol info, should not give error
-            service_data1 = {"protocol": "test11", "value": 42}
-            service_data2 = {"protocol": "test22", "value": 42}
-            self.hass.services.call(
-                pilight.DOMAIN,
-                pilight.SERVICE_NAME,
-                service_data=service_data1,
-                blocking=True,
-            )
-            self.hass.services.call(
-                pilight.DOMAIN,
-                pilight.SERVICE_NAME,
-                service_data=service_data2,
-                blocking=True,
-            )
-            service_data1["protocol"] = [service_data1["protocol"]]
-            service_data2["protocol"] = [service_data2["protocol"]]
-
-            async_fire_time_changed(self.hass, dt_util.utcnow())
-            self.hass.block_till_done()
-            error_log_call = mock_pilight_error.call_args_list[-1]
-            assert str(service_data1) in str(error_log_call)
-
-            new_time = dt_util.utcnow() + timedelta(seconds=5)
-            async_fire_time_changed(self.hass, new_time)
-            self.hass.block_till_done()
-            error_log_call = mock_pilight_error.call_args_list[-1]
-            assert str(service_data2) in str(error_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.components.pilight._LOGGER.error")
-    def test_start_stop(self, mock_pilight_error):
-        """Check correct startup and stop of pilight daemon."""
-        with assert_setup_component(4):
-            assert setup_component(self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
-
-            # Test startup
-            self.hass.start()
-            self.hass.block_till_done()
-            error_log_call = mock_pilight_error.call_args_list[-2]
-            assert "PilightDaemonSim callback" in str(error_log_call)
-            error_log_call = mock_pilight_error.call_args_list[-1]
-            assert "PilightDaemonSim start" in str(error_log_call)
-
-            # Test stop
-            self.skip_teardown_stop = True
-            self.hass.stop()
-            error_log_call = mock_pilight_error.call_args_list[-1]
-            assert "PilightDaemonSim stop" in str(error_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.core._LOGGER.info")
-    def test_receive_code(self, mock_info):
-        """Check if code receiving via pilight daemon works."""
-        with assert_setup_component(4):
-            assert setup_component(self.hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
-
-            # Test startup
-            self.hass.start()
-            self.hass.block_till_done()
-
-            expected_message = dict(
-                {
-                    "protocol": PilightDaemonSim.test_message["protocol"],
-                    "uuid": PilightDaemonSim.test_message["uuid"],
-                },
-                **PilightDaemonSim.test_message["message"],
-            )
-            error_log_call = mock_info.call_args_list[-1]
-
-            # Check if all message parts are put on event bus
-            for key, value in expected_message.items():
-                assert str(key) in str(error_log_call)
-                assert str(value) in str(error_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.core._LOGGER.info")
-    def test_whitelist_exact_match(self, mock_info):
-        """Check whitelist filter with matched data."""
-        with assert_setup_component(4):
-            whitelist = {
-                "protocol": [PilightDaemonSim.test_message["protocol"]],
-                "uuid": [PilightDaemonSim.test_message["uuid"]],
-                "id": [PilightDaemonSim.test_message["message"]["id"]],
-                "unit": [PilightDaemonSim.test_message["message"]["unit"]],
-            }
-            assert setup_component(
-                self.hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
-            )
-
-            self.hass.start()
-            self.hass.block_till_done()
-
-            expected_message = dict(
-                {
-                    "protocol": PilightDaemonSim.test_message["protocol"],
-                    "uuid": PilightDaemonSim.test_message["uuid"],
-                },
-                **PilightDaemonSim.test_message["message"],
-            )
-            info_log_call = mock_info.call_args_list[-1]
-
-            # Check if all message parts are put on event bus
-            for key, value in expected_message.items():
-                assert str(key) in str(info_log_call)
-                assert str(value) in str(info_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.core._LOGGER.info")
-    def test_whitelist_partial_match(self, mock_info):
-        """Check whitelist filter with partially matched data, should work."""
-        with assert_setup_component(4):
-            whitelist = {
-                "protocol": [PilightDaemonSim.test_message["protocol"]],
-                "id": [PilightDaemonSim.test_message["message"]["id"]],
-            }
-            assert setup_component(
-                self.hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
-            )
-
-            self.hass.start()
-            self.hass.block_till_done()
-
-            expected_message = dict(
-                {
-                    "protocol": PilightDaemonSim.test_message["protocol"],
-                    "uuid": PilightDaemonSim.test_message["uuid"],
-                },
-                **PilightDaemonSim.test_message["message"],
-            )
-            info_log_call = mock_info.call_args_list[-1]
-
-            # Check if all message parts are put on event bus
-            for key, value in expected_message.items():
-                assert str(key) in str(info_log_call)
-                assert str(value) in str(info_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.core._LOGGER.info")
-    def test_whitelist_or_match(self, mock_info):
-        """Check whitelist filter with several subsection, should work."""
-        with assert_setup_component(4):
-            whitelist = {
-                "protocol": [
-                    PilightDaemonSim.test_message["protocol"],
-                    "other_protocol",
-                ],
-                "id": [PilightDaemonSim.test_message["message"]["id"]],
-            }
-            assert setup_component(
-                self.hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
-            )
-
-            self.hass.start()
-            self.hass.block_till_done()
-
-            expected_message = dict(
-                {
-                    "protocol": PilightDaemonSim.test_message["protocol"],
-                    "uuid": PilightDaemonSim.test_message["uuid"],
-                },
-                **PilightDaemonSim.test_message["message"],
-            )
-            info_log_call = mock_info.call_args_list[-1]
-
-            # Check if all message parts are put on event bus
-            for key, value in expected_message.items():
-                assert str(key) in str(info_log_call)
-                assert str(value) in str(info_log_call)
-
-    @patch("pilight.pilight.Client", PilightDaemonSim)
-    @patch("homeassistant.core._LOGGER.info")
-    def test_whitelist_no_match(self, mock_info):
-        """Check whitelist filter with unmatched data, should not work."""
-        with assert_setup_component(4):
-            whitelist = {
-                "protocol": ["wrong_protocol"],
-                "id": [PilightDaemonSim.test_message["message"]["id"]],
-            }
-            assert setup_component(
-                self.hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
-            )
-
-            self.hass.start()
-            self.hass.block_till_done()
-
-            info_log_call = mock_info.call_args_list[-1]
-
-            assert not ("Event pilight_received" in info_log_call)
+            assert "Pilight send failed" in str(error_log_call)
 
 
-class TestPilightCallrateThrottler(unittest.TestCase):
-    """Test the Throttler used to throttle calls to send_code."""
+@patch("homeassistant.components.pilight._LOGGER.error")
+@patch("homeassistant.components.pilight._LOGGER", _LOGGER)
+@patch("pilight.pilight.Client", PilightDaemonSim)
+async def test_send_code_delay(mock_pilight_error, hass):
+    """Try to send proper data with delay afterwards."""
+    with assert_setup_component(4):
+        assert await async_setup_component(
+            hass,
+            pilight.DOMAIN,
+            {pilight.DOMAIN: {pilight.CONF_SEND_DELAY: 5.0}},
+        )
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.addCleanup(self.hass.stop)
+        # Call with protocol info, should not give error
+        service_data1 = {"protocol": "test11", "value": 42}
+        service_data2 = {"protocol": "test22", "value": 42}
+        await hass.services.async_call(
+            pilight.DOMAIN,
+            pilight.SERVICE_NAME,
+            service_data=service_data1,
+            blocking=True,
+        )
+        await hass.services.async_call(
+            pilight.DOMAIN,
+            pilight.SERVICE_NAME,
+            service_data=service_data2,
+            blocking=True,
+        )
+        service_data1["protocol"] = [service_data1["protocol"]]
+        service_data2["protocol"] = [service_data2["protocol"]]
 
-    def test_call_rate_delay_throttle_disabled(self):
-        """Test that the limiter is a noop if no delay set."""
-        runs = []
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+        error_log_call = mock_pilight_error.call_args_list[-1]
+        assert str(service_data1) in str(error_log_call)
 
-        limit = pilight.CallRateDelayThrottle(self.hass, 0.0)
-        action = limit.limited(lambda x: runs.append(x))
+        new_time = dt_util.utcnow() + timedelta(seconds=5)
+        async_fire_time_changed(hass, new_time)
+        await hass.async_block_till_done()
+        error_log_call = mock_pilight_error.call_args_list[-1]
+        assert str(service_data2) in str(error_log_call)
 
-        for i in range(3):
-            action(i)
 
-        assert runs == [0, 1, 2]
+@patch("homeassistant.components.pilight._LOGGER.error")
+@patch("homeassistant.components.pilight._LOGGER", _LOGGER)
+@patch("pilight.pilight.Client", PilightDaemonSim)
+async def test_start_stop(mock_pilight_error, hass):
+    """Check correct startup and stop of pilight daemon."""
+    with assert_setup_component(4):
+        assert await async_setup_component(hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
 
-    def test_call_rate_delay_throttle_enabled(self):
-        """Test that throttling actually work."""
-        runs = []
-        delay = 5.0
+        # Test startup
+        await hass.async_start()
+        await hass.async_block_till_done()
 
-        limit = pilight.CallRateDelayThrottle(self.hass, delay)
-        action = limit.limited(lambda x: runs.append(x))
+        error_log_call = mock_pilight_error.call_args_list[-2]
+        assert "PilightDaemonSim callback" in str(error_log_call)
+        error_log_call = mock_pilight_error.call_args_list[-1]
+        assert "PilightDaemonSim start" in str(error_log_call)
 
-        for i in range(3):
-            action(i)
+        # Test stop
+        with patch.object(hass.loop, "stop"):
+            await hass.async_stop()
+        error_log_call = mock_pilight_error.call_args_list[-1]
+        assert "PilightDaemonSim stop" in str(error_log_call)
 
-        self.hass.block_till_done()
-        assert runs == [0]
 
-        exp = []
-        now = dt_util.utcnow()
-        for i in range(3):
-            exp.append(i)
-            shifted_time = now + (timedelta(seconds=delay + 0.1) * i)
-            async_fire_time_changed(self.hass, shifted_time)
-            self.hass.block_till_done()
-            assert runs == exp
+@patch("pilight.pilight.Client", PilightDaemonSim)
+@patch("homeassistant.core._LOGGER.debug")
+async def test_receive_code(mock_debug, hass):
+    """Check if code receiving via pilight daemon works."""
+    with assert_setup_component(4):
+        assert await async_setup_component(hass, pilight.DOMAIN, {pilight.DOMAIN: {}})
+
+        # Test startup
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+        expected_message = dict(
+            {
+                "protocol": PilightDaemonSim.test_message["protocol"],
+                "uuid": PilightDaemonSim.test_message["uuid"],
+            },
+            **PilightDaemonSim.test_message["message"],
+        )
+        debug_log_call = mock_debug.call_args_list[-3]
+
+        # Check if all message parts are put on event bus
+        for key, value in expected_message.items():
+            assert str(key) in str(debug_log_call)
+            assert str(value) in str(debug_log_call)
+
+
+@patch("pilight.pilight.Client", PilightDaemonSim)
+@patch("homeassistant.core._LOGGER.debug")
+async def test_whitelist_exact_match(mock_debug, hass):
+    """Check whitelist filter with matched data."""
+    with assert_setup_component(4):
+        whitelist = {
+            "protocol": [PilightDaemonSim.test_message["protocol"]],
+            "uuid": [PilightDaemonSim.test_message["uuid"]],
+            "id": [PilightDaemonSim.test_message["message"]["id"]],
+            "unit": [PilightDaemonSim.test_message["message"]["unit"]],
+        }
+        assert await async_setup_component(
+            hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
+        )
+
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+        expected_message = dict(
+            {
+                "protocol": PilightDaemonSim.test_message["protocol"],
+                "uuid": PilightDaemonSim.test_message["uuid"],
+            },
+            **PilightDaemonSim.test_message["message"],
+        )
+        debug_log_call = mock_debug.call_args_list[-3]
+
+        # Check if all message parts are put on event bus
+        for key, value in expected_message.items():
+            assert str(key) in str(debug_log_call)
+            assert str(value) in str(debug_log_call)
+
+
+@patch("pilight.pilight.Client", PilightDaemonSim)
+@patch("homeassistant.core._LOGGER.debug")
+async def test_whitelist_partial_match(mock_debug, hass):
+    """Check whitelist filter with partially matched data, should work."""
+    with assert_setup_component(4):
+        whitelist = {
+            "protocol": [PilightDaemonSim.test_message["protocol"]],
+            "id": [PilightDaemonSim.test_message["message"]["id"]],
+        }
+        assert await async_setup_component(
+            hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
+        )
+
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+        expected_message = dict(
+            {
+                "protocol": PilightDaemonSim.test_message["protocol"],
+                "uuid": PilightDaemonSim.test_message["uuid"],
+            },
+            **PilightDaemonSim.test_message["message"],
+        )
+        debug_log_call = mock_debug.call_args_list[-3]
+
+        # Check if all message parts are put on event bus
+        for key, value in expected_message.items():
+            assert str(key) in str(debug_log_call)
+            assert str(value) in str(debug_log_call)
+
+
+@patch("pilight.pilight.Client", PilightDaemonSim)
+@patch("homeassistant.core._LOGGER.debug")
+async def test_whitelist_or_match(mock_debug, hass):
+    """Check whitelist filter with several subsection, should work."""
+    with assert_setup_component(4):
+        whitelist = {
+            "protocol": [
+                PilightDaemonSim.test_message["protocol"],
+                "other_protocol",
+            ],
+            "id": [PilightDaemonSim.test_message["message"]["id"]],
+        }
+        assert await async_setup_component(
+            hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
+        )
+
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+        expected_message = dict(
+            {
+                "protocol": PilightDaemonSim.test_message["protocol"],
+                "uuid": PilightDaemonSim.test_message["uuid"],
+            },
+            **PilightDaemonSim.test_message["message"],
+        )
+        debug_log_call = mock_debug.call_args_list[-3]
+
+        # Check if all message parts are put on event bus
+        for key, value in expected_message.items():
+            assert str(key) in str(debug_log_call)
+            assert str(value) in str(debug_log_call)
+
+
+@patch("pilight.pilight.Client", PilightDaemonSim)
+@patch("homeassistant.core._LOGGER.debug")
+async def test_whitelist_no_match(mock_debug, hass):
+    """Check whitelist filter with unmatched data, should not work."""
+    with assert_setup_component(4):
+        whitelist = {
+            "protocol": ["wrong_protocol"],
+            "id": [PilightDaemonSim.test_message["message"]["id"]],
+        }
+        assert await async_setup_component(
+            hass, pilight.DOMAIN, {pilight.DOMAIN: {"whitelist": whitelist}}
+        )
+
+        await hass.async_start()
+        await hass.async_block_till_done()
+        debug_log_call = mock_debug.call_args_list[-3]
+
+        assert not ("Event pilight_received" in debug_log_call)
+
+
+async def test_call_rate_delay_throttle_enabled(hass):
+    """Test that throttling actually work."""
+    runs = []
+    delay = 5.0
+
+    limit = pilight.CallRateDelayThrottle(hass, delay)
+    action = limit.limited(lambda x: runs.append(x))
+
+    for i in range(3):
+        await hass.async_add_executor_job(action, i)
+
+    await hass.async_block_till_done()
+    assert runs == [0]
+
+    exp = []
+    now = dt_util.utcnow()
+    for i in range(3):
+        exp.append(i)
+        shifted_time = now + (timedelta(seconds=delay + 0.1) * i)
+        async_fire_time_changed(hass, shifted_time)
+        await hass.async_block_till_done()
+        assert runs == exp
+
+
+def test_call_rate_delay_throttle_disabled(hass):
+    """Test that the limiter is a noop if no delay set."""
+    runs = []
+
+    limit = pilight.CallRateDelayThrottle(hass, 0.0)
+    action = limit.limited(lambda x: runs.append(x))
+
+    for i in range(3):
+        action(i)
+
+    assert runs == [0, 1, 2]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrites the `pilight` integration tests from the `test_init.py` module to pytest style functions. 

In some cases I also had to make changes in the content of the tests so that they could pass locally - most importantly perhaps in the `test_send_code_no_protocol` which raises a MultipleInvalid exception (according to the previous code the error was ignored and it was only checked in the test through the logger) - I am not sure if this was intended so 😄 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40876
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
