### PR TITLE
Rewrite the pilight/test_sensor.py tests to use async pytest functions

### DIFF
--- a/tests/components/pilight/test_sensor.py
+++ b/tests/components/pilight/test_sensor.py
@@ -1,42 +1,34 @@
 """The tests for the Pilight sensor platform."""
 import logging
 
+import pytest
+
 from homeassistant.components import pilight
 import homeassistant.components.sensor as sensor
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
-from tests.common import assert_setup_component, get_test_home_assistant, mock_component
-
-HASS = None
+from tests.common import assert_setup_component, mock_component
 
 
-def fire_pilight_message(protocol, data):
+@pytest.fixture(autouse=True)
+def setup_comp(hass):
+    """Initialize components."""
+    mock_component(hass, "pilight")
+
+
+def fire_pilight_message(hass, protocol, data):
     """Fire the fake Pilight message."""
     message = {pilight.CONF_PROTOCOL: protocol}
     message.update(data)
-    HASS.bus.fire(pilight.EVENT, message)
+
+    hass.bus.async_fire(pilight.EVENT, message)
 
 
-# pylint: disable=invalid-name
-def setup_function():
-    """Initialize a Home Assistant server."""
-    global HASS
-
-    HASS = get_test_home_assistant()
-    mock_component(HASS, "pilight")
-
-
-# pylint: disable=invalid-name
-def teardown_function():
-    """Stop the Home Assistant server."""
-    HASS.stop()
-
-
-def test_sensor_value_from_code():
+async def test_sensor_value_from_code(hass):
     """Test the setting of value via pilight."""
     with assert_setup_component(1):
-        setup_component(
-            HASS,
+        assert await async_setup_component(
+            hass,
             sensor.DOMAIN,
             {
                 sensor.DOMAIN: {
@@ -48,26 +40,26 @@ def test_sensor_value_from_code():
                 }
             },
         )
-        HASS.block_till_done()
+        await hass.async_block_till_done()
 
-        state = HASS.states.get("sensor.test")
+        state = hass.states.get("sensor.test")
         assert state.state == "unknown"
 
         unit_of_measurement = state.attributes.get("unit_of_measurement")
         assert unit_of_measurement == "fav unit"
 
         # Set value from data with correct payload
-        fire_pilight_message(protocol="test-protocol", data={"test": 42})
-        HASS.block_till_done()
-        state = HASS.states.get("sensor.test")
+        fire_pilight_message(hass, protocol="test-protocol", data={"test": 42})
+        await hass.async_block_till_done()
+        state = hass.states.get("sensor.test")
         assert state.state == "42"
 
 
-def test_disregard_wrong_payload():
+async def test_disregard_wrong_payload(hass):
     """Test omitting setting of value with wrong payload."""
     with assert_setup_component(1):
-        setup_component(
-            HASS,
+        assert await async_setup_component(
+            hass,
             sensor.DOMAIN,
             {
                 sensor.DOMAIN: {
@@ -78,40 +70,41 @@ def test_disregard_wrong_payload():
                 }
             },
         )
-        HASS.block_till_done()
+        await hass.async_block_till_done()
 
         # Try set value from data with incorrect payload
         fire_pilight_message(
-            protocol="test-protocol_2", data={"test": "data", "uuid": "0-0-0-0"}
+            hass, protocol="test-protocol_2", data={"test": "data", "uuid": "0-0-0-0"}
         )
-        HASS.block_till_done()
-        state = HASS.states.get("sensor.test_2")
+        await hass.async_block_till_done()
+        state = hass.states.get("sensor.test_2")
         assert state.state == "unknown"
 
         # Try set value from data with partially matched payload
         fire_pilight_message(
-            protocol="wrong-protocol", data={"test": "data", "uuid": "1-2-3-4"}
+            hass, protocol="wrong-protocol", data={"test": "data", "uuid": "1-2-3-4"}
         )
-        HASS.block_till_done()
-        state = HASS.states.get("sensor.test_2")
+        await hass.async_block_till_done()
+        state = hass.states.get("sensor.test_2")
         assert state.state == "unknown"
 
         # Try set value from data with fully matched payload
         fire_pilight_message(
+            hass,
             protocol="test-protocol_2",
             data={"test": "data", "uuid": "1-2-3-4", "other_payload": 3.141},
         )
-        HASS.block_till_done()
-        state = HASS.states.get("sensor.test_2")
+        await hass.async_block_till_done()
+        state = hass.states.get("sensor.test_2")
         assert state.state == "data"
 
 
-def test_variable_missing(caplog):
+async def test_variable_missing(hass, caplog):
     """Check if error message when variable missing."""
     caplog.set_level(logging.ERROR)
     with assert_setup_component(1):
-        setup_component(
-            HASS,
+        assert await async_setup_component(
+            hass,
             sensor.DOMAIN,
             {
                 sensor.DOMAIN: {
@@ -122,13 +115,15 @@ def test_variable_missing(caplog):
                 }
             },
         )
-        HASS.block_till_done()
+        await hass.async_block_till_done()
 
         # Create code without sensor variable
         fire_pilight_message(
-            protocol="test-protocol", data={"uuid": "1-2-3-4", "other_variable": 3.141}
+            hass,
+            protocol="test-protocol",
+            data={"uuid": "1-2-3-4", "other_variable": 3.141},
         )
-        HASS.block_till_done()
+        await hass.async_block_till_done()
 
         logs = caplog.text
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite the pilight/test_sensor.py tests to use async pytest functions

The tests were already implemented as standalone pytest functions however they used a global HASS object instead of the existing fixture. For consistency with the rest of the tests, I have rewritten them too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40876 (the rest of the modules are also rewritten)
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
