### PR TITLE
Use dict.values() when appropriate

### DIFF
--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -186,7 +186,7 @@ class ApnsNotificationService(BaseNotificationService):
     def write_devices(self):
         """Write all known devices to file."""
         with open(self.yaml_path, "w+") as out:
-            for _, device in self.devices.items():
+            for device in self.devices.values():
                 _write_device(out, device)
 
     def register(self, call):

--- a/homeassistant/components/netio/switch.py
+++ b/homeassistant/components/netio/switch.py
@@ -79,7 +79,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 def dispose(event):
     """Close connections to Netio Devices."""
-    for _, value in DEVICES.items():
+    for value in DEVICES.values():
         value.netio.stop()
 
 

--- a/homeassistant/components/scsgate/cover.py
+++ b/homeassistant/components/scsgate/cover.py
@@ -27,7 +27,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     scsgate = hass.data[DOMAIN]
 
     if devices:
-        for _, entity_info in devices.items():
+        for entity_info in devices.values():
             if entity_info[CONF_SCS_ID] in scsgate.devices:
                 continue
 

--- a/homeassistant/components/scsgate/light.py
+++ b/homeassistant/components/scsgate/light.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     scsgate = hass.data[DOMAIN]
 
     if devices:
-        for _, entity_info in devices.items():
+        for entity_info in devices.values():
             if entity_info[CONF_SCS_ID] in scsgate.devices:
                 continue
 

--- a/homeassistant/components/scsgate/switch.py
+++ b/homeassistant/components/scsgate/switch.py
@@ -42,7 +42,7 @@ def _setup_traditional_switches(logger, config, scsgate, add_entities_callback):
     switches = []
 
     if traditional:
-        for _, entity_info in traditional.items():
+        for entity_info in traditional.values():
             if entity_info[CONF_SCS_ID] in scsgate.devices:
                 continue
 
@@ -65,7 +65,7 @@ def _setup_scenario_switches(logger, config, scsgate, hass):
     scenario = config.get(CONF_SCENARIO)
 
     if scenario:
-        for _, entity_info in scenario.items():
+        for entity_info in scenario.values():
             if entity_info[CONF_SCS_ID] in scsgate.devices:
                 continue
 

--- a/homeassistant/components/wirelesstag/switch.py
+++ b/homeassistant/components/wirelesstag/switch.py
@@ -38,7 +38,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     switches = []
     tags = platform.load_tags()
     for switch_type in config.get(CONF_MONITORED_CONDITIONS):
-        for _, tag in tags.items():
+        for tag in tags.values():
             if switch_type in tag.allowed_monitoring_types:
                 switches.append(WirelessTagSwitch(platform, tag, switch_type))
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Just some small clean up for cases where `dict.items()` is used but the key variable is not used and therefore named `_`.
Replaced with `dict.values()` and removing the unused key variable `_`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
