### PR TITLE
Add guppy3 memory profile to Profiler integration

### DIFF
--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -69,7 +69,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
     start_time = int(time.time() * 1000000)
     hass.components.persistent_notification.async_create(
-        "The profile started. This notification will be updated when it is complete.",
+        "The profile has started. This notification will be updated when it is complete.",
         title="Profile Started",
         notification_id=f"profiler_{start_time}",
     )
@@ -93,7 +93,7 @@ async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
 async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall):
     start_time = int(time.time() * 1000000)
     hass.components.persistent_notification.async_create(
-        "The memory profile started. This notification will be updated when it is complete.",
+        "The memory profile has started. This notification will be updated when it is complete.",
         title="Profile Started",
         notification_id=f"memory_profiler_{start_time}",
     )
@@ -118,4 +118,4 @@ def _write_profile(profiler, cprofile_path, callgrind_path):
 
 
 def _write_memory_profile(heap, heap_path):
-    heap.dump(heap_path)
+    heap.byrcs.dump(heap_path)

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -73,7 +73,7 @@ async def _async_generate_profile(hass: HomeAssistant, call: ServiceCall):
         _write_profile, profiler, cprofile_path, callgrind_path, heap, heap_path
     )
     hass.components.persistent_notification.async_create(
-        f"Wrote cProfile data to {cprofile_path} and callgrind data to {callgrind_path}",
+        f"Wrote cProfile data to {cprofile_path}, callgrind data to {callgrind_path}, and heapy memory profile to {heap_path}",
         title="Profile Complete",
         notification_id=f"profiler_{start_time}",
     )

--- a/homeassistant/components/profiler/manifest.json
+++ b/homeassistant/components/profiler/manifest.json
@@ -2,12 +2,8 @@
   "domain": "profiler",
   "name": "Profiler",
   "documentation": "https://www.home-assistant.io/integrations/profiler",
-  "requirements": [
-    "pyprof2calltree==1.4.5"
-  ],
-  "codeowners": [
-    "@bdraco"
-  ],
+  "requirements": ["pyprof2calltree==1.4.5", "guppy3==3.1.0"],
+  "codeowners": ["@bdraco"],
   "quality_scale": "internal",
   "config_flow": true
 }

--- a/homeassistant/components/profiler/services.yaml
+++ b/homeassistant/components/profiler/services.yaml
@@ -4,3 +4,9 @@ start:
     seconds:
       description: The number of seconds to run the profiler.
       example: 60.0
+memory:
+  description: Start the Memory Profiler
+  fields:
+    seconds:
+      description: The number of seconds to run the memory profiler.
+      example: 60.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -713,6 +713,9 @@ growattServer==0.1.1
 # homeassistant.components.gstreamer
 gstreamer-player==1.1.2
 
+# homeassistant.components.profiler
+guppy3==3.1.0
+
 # homeassistant.components.ffmpeg
 ha-ffmpeg==2.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -357,6 +357,9 @@ greeclimate==0.9.0
 # homeassistant.components.griddy
 griddypower==0.1.0
 
+# homeassistant.components.profiler
+guppy3==3.1.0
+
 # homeassistant.components.ffmpeg
 ha-ffmpeg==2.0
 

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -2,7 +2,11 @@
 import os
 
 from homeassistant import setup
-from homeassistant.components.profiler import CONF_SECONDS, SERVICE_START
+from homeassistant.components.profiler import (
+    CONF_SECONDS,
+    SERVICE_MEMORY,
+    SERVICE_START,
+)
 from homeassistant.components.profiler.const import DOMAIN
 
 from tests.async_mock import patch
@@ -36,6 +40,38 @@ async def test_basic_usage(hass, tmpdir):
         await hass.async_block_till_done()
 
     assert os.path.exists(last_filename)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_memory_usage(hass, tmpdir):
+    """Test we can setup and the service is registered."""
+    test_dir = tmpdir.mkdir("profiles")
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.services.has_service(DOMAIN, SERVICE_MEMORY)
+
+    last_filename = None
+
+    def _mock_path(filename):
+        nonlocal last_filename
+        last_filename = f"{test_dir}/{filename}"
+        return last_filename
+
+    with patch("homeassistant.components.profiler.hpy") as mock_hpy, patch.object(
+        hass.config, "path", _mock_path
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_MEMORY, {CONF_SECONDS: 0.000001})
+        await hass.async_block_till_done()
+
+        mock_hpy.assert_called_once()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add guppy to the Profiler integration in order to also measure heap memory usage. Resulting file can be opened via the [Heapy Profile Browser](http://guppy-pe.sourceforge.net/ProfileBrowser.html).

```python
#! /usr/bin/python3
from guppy import hpy
# Open profile browser (requires tkinter)
hpy().pb()
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: #42390
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15441

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
