### PR TITLE
Add device info default values to Panasonic Viera

### DIFF
--- a/homeassistant/components/panasonic_viera/__init__.py
+++ b/homeassistant/components/panasonic_viera/__init__.py
@@ -245,7 +245,9 @@ class Remote:
         """Return device info."""
         if self._control is None:
             return None
-        return await self._handle_errors(self._control.get_device_info)
+        device_info = await self._handle_errors(self._control.get_device_info)
+        _LOGGER.debug("Fetched device info: %s", str(device_info))
+        return device_info
 
     async def _handle_errors(self, func, *args):
         """Handle errors from func, set available and reconnect if needed."""

--- a/homeassistant/components/panasonic_viera/const.py
+++ b/homeassistant/components/panasonic_viera/const.py
@@ -18,4 +18,7 @@ ATTR_MANUFACTURER = "manufacturer"
 ATTR_MODEL_NUMBER = "modelNumber"
 ATTR_UDN = "UDN"
 
+DEFAULT_MANUFACTURER = "Panasonic"
+DEFAULT_MODEL_NUMBER = "Panasonic Viera"
+
 ERROR_INVALID_PIN_CODE = "invalid_pin_code"

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -26,6 +26,8 @@ from .const import (
     ATTR_MODEL_NUMBER,
     ATTR_REMOTE,
     ATTR_UDN,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
     DOMAIN,
 )
 
@@ -69,11 +71,11 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
         self._device_info = device_info
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self):
         """Return the unique ID of the device."""
-        if self._device_info is not None:
-            return self._device_info[ATTR_UDN]
-        return None
+        if self._device_info is None:
+            return None
+        return self._device_info[ATTR_UDN]
 
     @property
     def device_info(self):
@@ -83,8 +85,10 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
         return {
             "name": self._name,
             "identifiers": {(DOMAIN, self._device_info[ATTR_UDN])},
-            "manufacturer": self._device_info[ATTR_MANUFACTURER],
-            "model": self._device_info[ATTR_MODEL_NUMBER],
+            "manufacturer": self._device_info.get(
+                ATTR_MANUFACTURER, DEFAULT_MANUFACTURER
+            ),
+            "model": self._device_info.get(ATTR_MODEL_NUMBER, DEFAULT_MODEL_NUMBER),
         }
 
     @property

--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -12,6 +12,8 @@ from homeassistant.components.panasonic_viera.const import (
     CONF_APP_ID,
     CONF_ENCRYPTION_KEY,
     CONF_ON_ACTION,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DOMAIN,
@@ -37,13 +39,14 @@ def panasonic_viera_setup_fixture():
 
 def get_mock_remote(
     host="1.2.3.4",
+    request_error=None,
     authorize_error=None,
     encrypted=False,
     app_id=None,
     encryption_key=None,
     name=DEFAULT_NAME,
-    manufacturer="mock-manufacturer",
-    model_number="mock-model-number",
+    manufacturer=DEFAULT_MANUFACTURER,
+    model_number=DEFAULT_MODEL_NUMBER,
     unique_id="mock-unique-id",
 ):
     """Return a mock remote."""
@@ -54,7 +57,8 @@ def get_mock_remote(
     mock_remote.enc_key = encryption_key
 
     def request_pin_code(name=None):
-        return
+        if request_error is not None:
+            raise request_error
 
     mock_remote.request_pin_code = request_pin_code
 
@@ -110,8 +114,8 @@ async def test_flow_non_encrypted(hass):
         CONF_ON_ACTION: None,
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }
@@ -154,6 +158,56 @@ async def test_flow_unknown_abort(hass):
     with patch(
         "homeassistant.components.panasonic_viera.config_flow.RemoteControl",
         side_effect=Exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_NAME: DEFAULT_NAME},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "unknown"
+
+
+async def test_flow_encrypted_not_connected_pin_code_request(hass):
+    """Test flow with encryption and PIN code request connection error abortion during pairing request step."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    mock_remote = get_mock_remote(encrypted=True, request_error=TimeoutError)
+
+    with patch(
+        "homeassistant.components.panasonic_viera.config_flow.RemoteControl",
+        return_value=mock_remote,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_NAME: DEFAULT_NAME},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_flow_encrypted_unknown_pin_code_request(hass):
+    """Test flow with encryption and PIN code request unknown error abortion during pairing request step."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    mock_remote = get_mock_remote(encrypted=True, request_error=Exception)
+
+    with patch(
+        "homeassistant.components.panasonic_viera.config_flow.RemoteControl",
+        return_value=mock_remote,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -208,8 +262,8 @@ async def test_flow_encrypted_valid_pin_code(hass):
         CONF_ENCRYPTION_KEY: "test-encryption-key",
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }
@@ -392,8 +446,8 @@ async def test_imported_flow_non_encrypted(hass):
         CONF_ON_ACTION: "test-on-action",
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }
@@ -442,8 +496,8 @@ async def test_imported_flow_encrypted_valid_pin_code(hass):
         CONF_ENCRYPTION_KEY: "test-encryption-key",
         ATTR_DEVICE_INFO: {
             ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-            ATTR_MANUFACTURER: "mock-manufacturer",
-            ATTR_MODEL_NUMBER: "mock-model-number",
+            ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+            ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
             ATTR_UDN: "mock-unique-id",
         },
     }

--- a/tests/components/panasonic_viera/test_init.py
+++ b/tests/components/panasonic_viera/test_init.py
@@ -8,6 +8,8 @@ from homeassistant.components.panasonic_viera.const import (
     CONF_APP_ID,
     CONF_ENCRYPTION_KEY,
     CONF_ON_ACTION,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DOMAIN,
@@ -33,8 +35,8 @@ MOCK_ENCRYPTION_DATA = {
 
 MOCK_DEVICE_INFO = {
     ATTR_FRIENDLY_NAME: DEFAULT_NAME,
-    ATTR_MANUFACTURER: "mock-manufacturer",
-    ATTR_MODEL_NUMBER: "mock-model-number",
+    ATTR_MANUFACTURER: DEFAULT_MANUFACTURER,
+    ATTR_MODEL_NUMBER: DEFAULT_MODEL_NUMBER,
     ATTR_UDN: "mock-unique-id",
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request derives from #42275, and it includes the addition of default values for the Panasonic Viera media player device info, as well as two extra missing tests for the config flow (also that file is getting wayyyy too big! would there be a way of creating like... test template functions?)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42205
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
