### PR TITLE
Add not internet accessible to base strings for config flows

### DIFF
--- a/homeassistant/components/dialogflow/strings.json
+++ b/homeassistant/components/dialogflow/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive Dialogflow messages."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [webhook integration of Dialogflow]({dialogflow_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/dialogflow/strings.json
+++ b/homeassistant/components/dialogflow/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [webhook integration of Dialogflow]({dialogflow_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/dialogflow/strings.json
+++ b/homeassistant/components/dialogflow/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [webhook integration of Dialogflow]({dialogflow_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/geofency/strings.json
+++ b/homeassistant/components/geofency/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Geofency."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Geofency.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/geofency/strings.json
+++ b/homeassistant/components/geofency/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Geofency.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/geofency/strings.json
+++ b/homeassistant/components/geofency/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Geofency.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/gpslogger/strings.json
+++ b/homeassistant/components/gpslogger/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from GPSLogger."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in GPSLogger.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/gpslogger/strings.json
+++ b/homeassistant/components/gpslogger/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in GPSLogger.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/gpslogger/strings.json
+++ b/homeassistant/components/gpslogger/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in GPSLogger.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/ifttt/strings.json
+++ b/homeassistant/components/ifttt/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive IFTTT messages."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to use the \"Make a web request\" action from the [IFTTT Webhook applet]({applet_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/ifttt/strings.json
+++ b/homeassistant/components/ifttt/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to use the \"Make a web request\" action from the [IFTTT Webhook applet]({applet_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/ifttt/strings.json
+++ b/homeassistant/components/ifttt/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to use the \"Make a web request\" action from the [IFTTT Webhook applet]({applet_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/locative/strings.json
+++ b/homeassistant/components/locative/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Geofency."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send locations to Home Assistant, you will need to setup the webhook feature in the Locative app.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/locative/strings.json
+++ b/homeassistant/components/locative/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send locations to Home Assistant, you will need to setup the webhook feature in the Locative app.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/locative/strings.json
+++ b/homeassistant/components/locative/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send locations to Home Assistant, you will need to setup the webhook feature in the Locative app.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive Mailgun messages."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [Webhooks with Mailgun]({mailgun_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [Webhooks with Mailgun]({mailgun_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [Webhooks with Mailgun]({mailgun_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/json\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/plaato/strings.json
+++ b/homeassistant/components/plaato/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Plaato Airlock."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Plaato Airlock.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/plaato/strings.json
+++ b/homeassistant/components/plaato/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Plaato Airlock.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/plaato/strings.json
+++ b/homeassistant/components/plaato/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Plaato Airlock.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Traccar."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Traccar.\n\nUse the following url: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Traccar.\n\nUse the following url: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup the webhook feature in Traccar.\n\nUse the following url: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive Twilio messages."
+      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [Webhooks with Twilio]({twilio_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [Webhooks with Twilio]({twilio_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/components/twilio/strings.json
+++ b/homeassistant/components/twilio/strings.json
@@ -8,7 +8,7 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::not_internet_accessible%]"
+      "webhook_not_internet_accessible": "[%key:common::config_flow::abort::webhook_not_internet_accessible%]"
     },
     "create_entry": {
       "default": "To send events to Home Assistant, you will need to setup [Webhooks with Twilio]({twilio_url}).\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n- Content Type: application/x-www-form-urlencoded\n\nSee [the documentation]({docs_url}) on how to configure automations to handle incoming data."

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -66,6 +66,7 @@
         "already_configured_service": "Service is already configured",
         "already_in_progress": "Configuration flow is already in progress",
         "no_devices_found": "No devices found on the network",
+        "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive webhook messages.",
         "oauth2_missing_configuration": "The component is not configured. Please follow the documentation.",
         "oauth2_authorize_url_timeout": "Timeout generating authorize URL.",
         "oauth2_no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -66,7 +66,7 @@
         "already_configured_service": "Service is already configured",
         "already_in_progress": "Configuration flow is already in progress",
         "no_devices_found": "No devices found on the network",
-        "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive webhook messages.",
+        "webhook_not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive webhook messages.",
         "oauth2_missing_configuration": "The component is not configured. Please follow the documentation.",
         "oauth2_authorize_url_timeout": "Timeout generating authorize URL.",
         "oauth2_no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add and use `not_internet_accessible` to base strings for config flows

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #37263 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
