### PR TITLE
Skip template result parsing in several places

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
   DEFAULT_PYTHON: 3.7
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 2
+  CACHE_VERSION: 1
   DEFAULT_PYTHON: 3.7
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -276,7 +276,7 @@ class Alert(ToggleEntity):
             self._send_done_message = True
 
             if self._message_template is not None:
-                message = self._message_template.async_render()
+                message = self._message_template.async_render(parse_result=False)
             else:
                 message = self._name
 
@@ -291,7 +291,7 @@ class Alert(ToggleEntity):
         if self._done_message_template is None:
             return
 
-        message = self._done_message_template.async_render()
+        message = self._done_message_template.async_render(parse_result=False)
 
         await self._send_notification_message(message)
 
@@ -300,7 +300,7 @@ class Alert(ToggleEntity):
         msg_payload = {ATTR_MESSAGE: message}
 
         if self._title_template is not None:
-            title = self._title_template.async_render()
+            title = self._title_template.async_render(parse_result=False)
             msg_payload.update({ATTR_TITLE: title})
         if self._data:
             msg_payload.update({ATTR_DATA: self._data})

--- a/homeassistant/components/alexa/flash_briefings.py
+++ b/homeassistant/components/alexa/flash_briefings.py
@@ -80,13 +80,17 @@ class AlexaFlashBriefingView(http.HomeAssistantView):
             output = {}
             if item.get(CONF_TITLE) is not None:
                 if isinstance(item.get(CONF_TITLE), template.Template):
-                    output[ATTR_TITLE_TEXT] = item[CONF_TITLE].async_render()
+                    output[ATTR_TITLE_TEXT] = item[CONF_TITLE].async_render(
+                        parse_result=False
+                    )
                 else:
                     output[ATTR_TITLE_TEXT] = item.get(CONF_TITLE)
 
             if item.get(CONF_TEXT) is not None:
                 if isinstance(item.get(CONF_TEXT), template.Template):
-                    output[ATTR_MAIN_TEXT] = item[CONF_TEXT].async_render()
+                    output[ATTR_MAIN_TEXT] = item[CONF_TEXT].async_render(
+                        parse_result=False
+                    )
                 else:
                     output[ATTR_MAIN_TEXT] = item.get(CONF_TEXT)
 
@@ -97,13 +101,17 @@ class AlexaFlashBriefingView(http.HomeAssistantView):
 
             if item.get(CONF_AUDIO) is not None:
                 if isinstance(item.get(CONF_AUDIO), template.Template):
-                    output[ATTR_STREAM_URL] = item[CONF_AUDIO].async_render()
+                    output[ATTR_STREAM_URL] = item[CONF_AUDIO].async_render(
+                        parse_result=False
+                    )
                 else:
                     output[ATTR_STREAM_URL] = item.get(CONF_AUDIO)
 
             if item.get(CONF_DISPLAY_URL) is not None:
                 if isinstance(item.get(CONF_DISPLAY_URL), template.Template):
-                    output[ATTR_REDIRECTION_URL] = item[CONF_DISPLAY_URL].async_render()
+                    output[ATTR_REDIRECTION_URL] = item[CONF_DISPLAY_URL].async_render(
+                        parse_result=False
+                    )
                 else:
                     output[ATTR_REDIRECTION_URL] = item.get(CONF_DISPLAY_URL)
 

--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -271,7 +271,7 @@ class AlexaResponse:
 
         self.reprompt = {
             "type": speech_type.value,
-            key: text.async_render(self.variables),
+            key: text.async_render(self.variables, parse_result=False),
         }
 
     def as_dict(self):

--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -229,7 +229,7 @@ class ApnsNotificationService(BaseNotificationService):
         if isinstance(message, str):
             rendered_message = message
         elif isinstance(message, template_helper.Template):
-            rendered_message = message.render()
+            rendered_message = message.render(parse_result=False)
         else:
             rendered_message = ""
 

--- a/homeassistant/components/arest/sensor.py
+++ b/homeassistant/components/arest/sensor.py
@@ -78,7 +78,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         def _render(value):
             try:
-                return value_template.async_render({"value": value})
+                return value_template.async_render({"value": value}, parse_result=False)
             except TemplateError:
                 _LOGGER.exception("Error parsing value")
                 return value

--- a/homeassistant/components/dialogflow/__init__.py
+++ b/homeassistant/components/dialogflow/__init__.py
@@ -161,7 +161,7 @@ class DialogflowResponse:
         assert self.speech is None
 
         if isinstance(text, template.Template):
-            text = text.async_render(self.parameters)
+            text = text.async_render(self.parameters, parse_result=False)
 
         self.speech = text
 

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -121,7 +121,7 @@ class GenericCamera(Camera):
     async def async_camera_image(self):
         """Return a still image response from the camera."""
         try:
-            url = self._still_image_url.async_render()
+            url = self._still_image_url.async_render(parse_result=False)
         except TemplateError as err:
             _LOGGER.error("Error parsing template %s: %s", self._still_image_url, err)
             return self._last_image
@@ -178,7 +178,7 @@ class GenericCamera(Camera):
             return None
 
         try:
-            return self._stream_source.async_render()
+            return self._stream_source.async_render(parse_result=False)
         except TemplateError as err:
             _LOGGER.error("Error parsing template %s: %s", self._stream_source, err)
             return None

--- a/homeassistant/components/hp_ilo/sensor.py
+++ b/homeassistant/components/hp_ilo/sensor.py
@@ -157,7 +157,9 @@ class HpIloSensor(Entity):
         ilo_data = getattr(self.hp_ilo_data.data, self._ilo_function)()
 
         if self._sensor_value_template is not None:
-            ilo_data = self._sensor_value_template.render(ilo_data=ilo_data)
+            ilo_data = self._sensor_value_template.render(
+                ilo_data=ilo_data, parse_result=False
+            )
 
         self._state = ilo_data
 

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -183,7 +183,7 @@ class EmailContentSensor(Entity):
             ATTR_DATE: email_message["Date"],
             ATTR_BODY: EmailContentSensor.get_msg_text(email_message),
         }
-        return self._value_template.render(variables)
+        return self._value_template.render(variables, parse_result=False)
 
     def sender_allowed(self, email_message):
         """Check if the sender is in the allowed senders list."""

--- a/homeassistant/components/influxdb/sensor.py
+++ b/homeassistant/components/influxdb/sensor.py
@@ -268,7 +268,7 @@ class InfluxFluxSensorData:
         """Get the latest data by querying influx."""
         _LOGGER.debug(RENDERING_QUERY_MESSAGE, self.query)
         try:
-            rendered_query = self.query.render()
+            rendered_query = self.query.render(parse_result=False)
         except TemplateError as ex:
             _LOGGER.error(RENDERING_QUERY_ERROR_MESSAGE, ex)
             return
@@ -312,7 +312,7 @@ class InfluxQLSensorData:
         """Get the latest data with a shell command."""
         _LOGGER.debug(RENDERING_WHERE_MESSAGE, self.where)
         try:
-            where_clause = self.where.render()
+            where_clause = self.where.render(parse_result=False)
         except TemplateError as ex:
             _LOGGER.error(RENDERING_WHERE_ERROR_MESSAGE, ex)
             return

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -87,13 +87,14 @@ class ScriptIntentHandler(intent.IntentHandler):
 
         if speech is not None:
             response.async_set_speech(
-                speech[CONF_TEXT].async_render(slots), speech[CONF_TYPE]
+                speech[CONF_TEXT].async_render(slots, parse_result=False),
+                speech[CONF_TYPE],
             )
 
         if card is not None:
             response.async_set_card(
-                card[CONF_TITLE].async_render(slots),
-                card[CONF_CONTENT].async_render(slots),
+                card[CONF_TITLE].async_render(slots, parse_result=False),
+                card[CONF_CONTENT].async_render(slots, parse_result=False),
                 card[CONF_TYPE],
             )
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -144,7 +144,7 @@ async def async_setup(hass, config):
             domain = DOMAIN
 
         message.hass = hass
-        message = message.async_render()
+        message = message.async_render(parse_result=False)
         async_log_entry(hass, name, message, domain, entity_id)
 
     hass.components.frontend.async_register_built_in_panel(

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -385,7 +385,9 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         if isinstance(self._code, str):
             alarm_code = self._code
         else:
-            alarm_code = self._code.render(from_state=self._state, to_state=state)
+            alarm_code = self._code.render(
+                parse_result=False, from_state=self._state, to_state=state
+            )
         check = not alarm_code or code == alarm_code
         if not check:
             _LOGGER.warning("Invalid code given for %s", state)

--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -406,7 +406,9 @@ class ManualMQTTAlarm(alarm.AlarmControlPanelEntity):
         if isinstance(self._code, str):
             alarm_code = self._code
         else:
-            alarm_code = self._code.render(from_state=self._state, to_state=state)
+            alarm_code = self._code.render(
+                from_state=self._state, to_state=state, parse_result=False
+            )
         check = not alarm_code or code == alarm_code
         if not check:
             _LOGGER.warning("Invalid code given for %s", state)

--- a/homeassistant/components/minio/__init__.py
+++ b/homeassistant/components/minio/__init__.py
@@ -124,7 +124,7 @@ def setup(hass, config):
     def _render_service_value(service, key):
         value = service.data[key]
         value.hass = hass
-        return value.async_render()
+        return value.async_render(parse_result=False)
 
     def put_file(service):
         """Upload file service."""

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -338,7 +338,7 @@ class MqttAlarm(
         """Publish via mqtt."""
         command_template = self._config[CONF_COMMAND_TEMPLATE]
         values = {"action": action, "code": code}
-        payload = command_template.async_render(**values)
+        payload = command_template.async_render(**values, parse_result=False)
         mqtt.async_publish(
             self.hass,
             self._config[CONF_COMMAND_TOPIC],

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -557,7 +557,7 @@ class MqttCover(
         position = kwargs[ATTR_POSITION]
         percentage_position = position
         if set_position_template is not None:
-            position = set_position_template.async_render(**kwargs)
+            position = set_position_template.async_render(parse_result=False, **kwargs)
         else:
             position = self.find_in_range_from_percent(position, COVER_PAYLOAD)
 

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -441,7 +441,9 @@ class MqttLightTemplate(
         mqtt.async_publish(
             self.hass,
             self._topics[CONF_COMMAND_TOPIC],
-            self._templates[CONF_COMMAND_ON_TEMPLATE].async_render(**values),
+            self._templates[CONF_COMMAND_ON_TEMPLATE].async_render(
+                parse_result=False, **values
+            ),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -464,7 +466,9 @@ class MqttLightTemplate(
         mqtt.async_publish(
             self.hass,
             self._topics[CONF_COMMAND_TOPIC],
-            self._templates[CONF_COMMAND_OFF_TEMPLATE].async_render(**values),
+            self._templates[CONF_COMMAND_OFF_TEMPLATE].async_render(
+                parse_result=False, **values
+            ),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -133,7 +133,7 @@ class BaseNotificationService:
 
         if title:
             title.hass = self.hass
-            kwargs[ATTR_TITLE] = title.async_render()
+            kwargs[ATTR_TITLE] = title.async_render(parse_result=False)
 
         if self._registered_targets.get(service.service) is not None:
             kwargs[ATTR_TARGET] = [self._registered_targets[service.service]]
@@ -141,7 +141,7 @@ class BaseNotificationService:
             kwargs[ATTR_TARGET] = service.data.get(ATTR_TARGET)
 
         message.hass = self.hass
-        kwargs[ATTR_MESSAGE] = message.async_render()
+        kwargs[ATTR_MESSAGE] = message.async_render(parse_result=False)
         kwargs[ATTR_DATA] = service.data.get(ATTR_DATA)
 
         await self.async_send_message(**kwargs)
@@ -229,12 +229,12 @@ async def async_setup(hass, config):
         payload = {}
         message = service.data[ATTR_MESSAGE]
         message.hass = hass
-        payload[ATTR_MESSAGE] = message.async_render()
+        payload[ATTR_MESSAGE] = message.async_render(parse_result=False)
 
         title = service.data.get(ATTR_TITLE)
         if title:
             title.hass = hass
-            payload[ATTR_TITLE] = title.async_render()
+            payload[ATTR_TITLE] = title.async_render(parse_result=False)
 
         await hass.services.async_call(
             pn.DOMAIN, pn.SERVICE_CREATE, payload, blocking=True

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -119,7 +119,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         if title is not None:
             try:
                 title.hass = hass
-                title = title.async_render()
+                title = title.async_render(parse_result=False)
             except TemplateError as ex:
                 _LOGGER.error("Error rendering title %s: %s", title, ex)
                 title = title.template
@@ -128,7 +128,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
         try:
             message.hass = hass
-            message = message.async_render()
+            message = message.async_render(parse_result=False)
         except TemplateError as ex:
             _LOGGER.error("Error rendering message %s: %s", message, ex)
             message = message.template

--- a/homeassistant/components/rest/binary_sensor.py
+++ b/homeassistant/components/rest/binary_sensor.py
@@ -84,7 +84,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     if resource_template is not None:
         resource_template.hass = hass
-        resource = resource_template.render()
+        resource = resource_template.render(parse_result=False)
 
     if value_template is not None:
         value_template.hass = hass
@@ -189,6 +189,6 @@ class RestBinarySensor(BinarySensorEntity):
     async def async_update(self):
         """Get the latest data from REST API and updates the state."""
         if self._resource_template is not None:
-            self.rest.set_url(self._resource_template.render())
+            self.rest.set_url(self._resource_template.render(parse_result=False))
 
         await self.rest.async_update()

--- a/homeassistant/components/rest/notify.py
+++ b/homeassistant/components/rest/notify.py
@@ -163,7 +163,7 @@ class RestNotificationService(BaseNotificationService):
                         key: _data_template_creator(item) for key, item in value.items()
                     }
                 value.hass = self._hass
-                return value.async_render(kwargs)
+                return value.async_render(kwargs, parse_result=False)
 
             data.update(_data_template_creator(self._data_template))
 

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -103,7 +103,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     if resource_template is not None:
         resource_template.hass = hass
-        resource = resource_template.render()
+        resource = resource_template.render(parse_result=False)
 
     if username and password:
         if config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
@@ -202,7 +202,7 @@ class RestSensor(Entity):
     async def async_update(self):
         """Get the latest data from REST API and update the state."""
         if self._resource_template is not None:
-            self.rest.set_url(self._resource_template.render())
+            self.rest.set_url(self._resource_template.render(parse_result=False))
 
         await self.rest.async_update()
 

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -162,7 +162,7 @@ class RestSwitch(SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        body_on_t = self._body_on.async_render()
+        body_on_t = self._body_on.async_render(parse_result=False)
 
         try:
             req = await self.set_device_state(body_on_t)
@@ -178,7 +178,7 @@ class RestSwitch(SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
-        body_off_t = self._body_off.async_render()
+        body_off_t = self._body_off.async_render(parse_result=False)
 
         try:
             req = await self.set_device_state(body_off_t)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -93,17 +93,22 @@ async def async_setup(hass, config):
             payload = None
             if template_payload:
                 payload = bytes(
-                    template_payload.async_render(variables=service.data), "utf-8"
+                    template_payload.async_render(
+                        variables=service.data, parse_result=False
+                    ),
+                    "utf-8",
                 )
 
-            request_url = template_url.async_render(variables=service.data)
+            request_url = template_url.async_render(
+                variables=service.data, parse_result=False
+            )
 
             headers = None
             if template_headers:
                 headers = {}
                 for header_name, template_header in template_headers.items():
                     headers[header_name] = template_header.async_render(
-                        variables=service.data
+                        variables=service.data, parse_result=False
                     )
 
             if content_type:

--- a/homeassistant/components/rss_feed_template/__init__.py
+++ b/homeassistant/components/rss_feed_template/__init__.py
@@ -83,17 +83,19 @@ class RssView(HomeAssistantView):
 
         response += "<rss>\n"
         if self._title is not None:
-            response += "  <title>%s</title>\n" % escape(self._title.async_render())
+            response += "  <title>%s</title>\n" % escape(
+                self._title.async_render(parse_result=False)
+            )
 
         for item in self._items:
             response += "  <item>\n"
             if "title" in item:
                 response += "    <title>"
-                response += escape(item["title"].async_render())
+                response += escape(item["title"].async_render(parse_result=False))
                 response += "</title>\n"
             if "description" in item:
                 response += "    <description>"
-                response += escape(item["description"].async_render())
+                response += escape(item["description"].async_render(parse_result=False))
                 response += "</description>\n"
             response += "  </item>\n"
 

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -118,7 +118,7 @@ def _async_templatize_blocks(hass, value):
         }
 
     tmpl = template.Template(value, hass=hass)
-    return tmpl.async_render()
+    return tmpl.async_render(parse_result=False)
 
 
 class SlackNotificationService(BaseNotificationService):

--- a/homeassistant/components/tcp/sensor.py
+++ b/homeassistant/components/tcp/sensor.py
@@ -136,7 +136,9 @@ class TcpSensor(Entity):
 
         if self._config[CONF_VALUE_TEMPLATE] is not None:
             try:
-                self._state = self._config[CONF_VALUE_TEMPLATE].render(value=value)
+                self._state = self._config[CONF_VALUE_TEMPLATE].render(
+                    parse_result=False, value=value
+                )
                 return
             except TemplateError:
                 _LOGGER.error(

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -329,7 +329,9 @@ async def async_setup(hass, config):
                 else:
                     attribute_templ.hass = hass
                     try:
-                        data[attribute] = attribute_templ.async_render()
+                        data[attribute] = attribute_templ.async_render(
+                            parse_result=False
+                        )
                     except TemplateError as exc:
                         _LOGGER.error(
                             "TemplateError in %s: %s -> %s",

--- a/homeassistant/components/xiaomi/camera.py
+++ b/homeassistant/components/xiaomi/camera.py
@@ -142,7 +142,7 @@ class XiaomiCamera(Camera):
         """Return a still image response from the camera."""
 
         try:
-            host = self.host.async_render()
+            host = self.host.async_render(parse_result=False)
         except TemplateError as exc:
             _LOGGER.error("Error parsing template %s: %s", self.host, exc)
             return self._last_image

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -108,7 +108,7 @@ async def test_sending_templated_message(hass, events):
     await hass.async_block_till_done()
     last_event = events[-1]
     assert last_event.data[notify.ATTR_TITLE] == "temperature"
-    assert last_event.data[notify.ATTR_MESSAGE] == 10
+    assert last_event.data[notify.ATTR_MESSAGE] == "10"
 
 
 async def test_method_forwards_correct_data(hass, events):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With templates now being native, we have several places that expect a string result from a template render.

This PR collects those calls and adjusts them to skip parsing the template result using `parse_result=False`.

Occurrences can be found by searching for `\.(async_)?render\((?!parse_result)` in our codebase.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #42203
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
