### PR TITLE
Add plant limits attributes

### DIFF
--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -39,6 +39,7 @@ READING_BRIGHTNESS = "brightness"
 
 ATTR_PROBLEM = "problem"
 ATTR_SENSORS = "sensors"
+ATTR_LIMITS = "limits"
 PROBLEM_NONE = "none"
 ATTR_MAX_BRIGHTNESS_HISTORY = "max_brightness"
 
@@ -165,6 +166,7 @@ class Plant(Entity):
         self._config = config
         self._sensormap = {}
         self._readingmap = {}
+        self._limitsmap = {}
         self._unit_of_measurement = {}
         for reading, entity_id in config["sensors"].items():
             self._sensormap[entity_id] = reading
@@ -182,6 +184,12 @@ class Plant(Entity):
         if CONF_CHECK_DAYS in self._config:
             self._conf_check_days = self._config[CONF_CHECK_DAYS]
         self._brightness_history = DailyHistory(self._conf_check_days)
+
+        for reading in self.READINGS.values():
+            if "min" in reading and reading["min"] in self._config:
+                self._limitsmap[reading["min"]] = self._config[reading["min"]]
+            if "max" in reading and reading["max"] in self._config:
+                self._limitsmap[reading["max"]] = self._config[reading["max"]]
 
     @callback
     def _state_changed_event(self, event):
@@ -357,6 +365,7 @@ class Plant(Entity):
         attrib = {
             ATTR_PROBLEM: self._problems,
             ATTR_SENSORS: self._readingmap,
+            ATTR_LIMITS: self._limitsmap,
             ATTR_DICT_OF_UNITS_OF_MEASUREMENT: self._unit_of_measurement,
         }
 

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -186,10 +186,9 @@ class Plant(Entity):
         self._brightness_history = DailyHistory(self._conf_check_days)
 
         for reading in self.READINGS.values():
-            if "min" in reading and reading["min"] in self._config:
-                self._limitsmap[reading["min"]] = self._config[reading["min"]]
-            if "max" in reading and reading["max"] in self._config:
-                self._limitsmap[reading["max"]] = self._config[reading["max"]]
+            for item in ["min", "max"]:
+                if item in reading and reading[item] in self._config:
+                    self._limitsmap[reading[item]] = self._config[reading[item]]
 
     @callback
     def _state_changed_event(self, event):

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -30,6 +30,15 @@ GOOD_DATA = {
 BRIGHTNESS_ENTITY = "sensor.mqtt_plant_brightness"
 MOISTURE_ENTITY = "sensor.mqtt_plant_moisture"
 
+GOOD_LIMITS = {
+    "min_moisture": 20,
+    "max_moisture": 60,
+    "min_battery": 17,
+    "min_conductivity": 500,
+    "min_temperature": 15,
+    "min_brightness": 500,
+}
+
 GOOD_CONFIG = {
     "sensors": {
         "moisture": MOISTURE_ENTITY,
@@ -38,12 +47,7 @@ GOOD_CONFIG = {
         "conductivity": "sensor.mqtt_plant_conductivity",
         "brightness": BRIGHTNESS_ENTITY,
     },
-    "min_moisture": 20,
-    "max_moisture": 60,
-    "min_battery": 17,
-    "min_conductivity": 500,
-    "min_temperature": 15,
-    "min_brightness": 500,
+    **GOOD_LIMITS,
 }
 
 
@@ -59,9 +63,9 @@ async def test_valid_data(hass):
         )
     assert sensor.state == "ok"
     attrib = sensor.state_attributes
+    assert attrib["problem"] == "none"
+    assert attrib["limits"] == GOOD_LIMITS
     for reading, value in GOOD_DATA.items():
-        # battery level has a different name in
-        # the JSON format than in hass
         assert attrib[reading] == value
 
 


### PR DESCRIPTION
## Proposed change

The plant sensor groups different sensors that monitor the environment of a plant and track its well-being. By adding the underlying limits as attributes it is possible to retrace this assessment.

This would allow cards like [lovelace-flower-card](https://github.com/thomasloven/lovelace-flower-card) to be build with a plant component as input. My first idea was to get this information from the component configuration but i haven't found any way for accessing this from a custom card.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
