### PR TITLE
WIP: Add sensor entity for the shopping list integration

### DIFF
--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -128,6 +128,10 @@ async def async_setup_entry(hass, config_entry):
         SCHEMA_WEBSOCKET_CLEAR_ITEMS,
     )
 
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
+    )
+
     return True
 
 
@@ -175,6 +179,7 @@ class ShoppingData:
     def save(self):
         """Save the items."""
         save_json(self.hass.config.path(PERSISTENCE), self.items)
+        self.hass.bus.async_fire(EVENT)
 
 
 class ShoppingListView(http.HomeAssistantView):

--- a/homeassistant/components/shopping_list/sensor.py
+++ b/homeassistant/components/shopping_list/sensor.py
@@ -1,0 +1,63 @@
+"""Sensor reporting on the shopping list items."""
+import logging
+
+from homeassistant.helpers.entity import Entity
+
+from . import EVENT
+from .const import DOMAIN
+
+ATTR_ITEMS = "items"
+NAME_SENSOR = "Shopping List"
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the shopping list sensor."""
+    await async_add_entities([ShoppingListEntity(hass)], True)
+
+
+class ShoppingListEntity(Entity):
+    """Representation of the shopping list sensor."""
+
+    def __init__(self, hass):
+        """Initialize the sensor."""
+        self._hass = hass
+        self._items = []
+
+        hass.bus.async_listen(EVENT, self._update)
+
+    def _update(self, _):
+        """Update the state on the `shopping_list_updated` signal."""
+        self.async_schedule_update_ha_state(True)
+
+    @property
+    def should_poll(self) -> bool:
+        """We update only based on change events."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return NAME_SENSOR
+
+    @property
+    def state(self):
+        """Return number of items in the shopping list."""
+        return len(self._items)
+
+    @property
+    def icon(self):
+        """Return the frontend icon for the shopping list."""
+        return "mdi:cart"
+
+    async def async_update(self):
+        """Update the items."""
+        self._items = self._hass.data[DOMAIN].items
+
+    @property
+    def device_state_attributes(self):
+        """Entries in shopping list."""
+        items_attr = ",".join([x["name"] for x in self._items])
+        return {"items": items_attr}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows automations to access the content of the shopping list. The state contains the number of items in the list, the data is reported as a comma-delimited strings under 'items' key. The sensor itself is non-polling and listens on the events to update itself. 

Before I proceed to update the documentation, it would be great to get some input on the design choices, including:
* Is a comma-delimited string of items the wanted format?
* Is there a better way to handle informing the sensor? Currently, website actions will cause a double-eventing (as `save()` emits the signal on all changes), which could be handled better.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
