### PR TITLE
Add data entry flow show progress step

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -363,7 +363,11 @@ class FlowHandler:
 
     @callback
     def async_show_progress(
-        self, *, step_id: str, description_placeholders: Optional[Dict] = None
+        self,
+        *,
+        step_id: str,
+        progress_action: str,
+        description_placeholders: Optional[Dict] = None,
     ) -> Dict[str, Any]:
         """Show a progress message to the user, without user input allowed."""
         return {
@@ -371,6 +375,7 @@ class FlowHandler:
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": step_id,
+            "progress_action": progress_action,
             "description_placeholders": description_placeholders,
         }
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -168,7 +168,7 @@ class FlowManager(abc.ABC):
                 RESULT_TYPE_INFO_STEP_DONE,
             ):
                 raise ValueError(
-                    "Info step can only transition to " "info step or info step done."
+                    "Info step can only transition to info step or info step done."
                 )
 
             # If the result has changed from last result, fire event to update

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -14,10 +14,10 @@ RESULT_TYPE_CREATE_ENTRY = "create_entry"
 RESULT_TYPE_ABORT = "abort"
 RESULT_TYPE_EXTERNAL_STEP = "external"
 RESULT_TYPE_EXTERNAL_STEP_DONE = "external_done"
-RESULT_TYPE_INFO_STEP = "info"
-RESULT_TYPE_INFO_STEP_DONE = "info_done"
+RESULT_TYPE_SHOW_PROGRESS = "progress"
+RESULT_TYPE_SHOW_PROGRESS_DONE = "progress_done"
 
-# Event that is fired when a flow is progressed via external or info source.
+# Event that is fired when a flow is progressed via external or progress source.
 EVENT_DATA_ENTRY_FLOW_PROGRESSED = "data_entry_flow_progressed"
 
 
@@ -154,7 +154,7 @@ class FlowManager(abc.ABC):
 
         result = await self._async_handle_step(flow, cur_step["step_id"], user_input)
 
-        if cur_step["type"] in (RESULT_TYPE_EXTERNAL_STEP, RESULT_TYPE_INFO_STEP):
+        if cur_step["type"] in (RESULT_TYPE_EXTERNAL_STEP, RESULT_TYPE_SHOW_PROGRESS):
             if cur_step["type"] == RESULT_TYPE_EXTERNAL_STEP and result["type"] not in (
                 RESULT_TYPE_EXTERNAL_STEP,
                 RESULT_TYPE_EXTERNAL_STEP_DONE,
@@ -163,12 +163,12 @@ class FlowManager(abc.ABC):
                     "External step can only transition to "
                     "external step or external step done."
                 )
-            if cur_step["type"] == RESULT_TYPE_INFO_STEP and result["type"] not in (
-                RESULT_TYPE_INFO_STEP,
-                RESULT_TYPE_INFO_STEP_DONE,
+            if cur_step["type"] == RESULT_TYPE_SHOW_PROGRESS and result["type"] not in (
+                RESULT_TYPE_SHOW_PROGRESS,
+                RESULT_TYPE_SHOW_PROGRESS_DONE,
             ):
                 raise ValueError(
-                    "Info step can only transition to info step or info step done."
+                    "Show progress can only transition to show progress or show progress done."
                 )
 
             # If the result has changed from last result, fire event to update
@@ -226,8 +226,8 @@ class FlowManager(abc.ABC):
             RESULT_TYPE_CREATE_ENTRY,
             RESULT_TYPE_ABORT,
             RESULT_TYPE_EXTERNAL_STEP_DONE,
-            RESULT_TYPE_INFO_STEP,
-            RESULT_TYPE_INFO_STEP_DONE,
+            RESULT_TYPE_SHOW_PROGRESS,
+            RESULT_TYPE_SHOW_PROGRESS_DONE,
         ):
             raise ValueError(f"Handler returned incorrect type: {result['type']}")
 
@@ -235,8 +235,8 @@ class FlowManager(abc.ABC):
             RESULT_TYPE_FORM,
             RESULT_TYPE_EXTERNAL_STEP,
             RESULT_TYPE_EXTERNAL_STEP_DONE,
-            RESULT_TYPE_INFO_STEP,
-            RESULT_TYPE_INFO_STEP_DONE,
+            RESULT_TYPE_SHOW_PROGRESS,
+            RESULT_TYPE_SHOW_PROGRESS_DONE,
         ):
             flow.cur_step = result
             return result
@@ -362,12 +362,12 @@ class FlowHandler:
         }
 
     @callback
-    def async_info_step(
+    def async_show_progress(
         self, *, step_id: str, description_placeholders: Optional[Dict] = None
     ) -> Dict[str, Any]:
-        """Show an info message to the user, without user input allowed."""
+        """Show a progress message to the user, without user input allowed."""
         return {
-            "type": RESULT_TYPE_INFO_STEP,
+            "type": RESULT_TYPE_SHOW_PROGRESS,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": step_id,
@@ -375,10 +375,10 @@ class FlowHandler:
         }
 
     @callback
-    def async_info_step_done(self, *, next_step_id: str) -> Dict[str, Any]:
-        """Mark the info step done."""
+    def async_show_progress_done(self, *, next_step_id: str) -> Dict[str, Any]:
+        """Mark the progress done."""
         return {
-            "type": RESULT_TYPE_INFO_STEP_DONE,
+            "type": RESULT_TYPE_SHOW_PROGRESS_DONE,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": next_step_id,

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -14,8 +14,10 @@ RESULT_TYPE_CREATE_ENTRY = "create_entry"
 RESULT_TYPE_ABORT = "abort"
 RESULT_TYPE_EXTERNAL_STEP = "external"
 RESULT_TYPE_EXTERNAL_STEP_DONE = "external_done"
+RESULT_TYPE_INFO_STEP = "info"
+RESULT_TYPE_INFO_STEP_DONE = "info_done"
 
-# Event that is fired when a flow is progressed via external source.
+# Event that is fired when a flow is progressed via external or info source.
 EVENT_DATA_ENTRY_FLOW_PROGRESSED = "data_entry_flow_progressed"
 
 
@@ -152,14 +154,21 @@ class FlowManager(abc.ABC):
 
         result = await self._async_handle_step(flow, cur_step["step_id"], user_input)
 
-        if cur_step["type"] == RESULT_TYPE_EXTERNAL_STEP:
-            if result["type"] not in (
+        if cur_step["type"] in (RESULT_TYPE_EXTERNAL_STEP, RESULT_TYPE_INFO_STEP):
+            if cur_step["type"] == RESULT_TYPE_EXTERNAL_STEP and result["type"] not in (
                 RESULT_TYPE_EXTERNAL_STEP,
                 RESULT_TYPE_EXTERNAL_STEP_DONE,
             ):
                 raise ValueError(
                     "External step can only transition to "
                     "external step or external step done."
+                )
+            if cur_step["type"] == RESULT_TYPE_INFO_STEP and result["type"] not in (
+                RESULT_TYPE_INFO_STEP,
+                RESULT_TYPE_INFO_STEP_DONE,
+            ):
+                raise ValueError(
+                    "Info step can only transition to " "info step or info step done."
                 )
 
             # If the result has changed from last result, fire event to update
@@ -217,6 +226,8 @@ class FlowManager(abc.ABC):
             RESULT_TYPE_CREATE_ENTRY,
             RESULT_TYPE_ABORT,
             RESULT_TYPE_EXTERNAL_STEP_DONE,
+            RESULT_TYPE_INFO_STEP,
+            RESULT_TYPE_INFO_STEP_DONE,
         ):
             raise ValueError(f"Handler returned incorrect type: {result['type']}")
 
@@ -224,6 +235,8 @@ class FlowManager(abc.ABC):
             RESULT_TYPE_FORM,
             RESULT_TYPE_EXTERNAL_STEP,
             RESULT_TYPE_EXTERNAL_STEP_DONE,
+            RESULT_TYPE_INFO_STEP,
+            RESULT_TYPE_INFO_STEP_DONE,
         ):
             flow.cur_step = result
             return result
@@ -343,6 +356,29 @@ class FlowHandler:
         """Return the definition of an external step for the user to take."""
         return {
             "type": RESULT_TYPE_EXTERNAL_STEP_DONE,
+            "flow_id": self.flow_id,
+            "handler": self.handler,
+            "step_id": next_step_id,
+        }
+
+    @callback
+    def async_info_step(
+        self, *, step_id: str, description_placeholders: Optional[Dict] = None
+    ) -> Dict[str, Any]:
+        """Show an info message to the user, without user input allowed."""
+        return {
+            "type": RESULT_TYPE_INFO_STEP,
+            "flow_id": self.flow_id,
+            "handler": self.handler,
+            "step_id": step_id,
+            "description_placeholders": description_placeholders,
+        }
+
+    @callback
+    def async_info_step_done(self, *, next_step_id: str) -> Dict[str, Any]:
+        """Mark the info step done."""
+        return {
+            "type": RESULT_TYPE_INFO_STEP_DONE,
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": next_step_id,

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -176,7 +176,6 @@ class FlowManager(abc.ABC):
             if (
                 cur_step["step_id"] != result.get("step_id")
                 or result["type"] == RESULT_TYPE_SHOW_PROGRESS
-                and result["progress_action"] != cur_step["progress_action"]
             ):
                 # Tell frontend to reload the flow state.
                 self.hass.bus.async_fire(

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -173,7 +173,11 @@ class FlowManager(abc.ABC):
 
             # If the result has changed from last result, fire event to update
             # the frontend.
-            if cur_step["step_id"] != result.get("step_id"):
+            if (
+                cur_step["step_id"] != result.get("step_id")
+                or result["type"] == RESULT_TYPE_SHOW_PROGRESS
+                and result["progress_action"] != cur_step["progress_action"]
+            ):
                 # Tell frontend to reload the flow state.
                 self.hass.bus.async_fire(
                     EVENT_DATA_ENTRY_FLOW_PROGRESSED,

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -285,8 +285,8 @@ async def test_external_step(hass, manager):
     assert result["title"] == "Hello"
 
 
-async def test_info_step(hass, manager):
-    """Test info step logic."""
+async def test_show_progress(hass, manager):
+    """Test show progress logic."""
     manager.hass = hass
 
     @manager.mock_reg_handler("test")
@@ -296,12 +296,12 @@ async def test_info_step(hass, manager):
 
         async def async_step_init(self, user_input=None):
             if not user_input:
-                return self.async_info_step(
+                return self.async_show_progress(
                     step_id="init",
                 )
 
             self.data = user_input
-            return self.async_info_step_done(next_step_id="finish")
+            return self.async_show_progress_done(next_step_id="finish")
 
         async def async_step_finish(self, user_input=None):
             return self.async_create_entry(title=self.data["title"], data=self.data)
@@ -311,13 +311,13 @@ async def test_info_step(hass, manager):
     )
 
     result = await manager.async_init("test")
-    assert result["type"] == data_entry_flow.RESULT_TYPE_INFO_STEP
+    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
     assert len(manager.async_progress()) == 1
 
     # Mimic task finishing and continuing step
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
     result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_INFO_STEP_DONE
+    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS_DONE
 
     await hass.async_block_till_done()
     assert len(events) == 1

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -285,6 +285,54 @@ async def test_external_step(hass, manager):
     assert result["title"] == "Hello"
 
 
+async def test_info_step(hass, manager):
+    """Test info step logic."""
+    manager.hass = hass
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 5
+        data = None
+
+        async def async_step_init(self, user_input=None):
+            if not user_input:
+                return self.async_info_step(
+                    step_id="init",
+                )
+
+            self.data = user_input
+            return self.async_info_step_done(next_step_id="finish")
+
+        async def async_step_finish(self, user_input=None):
+            return self.async_create_entry(title=self.data["title"], data=self.data)
+
+    events = async_capture_events(
+        hass, data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESSED
+    )
+
+    result = await manager.async_init("test")
+    assert result["type"] == data_entry_flow.RESULT_TYPE_INFO_STEP
+    assert len(manager.async_progress()) == 1
+
+    # Mimic task finishing and continuing step
+    # Called by integrations: `hass.config_entries.flow.async_configure(…)`
+    result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_INFO_STEP_DONE
+
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data == {
+        "handler": "test",
+        "flow_id": result["flow_id"],
+        "refresh": True,
+    }
+
+    # Frontend refreshses the flow
+    result = await manager.async_configure(result["flow_id"])
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "Hello"
+
+
 async def test_abort_flow_exception(manager):
     """Test that the AbortFlow exception works."""
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -298,6 +298,7 @@ async def test_show_progress(hass, manager):
             if not user_input:
                 return self.async_show_progress(
                     step_id="init",
+                    progress_action="presenting",
                 )
 
             self.data = user_input

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -293,12 +293,18 @@ async def test_show_progress(hass, manager):
     class TestFlow(data_entry_flow.FlowHandler):
         VERSION = 5
         data = None
+        task_one_done = False
 
         async def async_step_init(self, user_input=None):
             if not user_input:
+                if not self.task_one_done:
+                    self.task_one_done = True
+                    progress_action = "task_one"
+                else:
+                    progress_action = "task_two"
                 return self.async_show_progress(
                     step_id="init",
-                    progress_action="presenting",
+                    progress_action=progress_action,
                 )
 
             self.data = user_input
@@ -313,12 +319,14 @@ async def test_show_progress(hass, manager):
 
     result = await manager.async_init("test")
     assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
+    assert result["progress_action"] == "task_one"
     assert len(manager.async_progress()) == 1
 
-    # Mimic task finishing and continuing step
+    # Mimic task one done and moving to task two
     # Called by integrations: `hass.config_entries.flow.async_configure(…)`
-    result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS_DONE
+    result = await manager.async_configure(result["flow_id"])
+    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS
+    assert result["progress_action"] == "task_two"
 
     await hass.async_block_till_done()
     assert len(events) == 1
@@ -328,7 +336,20 @@ async def test_show_progress(hass, manager):
         "refresh": True,
     }
 
-    # Frontend refreshses the flow
+    # Mimic task two done and continuing step
+    # Called by integrations: `hass.config_entries.flow.async_configure(…)`
+    result = await manager.async_configure(result["flow_id"], {"title": "Hello"})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_SHOW_PROGRESS_DONE
+
+    await hass.async_block_till_done()
+    assert len(events) == 2
+    assert events[1].data == {
+        "handler": "test",
+        "flow_id": result["flow_id"],
+        "refresh": True,
+    }
+
+    # Frontend refreshes the flow
     result = await manager.async_configure(result["flow_id"])
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "Hello"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add a helper step that should show progress to the user and finish when a task is done.
- This step is similar to the external step, but doesn't take a url as parameter.
- This step is useful when a task takes long time (minutes) and we want to inform the user about this.
- We'll use this step in the upcoming extension of the ozw config flow.

## TODO
- [x] Frontend PR: https://github.com/home-assistant/frontend/pull/7592


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/717

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
