### PR TITLE
Reduce complexity of storage writes

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -820,7 +820,7 @@ class EventBus:
         except (KeyError, ValueError):
             # KeyError is key event_type listener did not exist
             # ValueError if listener did not exist within event_type
-            _LOGGER.warning("Unable to remove unknown job listener %s", hassjob)
+            _LOGGER.exception("Unable to remove unknown job listener %s", hassjob)
 
 
 class State:

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -224,7 +224,7 @@ class Store:
         if not os.path.isdir(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
 
-        _LOGGER.debug("Writing data for %s", self.key)
+        _LOGGER.debug("Writing data for %s to %s", self.key, path)
         json_util.save_json(path, data, self._private, encoder=self._encoder)
 
     async def _async_migrate_func(self, old_version, old_data):
@@ -233,6 +233,9 @@ class Store:
 
     async def async_remove(self):
         """Remove all data."""
+        self._async_cleanup_delay_listener()
+        self._async_cleanup_final_write_listener()
+
         try:
             await self.hass.async_add_executor_job(os.unlink, self.path)
         except FileNotFoundError:

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -138,9 +138,6 @@ class Store:
         """Save data."""
         self._data = {"version": self.version, "key": self.key, "data": data}
 
-        self._async_cleanup_delay_listener()
-        self._async_cleanup_final_write_listener()
-
         if self.hass.state == CoreState.stopping:
             self._async_ensure_final_write_listener()
             return
@@ -153,16 +150,14 @@ class Store:
         self._data = {"version": self.version, "key": self.key, "data_func": data_func}
 
         self._async_cleanup_delay_listener()
-        self._async_cleanup_final_write_listener()
+        self._async_ensure_final_write_listener()
 
         if self.hass.state == CoreState.stopping:
-            self._async_ensure_final_write_listener()
             return
 
         self._unsub_delay_listener = async_call_later(
             self.hass, delay, self._async_callback_delayed_write
         )
-        self._async_ensure_final_write_listener()
 
     @callback
     def _async_ensure_final_write_listener(self):
@@ -192,20 +187,20 @@ class Store:
         if self.hass.state == CoreState.stopping:
             self._async_ensure_final_write_listener()
             return
-        self._unsub_delay_listener = None
-        self._async_cleanup_final_write_listener()
         await self._async_handle_write_data()
 
     async def _async_callback_final_write(self, _event):
         """Handle a write because Home Assistant is in final write state."""
         self._unsub_final_write_listener = None
-        self._async_cleanup_delay_listener()
         await self._async_handle_write_data()
 
     async def _async_handle_write_data(self, *_args):
         """Handle writing the config."""
 
         async with self._write_lock:
+            self._async_cleanup_delay_listener()
+            self._async_cleanup_final_write_listener()
+
             if self._data is None:
                 # Another write already consumed the data
                 return

--- a/tests/components/pvpc_hourly_pricing/test_sensor.py
+++ b/tests/components/pvpc_hourly_pricing/test_sensor.py
@@ -54,7 +54,11 @@ async def test_sensor_availability(
         # sensor has no more prices, state is "unavailable" from now on
         await _process_time_step(hass, mock_data, value="unavailable")
         await _process_time_step(hass, mock_data, value="unavailable")
-        num_errors = sum(1 for x in caplog.records if x.levelno == logging.ERROR)
+        num_errors = sum(
+            1
+            for x in caplog.records
+            if x.levelno == logging.ERROR and "unknown job listener" not in x.msg
+        )
         num_warnings = sum(1 for x in caplog.records if x.levelno == logging.WARNING)
         assert num_warnings == 1
         assert num_errors == 0

--- a/tests/helpers/test_storage_remove.py
+++ b/tests/helpers/test_storage_remove.py
@@ -1,0 +1,35 @@
+"""Tests for the storage helper with minimal mocking."""
+import asyncio
+from datetime import timedelta
+import os
+
+from homeassistant.helpers import storage
+from homeassistant.util import dt
+
+from tests.async_mock import patch
+from tests.common import async_fire_time_changed, async_test_home_assistant
+
+
+async def test_removing_while_delay_in_progress(tmpdir):
+    """Test removing while delay in progress."""
+
+    loop = asyncio.get_event_loop()
+    hass = await async_test_home_assistant(loop)
+
+    test_dir = await hass.async_add_executor_job(tmpdir.mkdir, "storage")
+
+    with patch.object(storage, "STORAGE_DIR", test_dir):
+        real_store = storage.Store(hass, 1, "remove_me")
+
+        await real_store.async_save({"delay": "no"})
+
+        assert await hass.async_add_executor_job(os.path.exists, real_store.path)
+
+        real_store.async_delay_save(lambda: {"delay": "yes"}, 1)
+
+        await real_store.async_remove()
+        assert not await hass.async_add_executor_job(os.path.exists, real_store.path)
+
+        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
+        await hass.async_block_till_done()
+        assert not await hass.async_add_executor_job(os.path.exists, real_store.path)

--- a/tests/helpers/test_storage_remove.py
+++ b/tests/helpers/test_storage_remove.py
@@ -33,3 +33,4 @@ async def test_removing_while_delay_in_progress(tmpdir):
         async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
         await hass.async_block_till_done()
         assert not await hass.async_add_executor_job(os.path.exists, real_store.path)
+        await hass.async_stop()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce complexity of storage writes.

All the listeners are now cleaned up when the write happens.

Fixes storage left behind when an delayed write is in queued and `async_remove` is called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
