### PR TITLE
Fix broken time trigger test

### DIFF
--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -61,22 +61,23 @@ async def test_websocket_core_update(hass, client):
     assert hass.config.external_url != "https://www.example.com"
     assert hass.config.internal_url != "http://example.com"
 
-    await client.send_json(
-        {
-            "id": 5,
-            "type": "config/core/update",
-            "latitude": 60,
-            "longitude": 50,
-            "elevation": 25,
-            "location_name": "Huis",
-            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
-            "time_zone": "America/New_York",
-            "external_url": "https://www.example.com",
-            "internal_url": "http://example.local",
-        }
-    )
+    with patch("homeassistant.util.dt.set_default_time_zone") as mock_set_tz:
+        await client.send_json(
+            {
+                "id": 5,
+                "type": "config/core/update",
+                "latitude": 60,
+                "longitude": 50,
+                "elevation": 25,
+                "location_name": "Huis",
+                CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+                "time_zone": "America/New_York",
+                "external_url": "https://www.example.com",
+                "internal_url": "http://example.local",
+            }
+        )
 
-    msg = await client.receive_json()
+        msg = await client.receive_json()
 
     assert msg["id"] == 5
     assert msg["type"] == TYPE_RESULT
@@ -86,11 +87,11 @@ async def test_websocket_core_update(hass, client):
     assert hass.config.elevation == 25
     assert hass.config.location_name == "Huis"
     assert hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL
-    assert hass.config.time_zone.zone == "America/New_York"
     assert hass.config.external_url == "https://www.example.com"
     assert hass.config.internal_url == "http://example.local"
 
-    dt_util.set_default_time_zone(ORIG_TIME_ZONE)
+    assert len(mock_set_tz.mock_calls) == 1
+    assert mock_set_tz.mock_calls[0][1][0].zone == "America/New_York"
 
 
 async def test_websocket_core_update_not_admin(hass, hass_ws_client, hass_admin_user):

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -186,7 +186,8 @@ async def test_setup_core_push_timezone(hass, aioclient_mock):
     assert aioclient_mock.call_count == 7
     assert aioclient_mock.mock_calls[2][2]["timezone"] == "testzone"
 
-    await hass.config.async_update(time_zone="America/New_York")
+    with patch("homeassistant.util.dt.set_default_time_zone"):
+        await hass.config.async_update(time_zone="America/New_York")
     await hass.async_block_till_done()
     assert aioclient_mock.mock_calls[-1][2]["timezone"] == "America/New_York"
 

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -74,7 +74,7 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
         "input_datetime",
         {"input_datetime": {"trigger": {"has_date": has_date, "has_time": has_time}}},
     )
-
+    print("DEFAULT TZ", dt_util.DEFAULT_TIME_ZONE)
     now = dt_util.now()
 
     trigger_dt = now.replace(

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -74,7 +74,6 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
         "input_datetime",
         {"input_datetime": {"trigger": {"has_date": has_date, "has_time": has_time}}},
     )
-    print("DEFAULT TZ", dt_util.DEFAULT_TIME_ZONE)
     now = dt_util.now()
 
     trigger_dt = now.replace(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
