### PR TITLE
Set the translations cache under the lock

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -330,13 +330,14 @@ async def async_get_translations(
 
         if integration is not None:
             pass
-        elif config_flow:
-            loaded_comp_resources = await async_get_translations(
-                hass, language, category
-            )
-            resources.update(loaded_comp_resources)
-        else:
+
+        # The cache must be set while holding the lock
+        if not config_flow:
             assert cache is not None
             cache.async_set_cache(language, category, resources)
+
+    if config_flow:
+        loaded_comp_resources = await async_get_translations(hass, language, category)
+        resources.update(loaded_comp_resources)
 
     return resources

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -294,7 +294,8 @@ async def async_get_translations(
             }
 
     async with lock:
-        if integration is None and not config_flow:
+        use_cache = integration is None and not config_flow
+        if use_cache:
             cache = hass.data.get(TRANSLATION_FLATTEN_CACHE)
             if cache is None:
                 cache = hass.data[TRANSLATION_FLATTEN_CACHE] = FlatCache(hass)
@@ -329,7 +330,7 @@ async def async_get_translations(
             resources = {**base_resources, **resources}
 
         # The cache must be set while holding the lock
-        if integration is None and not config_flow:
+        if use_cache:
             assert cache is not None
             cache.async_set_cache(language, category, resources)
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -328,11 +328,8 @@ async def async_get_translations(
             base_resources = flatten(resource_func(results[1], components, category))
             resources = {**base_resources, **resources}
 
-        if integration is not None:
-            pass
-
         # The cache must be set while holding the lock
-        if not config_flow:
+        if integration is None and not config_flow:
             assert cache is not None
             cache.async_set_cache(language, category, resources)
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -317,24 +317,26 @@ async def async_get_translations(
 
         results = await asyncio.gather(*tasks)
 
-    if category == "state":
-        resource_func = merge_resources
-    else:
-        resource_func = build_resources
+        if category == "state":
+            resource_func = merge_resources
+        else:
+            resource_func = build_resources
 
-    resources = flatten(resource_func(results[0], components, category))
+        resources = flatten(resource_func(results[0], components, category))
 
-    if language != "en":
-        base_resources = flatten(resource_func(results[1], components, category))
-        resources = {**base_resources, **resources}
+        if language != "en":
+            base_resources = flatten(resource_func(results[1], components, category))
+            resources = {**base_resources, **resources}
 
-    if integration is not None:
-        pass
-    elif config_flow:
-        loaded_comp_resources = await async_get_translations(hass, language, category)
-        resources.update(loaded_comp_resources)
-    else:
-        assert cache is not None
-        cache.async_set_cache(language, category, resources)
+        if integration is not None:
+            pass
+        elif config_flow:
+            loaded_comp_resources = await async_get_translations(
+                hass, language, category
+            )
+            resources.update(loaded_comp_resources)
+        else:
+            assert cache is not None
+            cache.async_set_cache(language, category, resources)
 
     return resources


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With debug logging turned on, I noticed the translation cache wasn't effective on startup because we released the lock before the cache was set which meant the next caller would not see the cache because when the lock was released the cache was not yet set.

```text
root@alexanderalpha:/volume1/docker/alexander-homeassistant# grep ffmpeg home-assistant.log 
2020-10-27 15:31:19 INFO (MainThread) [homeassistant.bootstrap] Setting up stage 2: {'input_text', 'weather', 'garbage_collection', 'ssdp', 'input_number', 'lutron_caseta', 'senseme', 'lutron_caseta_pro', 'cast', 'system_health', 'nut', 'map', 'hacs', 'myq', 'fan', 'lock', 'hue', 'gogogate2', 'group', 'configurator', 'notify', 'counter', 'camera', 'tado', 'emulated_kasa', 'default_config', 'homekit', 'zeroconf', 'scene', 'cert_expiry', 'ipp', 'sense', 'script', 'device_tracker', 'input_select', 'nuheat', 'harmony', 'panel_iframe', 'autelis', 'coronavirus', 'hunterdouglas_powerview', 'timer', 'roomba', 'rachio', 'nexia', 'history', 'mobile_app', 'upnp', 'rest_command', 'unifiprotect', 'input_datetime', 'homekit_controller', 'shell_command', 'automation', 'tts', 'powerwall', 'tesla', 'light', 'binary_sensor', 'ifttt', 'ios', 'griddy', 'updater', 'media_source', 'xsmart_meter_texas', 'doorbird', 'profiler', 'zone', 'logbook', 'sun', 'input_boolean', 'sensor', 'switch', 'denonavr', 'apple_tv', 'esphome', 'tag', 'ffmpeg', 'media_player', 'variable', 'synology_dsm', 'elkm1', 'august', 'emulated_hue', 'ambient_station', 'persistent_notification', 'isy994', 'remote', 'sonos'}
2020-10-27 15:31:19 DEBUG (MainThread) [homeassistant.setup] Dependency homekit will wait for dependencies ['camera', 'ffmpeg']
2020-10-27 15:31:20 DEBUG (MainThread) [homeassistant.util.package] requirement: ha-ffmpeg==2.0
2020-10-27 15:31:20 INFO (MainThread) [homeassistant.loader] Imported ffmpeg from homeassistant.components.ffmpeg
2020-10-27 15:31:20 INFO (MainThread) [homeassistant.setup] Setting up ffmpeg
2020-10-27 15:31:21 INFO (MainThread) [homeassistant.setup] Setup of domain ffmpeg took 1.0 seconds
2020-10-27 15:31:26 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, state: input_text, auth, ssdp, senseme, lutron_caseta_pro, system_health, nut, camera.doorbird, binary_sensor.powerwall, recorder, fan, lock, config, gogogate2, configurator, notify, sensor.ambient_station, counter, camera, cover.lutron_caseta_pro, notify.smtp, climate.nexia, binary_sensor.senseme, sensor.garbage_collection, cover, tado, calendar, cert_expiry, scene, sensor.filter, sensor.history_stats, water_heater.tado, webhook, light.group, fan.senseme, sensor.nut, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, binary_sensor.roomba, history, mobile_app, api, upnp, logger, automation, powerwall, tts, light, ifttt, griddy, cover.gogogate2, doorbird, scene.lutron_caseta_pro, sensor, switch, climate.tado, light.senseme, notify.group, esphome, climate, alexa, sensor.nexia, vacuum.roomba, variable, emulated_hue, ambient_station, media_player, persistent_notification, binary_sensor.rachio, weather, fan.lutron_caseta_pro, sensor.roomba, binary_sensor.mobile_app, garbage_collection, input_number, cast, lock.template, water_heater, system_log, map, binary_sensor.esphome, sensor.esphome, switch.lutron_caseta_pro, notify.mobile_app, frontend, hue, weather.darksky, group, remote.apple_tv, binary_sensor.ambient_station, scene.homeassistant, scene.nexia, vacuum, media_player.universal, emulated_kasa, switch.esphome, homekit, zeroconf, ipp, binary_sensor.updater, climate.nuheat, light.lutron_caseta_pro, broadlink, nuheat, input_select, sensor.coronavirus, sensor.lutron_caseta_pro, panel_iframe, autelis, cover.homekit_controller, person, roomba, binary_sensor.template, device_automation, rest_command, input_datetime, homekit_controller, switch.rachio, shell_command, binary_sensor, sensor.tado, updater, media_player.sonos, media_source, websocket_api, switch.template, sensor.template, image, profiler, cloud, zone, logbook, sun, sensor.filesize, onboarding, homeassistant, input_boolean, sensor.powerwall, media_player.apple_tv, fan.template, apple_tv, lovelace, search, tag, ffmpeg, remote, http, remote.broadlink, switch.doorbird, sonos
2020-10-27 15:31:27 WARNING (SyncWorker_17) [homeassistant.util.yaml.loader] Load yaml: /usr/src/homeassistant/homeassistant/components/ffmpeg/services.yaml
2020-10-27 15:31:27 WARNING (SyncWorker_0) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:29 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, state: input_text, auth, ssdp, sensor.snmp, senseme, lutron_caseta_pro, sensor.hunterdouglas_powerview, system_health, nut, hacs, camera.doorbird, binary_sensor.powerwall, recorder, myq, fan, lock, config, binary_sensor.myq, gogogate2, configurator, notify, sensor.griddy, sensor.ambient_station, counter, camera, cover.lutron_caseta_pro, notify.smtp, climate.nexia, binary_sensor.senseme, sensor.garbage_collection, cover, tado, calendar, cert_expiry, scene, sensor.filter, sensor.history_stats, water_heater.tado, webhook, light.group, fan.senseme, sensor.nut, media_player.cast, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, binary_sensor.roomba, history, mobile_app, api, upnp, cover.myq, logger, automation, powerwall, tts, light, ifttt, griddy, cover.gogogate2, doorbird, sensor.mobile_app, scene.lutron_caseta_pro, sensor, switch, climate.tado, light.senseme, notify.group, scene.hunterdouglas_powerview, esphome, climate, alexa, sensor.nexia, vacuum.roomba, variable, emulated_hue, ambient_station, media_player, persistent_notification, binary_sensor.rachio, weather, fan.lutron_caseta_pro, sensor.roomba, binary_sensor.mobile_app, garbage_collection, input_number, cast, lock.template, water_heater, system_log, map, binary_sensor.esphome, sensor.esphome, switch.lutron_caseta_pro, notify.mobile_app, frontend, hue, weather.darksky, group, remote.apple_tv, binary_sensor.ambient_station, scene.homeassistant, scene.nexia, vacuum, media_player.universal, emulated_kasa, switch.esphome, homekit, zeroconf, ipp, binary_sensor.updater, climate.nuheat, light.lutron_caseta_pro, broadlink, nuheat, input_select, sensor.coronavirus, sensor.lutron_caseta_pro, panel_iframe, autelis, cover.homekit_controller, person, roomba, binary_sensor.template, device_automation, rest_command, input_datetime, homekit_controller, switch.rachio, shell_command, binary_sensor, sensor.tado, sensor.command_line, updater, media_player.sonos, media_source, websocket_api, switch.template, sensor.cert_expiry, binary_sensor.nexia, sensor.template, image, profiler, cloud, zone, logbook, sun, sensor.filesize, onboarding, homeassistant, input_boolean, sensor.powerwall, media_player.apple_tv, calendar.garbage_collection, fan.template, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, remote, http, remote.broadlink, switch.doorbird, sonos
2020-10-27 15:31:29 WARNING (SyncWorker_42) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:29 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, title: input_text, auth, ssdp, senseme, lutron_caseta_pro, system_health, nut, hacs, recorder, myq, fan, lock, config, gogogate2, configurator, notify, counter, camera, cover, tado, calendar, cert_expiry, scene, webhook, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, history, mobile_app, api, upnp, logger, automation, powerwall, tts, light, ifttt, griddy, doorbird, sensor, switch, esphome, climate, alexa, variable, emulated_hue, ambient_station, media_player, persistent_notification, weather, garbage_collection, input_number, cast, water_heater, system_log, map, frontend, hue, group, vacuum, emulated_kasa, homekit, zeroconf, ipp, broadlink, nuheat, input_select, panel_iframe, autelis, person, roomba, device_automation, rest_command, input_datetime, homekit_controller, shell_command, binary_sensor, updater, media_source, websocket_api, image, profiler, cloud, zone, logbook, sun, onboarding, homeassistant, input_boolean, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, remote, http, sonos
2020-10-27 15:31:29 WARNING (SyncWorker_41) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:30 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, state: input_text, binary_sensor.tesla, auth, ssdp, sensor.snmp, senseme, lutron_caseta_pro, sensor.hunterdouglas_powerview, system_health, switch.lutron_caseta, nut, hacs, camera.doorbird, binary_sensor.powerwall, recorder, myq, fan, lock, config, binary_sensor.myq, gogogate2, configurator, notify, sensor.griddy, sensor.ambient_station, counter, camera, cover.lutron_caseta_pro, notify.smtp, climate.nexia, binary_sensor.lutron_caseta, binary_sensor.senseme, sensor.garbage_collection, cover, tado, calendar, default_config, cert_expiry, scene, sensor.filter, sensor.history_stats, water_heater.tado, webhook, light.group, fan.senseme, sensor.nut, media_player.cast, climate.tesla, coronavirus, binary_sensor.unifiprotect, hunterdouglas_powerview, timer, rachio, nexia, binary_sensor.roomba, camera.unifiprotect, history, mobile_app, binary_sensor.synology_dsm, sensor.august, api, upnp, cover.myq, logger, unifiprotect, switch.unifiprotect, switch.tesla, automation, powerwall, tts, tesla, light, ifttt, griddy, cover.gogogate2, lock.tesla, doorbird, sensor.mobile_app, sensor.rest, sensor.synology_dsm, scene.lutron_caseta_pro, fan.lutron_caseta, sensor, switch, climate.tado, light.senseme, notify.group, scene.hunterdouglas_powerview, esphome, climate, alexa, sensor.nexia, vacuum.roomba, variable, emulated_hue, ambient_station, media_player, persistent_notification, remote.harmony, binary_sensor.rachio, weather, fan.lutron_caseta_pro, sensor.roomba, binary_sensor.mobile_app, garbage_collection, lock.august, input_number, lutron_caseta, cast, lock.template, water_heater, system_log, map, binary_sensor.esphome, binary_sensor.sense, sensor.esphome, switch.lutron_caseta_pro, notify.mobile_app, frontend, scene.lutron_caseta, hue, weather.darksky, group, sensor.sense, remote.apple_tv, sensor.tesla, binary_sensor.ambient_station, scene.homeassistant, scene.nexia, vacuum, media_player.universal, emulated_kasa, switch.esphome, cover.lutron_caseta, homekit, zeroconf, ipp, binary_sensor.updater, climate.nuheat, script, sense, light.lutron_caseta_pro, broadlink, nuheat, input_select, sensor.coronavirus, sensor.lutron_caseta_pro, sensor.unifiprotect, harmony, panel_iframe, autelis, cover.homekit_controller, light.lutron_caseta, person, camera.synology_dsm, roomba, camera.august, binary_sensor.template, device_automation, rest_command, input_datetime, homekit_controller, switch.rachio, sensor.wundergroundpws, shell_command, binary_sensor, binary_sensor.august, switch.synology_dsm, sensor.tado, sensor.command_line, updater, media_player.sonos, media_source, websocket_api, switch.template, sensor.cert_expiry, cover.hunterdouglas_powerview, binary_sensor.nexia, sensor.template, image, profiler, cloud, zone, logbook, sun, sensor.filesize, onboarding, homeassistant, input_boolean, sensor.powerwall, media_player.apple_tv, calendar.garbage_collection, fan.template, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, august, remote, http, stream, remote.broadlink, switch.doorbird, sonos
2020-10-27 15:31:30 WARNING (SyncWorker_35) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:30 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, title: input_text, auth, ssdp, senseme, lutron_caseta_pro, system_health, nut, hacs, recorder, myq, fan, lock, config, gogogate2, configurator, notify, counter, camera, cover, tado, calendar, default_config, cert_expiry, scene, webhook, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, history, mobile_app, api, upnp, logger, unifiprotect, automation, powerwall, tts, tesla, light, ifttt, griddy, doorbird, sensor, switch, esphome, climate, alexa, variable, emulated_hue, ambient_station, media_player, persistent_notification, weather, garbage_collection, input_number, lutron_caseta, cast, water_heater, system_log, map, frontend, hue, group, vacuum, emulated_kasa, homekit, zeroconf, ipp, sense, script, broadlink, nuheat, input_select, harmony, panel_iframe, autelis, person, roomba, device_automation, rest_command, input_datetime, homekit_controller, shell_command, binary_sensor, updater, media_source, websocket_api, image, profiler, cloud, zone, logbook, sun, onboarding, homeassistant, input_boolean, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, august, remote, http, stream, sonos
2020-10-27 15:31:30 WARNING (SyncWorker_32) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:32 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, state: input_text, binary_sensor.tesla, auth, ssdp, sensor.snmp, senseme, lutron_caseta_pro, sensor.hunterdouglas_powerview, system_health, switch.lutron_caseta, nut, hacs, camera.doorbird, binary_sensor.powerwall, recorder, myq, fan, lock, config, binary_sensor.myq, gogogate2, configurator, notify, sensor.griddy, sensor.ambient_station, counter, camera, cover.lutron_caseta_pro, notify.smtp, climate.nexia, binary_sensor.lutron_caseta, binary_sensor.senseme, sensor.garbage_collection, cover, tado, calendar, default_config, cert_expiry, scene, sensor.filter, sensor.history_stats, water_heater.tado, webhook, light.group, fan.senseme, sensor.nut, media_player.cast, climate.tesla, coronavirus, binary_sensor.unifiprotect, hunterdouglas_powerview, timer, rachio, nexia, binary_sensor.roomba, camera.unifiprotect, history, mobile_app, binary_sensor.synology_dsm, sensor.august, api, upnp, cover.myq, logger, unifiprotect, switch.unifiprotect, switch.tesla, device_tracker.tesla, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, cover.gogogate2, lock.tesla, sensor.ios, doorbird, sensor.mobile_app, sensor.rest, sensor.synology_dsm, scene.lutron_caseta_pro, fan.lutron_caseta, sensor, switch, climate.tado, light.senseme, notify.group, scene.hunterdouglas_powerview, esphome, climate, alexa, sensor.nexia, vacuum.roomba, variable, emulated_hue, ambient_station, media_player, persistent_notification, remote.harmony, binary_sensor.rachio, weather, fan.lutron_caseta_pro, sensor.roomba, binary_sensor.mobile_app, garbage_collection, lock.august, input_number, lutron_caseta, cast, lock.template, water_heater, system_log, map, binary_sensor.esphome, binary_sensor.sense, sensor.esphome, switch.lutron_caseta_pro, notify.mobile_app, frontend, scene.lutron_caseta, hue, weather.darksky, group, sensor.sense, remote.apple_tv, sensor.tesla, binary_sensor.ambient_station, scene.homeassistant, scene.nexia, vacuum, device_tracker.mobile_app, media_player.universal, emulated_kasa, switch.esphome, cover.lutron_caseta, notify.ios, homekit, zeroconf, ipp, binary_sensor.updater, climate.nuheat, script, sense, device_tracker, light.lutron_caseta_pro, broadlink, nuheat, input_select, sensor.coronavirus, sensor.lutron_caseta_pro, sensor.unifiprotect, harmony, panel_iframe, autelis, cover.homekit_controller, light.lutron_caseta, person, camera.synology_dsm, roomba, camera.august, binary_sensor.template, device_automation, rest_command, input_datetime, homekit_controller, switch.rachio, sensor.wundergroundpws, shell_command, binary_sensor, binary_sensor.august, switch.synology_dsm, sensor.tado, sensor.command_line, updater, media_player.sonos, media_source, websocket_api, switch.template, sensor.cert_expiry, cover.hunterdouglas_powerview, binary_sensor.nexia, sensor.template, image, profiler, cloud, zone, logbook, sun, sensor.filesize, onboarding, homeassistant, input_boolean, sensor.powerwall, media_player.apple_tv, calendar.garbage_collection, fan.template, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, august, remote, http, stream, remote.broadlink, switch.doorbird, sonos
2020-10-27 15:31:32 WARNING (SyncWorker_23) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:32 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, title: input_text, auth, ssdp, senseme, lutron_caseta_pro, system_health, nut, hacs, recorder, myq, fan, lock, config, gogogate2, configurator, notify, counter, camera, cover, tado, calendar, default_config, cert_expiry, scene, webhook, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, history, mobile_app, api, upnp, logger, unifiprotect, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, doorbird, sensor, switch, esphome, climate, alexa, variable, emulated_hue, ambient_station, media_player, persistent_notification, weather, garbage_collection, input_number, lutron_caseta, cast, water_heater, system_log, map, frontend, hue, group, vacuum, emulated_kasa, homekit, zeroconf, ipp, sense, script, device_tracker, broadlink, nuheat, input_select, harmony, panel_iframe, autelis, person, roomba, device_automation, rest_command, input_datetime, homekit_controller, shell_command, binary_sensor, updater, media_source, websocket_api, image, profiler, cloud, zone, logbook, sun, onboarding, homeassistant, input_boolean, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, august, remote, http, stream, sonos
2020-10-27 15:31:32 WARNING (SyncWorker_21) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:35 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, state: input_text, binary_sensor.tesla, auth, ssdp, sensor.snmp, climate.isy994, senseme, lutron_caseta_pro, sensor.hunterdouglas_powerview, system_health, switch.lutron_caseta, nut, hacs, camera.doorbird, binary_sensor.powerwall, recorder, myq, fan, lock, config, binary_sensor.myq, gogogate2, configurator, notify, sensor.griddy, sensor.ambient_station, counter, camera, cover.lutron_caseta_pro, notify.smtp, climate.nexia, binary_sensor.lutron_caseta, binary_sensor.senseme, sensor.garbage_collection, cover, tado, calendar, default_config, cert_expiry, scene, sensor.filter, sensor.history_stats, water_heater.tado, webhook, light.group, fan.senseme, sensor.nut, media_player.cast, climate.tesla, coronavirus, binary_sensor.unifiprotect, hunterdouglas_powerview, timer, rachio, nexia, binary_sensor.roomba, camera.unifiprotect, history, mobile_app, binary_sensor.synology_dsm, sensor.august, api, upnp, cover.myq, logger, unifiprotect, switch.unifiprotect, switch.tesla, device_tracker.tesla, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, cover.gogogate2, lock.tesla, sensor.ios, doorbird, sensor.mobile_app, sensor.rest, cover.isy994, sensor.synology_dsm, scene.lutron_caseta_pro, fan.lutron_caseta, binary_sensor.isy994, sensor, switch, climate.tado, light.senseme, notify.group, scene.hunterdouglas_powerview, esphome, climate, alexa, sensor.nexia, vacuum.roomba, variable, emulated_hue, ambient_station, media_player, persistent_notification, remote.harmony, binary_sensor.rachio, weather, fan.lutron_caseta_pro, sensor.roomba, binary_sensor.mobile_app, garbage_collection, lock.august, input_number, lutron_caseta, cast, lock.template, water_heater, fan.isy994, system_log, map, binary_sensor.esphome, binary_sensor.sense, sensor.esphome, switch.lutron_caseta_pro, notify.mobile_app, frontend, scene.lutron_caseta, hue, weather.darksky, group, sensor.sense, remote.apple_tv, sensor.tesla, binary_sensor.ambient_station, scene.homeassistant, scene.nexia, vacuum, device_tracker.mobile_app, media_player.universal, emulated_kasa, switch.esphome, cover.lutron_caseta, notify.ios, homekit, zeroconf, ipp, binary_sensor.updater, climate.nuheat, script, sense, device_tracker, light.lutron_caseta_pro, broadlink, nuheat, input_select, sensor.coronavirus, sensor.lutron_caseta_pro, sensor.unifiprotect, harmony, panel_iframe, autelis, cover.homekit_controller, light.lutron_caseta, person, camera.synology_dsm, roomba, camera.august, binary_sensor.template, device_automation, rest_command, input_datetime, homekit_controller, switch.rachio, sensor.wundergroundpws, shell_command, switch.isy994, binary_sensor, binary_sensor.august, switch.synology_dsm, sensor.tado, sensor.command_line, updater, media_player.sonos, media_source, websocket_api, switch.template, sensor.cert_expiry, cover.hunterdouglas_powerview, light.isy994, binary_sensor.nexia, sensor.template, image, sensor.isy994, profiler, cloud, zone, logbook, sun, sensor.filesize, onboarding, homeassistant, input_boolean, sensor.powerwall, media_player.apple_tv, calendar.garbage_collection, fan.template, apple_tv, lovelace, search, tag, lock.isy994, ffmpeg, synology_dsm, august, remote, http, stream, isy994, remote.broadlink, switch.doorbird, sonos
2020-10-27 15:31:36 WARNING (SyncWorker_14) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:36 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, title: input_text, auth, ssdp, senseme, lutron_caseta_pro, system_health, nut, hacs, recorder, myq, fan, lock, config, gogogate2, configurator, notify, counter, camera, cover, tado, calendar, default_config, cert_expiry, scene, webhook, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, history, mobile_app, api, upnp, logger, unifiprotect, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, doorbird, sensor, switch, esphome, climate, alexa, variable, emulated_hue, ambient_station, media_player, persistent_notification, weather, garbage_collection, input_number, lutron_caseta, cast, water_heater, system_log, map, frontend, hue, group, vacuum, emulated_kasa, homekit, zeroconf, ipp, sense, script, device_tracker, broadlink, nuheat, input_select, harmony, panel_iframe, autelis, person, roomba, device_automation, rest_command, input_datetime, homekit_controller, shell_command, binary_sensor, updater, media_source, websocket_api, image, profiler, cloud, zone, logbook, sun, onboarding, homeassistant, input_boolean, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, august, remote, http, stream, isy994, sonos
2020-10-27 15:31:36 WARNING (SyncWorker_11) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:40 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, state: input_text, binary_sensor.tesla, auth, ssdp, sensor.snmp, climate.isy994, senseme, lutron_caseta_pro, sensor.hunterdouglas_powerview, system_health, switch.lutron_caseta, nut, hacs, camera.doorbird, binary_sensor.powerwall, recorder, myq, fan, lock, config, binary_sensor.myq, gogogate2, configurator, notify, sensor.griddy, sensor.ambient_station, counter, camera, cover.lutron_caseta_pro, notify.smtp, climate.nexia, binary_sensor.lutron_caseta, binary_sensor.senseme, sensor.garbage_collection, alarm_control_panel, cover, tado, calendar, default_config, cert_expiry, scene, sensor.filter, sensor.history_stats, climate.elkm1, water_heater.tado, webhook, light.group, fan.senseme, sensor.nut, media_player.cast, climate.tesla, coronavirus, binary_sensor.unifiprotect, hunterdouglas_powerview, timer, rachio, nexia, binary_sensor.roomba, camera.unifiprotect, history, mobile_app, binary_sensor.synology_dsm, sensor.august, api, upnp, cover.myq, logger, unifiprotect, switch.unifiprotect, switch.tesla, device_tracker.tesla, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, cover.gogogate2, lock.tesla, sensor.ios, doorbird, sensor.mobile_app, sensor.rest, cover.isy994, sensor.synology_dsm, scene.lutron_caseta_pro, fan.lutron_caseta, binary_sensor.isy994, sensor, switch, climate.tado, light.senseme, notify.group, scene.hunterdouglas_powerview, esphome, scene.elkm1, climate, alexa, sensor.nexia, vacuum.roomba, variable, elkm1, emulated_hue, ambient_station, media_player, persistent_notification, remote.harmony, binary_sensor.rachio, light.elkm1, weather, fan.lutron_caseta_pro, sensor.roomba, binary_sensor.mobile_app, garbage_collection, lock.august, input_number, lutron_caseta, cast, lock.template, water_heater, fan.isy994, system_log, map, binary_sensor.esphome, alarm_control_panel.elkm1, switch.elkm1, binary_sensor.sense, sensor.esphome, switch.lutron_caseta_pro, notify.mobile_app, frontend, scene.lutron_caseta, hue, weather.darksky, group, sensor.sense, remote.apple_tv, sensor.tesla, sensor.elkm1, binary_sensor.ambient_station, scene.homeassistant, scene.nexia, vacuum, device_tracker.mobile_app, media_player.universal, emulated_kasa, switch.esphome, cover.lutron_caseta, notify.ios, homekit, zeroconf, ipp, binary_sensor.updater, climate.nuheat, script, sense, device_tracker, light.lutron_caseta_pro, broadlink, nuheat, input_select, sensor.coronavirus, sensor.lutron_caseta_pro, sensor.unifiprotect, harmony, panel_iframe, autelis, cover.homekit_controller, light.lutron_caseta, person, camera.synology_dsm, roomba, camera.august, binary_sensor.template, device_automation, rest_command, input_datetime, homekit_controller, switch.rachio, sensor.wundergroundpws, shell_command, switch.isy994, binary_sensor, binary_sensor.august, switch.synology_dsm, sensor.tado, sensor.command_line, updater, media_player.sonos, media_source, websocket_api, switch.template, sensor.cert_expiry, cover.hunterdouglas_powerview, light.isy994, binary_sensor.nexia, sensor.template, image, sensor.isy994, profiler, cloud, zone, logbook, sun, sensor.filesize, onboarding, homeassistant, input_boolean, sensor.powerwall, media_player.apple_tv, calendar.garbage_collection, fan.template, apple_tv, lovelace, search, tag, lock.isy994, ffmpeg, synology_dsm, august, remote, http, stream, isy994, remote.broadlink, switch.doorbird, sonos
2020-10-27 15:31:41 WARNING (SyncWorker_2) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:41 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, title: input_text, auth, ssdp, senseme, lutron_caseta_pro, system_health, nut, hacs, recorder, myq, fan, lock, config, gogogate2, configurator, notify, counter, camera, alarm_control_panel, cover, tado, calendar, default_config, cert_expiry, scene, webhook, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, history, mobile_app, api, upnp, logger, unifiprotect, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, doorbird, sensor, switch, esphome, climate, alexa, variable, elkm1, emulated_hue, ambient_station, media_player, persistent_notification, weather, garbage_collection, input_number, lutron_caseta, cast, water_heater, system_log, map, frontend, hue, group, vacuum, emulated_kasa, homekit, zeroconf, ipp, sense, script, device_tracker, broadlink, nuheat, input_select, harmony, panel_iframe, autelis, person, roomba, device_automation, rest_command, input_datetime, homekit_controller, shell_command, binary_sensor, updater, media_source, websocket_api, image, profiler, cloud, zone, logbook, sun, onboarding, homeassistant, input_boolean, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, august, remote, http, stream, isy994, sonos
2020-10-27 15:31:41 WARNING (SyncWorker_0) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:43 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, state: input_text, binary_sensor.tesla, auth, ssdp, sensor.snmp, climate.isy994, senseme, lutron_caseta_pro, sensor.hunterdouglas_powerview, system_health, switch.lutron_caseta, nut, hacs, camera.doorbird, binary_sensor.powerwall, recorder, myq, fan, lock, config, binary_sensor.myq, gogogate2, configurator, notify, sensor.griddy, sensor.ambient_station, counter, camera, cover.lutron_caseta_pro, notify.smtp, climate.nexia, binary_sensor.lutron_caseta, binary_sensor.senseme, sensor.garbage_collection, alarm_control_panel, cover, tado, calendar, default_config, cert_expiry, scene, sensor.filter, sensor.history_stats, climate.elkm1, water_heater.tado, webhook, light.group, fan.senseme, sensor.nut, media_player.cast, climate.tesla, coronavirus, binary_sensor.unifiprotect, hunterdouglas_powerview, timer, rachio, nexia, binary_sensor.roomba, camera.unifiprotect, history, mobile_app, binary_sensor.synology_dsm, sensor.august, api, upnp, cover.myq, logger, unifiprotect, switch.unifiprotect, switch.tesla, device_tracker.tesla, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, cover.gogogate2, lock.tesla, sensor.ios, doorbird, sensor.mobile_app, sensor.rest, cover.isy994, sensor.synology_dsm, scene.lutron_caseta_pro, fan.lutron_caseta, binary_sensor.isy994, sensor, switch, climate.tado, light.senseme, notify.group, scene.hunterdouglas_powerview, esphome, scene.elkm1, climate, alexa, sensor.nexia, vacuum.roomba, variable, elkm1, emulated_hue, ambient_station, media_player, persistent_notification, remote.harmony, binary_sensor.rachio, light.elkm1, weather, fan.lutron_caseta_pro, sensor.roomba, binary_sensor.mobile_app, garbage_collection, lock.august, input_number, lutron_caseta, cast, lock.template, water_heater, fan.isy994, system_log, map, binary_sensor.esphome, alarm_control_panel.elkm1, switch.elkm1, binary_sensor.sense, sensor.esphome, switch.lutron_caseta_pro, notify.mobile_app, frontend, scene.lutron_caseta, hue, weather.darksky, group, sensor.sense, remote.apple_tv, sensor.tesla, sensor.elkm1, binary_sensor.ambient_station, scene.homeassistant, scene.nexia, vacuum, device_tracker.mobile_app, media_player.universal, emulated_kasa, switch.esphome, cover.lutron_caseta, notify.ios, homekit, zeroconf, ipp, binary_sensor.updater, climate.nuheat, script, sense, device_tracker, light.lutron_caseta_pro, broadlink, nuheat, input_select, sensor.coronavirus, sensor.lutron_caseta_pro, sensor.unifiprotect, harmony, panel_iframe, autelis, cover.homekit_controller, light.lutron_caseta, person, camera.synology_dsm, roomba, camera.august, binary_sensor.template, device_automation, rest_command, input_datetime, homekit_controller, switch.rachio, sensor.wundergroundpws, shell_command, switch.isy994, binary_sensor, binary_sensor.august, switch.synology_dsm, sensor.tado, sensor.command_line, updater, media_player.sonos, media_source, websocket_api, switch.template, sensor.cert_expiry, cover.hunterdouglas_powerview, light.isy994, binary_sensor.nexia, sensor.template, image, sensor.isy994, profiler, cloud, zone, logbook, sun, sensor.filesize, onboarding, homeassistant, input_boolean, sensor.powerwall, media_player.apple_tv, calendar.garbage_collection, fan.template, denonavr, apple_tv, lovelace, search, tag, lock.isy994, ffmpeg, synology_dsm, august, remote, http, stream, isy994, remote.broadlink, switch.doorbird, sonos
2020-10-27 15:31:44 WARNING (SyncWorker_25) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
2020-10-27 15:31:44 DEBUG (MainThread) [homeassistant.helpers.translation] Cache miss for en, title: input_text, auth, ssdp, senseme, lutron_caseta_pro, system_health, nut, hacs, recorder, myq, fan, lock, config, gogogate2, configurator, notify, counter, camera, alarm_control_panel, cover, tado, calendar, default_config, cert_expiry, scene, webhook, coronavirus, hunterdouglas_powerview, timer, rachio, nexia, history, mobile_app, api, upnp, logger, unifiprotect, automation, powerwall, tts, tesla, light, ifttt, ios, griddy, doorbird, sensor, switch, esphome, climate, alexa, variable, elkm1, emulated_hue, ambient_station, media_player, persistent_notification, weather, garbage_collection, input_number, lutron_caseta, cast, water_heater, system_log, map, frontend, hue, group, vacuum, emulated_kasa, homekit, zeroconf, ipp, sense, script, device_tracker, broadlink, nuheat, input_select, harmony, panel_iframe, autelis, person, roomba, device_automation, rest_command, input_datetime, homekit_controller, shell_command, binary_sensor, updater, media_source, websocket_api, image, profiler, cloud, zone, logbook, sun, onboarding, homeassistant, input_boolean, denonavr, apple_tv, lovelace, search, tag, ffmpeg, synology_dsm, august, remote, http, stream, isy994, sonos
2020-10-27 15:31:44 WARNING (SyncWorker_6) [homeassistant.util.json] Load json: /usr/src/homeassistant/homeassistant/components/ffmpeg/translations/en.json
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
