### PR TITLE
Add ozw config flow add-on management

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -145,7 +145,7 @@ async def async_install_addon(hass: HomeAssistantType, slug: str) -> dict:
     """
     hassio = hass.data[DOMAIN]
     command = f"/addons/{slug}/install"
-    return await hassio.send_command(command, timeout=300)
+    return await hassio.send_command(command, timeout=None)
 
 
 @bind_hass

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -145,7 +145,7 @@ async def async_install_addon(hass: HomeAssistantType, slug: str) -> dict:
     """
     hassio = hass.data[DOMAIN]
     command = f"/addons/{slug}/install"
-    return await hassio.send_command(command)
+    return await hassio.send_command(command, timeout=300)
 
 
 @bind_hass

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -169,7 +169,7 @@ async def async_start_addon(hass: HomeAssistantType, slug: str) -> dict:
     """
     hassio = hass.data[DOMAIN]
     command = f"/addons/{slug}/start"
-    return await hassio.send_command(command)
+    return await hassio.send_command(command, timeout=60)
 
 
 @bind_hass

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from . import const
 from .const import (
+    CONF_INTEGRATION_CREATED_ADDON,
     DATA_UNSUBSCRIBE,
     DOMAIN,
     MANAGER,
@@ -261,6 +262,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     for unsubscribe_listener in hass.data[DOMAIN][entry.entry_id][DATA_UNSUBSCRIBE]:
         unsubscribe_listener()
     hass.data[DOMAIN].pop(entry.entry_id)
+
+    if entry.data.get(CONF_INTEGRATION_CREATED_ADDON):
+        await hass.components.hassio.async_stop_addon(hass, "core_zwave")
+        await hass.components.hassio.async_uninstall_addon(hass, "core_zwave")
 
     return True
 

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -267,7 +267,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove a config entry."""
     if not entry.data.get(CONF_INTEGRATION_CREATED_ADDON):
         return

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -273,12 +273,12 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         return
 
     try:
-        await hass.components.hassio.async_stop_addon(hass, "core_zwave")
+        await hass.components.hassio.async_stop_addon("core_zwave")
     except HassioAPIError as err:
         _LOGGER.error("Failed to stop the OpenZWave add-on: %s", err)
         return
     try:
-        await hass.components.hassio.async_uninstall_addon(hass, "core_zwave")
+        await hass.components.hassio.async_uninstall_addon("core_zwave")
     except HassioAPIError as err:
         _LOGGER.error("Failed to uninstall the OpenZWave add-on: %s", err)
 

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -263,11 +263,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         unsubscribe_listener()
     hass.data[DOMAIN].pop(entry.entry_id)
 
+    return True
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Remove a config entry."""
     if entry.data.get(CONF_INTEGRATION_CREATED_ADDON):
         await hass.components.hassio.async_stop_addon(hass, "core_zwave")
         await hass.components.hassio.async_uninstall_addon(hass, "core_zwave")
-
-    return True
 
 
 async def async_handle_remove_node(hass: HomeAssistant, node: OZWNode):

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -1,8 +1,17 @@
 """Config flow for ozw integration."""
+import voluptuous as vol
+
 from homeassistant import config_entries
 
 from .const import DOMAIN  # pylint:disable=unused-import
 
+ON_SUPERVISOR_SCHEMA = vol.Schema(
+    {
+        vol.Required("connection"): vol.In(
+            {"addon": "Add-on", "mqtt_integration": "MQTT integration"}
+        )
+    }
+)
 TITLE = "OpenZWave"
 
 
@@ -16,7 +25,11 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
-        return await self.async_step_use_mqtt_integration()
+
+        if not self.hass.components.hassio.is_hassio():
+            return await self.async_step_use_mqtt_integration()
+
+        return await self.async_step_on_supervisor()
 
     async def async_step_use_mqtt_integration(self, user_input=None):
         """Handle logic when using the MQTT integration."""
@@ -26,3 +39,19 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=TITLE, data={})
 
         return self.async_show_form(step_id="use_mqtt_integration")
+
+    async def async_step_on_supervisor(self, user_input=None):
+        """Handle logic when on Supervisor host."""
+        if user_input is not None:
+            connection = user_input["connection"]
+            if connection == "addon":
+                return await self.async_step_use_addon()
+            return await self.async_step_use_mqtt_integration()
+
+        return self.async_show_form(
+            step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
+        )
+
+    async def async_step_use_addon(self, user_input=None):
+        """Handle logic when using the OpenZWave add-on."""
+        pass

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -16,9 +16,13 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
+        return await self.async_step_use_mqtt_integration()
+
+    async def async_step_use_mqtt_integration(self, user_input=None):
+        """Handle logic when using the MQTT integration."""
         if "mqtt" not in self.hass.config.components:
             return self.async_abort(reason="mqtt_required")
         if user_input is not None:
             return self.async_create_entry(title=TITLE, data={})
 
-        return self.async_show_form(step_id="user")
+        return self.async_show_form(step_id="use_mqtt_integration")

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -143,7 +143,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except HassioAPIError as err:
                 _LOGGER.error("Failed to get OpenZWave add-on info: %s", err)
-                return self.async_abort(reason="addon_info_failed")
+                raise AbortFlow("addon_info_failed") from err
 
         return self.addon_info
 

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -35,7 +35,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.addon_info = None
         self.network_key = None
         self.usb_path = None
-        # If we install the the add-on we should uninstall it on entry unload.
+        # If we install the add-on we should uninstall it on entry unload.
         self.integration_created_addon = False
 
     async def async_step_user(self, user_input=None):
@@ -170,5 +170,5 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "core_zwave", options
             )
         except HassioAPIError as err:
-            _LOGGER.error("Failed to get OpenZWave add-on info: %s", err)
+            _LOGGER.error("Failed to set OpenZWave add-on config: %s", err)
             raise AbortFlow("addon_set_config_failed") from err

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -103,7 +103,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.usb_path = self.addon_config.get(CONF_ADDON_DEVICE)
         self.network_key = self.addon_config.get(CONF_ADDON_NETWORK_KEY)
 
-        if self.usb_path is None or self.network_key is None:
+        if user_input is None and None in (self.usb_path, self.network_key):
             data_schema = vol.Schema({})
 
             if not self.usb_path:

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -21,7 +21,7 @@ ADDON_CONFIG_SCHEMA = vol.Schema(
     }
 )
 
-ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Required(CONF_USE_ADDON): bool})
+ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=False): bool})
 
 
 class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -2,17 +2,26 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.core import callback
 
 from .const import DOMAIN  # pylint:disable=unused-import
 
-ON_SUPERVISOR_SCHEMA = vol.Schema(
+CONF_ADDON_DEVICE = "device"
+CONF_ADDON_NETWORK_KEY = "network_key"
+CONF_INTEGRATION_CREATED_ADDON = "integration_created_addon"
+CONF_NETWORK_KEY = "network_key"
+CONF_USB_PATH = "usb_path"
+CONF_USE_ADDON = "use_addon"
+TITLE = "OpenZWave"
+
+ADDON_CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Required("connection"): vol.In(
-            {"addon": "Add-on", "mqtt_integration": "MQTT integration"}
-        )
+        vol.Required(CONF_USB_PATH): str,
+        vol.Optional(CONF_NETWORK_KEY, default=""): str,
     }
 )
-TITLE = "OpenZWave"
+
+ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Required(CONF_USE_ADDON): bool})
 
 
 class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -21,37 +30,133 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
+    def __init__(self):
+        """Set up flow instance."""
+        self.addon_info = None
+        self.network_key = None
+        self.usb_path = None
+        # If we install the the add-on we should uninstall it on entry unload.
+        self.integration_created_addon = False
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
         if not self.hass.components.hassio.is_hassio():
-            return await self.async_step_use_mqtt_integration()
+            return self._async_use_mqtt_integration()
 
         return await self.async_step_on_supervisor()
 
-    async def async_step_use_mqtt_integration(self, user_input=None):
+    @callback
+    def _async_use_mqtt_integration(self):
         """Handle logic when using the MQTT integration."""
         if "mqtt" not in self.hass.config.components:
             return self.async_abort(reason="mqtt_required")
-        if user_input is not None:
-            return self.async_create_entry(title=TITLE, data={})
 
-        return self.async_show_form(step_id="use_mqtt_integration")
+        return self.async_create_entry(
+            title=TITLE,
+            data={
+                CONF_USB_PATH: self.usb_path,
+                CONF_NETWORK_KEY: self.network_key,
+                CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
+            },
+        )
 
     async def async_step_on_supervisor(self, user_input=None):
         """Handle logic when on Supervisor host."""
         if user_input is not None:
-            connection = user_input["connection"]
-            if connection == "addon":
-                return await self.async_step_use_addon()
-            return await self.async_step_use_mqtt_integration()
+            if user_input[CONF_USE_ADDON]:
+                return await self._async_use_addon()
+            return self._async_use_mqtt_integration()
 
         return self.async_show_form(
             step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
         )
 
-    async def async_step_use_addon(self, user_input=None):
+    async def _async_use_addon(self):
         """Handle logic when using the OpenZWave add-on."""
-        pass
+        if await self._async_is_addon_running():
+            return self._async_use_mqtt_integration()
+
+        if await self._async_is_addon_installed():
+            return await self.async_step_start_addon()
+
+        return await self.async_step_install_addon()
+
+    async def async_step_install_addon(self, user_input=None):
+        """Ask user for add-on config and install add-on."""
+        if user_input is not None:
+            self.network_key = user_input[CONF_NETWORK_KEY]
+            self.usb_path = user_input[CONF_USB_PATH]
+
+            await self.hass.components.hassio.async_install_addon("core_zwave")
+            self.integration_created_addon = True
+
+            return await self.async_step_start_addon()
+
+        return self.async_show_form(
+            step_id="install_addon", data_schema=ADDON_CONFIG_SCHEMA
+        )
+
+    async def async_step_start_addon(self, user_input=None):
+        """Ask for missing config and start add-on."""
+        if self.usb_path is None or self.network_key is None:
+            addon_config = await self._async_get_addon_config()
+
+            self.usb_path = self.usb_path or addon_config.get(CONF_ADDON_DEVICE)
+            self.network_key = self.network_key or addon_config.get(
+                CONF_ADDON_NETWORK_KEY
+            )
+            data_schema = vol.Schema({})
+
+            if not self.usb_path:
+                data_schema = data_schema.extend({vol.Required(CONF_USB_PATH): str})
+            if not self.network_key:
+                data_schema = data_schema.extend(
+                    {vol.Optional(CONF_NETWORK_KEY, default=""): str}
+                )
+
+            return self.async_show_form(step_id="start_addon", data_schema=data_schema)
+
+        if user_input is not None:
+            self.network_key = self.network_key or user_input[CONF_NETWORK_KEY]
+            self.usb_path = self.usb_path or user_input[CONF_USB_PATH]
+
+        new_addon_config = {CONF_ADDON_DEVICE: self.usb_path}
+        if self.network_key:
+            new_addon_config[CONF_ADDON_NETWORK_KEY] = self.network_key
+
+        await self._async_set_addon_config(new_addon_config)
+        await self.hass.components.hassio.async_start_addon("core_zwave")
+
+        return self._async_use_mqtt_integration()
+
+    async def _async_get_addon_info(self):
+        """Return and cache add-on info."""
+        if self.addon_info is None:
+            self.addon_info = await self.hass.components.hassio.async_get_addon_info(
+                "core_zwave"
+            )
+
+        return self.addon_info
+
+    async def _async_is_addon_running(self):
+        """Return True if add-on is running."""
+        addon_info = await self._async_get_addon_info()
+        return addon_info["state"] == "started"
+
+    async def _async_is_addon_installed(self):
+        """Return True if add-on is installed."""
+        addon_info = await self._async_get_addon_info()
+        return addon_info["version"] is not None
+
+    async def _async_get_addon_config(self):
+        """Get add-on config."""
+        addon_info = await self._async_get_addon_info()
+        return addon_info["options"]
+
+    async def _async_set_addon_config(self, config):
+        """Set add-on config."""
+        options = {"options": config}
+        await self.hass.components.hassio.async_set_addon_options("core_zwave", options)

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -4,11 +4,11 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 
+from .const import CONF_INTEGRATION_CREATED_ADDON
 from .const import DOMAIN  # pylint:disable=unused-import
 
 CONF_ADDON_DEVICE = "device"
 CONF_ADDON_NETWORK_KEY = "network_key"
-CONF_INTEGRATION_CREATED_ADDON = "integration_created_addon"
 CONF_NETWORK_KEY = "network_key"
 CONF_USB_PATH = "usb_path"
 CONF_USE_ADDON = "use_addon"

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -31,7 +31,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Set up flow instance."""
         self.addon_config = None
-        self.addon_info = None
         self.network_key = None
         self.usb_path = None
         self.use_addon = False
@@ -138,16 +137,15 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_get_addon_info(self):
         """Return and cache add-on info."""
-        if self.addon_info is None:
-            try:
-                self.addon_info = (
-                    await self.hass.components.hassio.async_get_addon_info("core_zwave")
-                )
-            except self.hass.components.hassio.HassioAPIError as err:
-                _LOGGER.error("Failed to get OpenZWave add-on info: %s", err)
-                raise AbortFlow("addon_info_failed") from err
+        try:
+            addon_info = await self.hass.components.hassio.async_get_addon_info(
+                "core_zwave"
+            )
+        except self.hass.components.hassio.HassioAPIError as err:
+            _LOGGER.error("Failed to get OpenZWave add-on info: %s", err)
+            raise AbortFlow("addon_info_failed") from err
 
-        return self.addon_info
+        return addon_info
 
     async def _async_is_addon_running(self):
         """Return True if add-on is running."""

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -49,7 +49,11 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @callback
     def _async_use_mqtt_integration(self):
-        """Handle logic when using the MQTT integration."""
+        """Handle logic when using the MQTT integration.
+        
+        This is the entry point for the logic that is needed
+        when this integration will depend on the MQTT integration.
+        """
         if "mqtt" not in self.hass.config.components:
             return self.async_abort(reason="mqtt_required")
 

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -35,6 +35,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.addon_info = None
         self.network_key = None
         self.usb_path = None
+        self.use_addon = False
         # If we install the add-on we should uninstall it on entry remove.
         self.integration_created_addon = False
 
@@ -59,6 +60,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data={
                 CONF_USB_PATH: self.usb_path,
                 CONF_NETWORK_KEY: self.network_key,
+                CONF_USE_ADDON: self.use_addon,
                 CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
             },
         )
@@ -67,6 +69,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle logic when on Supervisor host."""
         if user_input is not None:
             if user_input[CONF_USE_ADDON]:
+                self.use_addon = True
                 return await self._async_use_addon()
             return self._async_use_mqtt_integration()
 

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -117,9 +117,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.hass.components.hassio.async_start_addon("core_zwave")
             except HassioAPIError as err:
                 _LOGGER.error("Failed to start OpenZWave add-on: %s", err)
-                return self.async_abort(reason="addon_start_failed")
-
-            return self._async_use_mqtt_integration()
+                errors["base"] = "addon_start_failed"
+            else:
+                return self._async_use_mqtt_integration()
 
         self.usb_path = self.addon_config.get(CONF_ADDON_DEVICE, "")
         self.network_key = self.addon_config.get(CONF_ADDON_NETWORK_KEY, "")

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -80,13 +80,11 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
             )
-        if user_input[CONF_USE_ADDON]:
-            self.use_addon = True
-            return await self._async_use_addon()
-        return self._async_get_entry()
+        if not user_input[CONF_USE_ADDON]:
+            return self._async_get_entry()
 
-    async def _async_use_addon(self):
-        """Handle logic when using the OpenZWave add-on."""
+        self.use_addon = True
+
         if await self._async_is_addon_running():
             return self._async_get_entry()
 
@@ -96,7 +94,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_install_addon()
 
     async def async_step_install_addon(self):
-        """Install add-on."""
+        """Install OpenZWave add-on."""
         try:
             await self.hass.components.hassio.async_install_addon("core_zwave")
         except self.hass.components.hassio.HassioAPIError as err:
@@ -107,7 +105,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_start_addon()
 
     async def async_step_start_addon(self, user_input=None):
-        """Ask for config and start add-on."""
+        """Ask for config and start OpenZWave add-on."""
         if self.addon_config is None:
             self.addon_config = await self._async_get_addon_config()
 
@@ -147,7 +145,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _async_get_addon_info(self):
-        """Return and cache add-on info."""
+        """Return and cache OpenZWave add-on info."""
         try:
             addon_info = await self.hass.components.hassio.async_get_addon_info(
                 "core_zwave"
@@ -159,22 +157,22 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return addon_info
 
     async def _async_is_addon_running(self):
-        """Return True if add-on is running."""
+        """Return True if OpenZWave add-on is running."""
         addon_info = await self._async_get_addon_info()
         return addon_info["state"] == "started"
 
     async def _async_is_addon_installed(self):
-        """Return True if add-on is installed."""
+        """Return True if OpenZWave add-on is installed."""
         addon_info = await self._async_get_addon_info()
         return addon_info["version"] is not None
 
     async def _async_get_addon_config(self):
-        """Get add-on config."""
+        """Get OpenZWave add-on config."""
         addon_info = await self._async_get_addon_info()
         return addon_info["options"]
 
     async def _async_set_addon_config(self, config):
-        """Set add-on config."""
+        """Set OpenZWave add-on config."""
         options = {"options": config}
         try:
             await self.hass.components.hassio.async_set_addon_options(

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -4,7 +4,6 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 
@@ -91,7 +90,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Install add-on."""
         try:
             await self.hass.components.hassio.async_install_addon("core_zwave")
-        except HassioAPIError as err:
+        except self.hass.components.hassio.HassioAPIError as err:
             _LOGGER.error("Failed to install OpenZWave add-on: %s", err)
             return self.async_abort(reason="addon_install_failed")
         self.integration_created_addon = True
@@ -118,7 +117,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 await self.hass.components.hassio.async_start_addon("core_zwave")
-            except HassioAPIError as err:
+            except self.hass.components.hassio.HassioAPIError as err:
                 _LOGGER.error("Failed to start OpenZWave add-on: %s", err)
                 errors["base"] = "addon_start_failed"
             else:
@@ -145,7 +144,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.addon_info = (
                     await self.hass.components.hassio.async_get_addon_info("core_zwave")
                 )
-            except HassioAPIError as err:
+            except self.hass.components.hassio.HassioAPIError as err:
                 _LOGGER.error("Failed to get OpenZWave add-on info: %s", err)
                 raise AbortFlow("addon_info_failed") from err
 
@@ -173,6 +172,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.components.hassio.async_set_addon_options(
                 "core_zwave", options
             )
-        except HassioAPIError as err:
+        except self.hass.components.hassio.HassioAPIError as err:
             _LOGGER.error("Failed to set OpenZWave add-on config: %s", err)
             raise AbortFlow("addon_set_config_failed") from err

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -53,7 +53,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_on_supervisor()
 
-    def _async_get_entry(self):
+    def _async_create_entry_from_vars(self):
         """Return a config entry for the flow."""
         return self.async_create_entry(
             title=TITLE,
@@ -72,7 +72,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         This is the entry point for the logic that is needed
         when this integration will depend on the MQTT integration.
         """
-        return self._async_get_entry()
+        return self._async_create_entry_from_vars()
 
     async def async_step_on_supervisor(self, user_input=None):
         """Handle logic when on Supervisor host."""
@@ -81,12 +81,12 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
             )
         if not user_input[CONF_USE_ADDON]:
-            return self._async_get_entry()
+            return self._async_create_entry_from_vars()
 
         self.use_addon = True
 
         if await self._async_is_addon_running():
-            return self._async_get_entry()
+            return self._async_create_entry_from_vars()
 
         if await self._async_is_addon_installed():
             return await self.async_step_start_addon()
@@ -128,7 +128,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.error("Failed to start OpenZWave add-on: %s", err)
                 errors["base"] = "addon_start_failed"
             else:
-                return self._async_get_entry()
+                return self._async_create_entry_from_vars()
 
         self.usb_path = self.addon_config.get(CONF_ADDON_DEVICE, "")
         self.network_key = self.addon_config.get(CONF_ADDON_NETWORK_KEY, "")

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -35,7 +35,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.addon_info = None
         self.network_key = None
         self.usb_path = None
-        # If we install the add-on we should uninstall it on entry unload.
+        # If we install the add-on we should uninstall it on entry remove.
         self.integration_created_addon = False
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -82,9 +82,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if await self._async_is_addon_installed():
             return await self.async_step_start_addon()
 
-        return await self._async_install_addon()
+        return await self.async_step_install_addon()
 
-    async def _async_install_addon(self):
+    async def async_step_install_addon(self):
         """Install add-on."""
         try:
             await self.hass.components.hassio.async_install_addon("core_zwave")

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -66,15 +66,14 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_on_supervisor(self, user_input=None):
         """Handle logic when on Supervisor host."""
-        if user_input is not None:
-            if user_input[CONF_USE_ADDON]:
-                self.use_addon = True
-                return await self._async_use_addon()
-            return self._async_use_mqtt_integration()
-
-        return self.async_show_form(
-            step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
-        )
+        if user_input is None:
+            return self.async_show_form(
+                step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
+            )
+        if user_input[CONF_USE_ADDON]:
+            self.use_addon = True
+            return await self._async_use_addon()
+        return self._async_use_mqtt_integration()
 
     async def _async_use_addon(self):
         """Handle logic when using the OpenZWave add-on."""

--- a/homeassistant/components/ozw/const.py
+++ b/homeassistant/components/ozw/const.py
@@ -10,6 +10,9 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
 DOMAIN = "ozw"
 DATA_UNSUBSCRIBE = "unsubscribe"
+
+CONF_INTEGRATION_CREATED_ADDON = "integration_created_addon"
+
 PLATFORMS = [
     BINARY_SENSOR_DOMAIN,
     COVER_DOMAIN,

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -12,6 +12,10 @@
       }
     },
     "abort": {
+      "addon_info_failed": "Failed to get OpenZWave add-on info.",
+      "addon_install_failed": "Failed to install the OpenZWave add-on.",
+      "addon_set_config_failed": "Failed to set OpenZWave config.",
+      "addon_start_failed": "Failed to start the OpenZWave add-on.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "mqtt_required": "The MQTT integration is not set up"
     }

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -3,8 +3,8 @@
     "step": {
       "on_supervisor": {
         "title": "Select connection method",
-        "description": "Select how to connect to the OpenZWave controller MQTT broker",
-        "data": {"use_addon": "Do you want to use the OpenZWave Supervisor add-on?"}
+        "description": "Do you want to use the OpenZWave Supervisor add-on?",
+        "data": {"use_addon": "Use the OpenZWave Supervisor add-on"}
       },
       "start_addon": {
         "title": "Enter the OpenZWave add-on config",

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -6,10 +6,6 @@
         "description": "Select how to connect to the OpenZWave controller MQTT broker",
         "data": {"use_addon": "Do you want to use the OpenZWave Supervisor add-on?"}
       },
-      "install_addon": {
-        "title": "Enter the OpenZWave add-on config",
-        "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}
-      },
       "start_addon": {
         "title": "Enter the OpenZWave add-on config",
         "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "user": {
+      "use_mqtt_integration": {
         "title": "Confirm set up"
       }
     },

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -1,13 +1,18 @@
 {
   "config": {
     "step": {
-      "use_mqtt_integration": {
-        "title": "Confirm set up"
-      },
       "on_supervisor": {
         "title": "Select connection method",
         "description": "Select how to connect to the OpenZWave controller MQTT broker",
-        "data": {"connection": "Connection method"}
+        "data": {"use_addon": "Do you want to use the OpenZWave Supervisor add-on?"}
+      },
+      "install_addon": {
+        "title": "Enter the OpenZWave add-on config",
+        "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}
+      },
+      "start_addon": {
+        "title": "Enter the OpenZWave add-on config",
+        "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}
       }
     },
     "abort": {

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -3,6 +3,11 @@
     "step": {
       "use_mqtt_integration": {
         "title": "Confirm set up"
+      },
+      "on_supervisor": {
+        "title": "Select connection method",
+        "description": "Select how to connect to the OpenZWave controller MQTT broker",
+        "data": {"connection": "Connection method"}
       }
     },
     "abort": {

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -7,17 +7,19 @@
         "data": {"use_addon": "Use the OpenZWave Supervisor add-on"}
       },
       "start_addon": {
-        "title": "Enter the OpenZWave add-on config",
+        "title": "Enter the OpenZWave add-on configuration",
         "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}
       }
     },
     "abort": {
       "addon_info_failed": "Failed to get OpenZWave add-on info.",
       "addon_install_failed": "Failed to install the OpenZWave add-on.",
-      "addon_set_config_failed": "Failed to set OpenZWave config.",
-      "addon_start_failed": "Failed to start the OpenZWave add-on.",
+      "addon_set_config_failed": "Failed to set OpenZWave configuration.",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "mqtt_required": "The MQTT integration is not set up"
+    },
+    "error": {
+      "addon_start_failed": "Failed to start the OpenZWave add-on. Check the configuration."
     }
   }
 }

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -1,6 +1,10 @@
 {
     "config": {
         "abort": {
+            "addon_info_failed": "Failed to get OpenZWave add-on info.",
+            "addon_install_failed": "Failed to install the OpenZWave add-on.",
+            "addon_set_config_failed": "Failed to set OpenZWave config.",
+            "addon_start_failed": "Failed to start the OpenZWave add-on.",
             "mqtt_required": "The MQTT integration is not set up",
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         },

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -2,12 +2,29 @@
     "config": {
         "abort": {
             "mqtt_required": "The MQTT integration is not set up",
-            "one_instance_allowed": "The integration only supports one Z-Wave instance",
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         },
         "step": {
-            "user": {
-                "title": "Confirm set up"
+            "install_addon": {
+                "data": {
+                    "network_key": "Network Key",
+                    "usb_path": "USB Device Path"
+                },
+                "title": "Enter the OpenZWave add-on config"
+            },
+            "on_supervisor": {
+                "data": {
+                    "use_addon": "Do you want to use the OpenZWave Supervisor add-on?"
+                },
+                "description": "Select how to connect to the OpenZWave controller MQTT broker",
+                "title": "Select connection method"
+            },
+            "start_addon": {
+                "data": {
+                    "network_key": "Network Key",
+                    "usb_path": "USB Device Path"
+                },
+                "title": "Enter the OpenZWave add-on config"
             }
         }
     }

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -5,13 +5,6 @@
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         },
         "step": {
-            "install_addon": {
-                "data": {
-                    "network_key": "Network Key",
-                    "usb_path": "USB Device Path"
-                },
-                "title": "Enter the OpenZWave add-on config"
-            },
             "on_supervisor": {
                 "data": {
                     "use_addon": "Do you want to use the OpenZWave Supervisor add-on?"

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -3,10 +3,12 @@
         "abort": {
             "addon_info_failed": "Failed to get OpenZWave add-on info.",
             "addon_install_failed": "Failed to install the OpenZWave add-on.",
-            "addon_set_config_failed": "Failed to set OpenZWave config.",
-            "addon_start_failed": "Failed to start the OpenZWave add-on.",
+            "addon_set_config_failed": "Failed to set OpenZWave configuration.",
             "mqtt_required": "The MQTT integration is not set up",
             "single_instance_allowed": "Already configured. Only a single configuration possible."
+        },
+        "error": {
+            "addon_start_failed": "Failed to start the OpenZWave add-on. Check the configuration."
         },
         "step": {
             "on_supervisor": {
@@ -21,7 +23,7 @@
                     "network_key": "Network Key",
                     "usb_path": "USB Device Path"
                 },
-                "title": "Enter the OpenZWave add-on config"
+                "title": "Enter the OpenZWave add-on configuration"
             }
         }
     }

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -11,9 +11,9 @@
         "step": {
             "on_supervisor": {
                 "data": {
-                    "use_addon": "Do you want to use the OpenZWave Supervisor add-on?"
+                    "use_addon": "Use the OpenZWave Supervisor add-on"
                 },
-                "description": "Select how to connect to the OpenZWave controller MQTT broker",
+                "description": "Do you want to use the OpenZWave Supervisor add-on?",
                 "title": "Select connection method"
             },
             "start_addon": {

--- a/tests/components/ozw/conftest.py
+++ b/tests/components/ozw/conftest.py
@@ -237,3 +237,19 @@ async def lock_msg_fixture(hass):
     message = MQTTMessage(topic=lock_json["topic"], payload=lock_json["payload"])
     message.encode()
     return message
+
+
+@pytest.fixture(name="stop_addon")
+def mock_install_addon():
+    """Mock stop add-on."""
+    with patch("homeassistant.components.hassio.async_stop_addon") as stop_addon:
+        yield stop_addon
+
+
+@pytest.fixture(name="uninstall_addon")
+def mock_uninstall_addon():
+    """Mock uninstall add-on."""
+    with patch(
+        "homeassistant.components.hassio.async_uninstall_addon"
+    ) as uninstall_addon:
+        yield uninstall_addon

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -185,6 +185,7 @@ async def test_addon_running(hass, supervisor, addon_running):
 
 async def test_addon_info_failure(hass, supervisor, addon_info):
     """Test add-on info failure."""
+    hass.config.components.add("mqtt")
     addon_info.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -241,6 +242,7 @@ async def test_set_addon_config_failure(
     hass, supervisor, addon_installed, addon_options, set_addon_options
 ):
     """Test add-on set config failure."""
+    hass.config.components.add("mqtt")
     set_addon_options.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -263,6 +265,7 @@ async def test_start_addon_failure(
     hass, supervisor, addon_installed, addon_options, set_addon_options, start_addon
 ):
     """Test add-on start failure."""
+    hass.config.components.add("mqtt")
     start_addon.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -291,8 +294,8 @@ async def test_addon_not_installed(
     start_addon,
 ):
     """Test add-on not installed."""
-    addon_installed.return_value["version"] = None
     hass.config.components.add("mqtt")
+    addon_installed.return_value["version"] = None
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
@@ -327,6 +330,7 @@ async def test_addon_not_installed(
 
 async def test_install_addon_failure(hass, supervisor, addon_installed, install_addon):
     """Test add-on install failure."""
+    hass.config.components.add("mqtt")
     addon_installed.return_value["version"] = None
     install_addon.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -8,14 +8,9 @@ from tests.common import MockConfigEntry
 
 
 async def test_user_create_entry(hass):
-    """Test the user step creates an entry."""
+    """Test the user step creates an entry not on Supervisor."""
     hass.config.components.add("mqtt")
     await setup.async_setup_component(hass, "persistent_notification", {})
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == "form"
-    assert result["errors"] is None
 
     with patch(
         "homeassistant.components.ozw.async_setup", return_value=True
@@ -23,12 +18,18 @@ async def test_user_create_entry(hass):
         "homeassistant.components.ozw.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
         await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == TITLE
-    assert result2["data"] == {}
+    assert result["type"] == "create_entry"
+    assert result["title"] == TITLE
+    assert result["data"] == {
+        "usb_path": None,
+        "network_key": None,
+        "integration_created_addon": False,
+    }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -7,7 +7,7 @@ from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
 
-async def test_user_create_entry(hass):
+async def test_user_not_supervisor_create_entry(hass):
     """Test the user step creates an entry not on Supervisor."""
     hass.config.components.add("mqtt")
     await setup.async_setup_component(hass, "persistent_notification", {})

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -97,6 +97,7 @@ async def test_not_addon(hass, supervisor):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"use_addon": False}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE
@@ -105,7 +106,6 @@ async def test_not_addon(hass, supervisor):
         "network_key": None,
         "integration_created_addon": False,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -128,6 +128,7 @@ async def test_addon_running(hass, supervisor, addon_running):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"use_addon": True}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE
@@ -136,7 +137,6 @@ async def test_addon_running(hass, supervisor, addon_running):
         "network_key": None,
         "integration_created_addon": False,
     }
-    await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -91,6 +91,7 @@ async def test_user_not_supervisor_create_entry(hass):
     assert result["data"] == {
         "usb_path": None,
         "network_key": None,
+        "use_addon": False,
         "integration_created_addon": False,
     }
     assert len(mock_setup.mock_calls) == 1
@@ -143,6 +144,7 @@ async def test_not_addon(hass, supervisor):
     assert result["data"] == {
         "usb_path": None,
         "network_key": None,
+        "use_addon": False,
         "integration_created_addon": False,
     }
     assert len(mock_setup.mock_calls) == 1
@@ -174,6 +176,7 @@ async def test_addon_running(hass, supervisor, addon_running):
     assert result["data"] == {
         "usb_path": None,
         "network_key": None,
+        "use_addon": True,
         "integration_created_addon": False,
     }
     assert len(mock_setup.mock_calls) == 1
@@ -227,6 +230,7 @@ async def test_addon_installed(
     assert result["data"] == {
         "usb_path": "/test",
         "network_key": "abc123",
+        "use_addon": True,
         "integration_created_addon": False,
     }
     assert len(mock_setup.mock_calls) == 1
@@ -314,6 +318,7 @@ async def test_addon_not_installed(
     assert result["data"] == {
         "usb_path": "/test",
         "network_key": "abc123",
+        "use_addon": True,
         "integration_created_addon": True,
     }
     assert len(mock_setup.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Extend the ozw config flow with options to use the OpenZWave add-on.
- If the user selects to use the add-on we'll install or start the add-on if not already installed or started. Also allow the user to configure the add-on in that case.
- We plan to add a direct connection with an MQTT client not provided by the MQTT integration later. When that is added the user will no longer need to set up the MQTT integration when using the OpenZWave add-on. This will be done in a follow up PR.
- We're also aiming at hiding the option to (not) use the add-on if the user is running Supervisor and is not in advanced mode. This will be done in a follow up PR.

## TODO:
- [ ] ~~Inform the user that the installation of the add-on can take a long time.~~ This will be done in a follow up PR.
- [x] Tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
