### PR TITLE
Bump hatasmota to 0.0.24

### DIFF
--- a/homeassistant/components/tasmota/discovery.py
+++ b/homeassistant/components/tasmota/discovery.py
@@ -29,6 +29,9 @@ TASMOTA_DISCOVERY_INSTANCE = "tasmota_discovery_instance"
 
 def clear_discovery_hash(hass, discovery_hash):
     """Clear entry in ALREADY_DISCOVERED list."""
+    if ALREADY_DISCOVERED not in hass.data:
+        # Discovery is shutting down
+        return
     del hass.data[ALREADY_DISCOVERED][discovery_hash]
 
 

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.0.23"],
+  "requirements": ["hatasmota==0.0.24"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -732,7 +732,7 @@ hass-nabucasa==0.37.1
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.0.23
+hatasmota==0.0.24
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -367,7 +367,7 @@ hangups==0.4.11
 hass-nabucasa==0.37.1
 
 # homeassistant.components.tasmota
-hatasmota==0.0.23
+hatasmota==0.0.24
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -92,6 +92,30 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_OFF
 
 
+async def test_friendly_names(hass, mqtt_mock, setup_tasmota):
+    """Test state update via MQTT."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["rl"][0] = 1
+    config["swc"][0] = 1
+    config["swc"][1] = 1
+    mac = config["mac"]
+
+    async_fire_mqtt_message(
+        hass,
+        f"{DEFAULT_PREFIX}/{mac}/config",
+        json.dumps(config),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
+    assert state.state == "unavailable"
+    assert state.attributes.get("friendly_name") == "Tasmota binary_sensor 1"
+
+    state = hass.states.get("binary_sensor.beer")
+    assert state.state == "unavailable"
+    assert state.attributes.get("friendly_name") == "Beer"
+
+
 async def test_off_delay(hass, mqtt_mock, setup_tasmota):
     """Test off_delay option."""
     config = copy.deepcopy(DEFAULT_CONFIG)

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -830,3 +830,53 @@ async def test_attach_unknown_remove_device_from_registry(
     # Remove the device
     device_reg.async_remove_device(device_entry.id)
     await hass.async_block_till_done()
+
+
+async def test_attach_remove_config_entry(hass, mqtt_mock, setup_tasmota, device_reg):
+    """Test trigger cleanup when removing a Tasmota config entry."""
+    # Discover a device with device trigger
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["swc"][0] = 0
+    mac = config["mac"]
+
+    mqtt_mock.async_subscribe.reset_mock()
+
+    async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
+    await hass.async_block_till_done()
+
+    device_entry = device_reg.async_get_device(set(), {("mac", mac)})
+
+    calls = []
+
+    def callback(trigger, context):
+        calls.append(trigger["trigger"]["description"])
+
+    await async_attach_trigger(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device_entry.id,
+            "discovery_id": "00000049A3BC_switch_1_TOGGLE",
+            "type": "button_short_press",
+            "subtype": "switch_1",
+        },
+        callback,
+        None,
+    )
+
+    # Fake short press.
+    async_fire_mqtt_message(hass, "tasmota_49A3BC/stat/SWITCH1T", '{"TRIG":"TOGGLE"}')
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0] == "event 'tasmota_event'"
+
+    # Remove the Tasmota config entry
+    config_entries = hass.config_entries.async_entries("tasmota")
+    await hass.config_entries.async_remove(config_entries[0].entry_id)
+    await hass.async_block_till_done()
+
+    # Verify the triggers are no longer active
+    async_fire_mqtt_message(hass, "tasmota_49A3BC/stat/SWITCH1T", '{"TRIG":"TOGGLE"}')
+    await hass.async_block_till_done()
+    assert len(calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump hatasmota from 0.0.23 to 0.0.24 + improve tests
Also fix an exception when removing or reloading the Tasmota integration

Changes:
 - 0.0.24 (https://github.com/emontnemery/hatasmota/releases/tag/0.0.24)
   - Fix cleanup of relay configured as light (#21)
   - Tweak fallback friendly name (#20)
   - Support lights with Setoption20 enabled (#19)

https://github.com/emontnemery/hatasmota/compare/0.0.23...0.0.24

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
