### PR TITLE
Add additional status sensors

### DIFF
--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.0.24"],
+  "requirements": ["hatasmota==0.0.25"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/tasmota/sensor.py
+++ b/homeassistant/components/tasmota/sensor.py
@@ -1,6 +1,7 @@
 """Support for Tasmota sensors."""
 from typing import Optional
 
+from hatasmota import status_sensor
 from hatasmota.const import (
     SENSOR_AMBIENT,
     SENSOR_APPARENT_POWERUSAGE,
@@ -33,7 +34,12 @@ from hatasmota.const import (
     SENSOR_PRESSUREATSEALEVEL,
     SENSOR_PROXIMITY,
     SENSOR_REACTIVE_POWERUSAGE,
+    SENSOR_STATUS_IP,
+    SENSOR_STATUS_LINK_COUNT,
+    SENSOR_STATUS_MQTT_COUNT,
+    SENSOR_STATUS_RSSI,
     SENSOR_STATUS_SIGNAL,
+    SENSOR_STATUS_UPTIME,
     SENSOR_TEMPERATURE,
     SENSOR_TODAY,
     SENSOR_TOTAL,
@@ -53,6 +59,7 @@ from homeassistant.const import (
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_TIMESTAMP,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -82,7 +89,10 @@ SENSOR_DEVICE_CLASS_ICON_MAP = {
     SENSOR_FREQUENCY: {ICON: "mdi:current-ac"},
     SENSOR_HUMIDITY: {DEVICE_CLASS: DEVICE_CLASS_HUMIDITY},
     SENSOR_ILLUMINANCE: {DEVICE_CLASS: DEVICE_CLASS_ILLUMINANCE},
+    SENSOR_STATUS_IP: {ICON: "mdi:ip-network"},
+    SENSOR_STATUS_LINK_COUNT: {ICON: "mdi:counter"},
     SENSOR_MOISTURE: {ICON: "mdi:cup-water"},
+    SENSOR_STATUS_MQTT_COUNT: {ICON: "mdi:counter"},
     SENSOR_PB0_3: {ICON: "mdi:flask"},
     SENSOR_PB0_5: {ICON: "mdi:flask"},
     SENSOR_PB10: {ICON: "mdi:flask"},
@@ -99,11 +109,13 @@ SENSOR_DEVICE_CLASS_ICON_MAP = {
     SENSOR_PROXIMITY: {ICON: "mdi:ruler"},
     SENSOR_REACTIVE_POWERUSAGE: {DEVICE_CLASS: DEVICE_CLASS_POWER},
     SENSOR_STATUS_SIGNAL: {DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH},
+    SENSOR_STATUS_RSSI: {DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH},
     SENSOR_TEMPERATURE: {DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE},
     SENSOR_TODAY: {DEVICE_CLASS: DEVICE_CLASS_POWER},
     SENSOR_TOTAL: {DEVICE_CLASS: DEVICE_CLASS_POWER},
     SENSOR_TOTAL_START_TIME: {ICON: "mdi:progress-clock"},
     SENSOR_TVOC: {ICON: "mdi:air-filter"},
+    SENSOR_STATUS_UPTIME: {DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP},
     SENSOR_VOLTAGE: {ICON: "mdi:alpha-v-circle-outline"},
     SENSOR_WEIGHT: {ICON: "mdi:scale"},
     SENSOR_YESTERDAY: {DEVICE_CLASS: DEVICE_CLASS_POWER},
@@ -162,7 +174,7 @@ class TasmotaSensor(TasmotaAvailability, TasmotaDiscoveryUpdate, Entity):
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
         # Hide status sensors to not overwhelm users
-        if self._tasmota_entity.quantity == SENSOR_STATUS_SIGNAL:
+        if self._tasmota_entity.quantity in status_sensor.SENSORS:
             return False
         return True
 

--- a/homeassistant/components/tasmota/translations/it.json
+++ b/homeassistant/components/tasmota/translations/it.json
@@ -4,12 +4,12 @@
             "single_instance_allowed": "Gi\u00e0 configurato. \u00c8 possibile una sola configurazione."
         },
         "error": {
-            "invalid_discovery_topic": "Prefisso dell'argomento di individuazione non valido."
+            "invalid_discovery_topic": "Prefisso del topic di rilevamento non valido."
         },
         "step": {
             "config": {
                 "data": {
-                    "discovery_prefix": "Prefisso dell'argomento di individuazione"
+                    "discovery_prefix": "Prefisso del topic di rilevamento"
                 },
                 "description": "Inserire la configurazione Tasmota.",
                 "title": "Tasmota"

--- a/homeassistant/components/tasmota/translations/pt.json
+++ b/homeassistant/components/tasmota/translations/pt.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Já configurado. Apenas uma única configuração é possível."
+        },
+        "error": {
+            "invalid_discovery_topic": "prefixo do tópico de descoberta inválido."
+        },
+        "step": {
+            "config": {
+                "data": {
+                    "discovery_prefix": "Tópico de descoberta"
+                },
+                "description": "Por favor, entre na configuração do Tasmota.",
+                "title": "Tasmota"
+            },
+            "confirm": {
+                "description": "Você quer configurar o Tasmota?"
+            }
+        }
+    }
+}


### PR DESCRIPTION
New sensors:
- RSSI signal sensor
- Uptime sensor
- Mqtt count sensor
- Link count sensor

New translation for Portuguese and fix for the Italian one.

Bump HaTasmota to 0.0.25.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
