### PR TITLE
Add DPI Restriction switch to UniFi integration

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
     CONF_DETECTION_TIME,
+    CONF_DPI_RESTRICTIONS,
     CONF_IGNORE_WIRED_BUG,
     CONF_POE_CLIENTS,
     CONF_SITE_ID,
@@ -28,6 +29,7 @@ from .const import (
     CONF_TRACK_DEVICES,
     CONF_TRACK_WIRED_CLIENTS,
     CONTROLLER_ID,
+    DEFAULT_DPI_RESTRICTIONS,
     DEFAULT_POE_CLIENTS,
     DOMAIN as UNIFI_DOMAIN,
     LOGGER,
@@ -294,6 +296,12 @@ class UnifiOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_POE_CLIENTS,
                         default=self.options.get(CONF_POE_CLIENTS, DEFAULT_POE_CLIENTS),
+                    ): bool,
+                    vol.Optional(
+                        CONF_DPI_RESTRICTIONS,
+                        default=self.options.get(
+                            CONF_DPI_RESTRICTIONS, DEFAULT_DPI_RESTRICTIONS
+                        ),
                     ): bool,
                 }
             ),

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -15,6 +15,7 @@ CONF_ALLOW_BANDWIDTH_SENSORS = "allow_bandwidth_sensors"
 CONF_ALLOW_UPTIME_SENSORS = "allow_uptime_sensors"
 CONF_BLOCK_CLIENT = "block_client"
 CONF_DETECTION_TIME = "detection_time"
+CONF_DPI_RESTRICTIONS = "dpi_restrictions"
 CONF_IGNORE_WIRED_BUG = "ignore_wired_bug"
 CONF_POE_CLIENTS = "poe_clients"
 CONF_TRACK_CLIENTS = "track_clients"
@@ -24,6 +25,7 @@ CONF_SSID_FILTER = "ssid_filter"
 
 DEFAULT_ALLOW_BANDWIDTH_SENSORS = False
 DEFAULT_ALLOW_UPTIME_SENSORS = False
+DEFAULT_DPI_RESTRICTIONS = True
 DEFAULT_IGNORE_WIRED_BUG = False
 DEFAULT_POE_CLIENTS = True
 DEFAULT_TRACK_CLIENTS = True

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
     CONF_DETECTION_TIME,
+    CONF_DPI_RESTRICTIONS,
     CONF_IGNORE_WIRED_BUG,
     CONF_POE_CLIENTS,
     CONF_SITE_ID,
@@ -48,6 +49,7 @@ from .const import (
     DEFAULT_ALLOW_BANDWIDTH_SENSORS,
     DEFAULT_ALLOW_UPTIME_SENSORS,
     DEFAULT_DETECTION_TIME,
+    DEFAULT_DPI_RESTRICTIONS,
     DEFAULT_IGNORE_WIRED_BUG,
     DEFAULT_POE_CLIENTS,
     DEFAULT_TRACK_CLIENTS,
@@ -176,6 +178,13 @@ class UniFiController:
     def option_block_clients(self):
         """Config entry option with list of clients to control network access."""
         return self.config_entry.options.get(CONF_BLOCK_CLIENT, [])
+
+    @property
+    def option_dpi_restrictions(self):
+        """Config entry option to control DPI restriction groups."""
+        return self.config_entry.options.get(
+            CONF_DPI_RESTRICTIONS, DEFAULT_DPI_RESTRICTIONS
+        )
 
     # Statistics sensor options
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -7,6 +7,8 @@ from aiohttp import CookieJar
 import aiounifi
 from aiounifi.controller import (
     DATA_CLIENT_REMOVED,
+    DATA_DPI_GROUP,
+    DATA_DPI_GROUP_REMOVED,
     DATA_EVENT,
     SIGNAL_CONNECTION_STATE,
     SIGNAL_DATA,
@@ -255,6 +257,18 @@ class UniFiController:
             elif DATA_CLIENT_REMOVED in data:
                 async_dispatcher_send(
                     self.hass, self.signal_remove, data[DATA_CLIENT_REMOVED]
+                )
+
+            elif DATA_DPI_GROUP in data:
+                for key in data[DATA_DPI_GROUP]:
+                    if self.api.dpi_groups[key].dpiapp_ids:
+                        async_dispatcher_send(self.hass, self.signal_update)
+                    else:
+                        async_dispatcher_send(self.hass, self.signal_remove, {key})
+
+            elif DATA_DPI_GROUP_REMOVED in data:
+                async_dispatcher_send(
+                    self.hass, self.signal_remove, data[DATA_DPI_GROUP_REMOVED]
                 )
 
     @property

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ubiquiti UniFi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": ["aiounifi==24"],
+  "requirements": ["aiounifi==25"],
   "codeowners": ["@Kane610"],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ubiquiti UniFi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "requirements": ["aiounifi==23"],
+  "requirements": ["aiounifi==24"],
   "codeowners": ["@Kane610"],
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -39,7 +39,8 @@
       "client_control": {
         "data": {
           "block_client": "Network access controlled clients",
-          "poe_clients": "Allow POE control of clients"
+          "poe_clients": "Allow POE control of clients",
+          "dpi_restrictions": "Allow control of DPI restriction groups"
         },
         "description": "Configure client controls\n\nCreate switches for serial numbers you want to control network access for.",
         "title": "UniFi options 2/3"

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -14,12 +14,14 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN as UNIFI_DOMAIN
+from .const import ATTR_MANUFACTURER, CONF_DPI_RESTRICTIONS, DOMAIN as UNIFI_DOMAIN
 from .unifi_client import UniFiClient
+from .unifi_entity_base import UniFiBase
 
 _LOGGER = logging.getLogger(__name__)
 
 BLOCK_SWITCH = "block"
+DPI_SWITCH = "dpi"
 POE_SWITCH = "poe"
 
 CLIENT_BLOCKED = (WIRED_CLIENT_BLOCKED, WIRELESS_CLIENT_BLOCKED)
@@ -32,7 +34,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Switches are controlling network access and switch ports with POE.
     """
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-    controller.entities[DOMAIN] = {BLOCK_SWITCH: set(), POE_SWITCH: set()}
+    controller.entities[DOMAIN] = {
+        BLOCK_SWITCH: set(),
+        POE_SWITCH: set(),
+        DPI_SWITCH: set(),
+    }
 
     if controller.site_role != "admin":
         return
@@ -59,7 +65,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     @callback
     def items_added(
-        clients: set = controller.api.clients, devices: set = controller.api.devices
+        clients: set = controller.api.clients,
+        devices: set = controller.api.devices,
+        dpi_groups: set = controller.api.dpi_groups,
     ) -> None:
         """Update the values of the controller."""
         if controller.option_block_clients:
@@ -69,6 +77,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             add_poe_entities(
                 controller, async_add_entities, clients, previously_known_poe_clients
             )
+
+        if controller.option_dpi_restrictions:
+            add_dpi_entities(controller, async_add_entities, dpi_groups)
 
     for signal in (controller.signal_update, controller.signal_options_update):
         controller.listeners.append(async_dispatcher_connect(hass, signal, items_added))
@@ -138,6 +149,26 @@ def add_poe_entities(
             continue
 
         switches.append(UniFiPOEClientSwitch(client, controller))
+
+    if switches:
+        async_add_entities(switches)
+
+
+@callback
+def add_dpi_entities(controller, async_add_entities, dpi_groups):
+    """Add new switch entities from the controller."""
+    switches = []
+
+    for group in dpi_groups:
+        if (
+            group in controller.entities[DOMAIN][DPI_SWITCH]
+            or not dpi_groups[group].dpiapp_ids
+        ):
+            continue
+
+        switches.append(
+            UniFiDPIRestrictionSwitch(dpi_groups[group], controller, key=dpi_groups.KEY)
+        )
 
     if switches:
         async_add_entities(switches)
@@ -284,3 +315,65 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
         """Config entry options are updated, remove entity if option is disabled."""
         if self.client.mac not in self.controller.option_block_clients:
             await self.remove_item({self.client.mac})
+
+
+class UniFiDPIRestrictionSwitch(UniFiBase, SwitchEntity):
+    """Representation of a DPI restriction group."""
+
+    DOMAIN = DOMAIN
+    TYPE = DPI_SWITCH
+
+    @property
+    def is_on(self):
+        """Return true if client is allowed to connect."""
+        return self._item.enabled
+
+    async def async_update(self) -> None:
+        """Update DPI switch state."""
+        await self.controller.api.dpi_groups.update()
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on connectivity for client."""
+        await self.controller.api.dpi_groups.async_enable(self._item)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off connectivity for client."""
+        await self.controller.api.dpi_groups.async_disable(self._item)
+
+    @property
+    def should_poll(self) -> bool:
+        """We need to poll for current status."""
+        return True
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier for this switch."""
+        return self._item.id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the client."""
+        return self._item.name
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        if self._item.enabled:
+            return "mdi:network"
+        return "mdi:network-off"
+
+    @property
+    def device_info(self) -> dict:
+        """Return a service description for device registry."""
+        return {
+            "identifiers": {(DOMAIN, f"{CONF_DPI_RESTRICTIONS}_{self._item.site_id}")},
+            "name": "Deep Packet Inspection Restrictions",
+            "manufacturer": ATTR_MANUFACTURER,
+            "model": "Deep Packet Inspection",
+            "entry_type": "service",
+        }
+
+    async def options_updated(self) -> None:
+        """Config entry options are updated, remove entity if option is disabled."""
+        if not self.controller.option_dpi_restrictions:
+            await self.remove_item({self._item.get(self._key)})

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -15,7 +15,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import ATTR_MANUFACTURER, CONF_DPI_RESTRICTIONS, DOMAIN as UNIFI_DOMAIN
+from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
 from .unifi_client import UniFiClient
 from .unifi_entity_base import UniFiBase
 
@@ -366,9 +366,9 @@ class UniFiDPIRestrictionSwitch(UniFiBase, SwitchEntity):
     def device_info(self) -> dict:
         """Return a service description for device registry."""
         return {
-            "identifiers": {(DOMAIN, f"{CONF_DPI_RESTRICTIONS}_{self._item.site_id}")},
-            "name": "Deep Packet Inspection Restrictions",
+            "identifiers": {(DOMAIN, f"unifi_controller_{self._item.site_id}")},
+            "name": "UniFi Controller",
             "manufacturer": ATTR_MANUFACTURER,
-            "model": "Deep Packet Inspection",
+            "model": "UniFi Controller",
             "entry_type": "service",
         }

--- a/homeassistant/components/unifi/translations/en.json
+++ b/homeassistant/components/unifi/translations/en.json
@@ -27,6 +27,7 @@
             "client_control": {
                 "data": {
                     "block_client": "Network access controlled clients",
+                    "dpi_restrictions": "Allow control of DPI restriction groups",
                     "poe_clients": "Allow POE control of clients"
                 },
                 "description": "Configure client controls\n\nCreate switches for serial numbers you want to control network access for.",

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -1,5 +1,6 @@
 """Base class for UniFi entities."""
 import logging
+from typing import Optional
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -15,19 +16,23 @@ class UniFiBase(Entity):
     DOMAIN = ""
     TYPE = ""
 
-    def __init__(self, item, controller) -> None:
+    def __init__(self, item, controller, *, key: Optional[str] = None) -> None:
         """Set up UniFi entity base.
 
         Register mac to controller entities to cover disabled entities.
         """
         self._item = item
         self.controller = controller
-        self.controller.entities[self.DOMAIN][self.TYPE].add(item.mac)
+        self._key = key or "mac"
+        self.controller.entities[self.DOMAIN][self.TYPE].add(item.get(self._key))
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         _LOGGER.debug(
-            "New %s entity %s (%s)", self.TYPE, self.entity_id, self._item.mac
+            "New %s entity %s (%s)",
+            self.TYPE,
+            self.entity_id,
+            self._item.get(self._key),
         )
         for signal, method in (
             (self.controller.signal_reachable, self.async_update_callback),
@@ -40,16 +45,24 @@ class UniFiBase(Entity):
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect object when removed."""
         _LOGGER.debug(
-            "Removing %s entity %s (%s)", self.TYPE, self.entity_id, self._item.mac
+            "Removing %s entity %s (%s)",
+            self.TYPE,
+            self.entity_id,
+            self._item.get(self._key),
         )
         self._item.remove_callback(self.async_update_callback)
-        self.controller.entities[self.DOMAIN][self.TYPE].remove(self._item.mac)
+        self.controller.entities[self.DOMAIN][self.TYPE].remove(
+            self._item.get(self._key)
+        )
 
     @callback
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         _LOGGER.debug(
-            "Updating %s entity %s (%s)", self.TYPE, self.entity_id, self._item.mac
+            "Updating %s entity %s (%s)",
+            self.TYPE,
+            self.entity_id,
+            self._item.get(self._key),
         )
         self.async_write_ha_state()
 
@@ -57,15 +70,15 @@ class UniFiBase(Entity):
         """Config entry options are updated, remove entity if option is disabled."""
         raise NotImplementedError
 
-    async def remove_item(self, mac_addresses: set) -> None:
-        """Remove entity if MAC is part of set.
+    async def remove_item(self, keys: set) -> None:
+        """Remove entity if key is part of set.
 
         Remove entity if no entry in entity registry exist.
         Remove entity registry entry if no entry in device registry exist.
         Remove device registry entry if there is only one linked entity (this entity).
         Remove entity registry entry if there are more than one entity linked to the device registry entry.
         """
-        if self._item.mac not in mac_addresses:
+        if self._item.get(self._key) not in keys:
             return
 
         entity_registry = await self.hass.helpers.entity_registry.async_get_registry()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -227,7 +227,7 @@ aioshelly==0.4.0
 aioswitcher==1.2.1
 
 # homeassistant.components.unifi
-aiounifi==23
+aiounifi==24
 
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -227,7 +227,7 @@ aioshelly==0.4.0
 aioswitcher==1.2.1
 
 # homeassistant.components.unifi
-aiounifi==24
+aiounifi==25
 
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -143,7 +143,7 @@ aioshelly==0.4.0
 aioswitcher==1.2.1
 
 # homeassistant.components.unifi
-aiounifi==23
+aiounifi==24
 
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -143,7 +143,7 @@ aioshelly==0.4.0
 aioswitcher==1.2.1
 
 # homeassistant.components.unifi
-aiounifi==24
+aiounifi==25
 
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
     CONF_DETECTION_TIME,
+    CONF_DPI_RESTRICTIONS,
     CONF_IGNORE_WIRED_BUG,
     CONF_POE_CLIENTS,
     CONF_SITE_ID,
@@ -70,6 +71,14 @@ DEVICES = [
 WLANS = [
     {"name": "SSID 1"},
     {"name": "SSID 2", "name_combine_enabled": False, "name_combine_suffix": "_IOT"},
+]
+
+DPI_GROUPS = [
+    {
+        "_id": "5ba29dd8e3c58f026e9d7c4a",
+        "name": "Default",
+        "site_id": "5ba29dd4e3c58f026e9d7c38",
+    },
 ]
 
 
@@ -307,7 +316,12 @@ async def test_flow_fails_unknown_problem(hass, aioclient_mock):
 async def test_advanced_option_flow(hass):
     """Test advanced config flow options."""
     controller = await setup_unifi_integration(
-        hass, clients_response=CLIENTS, devices_response=DEVICES, wlans_response=WLANS
+        hass,
+        clients_response=CLIENTS,
+        devices_response=DEVICES,
+        wlans_response=WLANS,
+        dpigroup_response=DPI_GROUPS,
+        dpiapp_response=[],
     )
 
     result = await hass.config_entries.options.async_init(
@@ -336,7 +350,11 @@ async def test_advanced_option_flow(hass):
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]], CONF_POE_CLIENTS: False},
+        user_input={
+            CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
+            CONF_POE_CLIENTS: False,
+            CONF_DPI_RESTRICTIONS: False,
+        },
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -359,6 +377,7 @@ async def test_advanced_option_flow(hass):
         CONF_DETECTION_TIME: 100,
         CONF_IGNORE_WIRED_BUG: False,
         CONF_POE_CLIENTS: False,
+        CONF_DPI_RESTRICTIONS: False,
         CONF_BLOCK_CLIENT: [CLIENTS[0]["mac"]],
         CONF_ALLOW_BANDWIDTH_SENSORS: True,
         CONF_ALLOW_UPTIME_SENSORS: True,
@@ -368,7 +387,11 @@ async def test_advanced_option_flow(hass):
 async def test_simple_option_flow(hass):
     """Test simple config flow options."""
     controller = await setup_unifi_integration(
-        hass, clients_response=CLIENTS, wlans_response=WLANS
+        hass,
+        clients_response=CLIENTS,
+        wlans_response=WLANS,
+        dpigroup_response=DPI_GROUPS,
+        dpiapp_response=[],
     )
 
     result = await hass.config_entries.options.async_init(

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -81,6 +81,8 @@ async def setup_unifi_integration(
     devices_response=None,
     clients_all_response=None,
     wlans_response=None,
+    dpigroup_response=None,
+    dpiapp_response=None,
     known_wireless_clients=None,
     controllers=None,
 ):
@@ -116,6 +118,14 @@ async def setup_unifi_integration(
     if wlans_response:
         mock_wlans_responses.append(wlans_response)
 
+    mock_dpigroup_responses = deque()
+    if dpigroup_response:
+        mock_dpigroup_responses.append(dpigroup_response)
+
+    mock_dpiapp_responses = deque()
+    if dpiapp_response:
+        mock_dpiapp_responses.append(dpiapp_response)
+
     mock_requests = []
 
     async def mock_request(self, method, path, json=None):
@@ -129,6 +139,10 @@ async def setup_unifi_integration(
             return mock_client_all_responses.popleft()
         if path == "/rest/wlanconf" and mock_wlans_responses:
             return mock_wlans_responses.popleft()
+        if path == "/rest/dpigroup" and mock_dpigroup_responses:
+            return mock_dpigroup_responses.popleft()
+        if path == "/rest/dpiapp" and mock_dpiapp_responses:
+            return mock_dpiapp_responses.popleft()
         return {}
 
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -71,7 +71,7 @@ async def test_no_clients(hass):
         },
     )
 
-    assert len(controller.mock_requests) == 4
+    assert len(controller.mock_requests) == 6
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
 
 
@@ -88,7 +88,7 @@ async def test_sensors(hass):
         clients_response=CLIENTS,
     )
 
-    assert len(controller.mock_requests) == 4
+    assert len(controller.mock_requests) == 6
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
 
     wired_client_rx = hass.states.get("sensor.wired_client_name_rx")

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -761,8 +761,3 @@ async def test_restoring_client(hass):
 
     device_1 = hass.states.get("switch.client_1")
     assert device_1 is not None
-
-
-async def test_dpi_restriction_switch(hass):
-    """Test that DPI restriction switches are added."""
-    assert True

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -407,7 +407,7 @@ async def test_switches(hass):
         {"entity_id": "switch.block_media_streaming"},
         blocking=True,
     )
-    assert len(controller.mock_requests) == 11
+    assert len(controller.mock_requests) == 9
     assert controller.mock_requests[8] == {
         "json": {"enabled": False},
         "method": "put",
@@ -420,8 +420,8 @@ async def test_switches(hass):
         {"entity_id": "switch.block_media_streaming"},
         blocking=True,
     )
-    assert len(controller.mock_requests) == 12
-    assert controller.mock_requests[11] == {
+    assert len(controller.mock_requests) == 10
+    assert controller.mock_requests[9] == {
         "json": {"enabled": True},
         "method": "put",
         "path": "/rest/dpiapp/5f976f62e3c58f018ec7e17d",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Funny backstory... We recently caught my daughter watching YouTube on her Chromebook (daily for the past month) while supposed to be in school. In order to put a stop to it, I created a DPI filter in UniFi to block streaming media on the VLAN her machine is connected to.

This PR exposes that as a switch to Home Assistant, allowing the user to enable/disable the restriction without going layers deep in the UniFi settings. More importantly, one can create automations to time-box the restriction which is not a part of the standard UniFi functionality.

**Note: This PR is dependent on a PR in the parent library:** https://github.com/Kane610/aiounifi/pull/44

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15489

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
