### PR TITLE
Handle Shelly light domain for relay switches ( fw >=1.9 )

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -770,6 +770,7 @@ omit =
     homeassistant/components/shelly/light.py
     homeassistant/components/shelly/sensor.py
     homeassistant/components/shelly/switch.py
+    homeassistant/components/shelly/utils.py
     homeassistant/components/sht31/sensor.py
     homeassistant/components/sigfox/sensor.py
     homeassistant/components/simplepush/notify.py

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             == "light"
         ):
             blocks.append(block)
-            unique_id = wrapper.device.shelly["mac"] + "-relay_" + block.channel
+            unique_id = f'{wrapper.device.shelly["mac"]}-relay_{block.channel}'
             await async_remove_entity_by_domain(hass, "switch", unique_id)
 
     if not blocks:

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -29,17 +29,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for block in wrapper.device.blocks:
         if block.type == "light":
             blocks.append(block)
-        if block.type == "relay":
-            if (
+        elif (
+            block.type == "relay"
+            and wrapper.device.settings["relays"][int(block.channel)].get(
                 "appliance_type"
-                in wrapper.device.settings["relays"][int(block.channel)]
-            ):
-                if (
-                    wrapper.device.settings["relays"][int(block.channel)][
-                        "appliance_type"
-                    ]
-                ) == "light":
-                    blocks.append(block)
+            )
+            == "light"
+        ):
+            blocks.append(block)
 
     if not blocks:
         return

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -41,8 +41,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             == "light"
         ):
             blocks.append(block)
-            unique_id = f'{wrapper.device.shelly["mac"]}-relay_{block.channel}'
-            await async_remove_entity_by_domain(hass, "switch", unique_id)
+            unique_id = f'{wrapper.device.shelly["mac"]}-{block.type}_{block.channel}'
+            await async_remove_entity_by_domain(
+                hass, "switch", unique_id, config_entry.entry_id
+            )
 
     if not blocks:
         return

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -24,8 +24,6 @@ from .utils import async_remove_entity_by_domain
 
 _LOGGER = logging.getLogger(__name__)
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up lights for device."""

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -24,7 +24,22 @@ from .entity import ShellyBlockEntity
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up lights for device."""
     wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
-    blocks = [block for block in wrapper.device.blocks if block.type == "light"]
+
+    blocks = []
+    for block in wrapper.device.blocks:
+        if block.type == "light":
+            blocks.append(block)
+        if block.type == "relay":
+            if (
+                "appliance_type"
+                in wrapper.device.settings["relays"][int(block.channel)]
+            ):
+                if (
+                    wrapper.device.settings["relays"][int(block.channel)][
+                        "appliance_type"
+                    ]
+                ) == "light":
+                    blocks.append(block)
 
     if not blocks:
         return

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -1,5 +1,4 @@
 """Light for Shelly."""
-import logging
 from typing import Optional
 
 from aioshelly import Block
@@ -21,8 +20,6 @@ from . import ShellyDeviceWrapper
 from .const import DATA_CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
 from .utils import async_remove_entity_by_domain
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -24,6 +24,8 @@ from .utils import async_remove_entity_by_domain
 
 _LOGGER = logging.getLogger(__name__)
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up lights for device."""

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -20,6 +20,7 @@ from homeassistant.util.color import (
 from . import ShellyDeviceWrapper
 from .const import DATA_CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
+from .utils import async_remove_entity_by_domain
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,14 +41,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             == "light"
         ):
             blocks.append(block)
-            entity_reg = await hass.helpers.entity_registry.async_get_registry()
-            for entity in entity_reg.entities.values():
-                if entity.entity_id.startswith("switch.") and entity.unique_id == (
-                    wrapper.device.shelly["mac"] + "-relay_" + block.channel
-                ):
-                    entity_reg.async_remove(entity.entity_id)
-                    _LOGGER.debug("Removed switch domain for %s", entity.original_name)
-                    break
+            unique_id = wrapper.device.shelly["mac"] + "-relay_" + block.channel
+            await async_remove_entity_by_domain(hass, "switch", unique_id)
 
     if not blocks:
         return

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -28,11 +28,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             != "light"
         ):
             relay_blocks.append(block)
-            unique_id = f'{wrapper.device.shelly["mac"]}-light_{block.channel}'
+            unique_id = f'{wrapper.device.shelly["mac"]}-{block.type}_{block.channel}'
             await async_remove_entity_by_domain(
                 hass,
                 "light",
                 unique_id,
+                config_entry.entry_id,
             )
 
     if not relay_blocks:

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -20,7 +20,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     ):
         return
 
-    relay_blocks = [block for block in wrapper.device.blocks if block.type == "relay"]
+    relay_blocks = []
+    for block in wrapper.device.blocks:
+        if block.type == "relay" and (
+            wrapper.device.settings["relays"][int(block.channel)].get("appliance_type")
+            != "light"
+        ):
+            relay_blocks.append(block)
 
     if not relay_blocks:
         return

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             != "light"
         ):
             relay_blocks.append(block)
-            unique_id = wrapper.device.shelly["mac"] + "-light_" + block.channel
+            unique_id = f'{wrapper.device.shelly["mac"]}-light_{block.channel}'
             await async_remove_entity_by_domain(
                 hass,
                 "light",

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -7,6 +7,7 @@ from homeassistant.core import callback
 from . import ShellyDeviceWrapper
 from .const import DATA_CONFIG_ENTRY, DOMAIN
 from .entity import ShellyBlockEntity
+from .utils import async_remove_entity_by_domain
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -27,6 +28,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             != "light"
         ):
             relay_blocks.append(block)
+            unique_id = wrapper.device.shelly["mac"] + "-light_" + block.channel
+            await async_remove_entity_by_domain(
+                hass,
+                "light",
+                unique_id,
+            )
 
     if not relay_blocks:
         return

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -8,8 +8,8 @@ _LOGGER = logging.getLogger(__name__)
 async def async_remove_entity_by_domain(hass, domain, unique_id):
     """Remove entity by domain."""
     entity_reg = await hass.helpers.entity_registry.async_get_registry()
-    for entity in entity_reg.entities.values():
-        if entity.entity_id.startswith(domain + ".") and entity.unique_id == unique_id:
-            entity_reg.async_remove(entity.entity_id)
-            _LOGGER.debug("Removed %s domain for %s", domain, entity.original_name)
+    for entry in entity_reg.entities.values():
+        if entry.domain == domain and entry.unique_id == unique_id:
+            entity_reg.async_remove(entry.entity_id)
+            _LOGGER.debug("Removed %s domain for %s", domain, entry.original_name)
             break

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -2,13 +2,18 @@
 
 import logging
 
+from homeassistant.helpers import entity_registry
+
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_remove_entity_by_domain(hass, domain, unique_id):
+async def async_remove_entity_by_domain(hass, domain, unique_id, config_entry_id):
     """Remove entity by domain."""
+
     entity_reg = await hass.helpers.entity_registry.async_get_registry()
-    for entry in entity_reg.entities.values():
+    for entry in entity_registry.async_entries_for_config_entry(
+        entity_reg, config_entry_id
+    ):
         if entry.domain == domain and entry.unique_id == unique_id:
             entity_reg.async_remove(entry.entity_id)
             _LOGGER.debug("Removed %s domain for %s", domain, entry.original_name)

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -1,0 +1,15 @@
+"""Shelly helpers functions."""
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_remove_entity_by_domain(hass, domain, unique_id):
+    """Remove entity by domain."""
+    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    for entity in entity_reg.entities.values():
+        if entity.entity_id.startswith(domain + ".") and entity.unique_id == unique_id:
+            entity_reg.async_remove(entity.entity_id)
+            _LOGGER.debug("Removed %s domain for %s", domain, entity.original_name)
+            break


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Shelly devices configured with new (fw >= 1.9) property "appliance_type" can now be added to the light domain instead of the switch domain.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle "appliance_type" to better configured Shelly devices

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
