### PR TITLE
Remove pts adjustments in stream

### DIFF
--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -28,7 +28,6 @@ def recorder_save_worker(file_out: str, segments: List[Segment], container_forma
     # Get first_pts values from first segment
     if len(segments) > 0:
         segment = segments[0]
-        segment.segment.seek(0)
         source = av.open(segment.segment, "r", format=container_format)
         source_v = source.streams.video[0]
         first_pts["video"] = source_v.start_time
@@ -40,8 +39,7 @@ def recorder_save_worker(file_out: str, segments: List[Segment], container_forma
         source.close()
 
     for segment in segments:
-        # Seek to beginning and open segment
-        segment.segment.seek(0)
+        # Open segment
         source = av.open(segment.segment, "r", format=container_format)
         source_v = source.streams.video[0]
         # Add output streams

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -25,12 +25,25 @@ def recorder_save_worker(file_out: str, segments: List[Segment], container_forma
     output_v = None
     output_a = None
 
+    # Get first_pts values from first segment
+    if len(segments) > 0:
+        segment = segments[0]
+        segment.segment.seek(0)
+        source = av.open(segment.segment, "r", format=container_format)
+        source_v = source.streams.video[0]
+        first_pts["video"] = source_v.start_time
+        if len(source.streams.audio) > 0:
+            source_a = source.streams.audio[0]
+            first_pts["audio"] = int(
+                source_v.start_time * source_v.time_base / source_a.time_base
+            )
+        source.close()
+
     for segment in segments:
         # Seek to beginning and open segment
         segment.segment.seek(0)
         source = av.open(segment.segment, "r", format=container_format)
         source_v = source.streams.video[0]
-
         # Add output streams
         if not output_v:
             output_v = output.add_stream(template=source_v)
@@ -42,13 +55,12 @@ def recorder_save_worker(file_out: str, segments: List[Segment], container_forma
 
         # Remux video
         for packet in source.demux():
-            if packet is not None and packet.dts is not None:
-                if first_pts[packet.stream.type] is None:
-                    first_pts[packet.stream.type] = packet.pts
-                packet.pts -= first_pts[packet.stream.type]
-                packet.dts -= first_pts[packet.stream.type]
-                packet.stream = output_v if packet.stream.type == "video" else output_a
-                output.mux(packet)
+            if packet.dts is None:
+                continue
+            packet.pts -= first_pts[packet.stream.type]
+            packet.dts -= first_pts[packet.stream.type]
+            packet.stream = output_v if packet.stream.type == "video" else output_a
+            output.mux(packet)
 
         source.close()
 

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -89,9 +89,6 @@ def _stream_worker_internal(hass, stream, quit_event):
 
     # Iterator for demuxing
     container_packets = None
-    # The presentation timestamps of the first packet in each stream we receive
-    # Use to adjust before muxing or outputting, but we don't adjust internally
-    first_pts = {}
     # The decoder timestamps of the latest packet in each stream we processed
     last_dts = None
     # Keep track of consecutive packets without a dts to detect end of stream.
@@ -110,21 +107,14 @@ def _stream_worker_internal(hass, stream, quit_event):
     # 2 - seeking can be problematic https://trac.ffmpeg.org/ticket/7815
 
     def peek_first_pts():
-        nonlocal first_pts, audio_stream, container_packets
+        nonlocal segment_start_pts, audio_stream, container_packets
         missing_dts = 0
-
-        def empty_stream_dict():
-            return {
-                video_stream: None,
-                **({audio_stream: None} if audio_stream else {}),
-            }
-
+        found_audio = False
         try:
             container_packets = container.demux((video_stream, audio_stream))
-            first_packet = empty_stream_dict()
-            first_pts = empty_stream_dict()
+            first_packet = None
             # Get to first video keyframe
-            while first_packet[video_stream] is None:
+            while first_packet is None:
                 packet = next(container_packets)
                 if (
                     packet.dts is None
@@ -135,13 +125,17 @@ def _stream_worker_internal(hass, stream, quit_event):
                         )
                     missing_dts += 1
                     continue
-                if packet.stream == video_stream and packet.is_keyframe:
-                    first_packet[video_stream] = packet
+                if packet.stream == audio_stream:
+                    found_audio = True
+                elif packet.is_keyframe:  # video_keyframe
+                    first_packet = packet
                     initial_packets.append(packet)
             # Get first_pts from subsequent frame to first keyframe
-            while any(
-                [pts is None for pts in {**first_packet, **first_pts}.values()]
-            ) and (len(initial_packets) < PACKETS_TO_WAIT_FOR_AUDIO):
+            while segment_start_pts is None or (
+                audio_stream
+                and not found_audio
+                and len(initial_packets) < PACKETS_TO_WAIT_FOR_AUDIO
+            ):
                 packet = next(container_packets)
                 if (
                     packet.dts is None
@@ -152,24 +146,19 @@ def _stream_worker_internal(hass, stream, quit_event):
                         )
                     missing_dts += 1
                     continue
-                if (
-                    first_packet[packet.stream] is None
-                ):  # actually video already found above so only for audio
-                    if packet.is_keyframe:
-                        first_packet[packet.stream] = packet
-                    else:  # Discard leading non-keyframes
-                        continue
-                else:  # This is the second frame to calculate first_pts from
-                    if first_pts[packet.stream] is None:
-                        first_pts[packet.stream] = packet.dts - packet.duration
-                        first_packet[packet.stream].pts = first_pts[packet.stream]
-                        first_packet[packet.stream].dts = first_pts[packet.stream]
+                if packet.stream == audio_stream:
+                    found_audio = True
+                elif (
+                    segment_start_pts is None
+                ):  # This is the second video frame to calculate first_pts from
+                    segment_start_pts = packet.dts - packet.duration
+                    first_packet.pts = segment_start_pts
+                    first_packet.dts = segment_start_pts
                 initial_packets.append(packet)
-            if audio_stream and first_packet[audio_stream] is None:
+            if audio_stream and not found_audio:
                 _LOGGER.warning(
                     "Audio stream not found"
                 )  # Some streams declare an audio stream and never send any packets
-                del first_pts[audio_stream]
                 audio_stream = None
 
         except (av.AVError, StopIteration) as ex:
@@ -199,9 +188,6 @@ def _stream_worker_internal(hass, stream, quit_event):
             )
 
     def mux_video_packet(packet):
-        # adjust pts and dts before muxing
-        packet.pts -= first_pts[video_stream]
-        packet.dts -= first_pts[video_stream]
         # mux packets to each buffer
         for buffer, output_streams in outputs.values():
             # Assign the packet to the new stream & mux
@@ -210,9 +196,6 @@ def _stream_worker_internal(hass, stream, quit_event):
 
     def mux_audio_packet(packet):
         # almost the same as muxing video but add extra check
-        # adjust pts and dts before muxing
-        packet.pts -= first_pts[audio_stream]
-        packet.dts -= first_pts[audio_stream]
         for buffer, output_streams in outputs.values():
             # Assign the packet to the new stream & mux
             if output_streams.get(audio_stream):
@@ -228,8 +211,12 @@ def _stream_worker_internal(hass, stream, quit_event):
     if not peek_first_pts():
         container.close()
         return
-    last_dts = {k: v - 1 for k, v in first_pts.items()}
-    initialize_segment(first_pts[video_stream])
+    last_dts = {video_stream: segment_start_pts - 1}
+    if audio_stream:
+        last_dts[audio_stream] = (
+            int(segment_start_pts * video_stream.time_base / audio_stream.time_base) - 1
+        )
+    initialize_segment(segment_start_pts)
 
     while not quit_event.is_set():
         try:

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -107,6 +107,11 @@ def _stream_worker_internal(hass, stream, quit_event):
     # 2 - seeking can be problematic https://trac.ffmpeg.org/ticket/7815
 
     def peek_first_pts():
+        """Initialize by peeking into the first few packets of the stream.
+
+        Deal with problem #1 above (bad first packet pts/dts) by recalculating using pts/dts from second packet.
+        Also load the first video keyframe pts into segment_start_pts and check if the audio stream really exists.
+        """
         nonlocal segment_start_pts, audio_stream, container_packets
         missing_dts = 0
         found_audio = False

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -90,7 +90,7 @@ def _stream_worker_internal(hass, stream, quit_event):
     # Iterator for demuxing
     container_packets = None
     # The decoder timestamps of the latest packet in each stream we processed
-    last_dts = None
+    last_dts = {video_stream: float("-inf"), audio_stream: float("-inf")}
     # Keep track of consecutive packets without a dts to detect end of stream.
     missing_dts = 0
     # Holds the buffers for each stream provider
@@ -216,11 +216,7 @@ def _stream_worker_internal(hass, stream, quit_event):
     if not peek_first_pts():
         container.close()
         return
-    last_dts = {video_stream: segment_start_pts - 1}
-    if audio_stream:
-        last_dts[audio_stream] = (
-            int(segment_start_pts * video_stream.time_base / audio_stream.time_base) - 1
-        )
+
     initialize_segment(segment_start_pts)
 
     while not quit_event.is_set():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adjusting the incoming packet DTS/PTS of the audio and video streams to start from 0 based on the first packet of each stream received seems to be unnecessary for the hls segments and starting both from 0 may actually cause a slightly inaccurate A/V sync, as there might be a slight offset between the audio and video segments. Assuming the input audio and video streams are consistent, we can just use the original DTS/PTS values of the input streams. This PR removes the DTS/PTS adjustments in the stream worker and makes the peek_first_pts function slightly more readable.
In recorder, we still need to adjust the dts/pts to 0 for the video stream, but we should also use a common basis for adjustment for the audio stream to avoid the minor A/V sync issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
