### PR TITLE
Remove listener on async_unload_entry in devolo Home Control

### DIFF
--- a/homeassistant/components/devolo_home_control/binary_sensor.py
+++ b/homeassistant/components/devolo_home_control/binary_sensor.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
     """Get all binary sensor and multi level sensor devices and setup them via config entry."""
     entities = []
 
-    for gateway in hass.data[DOMAIN][entry.entry_id]:
+    for gateway in hass.data[DOMAIN][entry.entry_id]["gateways"]:
         for device in gateway.binary_sensor_devices:
             for binary_sensor in device.binary_sensor_property:
                 entities.append(

--- a/homeassistant/components/devolo_home_control/climate.py
+++ b/homeassistant/components/devolo_home_control/climate.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     """Get all cover devices and setup them via config entry."""
     entities = []
 
-    for gateway in hass.data[DOMAIN][entry.entry_id]:
+    for gateway in hass.data[DOMAIN][entry.entry_id]["gateways"]:
         for device in gateway.multi_level_switch_devices:
             for multi_level_switch in device.multi_level_switch_property:
                 if device.device_model_uid in [

--- a/homeassistant/components/devolo_home_control/cover.py
+++ b/homeassistant/components/devolo_home_control/cover.py
@@ -19,7 +19,7 @@ async def async_setup_entry(
     """Get all cover devices and setup them via config entry."""
     entities = []
 
-    for gateway in hass.data[DOMAIN][entry.entry_id]:
+    for gateway in hass.data[DOMAIN][entry.entry_id]["gateways"]:
         for device in gateway.multi_level_switch_devices:
             for multi_level_switch in device.multi_level_switch_property:
                 if multi_level_switch.startswith("devolo.Blinds"):

--- a/homeassistant/components/devolo_home_control/light.py
+++ b/homeassistant/components/devolo_home_control/light.py
@@ -17,7 +17,7 @@ async def async_setup_entry(
     """Get all light devices and setup them via config entry."""
     entities = []
 
-    for gateway in hass.data[DOMAIN][entry.entry_id]:
+    for gateway in hass.data[DOMAIN][entry.entry_id]["gateways"]:
         for device in gateway.multi_level_switch_devices:
             for multi_level_switch in device.multi_level_switch_property.values():
                 if multi_level_switch.switch_type == "dimmer":

--- a/homeassistant/components/devolo_home_control/sensor.py
+++ b/homeassistant/components/devolo_home_control/sensor.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     """Get all sensor devices and setup them via config entry."""
     entities = []
 
-    for gateway in hass.data[DOMAIN][entry.entry_id]:
+    for gateway in hass.data[DOMAIN][entry.entry_id]["gateways"]:
         for device in gateway.multi_level_sensor_devices:
             for multi_level_sensor in device.multi_level_sensor_property:
                 entities.append(

--- a/homeassistant/components/devolo_home_control/switch.py
+++ b/homeassistant/components/devolo_home_control/switch.py
@@ -13,7 +13,7 @@ async def async_setup_entry(
     """Get all devices and setup the switch devices via config entry."""
     entities = []
 
-    for gateway in hass.data[DOMAIN][entry.entry_id]:
+    for gateway in hass.data[DOMAIN][entry.entry_id]["gateways"]:
         for device in gateway.binary_switch_devices:
             for binary_switch in device.binary_switch_property:
                 # Exclude the binary switch which also has multi_level_switches here,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the (hopefully rare) case that someone removes the integration and restarts Home Assistant, the listener to the EVENT_HOMEASSISTANT_STOP event tries so access data, that does not exist anymore. So the listener needs to be removed on unloading.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
