### PR TITLE
Add F6 and D5 sensor types to the enocean integration

### DIFF
--- a/homeassistant/components/enocean/binary_sensor.py
+++ b/homeassistant/components/enocean/binary_sensor.py
@@ -11,6 +11,8 @@ import homeassistant.helpers.config_validation as cv
 
 from .device import EnOceanEntity
 
+CONF_TYPE = "type"
+
 DEFAULT_NAME = "EnOcean binary sensor"
 DEPENDENCIES = ["enocean"]
 EVENT_BUTTON_PRESSED = "button_pressed"
@@ -20,6 +22,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_TYPE, default=2): cv.positive_int,
     }
 )
 
@@ -29,8 +32,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev_id = config.get(CONF_ID)
     dev_name = config.get(CONF_NAME)
     device_class = config.get(CONF_DEVICE_CLASS)
+    device_type = config.get(CONF_TYPE)
 
-    add_entities([EnOceanBinarySensor(dev_id, dev_name, device_class)])
+    add_entities([EnOceanBinarySensor(dev_id, dev_name, device_class, device_type)])
 
 
 class EnOceanBinarySensor(EnOceanEntity, BinarySensorEntity):
@@ -41,10 +45,11 @@ class EnOceanBinarySensor(EnOceanEntity, BinarySensorEntity):
     - F6-02-02 (Light and Blind Control - Application Style 1)
     """
 
-    def __init__(self, dev_id, dev_name, device_class):
+    def __init__(self, dev_id, dev_name, device_class, device_type):
         """Initialize the EnOcean binary sensor."""
         super().__init__(dev_id, dev_name)
         self._device_class = device_class
+        self._device_type = device_type
         self.which = -1
         self.onoff = -1
 
@@ -58,53 +63,75 @@ class EnOceanBinarySensor(EnOceanEntity, BinarySensorEntity):
         """Return the class of this sensor."""
         return self._device_class
 
+    @property
+    def device_type(self):
+        """Return the type of this sensor."""
+        return self._device_type
+
     def value_changed(self, packet):
         """Fire an event with the data that have changed.
 
         This method is called when there is an incoming packet associated
         with this platform.
-
         Example packet data:
         - 2nd button pressed
             ['0xf6', '0x10', '0x00', '0x2d', '0xcf', '0x45', '0x30']
         - button released
             ['0xf6', '0x00', '0x00', '0x2d', '0xcf', '0x45', '0x20']
         """
-        # Energy Bow
-        pushed = None
 
-        if packet.data[6] == 0x30:
-            pushed = 1
-        elif packet.data[6] == 0x20:
-            pushed = 0
+        if packet.data[0] == 0xF6:
+            # Energy Bow
+            pushed = None
+            pressed = None
+            first_action = None
+            second_action = None
+            second_action_valid = None
 
-        self.schedule_update_ha_state()
+            if self._device_type == 2:
+                packet.parse_eep(0x02, 0x02)
+                pressed = packet.parsed["EB"]["raw_value"]
+                first_action = packet.parsed["R1"]["raw_value"]
+                second_action = packet.parsed["R2"]["raw_value"]
+                second_action_valid = packet.parsed["SA"]["raw_value"]
 
-        action = packet.data[1]
-        if action == 0x70:
-            self.which = 0
-            self.onoff = 0
-        elif action == 0x50:
-            self.which = 0
-            self.onoff = 1
-        elif action == 0x30:
-            self.which = 1
-            self.onoff = 0
-        elif action == 0x10:
-            self.which = 1
-            self.onoff = 1
-        elif action == 0x37:
-            self.which = 10
-            self.onoff = 0
-        elif action == 0x15:
-            self.which = 10
-            self.onoff = 1
-        self.hass.bus.fire(
-            EVENT_BUTTON_PRESSED,
-            {
-                "id": self.dev_id,
-                "pushed": pushed,
-                "which": self.which,
-                "onoff": self.onoff,
-            },
-        )
+            if packet.data[6] == 0x30:
+                pushed = 1
+            elif packet.data[6] == 0x20:
+                pushed = 0
+
+            self.schedule_update_ha_state()
+
+            action = packet.data[1]
+            if action == 0x70:
+                self.which = 0
+                self.onoff = 0
+            elif action == 0x50:
+                self.which = 0
+                self.onoff = 1
+            elif action == 0x30:
+                self.which = 1
+                self.onoff = 0
+            elif action == 0x10:
+                self.which = 1
+                self.onoff = 1
+            elif action == 0x37:
+                self.which = 10
+                self.onoff = 0
+            elif action == 0x15:
+                self.which = 10
+                self.onoff = 1
+
+            self.hass.bus.fire(
+                EVENT_BUTTON_PRESSED,
+                {
+                    "id": self.dev_id,
+                    "pushed": pushed,
+                    "which": self.which,
+                    "onoff": self.onoff,
+                    "pressed": pressed,
+                    "first_action": first_action,
+                    "second_action": second_action,
+                    "second_action_valid": second_action_valid,
+                },
+            )

--- a/homeassistant/components/enocean/switch.py
+++ b/homeassistant/components/enocean/switch.py
@@ -95,3 +95,6 @@ class EnOceanSwitch(EnOceanEntity, ToggleEntity):
                 if channel == self.channel:
                     self._on_state = output > 0
                     self.schedule_update_ha_state()
+        elif packet.data[0] == 0xD5:
+            # actuator status telegram
+            packet.parse_eep(0x00, 0x01)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Change to add new sensor types to the enocean integration.
These types are F6-02-02 (just an update of the existing one so a Nodon Soft Remote works for example), and D5 integration (Nodon door sensor for instance)
I propose these changes after the first part of the enOcean Refactor has been made, as they were not accepted before (Pull Request #32207) because of the way the entire component was made.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
binary_sensor:
  - name: Soft button
    platform: enocean
    id: [0x00, 0x01, 0x02, 0x03]
    type: 2

sensor:
  - name: Entrance Door
    platform: enocean
    id: [0x01,0x02,0x03,0x04]
    device_class: door
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I tried not to break any existing code so that the changes would be non-breaking and people could use it and add new sensors without having to change existing configs.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
