### PR TITLE
Fix MQTT publish from a script with templates

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -322,7 +322,7 @@ MQTT_RW_PLATFORM_SCHEMA = MQTT_BASE_PLATFORM_SCHEMA.extend(
 MQTT_PUBLISH_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_TOPIC): valid_publish_topic,
-        vol.Exclusive(ATTR_PAYLOAD, CONF_PAYLOAD): object,
+        vol.Exclusive(ATTR_PAYLOAD, CONF_PAYLOAD): cv.string,
         vol.Exclusive(ATTR_PAYLOAD_TEMPLATE, CONF_PAYLOAD): cv.string,
         vol.Optional(ATTR_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA,
         vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -567,7 +567,9 @@ async def async_setup_entry(hass, entry):
         retain: bool = call.data[ATTR_RETAIN]
         if payload_template is not None:
             try:
-                payload = template.Template(payload_template, hass).async_render()
+                payload = template.Template(payload_template, hass).async_render(
+                    parse_result=False
+                )
             except template.jinja2.TemplateError as exc:
                 _LOGGER.error(
                     "Unable to publish to %s: rendering payload template of "

--- a/homeassistant/components/snips/__init__.py
+++ b/homeassistant/components/snips/__init__.py
@@ -98,7 +98,7 @@ async def async_setup(hass, config):
         for site_id in site_ids:
             payload = json.dumps({"siteId": site_id})
             hass.components.mqtt.async_publish(
-                FEEDBACK_ON_TOPIC, None, qos=0, retain=False
+                FEEDBACK_ON_TOPIC, "", qos=0, retain=False
             )
             hass.components.mqtt.async_publish(
                 topic, payload, qos=int(state), retain=state

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -397,9 +397,9 @@ async def test_disarm_publishes_mqtt_with_template(hass, mqtt_mock):
     """
     config = copy.deepcopy(DEFAULT_CONFIG_CODE)
     config[alarm_control_panel.DOMAIN]["code"] = "0123"
-    config[alarm_control_panel.DOMAIN]["command_template"] = (
-        '{"action":"{{ action }}",' '"code":"{{ code }}"}'
-    )
+    config[alarm_control_panel.DOMAIN][
+        "command_template"
+    ] = '{"action":"{{ action }}","code":"{{ code }}"}'
     assert await async_setup_component(
         hass,
         alarm_control_panel.DOMAIN,
@@ -409,7 +409,7 @@ async def test_disarm_publishes_mqtt_with_template(hass, mqtt_mock):
 
     await common.async_alarm_disarm(hass, "0123")
     mqtt_mock.async_publish.assert_called_once_with(
-        "alarm/command", {"action": "DISARM", "code": "0123"}, 0, False
+        "alarm/command", '{"action":"DISARM","code":"0123"}', 0, False
     )
 
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -322,7 +322,9 @@ async def test_set_target_temperature(hass, mqtt_mock):
     await common.async_set_temperature(hass, temperature=47, entity_id=ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("temperature") == 47
-    mqtt_mock.async_publish.assert_called_once_with("temperature-topic", 47, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "temperature-topic", "47.0", 0, False
+    )
 
     # also test directly supplying the operation mode to set_temperature
     mqtt_mock.async_publish.reset_mock()
@@ -333,7 +335,10 @@ async def test_set_target_temperature(hass, mqtt_mock):
     assert state.state == "cool"
     assert state.attributes.get("temperature") == 21
     mqtt_mock.async_publish.assert_has_calls(
-        [call("mode-topic", "cool", 0, False), call("temperature-topic", 21, 0, False)]
+        [
+            call("mode-topic", "cool", 0, False),
+            call("temperature-topic", "21.0", 0, False),
+        ]
     )
     mqtt_mock.async_publish.reset_mock()
 
@@ -372,8 +377,8 @@ async def test_set_target_temperature_low_high(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("target_temp_low") == 20
     assert state.attributes.get("target_temp_high") == 23
-    mqtt_mock.async_publish.assert_any_call("temperature-low-topic", 20, 0, False)
-    mqtt_mock.async_publish.assert_any_call("temperature-high-topic", 23, 0, False)
+    mqtt_mock.async_publish.assert_any_call("temperature-low-topic", "20.0", 0, False)
+    mqtt_mock.async_publish.assert_any_call("temperature-high-topic", "23.0", 0, False)
 
 
 async def test_set_target_temperature_low_highpessimistic(hass, mqtt_mock):

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -702,7 +702,9 @@ async def test_set_position_templated(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("set-position-topic", 38, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "set-position-topic", "38", 0, False
+    )
 
 
 async def test_set_position_untemplated(hass, mqtt_mock):
@@ -732,7 +734,7 @@ async def test_set_position_untemplated(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("position-topic", 62, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("position-topic", "62", 0, False)
 
 
 async def test_set_position_untemplated_custom_percentage_range(hass, mqtt_mock):
@@ -764,7 +766,7 @@ async def test_set_position_untemplated_custom_percentage_range(hass, mqtt_mock)
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("position-topic", 62, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("position-topic", "62", 0, False)
 
 
 async def test_no_command_topic(hass, mqtt_mock):
@@ -896,7 +898,9 @@ async def test_tilt_via_invocation_defaults(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 100, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "100", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
@@ -906,7 +910,7 @@ async def test_tilt_via_invocation_defaults(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 0, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", "0", 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     # Close tilt status would be received from device when non-optimistic
@@ -924,7 +928,9 @@ async def test_tilt_via_invocation_defaults(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 100, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "100", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     # Open tilt status would be received from device when non-optimistic
@@ -942,7 +948,7 @@ async def test_tilt_via_invocation_defaults(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 0, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", "0", 0, False)
 
 
 async def test_tilt_given_value(hass, mqtt_mock):
@@ -976,7 +982,9 @@ async def test_tilt_given_value(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 80, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "80", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
@@ -986,7 +994,9 @@ async def test_tilt_given_value(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 25, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "25", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     # Close tilt status would be received from device when non-optimistic
@@ -1004,7 +1014,9 @@ async def test_tilt_given_value(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 80, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "80", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     # Open tilt status would be received from device when non-optimistic
@@ -1022,7 +1034,9 @@ async def test_tilt_given_value(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 25, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "25", 0, False
+    )
 
 
 async def test_tilt_given_value_optimistic(hass, mqtt_mock):
@@ -1062,7 +1076,9 @@ async def test_tilt_given_value_optimistic(hass, mqtt_mock):
     ]
     assert current_cover_tilt_position == 80
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 80, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "80", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
@@ -1077,7 +1093,9 @@ async def test_tilt_given_value_optimistic(hass, mqtt_mock):
     ]
     assert current_cover_tilt_position == 25
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 25, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "25", 0, False
+    )
 
 
 async def test_tilt_given_value_altered_range(hass, mqtt_mock):
@@ -1119,7 +1137,9 @@ async def test_tilt_given_value_altered_range(hass, mqtt_mock):
     ]
     assert current_cover_tilt_position == 50
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 25, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "25", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
@@ -1134,7 +1154,7 @@ async def test_tilt_given_value_altered_range(hass, mqtt_mock):
     ]
     assert current_cover_tilt_position == 0
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 0, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", "0", 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
@@ -1149,7 +1169,9 @@ async def test_tilt_given_value_altered_range(hass, mqtt_mock):
     ]
     assert current_cover_tilt_position == 50
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 25, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "25", 0, False
+    )
 
 
 async def test_tilt_via_topic(hass, mqtt_mock):
@@ -1353,7 +1375,9 @@ async def test_tilt_position(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 50, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "50", 0, False
+    )
 
 
 async def test_tilt_position_altered_range(hass, mqtt_mock):
@@ -1389,7 +1413,9 @@ async def test_tilt_position_altered_range(hass, mqtt_mock):
         blocking=True,
     )
 
-    mqtt_mock.async_publish.assert_called_once_with("tilt-command-topic", 25, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic", "25", 0, False
+    )
 
 
 async def test_find_percentage_in_range_defaults(hass, mqtt_mock):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -122,7 +122,7 @@ async def test_service_call_with_template_payload_renders_template(hass, mqtt_mo
     mqtt.async_publish_template(hass, "test/topic", "{{ 1+1 }}")
     await hass.async_block_till_done()
     assert mqtt_mock.async_publish.called
-    assert mqtt_mock.async_publish.call_args[0][1] == 2
+    assert mqtt_mock.async_publish.call_args[0][1] == "2"
 
 
 async def test_service_call_with_payload_doesnt_render_template(hass, mqtt_mock):

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -760,11 +760,11 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
         [
             call("test_light_rgb/set", "on", 2, False),
             call("test_light_rgb/rgb/set", "255,128,0", 2, False),
-            call("test_light_rgb/brightness/set", 50, 2, False),
+            call("test_light_rgb/brightness/set", "50", 2, False),
             call("test_light_rgb/hs/set", "359.0,78.0", 2, False),
-            call("test_light_rgb/white_value/set", 80, 2, False),
+            call("test_light_rgb/white_value/set", "80", 2, False),
             call("test_light_rgb/xy/set", "0.14,0.131", 2, False),
-            call("test_light_rgb/color_temp/set", 125, 2, False),
+            call("test_light_rgb/color_temp/set", "125", 2, False),
         ],
         any_order=True,
     )
@@ -841,7 +841,7 @@ async def test_sending_mqtt_color_temp_command_with_template(hass, mqtt_mock):
     mqtt_mock.async_publish.assert_has_calls(
         [
             call("test_light_color_temp/set", "on", 0, False),
-            call("test_light_color_temp/color_temp/set", 10, 0, False),
+            call("test_light_color_temp/color_temp/set", "10", 0, False),
         ],
         any_order=True,
     )
@@ -877,7 +877,7 @@ async def test_on_command_first(hass, mqtt_mock):
     mqtt_mock.async_publish.assert_has_calls(
         [
             call("test_light/set", "ON", 0, False),
-            call("test_light/bright", 50, 0, False),
+            call("test_light/bright", "50", 0, False),
         ],
     )
     mqtt_mock.async_publish.reset_mock()
@@ -911,7 +911,7 @@ async def test_on_command_last(hass, mqtt_mock):
     #    test_light/set: 'ON'
     mqtt_mock.async_publish.assert_has_calls(
         [
-            call("test_light/bright", 50, 0, False),
+            call("test_light/bright", "50", 0, False),
             call("test_light/set", "ON", 0, False),
         ],
     )
@@ -946,7 +946,9 @@ async def test_on_command_brightness(hass, mqtt_mock):
 
     # Should get the following MQTT messages.
     #    test_light/bright: 255
-    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", 255, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "test_light/bright", "255", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     await common.async_turn_off(hass, "light.test")
@@ -957,7 +959,7 @@ async def test_on_command_brightness(hass, mqtt_mock):
     # Turn on w/ brightness
     await common.async_turn_on(hass, "light.test", brightness=50)
 
-    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", 50, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", "50", 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await common.async_turn_off(hass, "light.test")
@@ -969,7 +971,7 @@ async def test_on_command_brightness(hass, mqtt_mock):
     mqtt_mock.async_publish.assert_has_calls(
         [
             call("test_light/rgb", "255,128,0", 0, False),
-            call("test_light/bright", 50, 0, False),
+            call("test_light/bright", "50", 0, False),
         ],
         any_order=True,
     )
@@ -1000,7 +1002,9 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock):
 
     # Should get the following MQTT messages.
     #    test_light/bright: 100
-    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", 100, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "test_light/bright", "100", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     await common.async_turn_off(hass, "light.test")
@@ -1011,19 +1015,21 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock):
     # Turn on w/ brightness
     await common.async_turn_on(hass, "light.test", brightness=50)
 
-    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", 20, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", "20", 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     # Turn on w/ max brightness
     await common.async_turn_on(hass, "light.test", brightness=255)
 
-    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", 100, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "test_light/bright", "100", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
 
     # Turn on w/ min brightness
     await common.async_turn_on(hass, "light.test", brightness=1)
 
-    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", 1, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with("test_light/bright", "1", 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await common.async_turn_off(hass, "light.test")
@@ -1035,7 +1041,7 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock):
     mqtt_mock.async_publish.assert_has_calls(
         [
             call("test_light/rgb", "255,128,0", 0, False),
-            call("test_light/bright", 1, 0, False),
+            call("test_light/bright", "1", 0, False),
         ],
         any_order=True,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make sure we use the original string values inside MQTT publish instead of the complex objects that templates might generate. 

This converts MQTT validator to be `cv.string`. This is possible because `cv.string` will convert numbers to strings, just like [Paho MQTT does](https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1254-L1264). We do not allow sending bytes in service calls, so that's not a problem.

This PR relies on a pending PR from @frenck that allows us to have template results not be parsed to native types. Test has already been added for that.

Related to issue #42203

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
