### PR TITLE
Restore somfy state in optimistic mode on restart

### DIFF
--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -171,6 +171,11 @@ class SomfyEntity(Entity):
         capabilities = self.device.capabilities
         return bool([c for c in capabilities if c.name == capability])
 
+    @property
+    def assumed_state(self):
+        """Return if the device has an assumed state."""
+        return not bool(self.device.states)
+
 
 @Throttle(SCAN_INTERVAL)
 async def update_all_devices(hass):

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -64,6 +64,7 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
     def close_cover(self, **kwargs):
         """Close the cover."""
         self._is_closing = True
+        self.schedule_update_ha_state()
         try:
             # Blocks until the close command is sent
             self.cover.close()
@@ -72,10 +73,12 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
             raise
         finally:
             self._is_closing = None
+            self.schedule_update_ha_state()
 
     def open_cover(self, **kwargs):
         """Open the cover."""
         self._is_opening = True
+        self.schedule_update_ha_state()
         try:
             # Blocks until the open command is sent
             self.cover.open()
@@ -84,6 +87,7 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
             raise
         finally:
             self._is_opening = None
+            self.schedule_update_ha_state()
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -2,7 +2,6 @@
 
 from pymfy.api.devices.blind import Blind
 from pymfy.api.devices.category import Category
-import requests
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -69,8 +68,6 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
             # Blocks until the close command is sent
             self.cover.close()
             self._closed = True
-        except requests.exceptions.HTTPError:
-            raise
         finally:
             self._is_closing = None
             self.schedule_update_ha_state()
@@ -83,8 +80,6 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
             # Blocks until the open command is sent
             self.cover.open()
             self._closed = False
-        except requests.exceptions.HTTPError:
-            raise
         finally:
             self._is_opening = None
             self.schedule_update_ha_state()

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -16,9 +16,9 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import API, CONF_OPTIMISTIC, DEVICES, DOMAIN, SomfyEntity
 
-BLIND_DEVICE_CATAGORIES = {Category.INTERIOR_BLIND.value, Category.EXTERIOR_BLIND.value}
-SHUTTER_DEVICE_CATAGORIES = {Category.EXTERIOR_BLIND.value}
-SUPPORTED_CATAGORIES = {
+BLIND_DEVICE_CATEGORIES = {Category.INTERIOR_BLIND.value, Category.EXTERIOR_BLIND.value}
+SHUTTER_DEVICE_CATEGORIES = {Category.EXTERIOR_BLIND.value}
+SUPPORTED_CATEGORIES = {
     Category.ROLLER_SHUTTER.value,
     Category.INTERIOR_BLIND.value,
     Category.EXTERIOR_BLIND.value,
@@ -37,7 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 cover, hass.data[DOMAIN][API], hass.data[DOMAIN][CONF_OPTIMISTIC]
             )
             for cover in devices
-            if SUPPORTED_CATAGORIES & set(cover.categories)
+            if SUPPORTED_CATEGORIES & set(cover.categories)
         ]
 
     async_add_entities(await hass.async_add_executor_job(get_covers))
@@ -100,9 +100,9 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
     @property
     def device_class(self):
         """Return the device class."""
-        if self.categories & BLIND_DEVICE_CATAGORIES:
+        if self.categories & BLIND_DEVICE_CATEGORIES:
             return DEVICE_CLASS_BLIND
-        if self.categories & SHUTTER_DEVICE_CATAGORIES:
+        if self.categories & SHUTTER_DEVICE_CATEGORIES:
             return DEVICE_CLASS_SHUTTER
         return None
 

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -139,13 +139,6 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         return is_closed
 
     @property
-    def assumed_state(self):
-        """Return if the cover has an assumed state."""
-        if not self.optimistic:
-            return None
-        return not bool(self.device.states)
-
-    @property
     def current_cover_tilt_position(self):
         """Return current position of cover tilt.
 

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -71,7 +71,7 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         except requests.exceptions.HTTPError:
             raise
         finally:
-            self._is_closing = False
+            self._is_closing = None
 
     def open_cover(self, **kwargs):
         """Open the cover."""
@@ -83,7 +83,7 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         except requests.exceptions.HTTPError:
             raise
         finally:
-            self._is_opening = False
+            self._is_opening = None
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -133,6 +133,17 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         elif self.optimistic:
             is_closed = self._closed
         return is_closed
+
+    @property
+    def assumed_state(self):
+        """Return if the cover has an assumed state."""
+        if not self.optimistic:
+            return None
+        return (
+            self._is_closing is not None
+            or self._is_opening is not None
+            or self._closed is not None
+        )
 
     @property
     def current_cover_tilt_position(self):

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -143,11 +143,7 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         """Return if the cover has an assumed state."""
         if not self.optimistic:
             return None
-        return (
-            self._is_closing is not None
-            or self._is_opening is not None
-            or self._closed is not None
-        )
+        return bool(self.device.states)
 
     @property
     def current_cover_tilt_position(self):

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -143,7 +143,7 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         """Return if the cover has an assumed state."""
         if not self.optimistic:
             return None
-        return bool(self.device.states)
+        return not bool(self.device.states)
 
     @property
     def current_cover_tilt_position(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Restore somfy state in optimistic mode on restart so shades don't get out
of sync on restart.

Device class was missing which meant all the blinds seemed like windows in the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
