### PR TITLE
Move async_add_entities back to event loop for tplink component

### DIFF
--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -140,18 +140,18 @@ def add_available_devices(hass, device_type, device_class):
         devices = hass.data[TPLINK_DOMAIN][f"{device_type}_remaining"]
 
     entities_ready = []
-    entities_unavailable = []
+    devices_unavailable = []
     for device in devices:
         try:
             device.get_sysinfo()
             entities_ready.append(device_class(device))
         except SmartDeviceException as ex:
-            entities_unavailable.append(device)
+            devices_unavailable.append(device)
             _LOGGER.warning(
                 "Unable to communicate with device %s: %s",
                 device.host,
                 ex,
             )
 
-    hass.data[TPLINK_DOMAIN][f"{device_type}_remaining"] = entities_unavailable
+    hass.data[TPLINK_DOMAIN][f"{device_type}_remaining"] = devices_unavailable
     return entities_ready

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -131,7 +131,7 @@ def get_static_devices(config_data) -> SmartDevices:
     return SmartDevices(lights, switches)
 
 
-def add_available_devices(hass, device_type, device_class, async_add_entities):
+def add_available_devices(hass, device_type, device_class):
     """Get sysinfo for all devices."""
 
     devices = hass.data[TPLINK_DOMAIN][device_type]
@@ -153,7 +153,5 @@ def add_available_devices(hass, device_type, device_class, async_add_entities):
                 ex,
             )
 
+    hass.data[TPLINK_DOMAIN][f"{device_type}_ready"] = entities_ready
     hass.data[TPLINK_DOMAIN][f"{device_type}_remaining"] = entities_unavailable
-
-    if entities_ready:
-        async_add_entities(entities_ready, update_before_add=True)

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -153,5 +153,5 @@ def add_available_devices(hass, device_type, device_class):
                 ex,
             )
 
-    hass.data[TPLINK_DOMAIN][f"{device_type}_ready"] = entities_ready
     hass.data[TPLINK_DOMAIN][f"{device_type}_remaining"] = entities_unavailable
+    return entities_ready

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -61,13 +61,12 @@ SLEEP_TIME = 2
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up lights."""
-    devices = []
-    devices = await hass.async_add_executor_job(
+    entities = await hass.async_add_executor_job(
         add_available_devices, hass, CONF_LIGHT, TPLinkSmartBulb
     )
 
-    if devices:
-        async_add_entities(devices, update_before_add=True)
+    if entities:
+        async_add_entities(entities, update_before_add=True)
 
     if hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_remaining"]:
         raise PlatformNotReady

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -61,14 +61,13 @@ SLEEP_TIME = 2
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up lights."""
-    await hass.async_add_executor_job(
+    devices = []
+    devices = await hass.async_add_executor_job(
         add_available_devices, hass, CONF_LIGHT, TPLinkSmartBulb
     )
 
-    if hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_ready"]:
-        async_add_entities(
-            hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_ready"], update_before_add=True
-        )
+    if devices:
+        async_add_entities(devices, update_before_add=True)
 
     if hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_remaining"]:
         raise PlatformNotReady

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -62,8 +62,13 @@ SLEEP_TIME = 2
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up lights."""
     await hass.async_add_executor_job(
-        add_available_devices, hass, CONF_LIGHT, TPLinkSmartBulb, async_add_entities
+        add_available_devices, hass, CONF_LIGHT, TPLinkSmartBulb
     )
+
+    if hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_ready"]:
+        async_add_entities(
+            hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_ready"], update_before_add=True
+        )
 
     if hass.data[TPLINK_DOMAIN][f"{CONF_LIGHT}_remaining"]:
         raise PlatformNotReady

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -31,14 +31,13 @@ SLEEP_TIME = 2
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up switches."""
-    await hass.async_add_executor_job(
+    devices = []
+    devices = await hass.async_add_executor_job(
         add_available_devices, hass, CONF_SWITCH, SmartPlugSwitch
     )
 
-    if hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_ready"]:
-        async_add_entities(
-            hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_ready"], update_before_add=True
-        )
+    if devices:
+        async_add_entities(devices, update_before_add=True)
 
     if hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_remaining"]:
         raise PlatformNotReady

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -32,8 +32,13 @@ SLEEP_TIME = 2
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up switches."""
     await hass.async_add_executor_job(
-        add_available_devices, hass, CONF_SWITCH, SmartPlugSwitch, async_add_entities
+        add_available_devices, hass, CONF_SWITCH, SmartPlugSwitch
     )
+
+    if hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_ready"]:
+        async_add_entities(
+            hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_ready"], update_before_add=True
+        )
 
     if hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_remaining"]:
         raise PlatformNotReady

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -31,13 +31,12 @@ SLEEP_TIME = 2
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
     """Set up switches."""
-    devices = []
-    devices = await hass.async_add_executor_job(
+    entities = await hass.async_add_executor_job(
         add_available_devices, hass, CONF_SWITCH, SmartPlugSwitch
     )
 
-    if devices:
-        async_add_entities(devices, update_before_add=True)
+    if entities:
+        async_add_entities(entities, update_before_add=True)
 
     if hass.data[TPLINK_DOMAIN][f"{CONF_SWITCH}_remaining"]:
         raise PlatformNotReady

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -1,6 +1,6 @@
 """Tests for light platform."""
-import logging
 from datetime import timedelta
+import logging
 from typing import Callable, NamedTuple
 
 from pyHS100 import SmartDeviceException

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -1,5 +1,6 @@
 """Tests for light platform."""
 import logging
+from datetime import timedelta
 from typing import Callable, NamedTuple
 
 from pyHS100 import SmartDeviceException
@@ -30,8 +31,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
 
 from tests.async_mock import Mock, PropertyMock, patch
+from tests.common import async_fire_time_changed
 
 
 class LightMockData(NamedTuple):
@@ -605,5 +608,9 @@ async def test_async_setup_entry_unavailable(
         )
 
         await hass.async_block_till_done()
-        assert "Unable to communicate with device 123.123.123.123" in caplog.text
-        assert len(hass.data[tplink.DOMAIN][f"{CONF_LIGHT}_remaining"]) == 1
+        assert not hass.states.get("light.light1")
+
+    future = utcnow() + timedelta(seconds=30)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+    assert hass.states.get("light.light1")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR moves the async_add_entities calls back to their respective async_setup_entry functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [x ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
