### PR TITLE
Gather all collection listeners and changes at the same time

### DIFF
--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -1,8 +1,9 @@
 """Helper to deal with YAML + storage."""
 from abc import ABC, abstractmethod
 import asyncio
+from dataclasses import dataclass
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, cast
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
@@ -24,6 +25,20 @@ SAVE_DELAY = 10
 CHANGE_ADDED = "added"
 CHANGE_UPDATED = "updated"
 CHANGE_REMOVED = "removed"
+
+
+@dataclass
+class CollectionChangeSet:
+    """Class to represent a change set.
+
+    change_type: One of CHANGE_*
+    item_id: The id of the item
+    item: The item
+    """
+
+    change_type: str
+    item_id: str
+    item: Any
 
 
 ChangeListener = Callable[
@@ -105,11 +120,14 @@ class ObservableCollection(ABC):
         """
         self.listeners.append(listener)
 
-    async def notify_change(self, change_type: str, item_id: str, item: dict) -> None:
+    async def notify_changes(self, change_sets: Iterable[CollectionChangeSet]) -> None:
         """Notify listeners of a change."""
-        self.logger.debug("%s %s: %s", change_type, item_id, item)
         await asyncio.gather(
-            *[listener(change_type, item_id, item) for listener in self.listeners]
+            *[
+                listener(change_set.change_type, change_set.item_id, change_set.item)
+                for listener in self.listeners
+                for change_set in change_sets
+            ]
         )
 
 
@@ -118,9 +136,10 @@ class YamlCollection(ObservableCollection):
 
     async def async_load(self, data: List[dict]) -> None:
         """Load the YAML collection. Overrides existing data."""
+
         old_ids = set(self.data)
 
-        tasks = []
+        change_sets = []
 
         for item in data:
             item_id = item[CONF_ID]
@@ -135,15 +154,15 @@ class YamlCollection(ObservableCollection):
                 event = CHANGE_ADDED
 
             self.data[item_id] = item
-            tasks.append(self.notify_change(event, item_id, item))
+            change_sets.append(CollectionChangeSet(event, item_id, item))
 
         for item_id in old_ids:
-            tasks.append(
-                self.notify_change(CHANGE_REMOVED, item_id, self.data.pop(item_id))
+            change_sets.append(
+                CollectionChangeSet(CHANGE_REMOVED, item_id, self.data.pop(item_id))
             )
 
-        if tasks:
-            await asyncio.gather(*tasks)
+        if change_sets:
+            await self.notify_changes(change_sets)
 
 
 class StorageCollection(ObservableCollection):
@@ -178,9 +197,9 @@ class StorageCollection(ObservableCollection):
         for item in raw_storage["items"]:
             self.data[item[CONF_ID]] = item
 
-        await asyncio.gather(
-            *[
-                self.notify_change(CHANGE_ADDED, item[CONF_ID], item)
+        await self.notify_changes(
+            [
+                CollectionChangeSet(CHANGE_ADDED, item[CONF_ID], item)
                 for item in raw_storage["items"]
             ]
         )
@@ -204,7 +223,9 @@ class StorageCollection(ObservableCollection):
         item[CONF_ID] = self.id_manager.generate_id(self._get_suggested_id(item))
         self.data[item[CONF_ID]] = item
         self._async_schedule_save()
-        await self.notify_change(CHANGE_ADDED, item[CONF_ID], item)
+        await self.notify_changes(
+            [CollectionChangeSet(CHANGE_ADDED, item[CONF_ID], item)]
+        )
         return item
 
     async def async_update_item(self, item_id: str, updates: dict) -> dict:
@@ -222,7 +243,9 @@ class StorageCollection(ObservableCollection):
         self.data[item_id] = updated
         self._async_schedule_save()
 
-        await self.notify_change(CHANGE_UPDATED, item_id, updated)
+        await self.notify_changes(
+            [CollectionChangeSet(CHANGE_UPDATED, item_id, updated)]
+        )
 
         return self.data[item_id]
 
@@ -234,7 +257,7 @@ class StorageCollection(ObservableCollection):
         item = self.data.pop(item_id)
         self._async_schedule_save()
 
-        await self.notify_change(CHANGE_REMOVED, item_id, item)
+        await self.notify_changes([CollectionChangeSet(CHANGE_REMOVED, item_id, item)])
 
     @callback
     def _async_schedule_save(self) -> None:
@@ -254,9 +277,9 @@ class IDLessCollection(ObservableCollection):
 
     async def async_load(self, data: List[dict]) -> None:
         """Load the collection. Overrides existing data."""
-        await asyncio.gather(
-            *[
-                self.notify_change(CHANGE_REMOVED, item_id, item)
+        await self.notify_changes(
+            [
+                CollectionChangeSet(CHANGE_REMOVED, item_id, item)
                 for item_id, item in list(self.data.items())
             ]
         )
@@ -269,9 +292,9 @@ class IDLessCollection(ObservableCollection):
 
             self.data[item_id] = item
 
-        await asyncio.gather(
-            *[
-                self.notify_change(CHANGE_ADDED, item_id, item)
+        await self.notify_changes(
+            [
+                CollectionChangeSet(CHANGE_ADDED, item_id, item)
                 for item_id, item in self.data.items()
             ]
         )

--- a/tests/helpers/test_collection.py
+++ b/tests/helpers/test_collection.py
@@ -91,7 +91,9 @@ async def test_observable_collection():
     assert coll.async_items() == [1]
 
     changes = track_changes(coll)
-    await coll.notify_change("mock_type", "mock_id", {"mock": "item"})
+    await coll.notify_changes(
+        [collection.CollectionChangeSet("mock_type", "mock_id", {"mock": "item"})]
+    )
     assert len(changes) == 1
     assert changes[0] == ("mock_type", "mock_id", {"mock": "item"})
 
@@ -226,25 +228,35 @@ async def test_attach_entity_component_collection(hass):
     coll = collection.ObservableCollection(_LOGGER)
     collection.attach_entity_component_collection(ent_comp, coll, MockEntity)
 
-    await coll.notify_change(
-        collection.CHANGE_ADDED,
-        "mock_id",
-        {"id": "mock_id", "state": "initial", "name": "Mock 1"},
+    await coll.notify_changes(
+        [
+            collection.CollectionChangeSet(
+                collection.CHANGE_ADDED,
+                "mock_id",
+                {"id": "mock_id", "state": "initial", "name": "Mock 1"},
+            )
+        ],
     )
 
     assert hass.states.get("test.mock_1").name == "Mock 1"
     assert hass.states.get("test.mock_1").state == "initial"
 
-    await coll.notify_change(
-        collection.CHANGE_UPDATED,
-        "mock_id",
-        {"id": "mock_id", "state": "second", "name": "Mock 1 updated"},
+    await coll.notify_changes(
+        [
+            collection.CollectionChangeSet(
+                collection.CHANGE_UPDATED,
+                "mock_id",
+                {"id": "mock_id", "state": "second", "name": "Mock 1 updated"},
+            )
+        ],
     )
 
     assert hass.states.get("test.mock_1").name == "Mock 1 updated"
     assert hass.states.get("test.mock_1").state == "second"
 
-    await coll.notify_change(collection.CHANGE_REMOVED, "mock_id", None)
+    await coll.notify_changes(
+        [collection.CollectionChangeSet(collection.CHANGE_REMOVED, "mock_id", None)],
+    )
 
     assert hass.states.get("test.mock_1") is None
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I noticed the zone integration was taking a bit longer to load than
expected when I added more zones.  

This builds on the improvements in #34783 to gather all the changes at once.

Before

```
2020-10-27 23:52:48 INFO (MainThread) [homeassistant.setup] Setup of domain zone took 3.9 seconds
2020-10-27 23:53:18 INFO (MainThread) [homeassistant.setup] Setup of domain zone took 3.8 seconds
2020-10-27 23:53:53 INFO (MainThread) [homeassistant.setup] Setup of domain zone took 4.0 seconds
```

After

```
2020-10-27 23:54:48 INFO (MainThread) [homeassistant.setup] Setup of domain zone took 2.8 seconds
2020-10-27 23:55:17 INFO (MainThread) [homeassistant.setup] Setup of domain zone took 2.7 seconds
2020-10-27 23:55:41 INFO (MainThread) [homeassistant.setup] Setup of domain zone took 2.8 seconds
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
