### PR TITLE
Update definition of onewire device specifications

### DIFF
--- a/homeassistant/components/onewire/const.py
+++ b/homeassistant/components/onewire/const.py
@@ -30,32 +30,27 @@ DOMAIN = "onewire"
 
 PRESSURE_CBAR = "cbar"
 
+SENSOR_TYPE_COUNT = "count"
+SENSOR_TYPE_CURRENT = "current"
+SENSOR_TYPE_HUMIDITY = "humidity"
+SENSOR_TYPE_ILLUMINANCE = "illuminance"
+SENSOR_TYPE_MOISTURE = "moisture"
+SENSOR_TYPE_PRESSURE = "pressure"
+SENSOR_TYPE_TEMPERATURE = "temperature"
+SENSOR_TYPE_VOLTAGE = "voltage"
+SENSOR_TYPE_WETNESS = "wetness"
+
 SENSOR_TYPES = {
-    # SensorType: [ Measured unit, Unit, DeviceClass ]
-    "temperature": ["temperature", TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    "humidity": ["humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "humidity_hih3600": ["humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "humidity_hih4000": ["humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "humidity_hih5030": ["humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "humidity_htm1735": ["humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "humidity_raw": ["humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "pressure": ["pressure", PRESSURE_MBAR, DEVICE_CLASS_PRESSURE],
-    "illuminance": ["illuminance", LIGHT_LUX, DEVICE_CLASS_ILLUMINANCE],
-    "wetness_0": ["wetness", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "wetness_1": ["wetness", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "wetness_2": ["wetness", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "wetness_3": ["wetness", PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    "moisture_0": ["moisture", PRESSURE_CBAR, DEVICE_CLASS_PRESSURE],
-    "moisture_1": ["moisture", PRESSURE_CBAR, DEVICE_CLASS_PRESSURE],
-    "moisture_2": ["moisture", PRESSURE_CBAR, DEVICE_CLASS_PRESSURE],
-    "moisture_3": ["moisture", PRESSURE_CBAR, DEVICE_CLASS_PRESSURE],
-    "counter_a": ["counter", "count", None],
-    "counter_b": ["counter", "count", None],
-    "HobbyBoard": ["none", "none", None],
-    "voltage": ["voltage", VOLT, DEVICE_CLASS_VOLTAGE],
-    "voltage_VAD": ["voltage", VOLT, DEVICE_CLASS_VOLTAGE],
-    "voltage_VDD": ["voltage", VOLT, DEVICE_CLASS_VOLTAGE],
-    "current": ["current", ELECTRICAL_CURRENT_AMPERE, DEVICE_CLASS_CURRENT],
+    # SensorType: [ Unit, DeviceClass ]
+    SENSOR_TYPE_TEMPERATURE: [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
+    SENSOR_TYPE_HUMIDITY: [PERCENTAGE, DEVICE_CLASS_HUMIDITY],
+    SENSOR_TYPE_PRESSURE: [PRESSURE_MBAR, DEVICE_CLASS_PRESSURE],
+    SENSOR_TYPE_ILLUMINANCE: [LIGHT_LUX, DEVICE_CLASS_ILLUMINANCE],
+    SENSOR_TYPE_WETNESS: [PERCENTAGE, DEVICE_CLASS_HUMIDITY],
+    SENSOR_TYPE_MOISTURE: [PRESSURE_CBAR, DEVICE_CLASS_PRESSURE],
+    SENSOR_TYPE_COUNT: ["count", None],
+    SENSOR_TYPE_VOLTAGE: [VOLT, DEVICE_CLASS_VOLTAGE],
+    SENSOR_TYPE_CURRENT: [ELECTRICAL_CURRENT_AMPERE, DEVICE_CLASS_CURRENT],
 }
 
 SUPPORTED_PLATFORMS = [

--- a/homeassistant/components/onewire/onewire_entities.py
+++ b/homeassistant/components/onewire/onewire_entities.py
@@ -15,12 +15,20 @@ _LOGGER = logging.getLogger(__name__)
 class OneWire(Entity):
     """Implementation of a 1-Wire sensor."""
 
-    def __init__(self, name, device_file, sensor_type, device_info=None):
+    def __init__(
+        self,
+        name,
+        device_file,
+        sensor_type: str,
+        sensor_name: str = None,
+        device_info=None,
+    ):
         """Initialize the sensor."""
-        self._name = f"{name} {sensor_type.capitalize()}"
+        self._name = f"{name} {(sensor_name or sensor_type).capitalize()}"
         self._device_file = device_file
-        self._device_class = SENSOR_TYPES[sensor_type][2]
-        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self._sensor_type = sensor_type
+        self._device_class = SENSOR_TYPES[sensor_type][1]
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][0]
         self._device_info = device_info
         self._state = None
         self._value_raw = None
@@ -64,9 +72,17 @@ class OneWire(Entity):
 class OneWireProxy(OneWire):
     """Implementation of a 1-Wire sensor through owserver."""
 
-    def __init__(self, name, device_file, sensor_type, device_info, owproxy):
+    def __init__(
+        self,
+        name: str,
+        device_file: str,
+        sensor_type: str,
+        sensor_name: str,
+        device_info: Dict[str, Any],
+        owproxy: protocol._Proxy,
+    ):
         """Initialize the sensor."""
-        super().__init__(name, device_file, sensor_type, device_info)
+        super().__init__(name, device_file, sensor_type, sensor_name, device_info)
         self._owproxy = owproxy
 
     def _read_value_ownet(self):

--- a/homeassistant/components/onewire/onewire_entities.py
+++ b/homeassistant/components/onewire/onewire_entities.py
@@ -24,7 +24,7 @@ class OneWire(Entity):
         device_info=None,
     ):
         """Initialize the sensor."""
-        self._name = f"{name} {(sensor_name or sensor_type).capitalize()}"
+        self._name = f"{name} {sensor_name or sensor_type.capitalize()}"
         self._device_file = device_file
         self._sensor_type = sensor_type
         self._device_class = SENSOR_TYPES[sensor_type][1]

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -20,6 +20,15 @@ from .const import (
     DEFAULT_OWSERVER_PORT,
     DEFAULT_SYSBUS_MOUNT_DIR,
     DOMAIN,
+    SENSOR_TYPE_COUNT,
+    SENSOR_TYPE_CURRENT,
+    SENSOR_TYPE_HUMIDITY,
+    SENSOR_TYPE_ILLUMINANCE,
+    SENSOR_TYPE_MOISTURE,
+    SENSOR_TYPE_PRESSURE,
+    SENSOR_TYPE_TEMPERATURE,
+    SENSOR_TYPE_VOLTAGE,
+    SENSOR_TYPE_WETNESS,
 )
 from .onewire_entities import OneWire, OneWireProxy
 from .onewirehub import OneWireHub
@@ -28,27 +37,67 @@ _LOGGER = logging.getLogger(__name__)
 
 DEVICE_SENSORS = {
     # Family : { SensorType: owfs path }
-    "10": {"temperature": "temperature"},
-    "12": {"temperature": "TAI8570/temperature", "pressure": "TAI8570/pressure"},
-    "22": {"temperature": "temperature"},
-    "26": {
-        "temperature": "temperature",
-        "humidity": "humidity",
-        "humidity_hih3600": "HIH3600/humidity",
-        "humidity_hih4000": "HIH4000/humidity",
-        "humidity_hih5030": "HIH5030/humidity",
-        "humidity_htm1735": "HTM1735/humidity",
-        "pressure": "B1-R1-A/pressure",
-        "illuminance": "S3-R1-A/illuminance",
-        "voltage_VAD": "VAD",
-        "voltage_VDD": "VDD",
-        "current": "IAD",
-    },
-    "28": {"temperature": "temperature"},
-    "3B": {"temperature": "temperature"},
-    "42": {"temperature": "temperature"},
-    "1D": {"counter_a": "counter.A", "counter_b": "counter.B"},
-    "EF": {"HobbyBoard": "special"},
+    "10": [
+        {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE}
+    ],
+    "12": [
+        {
+            "path": "TAI8570/temperature",
+            "name": "Temperature",
+            "type": SENSOR_TYPE_TEMPERATURE,
+        },
+        {"path": "TAI8570/pressure", "name": "Pressure", "type": SENSOR_TYPE_PRESSURE},
+    ],
+    "22": [
+        {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE}
+    ],
+    "26": [
+        {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE},
+        {"path": "humidity", "name": "Humidity", "type": SENSOR_TYPE_HUMIDITY},
+        {
+            "path": "HIH3600/humidity",
+            "name": "Humidity HIH3600",
+            "type": SENSOR_TYPE_HUMIDITY,
+        },
+        {
+            "path": "HIH4000/humidity",
+            "name": "Humidity HIH4000",
+            "type": SENSOR_TYPE_HUMIDITY,
+        },
+        {
+            "path": "HIH5030/humidity",
+            "name": "Humidity HIH5030",
+            "type": SENSOR_TYPE_HUMIDITY,
+        },
+        {
+            "path": "HTM1735/humidity",
+            "name": "Humidity HTM1735",
+            "type": SENSOR_TYPE_HUMIDITY,
+        },
+        {"path": "B1-R1-A/pressure", "name": "Pressure", "type": SENSOR_TYPE_PRESSURE},
+        {
+            "path": "S3-R1-A/illuminance",
+            "name": "Illuminance",
+            "type": SENSOR_TYPE_ILLUMINANCE,
+        },
+        {"path": "VAD", "name": "Voltage VAD", "type": SENSOR_TYPE_VOLTAGE},
+        {"path": "VDD", "name": "Voltage VDD", "type": SENSOR_TYPE_VOLTAGE},
+        {"path": "IAD", "name": "Current", "type": SENSOR_TYPE_CURRENT},
+    ],
+    "28": [
+        {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE}
+    ],
+    "3B": [
+        {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE}
+    ],
+    "42": [
+        {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE}
+    ],
+    "1D": [
+        {"path": "counter.A", "name": "Counter A", "type": SENSOR_TYPE_COUNT},
+        {"path": "counter.B", "name": "Counter B", "type": SENSOR_TYPE_COUNT},
+    ],
+    "EF": [],  # "HobbyBoard": special
 }
 
 DEVICE_SUPPORT_SYSBUS = ["10", "22", "28", "3B", "42"]
@@ -58,19 +107,46 @@ DEVICE_SUPPORT_SYSBUS = ["10", "22", "28", "3B", "42"]
 # via owserver (network protocol)
 
 HOBBYBOARD_EF = {
-    "HobbyBoards_EF": {
-        "humidity": "humidity/humidity_corrected",
-        "humidity_raw": "humidity/humidity_raw",
-        "temperature": "humidity/temperature",
-    },
-    "HB_MOISTURE_METER": {
-        "moisture_0": "moisture/sensor.0",
-        "moisture_1": "moisture/sensor.1",
-        "moisture_2": "moisture/sensor.2",
-        "moisture_3": "moisture/sensor.3",
-    },
+    "HobbyBoards_EF": [
+        {
+            "path": "humidity/humidity_corrected",
+            "name": "Humidity",
+            "type": SENSOR_TYPE_HUMIDITY,
+        },
+        {
+            "path": "humidity/humidity_raw",
+            "name": "Humidity Raw",
+            "type": SENSOR_TYPE_HUMIDITY,
+        },
+        {
+            "path": "humidity/temperature",
+            "name": "Temperature",
+            "type": SENSOR_TYPE_TEMPERATURE,
+        },
+    ],
+    "HB_MOISTURE_METER": [
+        {
+            "path": "moisture/sensor.0",
+            "name": "Moisture 0",
+            "type": SENSOR_TYPE_MOISTURE,
+        },
+        {
+            "path": "moisture/sensor.1",
+            "name": "Moisture 1",
+            "type": SENSOR_TYPE_MOISTURE,
+        },
+        {
+            "path": "moisture/sensor.2",
+            "name": "Moisture 2",
+            "type": SENSOR_TYPE_MOISTURE,
+        },
+        {
+            "path": "moisture/sensor.3",
+            "name": "Moisture 3",
+            "type": SENSOR_TYPE_MOISTURE,
+        },
+    ],
 }
-
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -150,24 +226,26 @@ def get_entities(onewirehub: OneWireHub, config):
                 "model": device_type,
                 "name": sensor_id,
             }
-            for sensor_key, sensor_value in hb_info_from_type(dev_type)[family].items():
-                if "moisture" in sensor_key:
-                    s_id = sensor_key.split("_")[1]
+            for device_sensor in hb_info_from_type(dev_type)[family]:
+                if device_sensor["type"] == SENSOR_TYPE_MOISTURE:
+                    s_id = device_sensor["path"].split(".")[1]
                     is_leaf = int(
                         onewirehub.owproxy.read(
                             f"{device['path']}moisture/is_leaf.{s_id}"
                         ).decode()
                     )
                     if is_leaf:
-                        sensor_key = f"wetness_{s_id}"
+                        device_sensor["type"] = SENSOR_TYPE_WETNESS
+                        device_sensor["name"] = f"Wetness {s_id}"
                 device_file = os.path.join(
-                    os.path.split(device["path"])[0], sensor_value
+                    os.path.split(device["path"])[0], device_sensor["path"]
                 )
                 entities.append(
                     OneWireProxy(
                         device_names.get(sensor_id, sensor_id),
                         device_file,
-                        sensor_key,
+                        device_sensor["type"],
+                        device_sensor["name"],
                         device_info,
                         onewirehub.owproxy,
                     )
@@ -199,7 +277,6 @@ def get_entities(onewirehub: OneWireHub, config):
                 OneWireDirect(
                     device_names.get(sensor_id, sensor_id),
                     device_file,
-                    "temperature",
                     device_info,
                     p1sensor,
                 )
@@ -249,9 +326,9 @@ def get_entities(onewirehub: OneWireHub, config):
 class OneWireDirect(OneWire):
     """Implementation of a 1-Wire sensor directly connected to RPI GPIO."""
 
-    def __init__(self, name, device_file, sensor_type, device_info, owsensor):
+    def __init__(self, name, device_file, device_info, owsensor):
         """Initialize the sensor."""
-        super().__init__(name, device_file, sensor_type, device_info)
+        super().__init__(name, device_file, "temperature", "Temperature", device_info)
         self._owsensor = owsensor
 
     def update(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update definition of onewire device specifications using dictionary (path/name/type) instead of ordered list (key/path).

Removes need for duplicate entries in const file.
- wetness_0..3 => wetness
- moisture_0..3 => moisture
- counter_a..b => count
- voltage...VAD...VDD => voltage
- humidity...hihxxx...hihyyy...hihzzz => humidity 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
