### PR TITLE
Ensure config entry platforms are excluded from reload

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -79,6 +79,10 @@ class EntityPlatform:
             self.platform_name, []
         ).append(self)
 
+    def __repr__(self):
+        """Represent an EntityPlatform."""
+        return f"<EntityPlatform domain={self.domain} platform_name={self.platform_name} config_entry={self.config_entry}>"
+
     @callback
     def _get_parallel_updates_semaphore(
         self, entity_has_async_update: bool

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -80,7 +80,9 @@ async def _resetup_platform(
 
     # If its an entity platform, we use the entity_platform
     # async_reset method
-    platform = async_get_platform(hass, integration_name, integration_platform)
+    platform = async_get_platform_without_config_entry(
+        hass, integration_name, integration_platform
+    )
     if platform:
         await _async_reconfig_platform(platform, root_config[integration_platform])
         return
@@ -137,11 +139,13 @@ async def async_integration_yaml_config(
 
 
 @callback
-def async_get_platform(
+def async_get_platform_without_config_entry(
     hass: HomeAssistantType, integration_name: str, integration_platform_name: str
 ) -> Optional[EntityPlatform]:
-    """Find an existing platform."""
+    """Find an existing platform that is not a config entry."""
     for integration_platform in async_get_platforms(hass, integration_name):
+        if integration_platform.config_entry is not None:
+            continue
         if integration_platform.domain == integration_platform_name:
             platform: EntityPlatform = integration_platform
             return platform

--- a/tests/helpers/test_reload.py
+++ b/tests/helpers/test_reload.py
@@ -7,8 +7,9 @@ import pytest
 from homeassistant import config
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.helpers.reload import (
-    async_get_platform,
+    async_get_platform_without_config_entry,
     async_integration_yaml_config,
     async_reload_integration_platforms,
     async_setup_reload_service,
@@ -52,7 +53,7 @@ async def test_reload_platform(hass):
     assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
     assert len(setup_called) == 1
 
-    platform = async_get_platform(hass, PLATFORM, DOMAIN)
+    platform = async_get_platform_without_config_entry(hass, PLATFORM, DOMAIN)
     assert platform.platform_name == PLATFORM
     assert platform.domain == DOMAIN
 
@@ -65,6 +66,11 @@ async def test_reload_platform(hass):
         await async_reload_integration_platforms(hass, PLATFORM, [DOMAIN])
 
     assert len(setup_called) == 2
+
+    existing_platforms = async_get_platforms(hass, PLATFORM)
+    for existing_platform in existing_platforms:
+        existing_platform.config_entry = "abc"
+    assert not async_get_platform_without_config_entry(hass, PLATFORM, DOMAIN)
 
 
 async def test_setup_reload_service(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
mqtt has platform setup and config entries.  We need to exclude the config entry platforms from being reloaded.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42285
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
