### PR TITLE
Add unique_id property to ARWN sensors

### DIFF
--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -94,12 +94,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 sensor.hass = hass
                 sensor.set_event(event)
                 store[sensor.name] = sensor
-                _LOGGER.debug(
-                    "Registering new sensor %(name)s => %(event)s",
+                _LOGGER.info(
+                    "Registering sensor %(name)s => %(event)s",
                     {"name": sensor.name, "event": event},
                 )
                 async_add_entities((sensor,), True)
             else:
+                _LOGGER.info(
+                    "Recording sensor %(name)s => %(event)s",
+                    {"name": sensor.name, "event": event},
+                )
                 store[sensor.name].set_event(event)
 
     await mqtt.async_subscribe(hass, TOPIC, async_sensor_event_received, 0)
@@ -134,6 +138,11 @@ class ArwnSensor(Entity):
     def name(self):
         """Get the name of the sensor."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self.entity_id
 
     @property
     def state_attributes(self):

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -30,7 +30,7 @@ def discover_sensors(topic, payload):
             unit = TEMP_FAHRENHEIT
         else:
             unit = TEMP_CELSIUS
-        return ArwnSensor(name, "temp", unit)
+        return ArwnSensor(topic, name, "temp", unit)
     if domain == "moisture":
         name = f"{parts[2]} Moisture"
         return ArwnSensor(topic, name, "moisture", unit, "mdi:water-percent")

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -123,8 +123,7 @@ class ArwnSensor(Entity):
         self.entity_id = _slug(name)
         self._name = name
         # This mqtt topic for the sensor which is its uid
-        self._uid = slugify(topic)
-        print(self._uid, self._name)
+        self._uid = topic
         self._state_key = state_key
         self.event = {}
         self._unit_of_measurement = units

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -40,16 +40,20 @@ def discover_sensors(topic, payload):
                 topic, "Rain Since Midnight", "since_midnight", "in", "mdi:water"
             )
         return (
-            ArwnSensor(topic, "Total Rainfall", "total", unit, "mdi:water"),
-            ArwnSensor(topic, "Rainfall Rate", "rate", unit, "mdi:water"),
+            ArwnSensor(topic + "/total", "Total Rainfall", "total", unit, "mdi:water"),
+            ArwnSensor(topic + "/rate", "Rainfall Rate", "rate", unit, "mdi:water"),
         )
     if domain == "barometer":
         return ArwnSensor(topic, "Barometer", "pressure", unit, "mdi:thermometer-lines")
     if domain == "wind":
         return (
-            ArwnSensor(topic, "Wind Speed", "speed", unit, "mdi:speedometer"),
-            ArwnSensor(topic, "Wind Gust", "gust", unit, "mdi:speedometer"),
-            ArwnSensor(topic, "Wind Direction", "direction", DEGREE, "mdi:compass"),
+            ArwnSensor(
+                topic + "/speed", "Wind Speed", "speed", unit, "mdi:speedometer"
+            ),
+            ArwnSensor(topic + "/gust", "Wind Gust", "gust", unit, "mdi:speedometer"),
+            ArwnSensor(
+                topic + "/dir", "Wind Direction", "direction", DEGREE, "mdi:compass"
+            ),
         )
 
 
@@ -119,7 +123,8 @@ class ArwnSensor(Entity):
         self.entity_id = _slug(name)
         self._name = name
         # This mqtt topic for the sensor which is its uid
-        self._topic = topic
+        self._uid = slugify(topic)
+        print(self._uid, self._name)
         self._state_key = state_key
         self.event = {}
         self._unit_of_measurement = units
@@ -147,7 +152,7 @@ class ArwnSensor(Entity):
 
         This is based on the topic that comes from mqtt
         """
-        return self._topic
+        return self._uid
 
     @property
     def state_attributes(self):

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -36,8 +36,8 @@ def discover_sensors(topic, payload):
         return ArwnSensor(topic, name, "moisture", unit, "mdi:water-percent")
     if domain == "rain":
         if len(parts) >= 3 and parts[2] == "today":
-            return ArwnSensor(topic,
-                "Rain Since Midnight", "since_midnight", "in", "mdi:water"
+            return ArwnSensor(
+                topic, "Rain Since Midnight", "since_midnight", "in", "mdi:water"
             )
         return (
             ArwnSensor(topic, "Total Rainfall", "total", unit, "mdi:water"),


### PR DESCRIPTION
## Proposed change

After HA 0.111 the ARWN platform's lack of a unique_id causes the
sensors to fail to register correctly. The unique_id for a sensor is 
it's MQTT topic in most cases (with an additional suffix for devices that 
really explode into more than 1 sensor).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
