### PR TITLE
Implement PlatformNotReady on onewire integration

### DIFF
--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -2,10 +2,11 @@
 import asyncio
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import DOMAIN, SUPPORTED_PLATFORMS
-from .onewirehub import OneWireHub
+from .onewirehub import CannotConnect, OneWireHub
 
 
 async def async_setup(hass, config):
@@ -18,7 +19,10 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
 
     onewirehub = OneWireHub(hass)
-    await onewirehub.initialize(config_entry)
+    try:
+        await onewirehub.initialize(config_entry)
+    except CannotConnect as exc:
+        raise ConfigEntryNotReady() from exc
 
     hass.data[DOMAIN][config_entry.unique_id] = onewirehub
 

--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -1,7 +1,11 @@
 """The 1-Wire component."""
 import asyncio
 
-from .const import SUPPORTED_PLATFORMS
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN, SUPPORTED_PLATFORMS
+from .onewirehub import OneWireHub
 
 
 async def async_setup(hass, config):
@@ -9,8 +13,15 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass, config_entry):
+async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
     """Set up a 1-Wire proxy for a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    onewirehub = OneWireHub(hass)
+    await onewirehub.initialize(config_entry)
+
+    hass.data[DOMAIN][config_entry.unique_id] = onewirehub
+
     for component in SUPPORTED_PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, component)
@@ -18,7 +29,7 @@ async def async_setup_entry(hass, config_entry):
     return True
 
 
-async def async_unload_entry(hass, config_entry):
+async def async_unload_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
     """Unload a config entry."""
     unload_ok = all(
         await asyncio.gather(
@@ -28,4 +39,6 @@ async def async_unload_entry(hass, config_entry):
             ]
         )
     )
+    if unload_ok:
+        hass.data[DOMAIN].pop(config_entry.unique_id)
     return unload_ok

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -5,7 +5,7 @@ from pyownet import protocol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
-from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import CONF_MOUNT_DIR, CONF_TYPE_OWSERVER, CONF_TYPE_SYSBUS
@@ -40,10 +40,7 @@ class OneWireHub:
         elif config_entry.data[CONF_TYPE] == CONF_TYPE_OWSERVER:
             host = config_entry.data[CONF_HOST]
             port = config_entry.data[CONF_PORT]
-            try:
-                await self.connect(host, port)
-            except CannotConnect as exc:
-                raise PlatformNotReady() from exc
+            await self.connect(host, port)
 
 
 class CannotConnect(HomeAssistantError):

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -41,7 +41,7 @@ class OneWireHub:
             raise InvalidPath
 
     async def initialize(self, config_entry: ConfigEntry) -> None:
-        """Initialize a config entry"""
+        """Initialize a config entry."""
         _LOGGER.debug("Initialising config entry %s", config_entry.data)
         if config_entry.data[CONF_TYPE] == CONF_TYPE_SYSBUS:
             await self.check_mount_dir(config_entry.data[CONF_MOUNT_DIR])

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -1,5 +1,4 @@
 """Hub for communication with 1-Wire server or mount_dir."""
-import logging
 import os
 
 from pyownet import protocol
@@ -10,8 +9,6 @@ from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import CONF_MOUNT_DIR, CONF_TYPE_OWSERVER, CONF_TYPE_SYSBUS
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class OneWireHub:
@@ -29,20 +26,15 @@ class OneWireHub:
                 protocol.proxy, host, port
             )
         except protocol.ConnError as exc:
-            _LOGGER.error(
-                "Cannot connect to owserver on %s:%d, got: %s", host, port, exc
-            )
             raise CannotConnect from exc
 
     async def check_mount_dir(self, mount_dir: str) -> None:
         """Test that the mount_dir is a valid path."""
         if not await self.hass.async_add_executor_job(os.path.isdir, mount_dir):
-            _LOGGER.error("Cannot find directory %s", mount_dir)
             raise InvalidPath
 
     async def initialize(self, config_entry: ConfigEntry) -> None:
         """Initialize a config entry."""
-        _LOGGER.debug("Initialising config entry %s", config_entry.data)
         if config_entry.data[CONF_TYPE] == CONF_TYPE_SYSBUS:
             await self.check_mount_dir(config_entry.data[CONF_MOUNT_DIR])
         elif config_entry.data[CONF_TYPE] == CONF_TYPE_OWSERVER:

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -4,7 +4,12 @@ import os
 
 from pyownet import protocol
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import CONF_MOUNT_DIR, CONF_TYPE_OWSERVER, CONF_TYPE_SYSBUS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,21 +20,43 @@ class OneWireHub:
     def __init__(self, hass: HomeAssistantType):
         """Initialize."""
         self.hass = hass
+        self.owproxy: protocol._Proxy = None
 
-    async def can_connect(self, host, port) -> bool:
-        """Test if we can authenticate with the host."""
+    async def connect(self, host: str, port: int) -> None:
+        """Connect to the owserver host."""
         try:
-            await self.hass.async_add_executor_job(protocol.proxy, host, port)
-        except (protocol.Error, protocol.ConnError) as exc:
+            self.owproxy = await self.hass.async_add_executor_job(
+                protocol.proxy, host, port
+            )
+        except protocol.ConnError as exc:
             _LOGGER.error(
                 "Cannot connect to owserver on %s:%d, got: %s", host, port, exc
             )
-            return False
-        return True
+            raise CannotConnect from exc
 
-    async def is_valid_mount_dir(self, mount_dir) -> bool:
+    async def check_mount_dir(self, mount_dir: str) -> None:
         """Test that the mount_dir is a valid path."""
         if not await self.hass.async_add_executor_job(os.path.isdir, mount_dir):
             _LOGGER.error("Cannot find directory %s", mount_dir)
-            return False
-        return True
+            raise InvalidPath
+
+    async def initialize(self, config_entry: ConfigEntry) -> None:
+        """Initialize a config entry"""
+        _LOGGER.debug("Initialising config entry %s", config_entry.data)
+        if config_entry.data[CONF_TYPE] == CONF_TYPE_SYSBUS:
+            await self.check_mount_dir(config_entry.data[CONF_MOUNT_DIR])
+        elif config_entry.data[CONF_TYPE] == CONF_TYPE_OWSERVER:
+            host = config_entry.data[CONF_HOST]
+            port = config_entry.data[CONF_PORT]
+            try:
+                await self.connect(host, port)
+            except CannotConnect as exc:
+                raise PlatformNotReady() from exc
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidPath(HomeAssistantError):
+    """Error to indicate the path is invalid."""

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -2,6 +2,7 @@
 from asynctest.mock import patch
 
 from homeassistant.components.onewire.const import (
+    CONF_MOUNT_DIR,
     CONF_TYPE_OWSERVER,
     CONF_TYPE_SYSBUS,
     DEFAULT_SYSBUS_MOUNT_DIR,
@@ -20,6 +21,7 @@ async def setup_onewire_sysbus_integration(hass):
         source="user",
         data={
             CONF_TYPE: CONF_TYPE_SYSBUS,
+            CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
         },
         unique_id=f"{CONF_TYPE_SYSBUS}:{DEFAULT_SYSBUS_MOUNT_DIR}",
         connection_class=CONN_CLASS_LOCAL_POLL,
@@ -28,8 +30,11 @@ async def setup_onewire_sysbus_integration(hass):
     )
     config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.onewire.onewirehub.os.path.isdir", return_value=True
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     return config_entry
 
@@ -52,7 +57,7 @@ async def setup_onewire_owserver_integration(hass):
     config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.onewire.sensor.protocol.proxy",
+        "homeassistant.components.onewire.onewirehub.protocol.proxy",
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import (
     CONN_CLASS_LOCAL_POLL,
     ENTRY_STATE_LOADED,
     ENTRY_STATE_NOT_LOADED,
-    ENTRY_STATE_SETUP_ERROR,
+    ENTRY_STATE_SETUP_RETRY,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 
@@ -41,7 +41,7 @@ async def test_owserver_platform_not_ready(hass):
         await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry_owserver.state == ENTRY_STATE_SETUP_ERROR
+    assert config_entry_owserver.state == ENTRY_STATE_SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -1,8 +1,73 @@
 """Tests for 1-Wire config flow."""
-from homeassistant.components.onewire.const import DOMAIN
-from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
+from asynctest.mock import patch
+from pyownet.protocol import ConnError, OwnetError
+
+from homeassistant.components.onewire.const import CONF_TYPE_OWSERVER, DOMAIN
+from homeassistant.config_entries import (
+    CONN_CLASS_LOCAL_POLL,
+    ENTRY_STATE_LOADED,
+    ENTRY_STATE_NOT_LOADED,
+    ENTRY_STATE_SETUP_ERROR,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 
 from . import setup_onewire_owserver_integration, setup_onewire_sysbus_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_owserver_platform_not_ready(hass):
+    """Create the 1-Wire integration."""
+    config_entry_owserver = MockConfigEntry(
+        domain=DOMAIN,
+        source="user",
+        data={
+            CONF_TYPE: CONF_TYPE_OWSERVER,
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: "1234",
+        },
+        unique_id=f"{CONF_TYPE_OWSERVER}:1.2.3.4:1234",
+        connection_class=CONN_CLASS_LOCAL_POLL,
+        options={},
+        entry_id="2",
+    )
+    config_entry_owserver.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.onewire.onewirehub.protocol.proxy",
+        side_effect=ConnError,
+    ):
+        await hass.config_entries.async_setup(config_entry_owserver.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert config_entry_owserver.state == ENTRY_STATE_SETUP_ERROR
+    assert not hass.data.get(DOMAIN)
+
+
+async def test_failed_owserver_listing(hass):
+    """Create the 1-Wire integration."""
+    config_entry_owserver = MockConfigEntry(
+        domain=DOMAIN,
+        source="user",
+        data={
+            CONF_TYPE: CONF_TYPE_OWSERVER,
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: "1234",
+        },
+        unique_id=f"{CONF_TYPE_OWSERVER}:1.2.3.4:1234",
+        connection_class=CONN_CLASS_LOCAL_POLL,
+        options={},
+        entry_id="2",
+    )
+    config_entry_owserver.add_to_hass(hass)
+
+    with patch("homeassistant.components.onewire.onewirehub.protocol.proxy") as owproxy:
+        owproxy.return_value.dir.side_effect = OwnetError
+        await hass.config_entries.async_setup(config_entry_owserver.entry_id)
+        await hass.async_block_till_done()
+
+        return config_entry_owserver
 
 
 async def test_unload_entry(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Initialize OneWireHub on `__init__.async_setup_entry`, and run basic checks before forwarding to individual platform.
Raise PlatformNotReady if unable to connect to OWServer during initialization
Update Sensor platform to use initialized OneWireHub


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
