### PR TITLE
Extend eQ-3 Bluetooth Smart thermostats integration

### DIFF
--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -1,1 +1,4 @@
 """The eq3btsmart component."""
+
+DOMAIN = "eq3btsmart"
+PLATFORMS = ["climate"]

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -76,17 +76,17 @@ ATTR_STATE_ERROR = "error"
 ATTR_STATE_LAST_ERROR_AT = "last_error_at"
 
 EQ_TO_HA_HVAC = {
-    eq3.Mode.Open: HVAC_MODE_HEAT,
     eq3.Mode.Closed: HVAC_MODE_OFF,
+    eq3.Mode.Open: HVAC_MODE_HEAT,
     eq3.Mode.Auto: HVAC_MODE_AUTO,
     eq3.Mode.Manual: HVAC_MODE_HEAT,
-    eq3.Mode.Boost: HVAC_MODE_AUTO,
     eq3.Mode.Away: HVAC_MODE_HEAT,
+    eq3.Mode.Boost: HVAC_MODE_AUTO,
 }
 
 HA_TO_EQ_HVAC = {
-    HVAC_MODE_HEAT: eq3.Mode.Manual,
     HVAC_MODE_OFF: eq3.Mode.Closed,
+    HVAC_MODE_HEAT: eq3.Mode.Manual,
     HVAC_MODE_AUTO: eq3.Mode.Auto,
 }
 HA_TO_EQ_HVAC_SENSOR_CONTROL = {

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -26,6 +26,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
     ATTR_TEMPERATURE,
     CONF_DEVICES,
     CONF_MAC,
@@ -115,6 +116,7 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Optional(CONF_COLD_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
         vol.Optional(CONF_HOT_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
         vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
     }
 )
 
@@ -144,7 +146,7 @@ class EQ3BTSmartThermostat(ClimateEntity, RestoreEntity):
         # We want to avoid name clash with this module.
 
         self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, _name, hass=hass)
-        self._name = _name
+        self._name = device_cfg.get(ATTR_FRIENDLY_NAME, _name)
         self._unique_id = device_cfg.get(
             CONF_UNIQUE_ID, self.entity_id + "_" + device_cfg[CONF_MAC]
         )

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -1,4 +1,5 @@
 """Support for eQ-3 Bluetooth Smart thermostats."""
+import asyncio
 import logging
 
 from bluepy.btle import BTLEException  # pylint: disable=import-error, no-name-in-module
@@ -7,6 +8,9 @@ import voluptuous as vol
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
 from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
@@ -20,18 +24,30 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_DEVICES,
     CONF_MAC,
+    EVENT_HOMEASSISTANT_START,
     PRECISION_HALVES,
     PRECISION_TENTHS,
     PRECISION_WHOLE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     TEMP_CELSIUS,
 )
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.restore_state import RestoreEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_SENSOR = "target_sensor"
+CONF_SENSOR_CONTROL = "control_by_target_sensor"
 CONF_MIN_TEMP = "min_temp"
 CONF_MAX_TEMP = "max_temp"
 CONF_PRECISION = "precision"
+CONF_COLD_TOLERANCE = "cold_tolerance"
+CONF_HOT_TOLERANCE = "hot_tolerance"
+
+DEFAULT_TOLERANCE = 0.3
 STATE_BOOST = "boost"
 
 ATTR_STATE_WINDOW_OPEN = "window_open"
@@ -39,6 +55,7 @@ ATTR_STATE_VALVE = "valve"
 ATTR_STATE_LOCKED = "is_locked"
 ATTR_STATE_LOW_BAT = "low_battery"
 ATTR_STATE_AWAY_END = "away_end"
+ATTR_STATE_THERMOSTAT = "thermostat_state"
 
 EQ_TO_HA_HVAC = {
     eq3.Mode.Open: HVAC_MODE_HEAT,
@@ -54,20 +71,42 @@ HA_TO_EQ_HVAC = {
     HVAC_MODE_OFF: eq3.Mode.Closed,
     HVAC_MODE_AUTO: eq3.Mode.Auto,
 }
+HA_TO_EQ_HVAC_SENSOR_CONTROL = {
+    HVAC_MODE_OFF: eq3.Mode.Closed,
+    HVAC_MODE_HEAT: eq3.Mode.Open,
+}
 
 EQ_TO_HA_PRESET = {eq3.Mode.Boost: PRESET_BOOST, eq3.Mode.Away: PRESET_AWAY}
 
 HA_TO_EQ_PRESET = {PRESET_BOOST: eq3.Mode.Boost, PRESET_AWAY: eq3.Mode.Away}
 
+EQ_TO_STRING = {
+    eq3.Mode.Unknown: "unknown",
+    eq3.Mode.Closed: "closed",
+    eq3.Mode.Open: "open",
+    eq3.Mode.Auto: "auto",
+    eq3.Mode.Manual: "manual",
+    eq3.Mode.Away: "away",
+    eq3.Mode.Boost: "boost",
+}
+
+EQ_TO_HA_HVAC_ACTION = {
+    eq3.Mode.Open: CURRENT_HVAC_HEAT,
+    eq3.Mode.Closed: CURRENT_HVAC_IDLE,
+}
 
 DEVICE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_MAC): cv.string,
+        vol.Optional(CONF_SENSOR): cv.entity_id,
+        vol.Optional(CONF_SENSOR_CONTROL, default=False): cv.boolean,
         vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
         vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
         vol.Optional(CONF_PRECISION): vol.In(
             [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
         ),
+        vol.Optional(CONF_COLD_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
+        vol.Optional(CONF_HOT_TOLERANCE, default=DEFAULT_TOLERANCE): vol.Coerce(float),
     }
 )
 
@@ -76,19 +115,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+SUPPORT_FLAGS_SENSOR_CONTROL = SUPPORT_TARGET_TEMPERATURE
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the eQ-3 BLE thermostats."""
     devices = []
 
     for name, device_cfg in config[CONF_DEVICES].items():
         devices.append(EQ3BTSmartThermostat(hass, name, device_cfg))
 
-    add_entities(devices, True)
+    async_add_entities(devices, True)
 
 
-class EQ3BTSmartThermostat(ClimateEntity):
+class EQ3BTSmartThermostat(ClimateEntity, RestoreEntity):
     """Representation of an eQ-3 Bluetooth Smart thermostat."""
 
     def __init__(self, hass, _name, device_cfg):
@@ -97,13 +137,162 @@ class EQ3BTSmartThermostat(ClimateEntity):
         self._name = _name
         self._thermostat = eq3.Thermostat(device_cfg[CONF_MAC])
 
+        self._sensor_entity_id = device_cfg.get(CONF_SENSOR)
+        self._sensor_control = device_cfg.get(CONF_SENSOR_CONTROL)
         self._min_temp = device_cfg.get(CONF_MIN_TEMP)
         self._max_temp = device_cfg.get(CONF_MAX_TEMP)
         self._temp_precision = device_cfg.get(CONF_PRECISION)
+        self._cold_tolerance = device_cfg.get(CONF_COLD_TOLERANCE)
+        self._hot_tolerance = device_cfg.get(CONF_HOT_TOLERANCE)
+
+        self._cur_temp = None
+        self._target_temp = None
+        self._hvac_mode = None
+        self._active = False
+        self._temp_lock = asyncio.Lock()
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added."""
+        await super().async_added_to_hass()
+
+        if not self._sensor_entity_id:
+            return
+
+        # Add listener
+        async_track_state_change(
+            self.hass, self._sensor_entity_id, self._async_sensor_changed
+        )
+
+        @callback
+        def _async_startup(event):
+            """Init on startup."""
+            sensor_state = self.hass.states.get(self._sensor_entity_id)
+            if sensor_state and sensor_state.state not in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+            ):
+                self._async_update_temp(sensor_state)
+
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_startup)
+
+        if not self._sensor_control:
+            return
+
+        # If target sensor controls the thermostat we try to restore the old state
+        old_state = await self.async_get_last_state()
+        if (
+            old_state is not None
+            and old_state.attributes.get(ATTR_TEMPERATURE) is not None
+        ):
+            # If we have a previously saved temperature
+            self._target_temp = float(old_state.attributes[ATTR_TEMPERATURE])
+            _LOGGER.info(
+                "%s - Restored previously saved target temperature %s",
+                self._name,
+                self._target_temp,
+            )
+        else:
+            self._target_temp = self.min_temp
+            _LOGGER.warning(
+                "%s - No previously saved target temperature, setting to %s",
+                self._name,
+                self._target_temp,
+            )
+
+        if old_state is None or old_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            # Set default state to off
+            self._hvac_mode = HVAC_MODE_OFF
+            _LOGGER.warning(
+                "%s - No previously state, setting to %s", self._name, self._hvac_mode
+            )
+        else:
+            self._hvac_mode = old_state.state
+            _LOGGER.info(
+                "%s - Restored previous state, setting to %s",
+                self._name,
+                self._hvac_mode,
+            )
+
+        # Turn thermostat off on start if HVAC_MODE is off to get in sync (it's possible that while HA was off the EQ3 state was changed by other means)
+        if self._hvac_mode == HVAC_MODE_OFF or self._cur_temp is None:
+            self.turn_off()
+
+    async def _async_sensor_changed(self, entity_id, old_state, new_state):
+        """Handle temperature changes."""
+        self._async_update_temp(new_state)
+        await self._async_control_heating()
+        self.async_write_ha_state()
+
+    @callback
+    def _async_update_temp(self, state):
+        """Update thermostat with latest state from sensor."""
+        if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            self._cur_temp = None
+            return
+
+        try:
+            self._cur_temp = float(state.state)
+        except ValueError as ex:
+            _LOGGER.error("%s - Unable to update from sensor: %s", self._name, ex)
+
+    async def _async_control_heating(self):
+        """Check if we need to turn heating on or off."""
+        if not self._sensor_control:
+            return
+
+        async with self._temp_lock:
+            if not self._active and None not in (self._cur_temp, self._target_temp):
+                self._active = True
+                _LOGGER.info(
+                    "%s - Obtained current (%s) and target temperature (%s). "
+                    "Thermostat active",
+                    self._name,
+                    self._cur_temp,
+                    self._target_temp,
+                )
+
+            if not self._active:
+                return
+
+            if self._cur_temp is None:
+                self._active = False
+                if self._is_device_active:
+                    _LOGGER.warning(
+                        "%s - Target sensor became unavailable. "
+                        "Turning off thermostat until it comes back online",
+                        self._name,
+                    )
+                    self.turn_off()
+                else:
+                    _LOGGER.warning(
+                        "%s - Target sensor became unavailable. ",
+                        self._name,
+                    )
+                return
+
+            too_cold = self._target_temp >= self._cur_temp + self._cold_tolerance
+            too_hot = self._cur_temp >= self._target_temp + self._hot_tolerance
+
+            if self._is_device_active and (self._hvac_mode == HVAC_MODE_OFF or too_hot):
+                self.turn_off()
+            elif (
+                self._hvac_mode == HVAC_MODE_HEAT
+                and not self._is_device_active
+                and too_cold
+            ):
+                self.turn_on()
+
+    @property
+    def _is_device_active(self):
+        """If the thermostat currently active."""
+        return self._thermostat.mode == eq3.Mode.Open
 
     @property
     def supported_features(self):
         """Return the list of supported features."""
+        if self._sensor_control:
+            return SUPPORT_FLAGS_SENSOR_CONTROL
+
         return SUPPORT_FLAGS
 
     @property
@@ -131,38 +320,83 @@ class EQ3BTSmartThermostat(ClimateEntity):
 
     @property
     def current_temperature(self):
-        """Can not report temperature, so return target_temperature."""
+        """Return the sensor temperature if defined, otherwise return target_temperature."""
+        if self._sensor_entity_id:
+            return self._cur_temp
+
         return self.target_temperature
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
+        if self._sensor_control:
+            return self._target_temp
+
         return self._thermostat.target_temperature
 
-    def set_temperature(self, **kwargs):
+    async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
+
+        if self._sensor_control:
+            self._target_temp = temperature
+            await self._async_control_heating()
+            self.async_write_ha_state()
+            return
+
         self._thermostat.target_temperature = temperature
 
     @property
     def hvac_mode(self):
         """Return the current operation mode."""
+        if self._sensor_control:
+            return self._hvac_mode
+
         if self._thermostat.mode < 0:
             return HVAC_MODE_OFF
         return EQ_TO_HA_HVAC[self._thermostat.mode]
 
     @property
+    def hvac_action(self):
+        """Return the current running hvac operation if supported.
+
+        Need to be one of CURRENT_HVAC_*.
+        """
+        if not self._sensor_control:
+            return None
+
+        if self.hvac_mode == HVAC_MODE_OFF:
+            return CURRENT_HVAC_OFF
+
+        return EQ_TO_HA_HVAC_ACTION.get(self._thermostat.mode, "-")
+
+    @property
     def hvac_modes(self):
         """Return the list of available operation modes."""
-        return list(HA_TO_EQ_HVAC)
+        if self._sensor_control:
+            return list(HA_TO_EQ_HVAC_SENSOR_CONTROL.keys())
 
-    def set_hvac_mode(self, hvac_mode):
+        return list(HA_TO_EQ_HVAC.keys())
+
+    async def async_set_hvac_mode(self, hvac_mode):
         """Set operation mode."""
+        if self._sensor_control:
+            if hvac_mode not in (HVAC_MODE_HEAT, HVAC_MODE_OFF):
+                _LOGGER.error("%s - Unrecognized hvac mode: %s", self._name, hvac_mode)
+                return
+
+            _LOGGER.debug("%s - Setting HVAC state to %s", self._name, hvac_mode)
+            self._hvac_mode = hvac_mode
+            await self._async_control_heating()
+            self.schedule_update_ha_state()
+            return
+
         if self.preset_mode:
             return
-        self._thermostat.mode = HA_TO_EQ_HVAC[hvac_mode]
+
+        self.set_device_mode(HA_TO_EQ_HVAC[hvac_mode])
 
     @property
     def min_temp(self):
@@ -190,6 +424,8 @@ class EQ3BTSmartThermostat(ClimateEntity):
             ATTR_STATE_VALVE: self._thermostat.valve_state,
             ATTR_STATE_WINDOW_OPEN: self._thermostat.window_open,
         }
+        if self._sensor_control:
+            dev_specific[ATTR_STATE_THERMOSTAT] = EQ_TO_STRING[self._thermostat.mode]
 
         return dev_specific
 
@@ -207,18 +443,53 @@ class EQ3BTSmartThermostat(ClimateEntity):
 
         Requires SUPPORT_PRESET_MODE.
         """
-        return list(HA_TO_EQ_PRESET)
+        if self._sensor_control:
+            return PRESET_NONE
 
-    def set_preset_mode(self, preset_mode):
+        return list(HA_TO_EQ_PRESET.keys())
+
+    async def async_set_preset_mode(self, preset_mode: str):
         """Set new preset mode."""
+        if self._sensor_control:
+            return
+
         if preset_mode == PRESET_NONE:
-            self.set_hvac_mode(HVAC_MODE_HEAT)
-        self._thermostat.mode = HA_TO_EQ_PRESET[preset_mode]
+            await self.async_set_hvac_mode(HVAC_MODE_HEAT)
+
+        self.set_device_mode(HA_TO_EQ_PRESET[preset_mode])
 
     def update(self):
         """Update the data from the thermostat."""
 
+        _LOGGER.debug("%s - Updating thermostat", self._name)
         try:
             self._thermostat.update()
         except BTLEException as ex:
-            _LOGGER.warning("Updating the state failed: %s", ex)
+            _LOGGER.warning("%s - Updating the state failed: %s", self._name, ex)
+
+    def set_device_mode(self, mode):
+        """Set the thermostat mode."""
+
+        _LOGGER.debug(
+            "%s - Setting thermostat mode to %s", self._name, EQ_TO_STRING[mode]
+        )
+        try:
+            self._thermostat.mode = mode
+        except BTLEException as ex:
+            _LOGGER.warning("%s - Setting the state failed: %s", self._name, ex)
+
+    def turn_off(self):
+        """Turn off thermostat."""
+
+        _LOGGER.info("%s - Turning off thermostat", self._name)
+        self.set_device_mode(eq3.Mode.Closed)
+
+    def turn_on(self):
+        """Turn on thermostat."""
+
+        if self._hvac_mode == HVAC_MODE_OFF:
+            _LOGGER.error("%s - Invalid turn on request", self._name)
+            return
+
+        _LOGGER.debug("%s - Turning on thermostat", self._name)
+        self.set_device_mode(eq3.Mode.Open)

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -45,8 +45,11 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util.dt import utcnow
+
+from . import DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -135,6 +138,9 @@ SUPPORT_FLAGS_SENSOR_CONTROL = SUPPORT_TARGET_TEMPERATURE
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the eQ-3 BLE thermostats."""
+
+    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
+
     devices = []
 
     for name, device_cfg in config[CONF_DEVICES].items():

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -109,7 +109,7 @@ class EQ3BTSmartThermostat(ClimateEntity):
     @property
     def available(self) -> bool:
         """Return if thermostat is available."""
-        return self._thermostat.mode >= 0
+        return self._thermostat.mode != eq3.Mode.Unknown
 
     @property
     def name(self):

--- a/homeassistant/components/eq3btsmart/services.yaml
+++ b/homeassistant/components/eq3btsmart/services.yaml
@@ -1,0 +1,2 @@
+reload:
+  description: Reload all eQ-3 entities.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extended the support for eQ-3 Bluetooth thermostats, and improved the logging.
Added the following new configuration options:
- "**target_sensor**" allows specifying an external temperature sensor to report the current temperature in the room, since these devices do not contain a temperature sensor;
- "**control_by_target_sensor**" allows to run the thermostat in manual mode controlled by the readings of the "target_sensor".

Added the following options, similar with the ones from "Generic Thermostat" integration:
- "min_temp"
- "max_temp"
- "precision"
- "cold_tolerance"
- "hot_tolerance"

When the **control_by_target_sensor** is enabled, the thermostat will run in manual mode and no presets will be available.
The only available HVAC modes will be limited to **HEAT** or **OFF**.
When mode is **HEAT**:
- When the **target temperature** is above the temperature reported by the **target_sensor**, the bluetooth thermostat will switch to "ON" mode, and the climate entity will switch to **heating**.
- When the **target temperature** is below the temperature reported by the **target_sensor**, the bluetooth thermostat will switch to "OFF" mode, and the climate entity will switch to **idle**.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
climate:
  - platform: eq3btsmart
    scan_interval: 300 #set to 5 min, to reduce the number of times the thermostats are querried
    devices:
      office:
        mac: 'xx:xx:xx:xx:xx:xx'
        target_sensor: sensor.mi_temperature_office
        control_by_target_sensor: true
        min_temp: 18
        max_temp: 24
        precision: 0.1
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
