### PR TITLE
Use list literal without using dict.keys()

### DIFF
--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -207,7 +207,7 @@ class LoginFlow(data_entry_flow.FlowHandler):
             errors["base"] = "invalid_auth_module"
 
         if len(self.available_mfa_modules) == 1:
-            self._auth_module_id = list(self.available_mfa_modules.keys())[0]
+            self._auth_module_id = list(self.available_mfa_modules)[0]
             return await self.async_step_mfa()
 
         return self.async_show_form(

--- a/homeassistant/components/asuswrt/device_tracker.py
+++ b/homeassistant/components/asuswrt/device_tracker.py
@@ -35,7 +35,7 @@ class AsusWrtDeviceScanner(DeviceScanner):
     async def async_scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         await self.async_update_info()
-        return list(self.last_results.keys())
+        return list(self.last_results)
 
     async def async_get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""

--- a/homeassistant/components/blink/alarm_control_panel.py
+++ b/homeassistant/components/blink/alarm_control_panel.py
@@ -66,7 +66,7 @@ class BlinkSyncModule(AlarmControlPanelEntity):
         """Return the state attributes."""
         attr = self.sync.attributes
         attr["network_info"] = self.data.networks
-        attr["associated_cameras"] = list(self.sync.cameras.keys())
+        attr["associated_cameras"] = list(self.sync.cameras)
         attr[ATTR_ATTRIBUTION] = DEFAULT_ATTRIBUTION
         return attr
 

--- a/homeassistant/components/denon/media_player.py
+++ b/homeassistant/components/denon/media_player.py
@@ -230,7 +230,7 @@ class DenonDevice(MediaPlayerEntity):
     @property
     def source_list(self):
         """Return the list of available input sources."""
-        return sorted(list(self._source_list.keys()))
+        return sorted(list(self._source_list))
 
     @property
     def media_title(self):

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         lon = config.get(CONF_LONGITUDE, hass.config.longitude)
         ec_data = ECData(coordinates=(lat, lon), language=config.get(CONF_LANGUAGE))
 
-    sensor_list = list(ec_data.conditions.keys()) + list(ec_data.alerts.keys())
+    sensor_list = list(ec_data.conditions) + list(ec_data.alerts)
     add_entities([ECSensor(sensor_type, ec_data) for sensor_type in sensor_list], True)
 
 

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -136,7 +136,7 @@ class EQ3BTSmartThermostat(ClimateEntity):
     @property
     def hvac_modes(self):
         """Return the list of available operation modes."""
-        return list(HA_TO_EQ_HVAC.keys())
+        return list(HA_TO_EQ_HVAC)
 
     def set_hvac_mode(self, hvac_mode):
         """Set operation mode."""
@@ -181,7 +181,7 @@ class EQ3BTSmartThermostat(ClimateEntity):
 
         Requires SUPPORT_PRESET_MODE.
         """
-        return list(HA_TO_EQ_PRESET.keys())
+        return list(HA_TO_EQ_PRESET)
 
     def set_preset_mode(self, preset_mode):
         """Set new preset mode."""

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -357,7 +357,7 @@ class HomeKitSpeedMapping:
         for state, speed_range in reversed(self.speed_ranges.items()):
             if speed_range.start <= speed:
                 return state
-        return list(self.speed_ranges.keys())[0]
+        return list(self.speed_ranges)[0]
 
 
 def show_setup_message(hass, entry_id, bridge_name, pincode, uri):

--- a/homeassistant/components/insteon/climate.py
+++ b/homeassistant/components/insteon/climate.py
@@ -202,12 +202,12 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        mode = list(FAN_MODES.keys())[list(FAN_MODES.values()).index(fan_mode)]
+        mode = list(FAN_MODES)[list(FAN_MODES.values()).index(fan_mode)]
         await self._insteon_device.async_set_mode(mode)
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
-        mode = list(HVAC_MODES.keys())[list(HVAC_MODES.values()).index(hvac_mode)]
+        mode = list(HVAC_MODES)[list(HVAC_MODES.values()).index(hvac_mode)]
         await self._insteon_device.async_set_mode(mode)
 
     async def async_set_humidity(self, humidity):

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -509,7 +509,7 @@ class ZoneDevice(ClimateEntity):
     @property
     def hvac_modes(self):
         """Return the list of available operation modes."""
-        return list(self._state_to_pizone.keys())
+        return list(self._state_to_pizone)
 
     @property
     def current_temperature(self):

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -102,14 +102,14 @@ async def async_start(
 
         payload = MQTTConfig(payload)
 
-        for key in list(payload.keys()):
+        for key in list(payload):
             abbreviated_key = key
             key = ABBREVIATIONS.get(key, key)
             payload[key] = payload.pop(abbreviated_key)
 
         if CONF_DEVICE in payload:
             device = payload[CONF_DEVICE]
-            for key in list(device.keys()):
+            for key in list(device):
                 abbreviated_key = key
                 key = DEVICE_ABBREVIATIONS.get(key, key)
                 device[key] = device.pop(abbreviated_key)

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -163,7 +163,7 @@ class NAD(MediaPlayerEntity):
     @property
     def source_list(self):
         """List of available input sources."""
-        return sorted(list(self._reverse_mapping.keys()))
+        return sorted(list(self._reverse_mapping))
 
     @property
     def available(self):

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -203,7 +203,7 @@ class PioneerDevice(MediaPlayerEntity):
     @property
     def source_list(self):
         """List of available input sources."""
-        return list(self._source_name_to_number.keys())
+        return list(self._source_name_to_number)
 
     @property
     def media_title(self):

--- a/homeassistant/components/qnap/sensor.py
+++ b/homeassistant/components/qnap/sensor.py
@@ -85,12 +85,12 @@ _VOLUME_MON_COND = {
 }
 
 _MONITORED_CONDITIONS = (
-    list(_SYSTEM_MON_COND.keys())
-    + list(_CPU_MON_COND.keys())
-    + list(_MEMORY_MON_COND.keys())
-    + list(_NETWORK_MON_COND.keys())
-    + list(_DRIVE_MON_COND.keys())
-    + list(_VOLUME_MON_COND.keys())
+    list(_SYSTEM_MON_COND)
+    + list(_CPU_MON_COND)
+    + list(_MEMORY_MON_COND)
+    + list(_NETWORK_MON_COND)
+    + list(_DRIVE_MON_COND)
+    + list(_VOLUME_MON_COND)
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -40,7 +40,7 @@ def _check_sensor_schema(conf):
     except (ImportError, AttributeError):
         return conf
 
-    customs = list(conf[CONF_CUSTOM].keys())
+    customs = list(conf[CONF_CUSTOM])
 
     for sensor in conf[CONF_SENSORS]:
         if sensor in customs:
@@ -120,7 +120,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if isinstance(config_sensors, list):
         if not config_sensors:  # Use all sensors by default
             config_sensors = [s.name for s in sensor_def]
-        used_sensors = list(set(config_sensors + list(config[CONF_CUSTOM].keys())))
+        used_sensors = list(set(config_sensors + list(config[CONF_CUSTOM])))
         for sensor in used_sensors:
             hass_sensors.append(SMAsensor(sensor_def[sensor], []))
 

--- a/homeassistant/components/upnp/sensor.py
+++ b/homeassistant/components/upnp/sensor.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
         udn = data[CONFIG_ENTRY_UDN]
     else:
         # any device will do
-        udn = list(hass.data[DOMAIN][DOMAIN_DEVICES].keys())[0]
+        udn = list(hass.data[DOMAIN][DOMAIN_DEVICES])[0]
 
     device: Device = hass.data[DOMAIN][DOMAIN_DEVICES][udn]
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -271,7 +271,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @property
     def source_list(self):
         """List of available input sources."""
-        return sorted(self._source_list.keys())
+        return sorted(list(self._source_list))
 
     @property
     def media_content_type(self):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -471,7 +471,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     @property
     def custom_effects_names(self):
         """Return list with custom effects names."""
-        return list(self.custom_effects.keys())
+        return list(self.custom_effects)
 
     @property
     def light_type(self):

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -233,7 +233,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        "implementation", default=list(implementations.keys())[0]
+                        "implementation", default=list(implementations)[0]
                     ): vol.In({key: impl.name for key, impl in implementations.items()})
                 }
             ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Just some more clean up, removing using `dict.keys()` inside of a `list` literal.


Example:
```python
# Before:
list(my_dict.keys())

# After:
list(my_dict)
```

Doing this because it is faster and IMO easier to read as well.
```python
import timeit

old_thing = """
mydict = {}
for x in range(500):
    mydict[str(x)] = x

keys = list(mydict.keys())
"""

new_thing = """
mydict = {}
for x in range(500):
    mydict[str(x)] = x

mylist = list(mydict)
"""

print("old: ", timeit.timeit(stmt=old_thing))
print("new: ", timeit.timeit(stmt=new_thing))
```
Output:
```
old:  130.94198324799981
new:  130.59963818100005
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
