### PR TITLE
Add hdmi input attribute to AndroidTV

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
     "adb-shell[async]==0.2.1",
-    "androidtv[async]==0.0.52",
+    "androidtv[async]==0.0.53",
     "pure-python-adb[async]==0.3.0.dev0"
   ],
   "codeowners": ["@JeffLIrion"]

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -445,6 +445,7 @@ class ADBDevice(MediaPlayerEntity):
         self._current_app = None
         self._sources = None
         self._state = None
+        self._hdmi_input = None
 
     @property
     def app_id(self):
@@ -464,7 +465,10 @@ class ADBDevice(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Provide the last ADB command's response as an attribute."""
-        return {"adb_response": self._adb_response}
+        return {
+            "adb_response": self._adb_response,
+            "hdmi_input": self._hdmi_input,
+        }
 
     @property
     def media_image_hash(self):
@@ -670,6 +674,7 @@ class AndroidTVDevice(ADBDevice):
             _,
             self._is_volume_muted,
             self._volume_level,
+            self._hdmi_input,
         ) = await self.aftv.update(self._get_sources)
 
         self._state = ANDROIDTV_STATES.get(state)
@@ -744,9 +749,12 @@ class FireTVDevice(ADBDevice):
             return
 
         # Get the `state`, `current_app`, and `running_apps`.
-        state, self._current_app, running_apps = await self.aftv.update(
-            self._get_sources
-        )
+        (
+            state,
+            self._current_app,
+            running_apps,
+            self._hdmi_input,
+        ) = await self.aftv.update(self._get_sources)
 
         self._state = ANDROIDTV_STATES.get(state)
         if self._state is None:

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -464,7 +464,7 @@ class ADBDevice(MediaPlayerEntity):
 
     @property
     def device_state_attributes(self):
-        """Provide the last ADB command's response as an attribute."""
+        """Provide the last ADB command's response and the device's HDMI input as attributes."""
         return {
             "adb_response": self._adb_response,
             "hdmi_input": self._hdmi_input,
@@ -748,7 +748,7 @@ class FireTVDevice(ADBDevice):
         if not self._available:
             return
 
-        # Get the `state`, `current_app`, and `running_apps`.
+        # Get the `state`, `current_app`, `running_apps` and `hdmi_input`.
         (
             state,
             self._current_app,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -248,7 +248,7 @@ ambiclimate==0.2.1
 amcrest==1.7.0
 
 # homeassistant.components.androidtv
-androidtv[async]==0.0.52
+androidtv[async]==0.0.53
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -155,7 +155,7 @@ airly==1.0.0
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv[async]==0.0.52
+androidtv[async]==0.0.53
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -155,16 +155,16 @@ PATCH_ISFILE = patch("os.path.isfile", isfile)
 PATCH_ACCESS = patch("os.access", return_value=True)
 
 
-def patch_firetv_update(state, current_app, running_apps):
+def patch_firetv_update(state, current_app, running_apps, hdmi_input):
     """Patch the `FireTV.update()` method."""
     return patch(
         "androidtv.firetv.firetv_async.FireTVAsync.update",
-        return_value=(state, current_app, running_apps),
+        return_value=(state, current_app, running_apps, hdmi_input),
     )
 
 
 def patch_androidtv_update(
-    state, current_app, running_apps, device, is_volume_muted, volume_level
+    state, current_app, running_apps, device, is_volume_muted, volume_level, hdmi_input
 ):
     """Patch the `AndroidTV.update()` method."""
     return patch(
@@ -176,6 +176,7 @@ def patch_androidtv_update(
             device,
             is_volume_muted,
             volume_level,
+            hdmi_input,
         ),
     )
 

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -341,12 +341,14 @@ async def _test_sources(hass, config0):
             "hdmi",
             False,
             1,
+            "HW5",
         )
     else:
         patch_update = patchers.patch_firetv_update(
             "playing",
             "com.app.test1",
             ["com.app.test1", "com.app.test2", "com.app.test3", "com.app.test4"],
+            "HW5",
         )
 
     with patch_update:
@@ -365,12 +367,14 @@ async def _test_sources(hass, config0):
             "hdmi",
             True,
             0,
+            "HW5",
         )
     else:
         patch_update = patchers.patch_firetv_update(
             "playing",
             "com.app.test2",
             ["com.app.test2", "com.app.test1", "com.app.test3", "com.app.test4"],
+            "HW5",
         )
 
     with patch_update:
@@ -428,6 +432,7 @@ async def _test_exclude_sources(hass, config0, expected_sources):
             "hdmi",
             False,
             1,
+            "HW5",
         )
     else:
         patch_update = patchers.patch_firetv_update(
@@ -440,6 +445,7 @@ async def _test_exclude_sources(hass, config0, expected_sources):
                 "com.app.test4",
                 "com.app.test5",
             ],
+            "HW5",
         )
 
     with patch_update:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds an "hdmi_input" attribute for AndroidTV media players. The heavy lifting was done by @JeffLIrion, as he implemented this feature in his underlying `python-androidtv` package, so credit where credit is due.

More information on this feature can be found here:
https://github.com/JeffLIrion/python-androidtv/issues/202

Only device responses that match the regex `HW[0-9]` are supported, but it seems like it covers both AndroidTV and FireTV sticks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/JeffLIrion/python-androidtv/issues/202
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
