### PR TITLE
Remove classes in nx584 tests

### DIFF
--- a/tests/components/nx584/test_binary_sensor.py
+++ b/tests/components/nx584/test_binary_sensor.py
@@ -46,93 +46,97 @@ def client(fake_zones):
 
 
 @pytest.mark.usefixtures("client")
-class TestNX584SensorSetup:
-    """Test the NX584 sensor platform."""
+@mock.patch("homeassistant.components.nx584.binary_sensor.NX584Watcher")
+@mock.patch("homeassistant.components.nx584.binary_sensor.NX584ZoneSensor")
+def test_nx584_sensor_setup_defaults(mock_nx, mock_watcher, hass, fake_zones):
+    """Test the setup with no configuration."""
+    add_entities = mock.MagicMock()
+    config = {
+        "host": nx584.DEFAULT_HOST,
+        "port": nx584.DEFAULT_PORT,
+        "exclude_zones": [],
+        "zone_types": {},
+    }
+    assert nx584.setup_platform(hass, config, add_entities)
+    mock_nx.assert_has_calls([mock.call(zone, "opening") for zone in fake_zones])
+    assert add_entities.called
+    assert nx584_client.Client.call_count == 1
+    assert nx584_client.Client.call_args == mock.call("http://localhost:5007")
 
-    @staticmethod
-    @mock.patch("homeassistant.components.nx584.binary_sensor.NX584Watcher")
-    @mock.patch("homeassistant.components.nx584.binary_sensor.NX584ZoneSensor")
-    def test_setup_defaults(mock_nx, mock_watcher, hass, fake_zones):
-        """Test the setup with no configuration."""
-        add_entities = mock.MagicMock()
-        config = {
-            "host": nx584.DEFAULT_HOST,
-            "port": nx584.DEFAULT_PORT,
-            "exclude_zones": [],
-            "zone_types": {},
-        }
-        assert nx584.setup_platform(hass, config, add_entities)
-        mock_nx.assert_has_calls([mock.call(zone, "opening") for zone in fake_zones])
-        assert add_entities.called
-        assert nx584_client.Client.call_count == 1
-        assert nx584_client.Client.call_args == mock.call("http://localhost:5007")
 
-    @staticmethod
-    @mock.patch("homeassistant.components.nx584.binary_sensor.NX584Watcher")
-    @mock.patch("homeassistant.components.nx584.binary_sensor.NX584ZoneSensor")
-    def test_setup_full_config(mock_nx, mock_watcher, hass, fake_zones):
-        """Test the setup with full configuration."""
-        config = {
-            "host": "foo",
-            "port": 123,
-            "exclude_zones": [2],
-            "zone_types": {3: "motion"},
-        }
-        add_entities = mock.MagicMock()
-        assert nx584.setup_platform(hass, config, add_entities)
-        mock_nx.assert_has_calls(
-            [
-                mock.call(fake_zones[0], "opening"),
-                mock.call(fake_zones[2], "motion"),
-            ]
-        )
-        assert add_entities.called
-        assert nx584_client.Client.call_count == 1
-        assert nx584_client.Client.call_args == mock.call("http://foo:123")
-        assert mock_watcher.called
-
-    @staticmethod
-    async def _test_assert_graceful_fail(hass, config):
-        """Test the failing."""
-        assert not await async_setup_component(hass, "nx584", config)
-
-    @pytest.mark.parametrize(
-        "config",
+@pytest.mark.usefixtures("client")
+@mock.patch("homeassistant.components.nx584.binary_sensor.NX584Watcher")
+@mock.patch("homeassistant.components.nx584.binary_sensor.NX584ZoneSensor")
+def test_nx584_sensor_setup_full_config(mock_nx, mock_watcher, hass, fake_zones):
+    """Test the setup with full configuration."""
+    config = {
+        "host": "foo",
+        "port": 123,
+        "exclude_zones": [2],
+        "zone_types": {3: "motion"},
+    }
+    add_entities = mock.MagicMock()
+    assert nx584.setup_platform(hass, config, add_entities)
+    mock_nx.assert_has_calls(
         [
-            ({"exclude_zones": ["a"]}),
-            ({"zone_types": {"a": "b"}}),
-            ({"zone_types": {1: "notatype"}}),
-            ({"zone_types": {"notazone": "motion"}}),
-        ],
+            mock.call(fake_zones[0], "opening"),
+            mock.call(fake_zones[2], "motion"),
+        ]
     )
-    async def test_setup_bad_config(self, hass, config):
-        """Test the setup with bad configuration."""
-        await self._test_assert_graceful_fail(hass, config)
+    assert add_entities.called
+    assert nx584_client.Client.call_count == 1
+    assert nx584_client.Client.call_args == mock.call("http://foo:123")
+    assert mock_watcher.called
 
-    @pytest.mark.parametrize(
-        "exception_type",
-        [
-            pytest.param(requests.exceptions.ConnectionError, id="connect_failed"),
-            pytest.param(IndexError, id="no_partitions"),
-        ],
-    )
-    async def test_setup_with_exceptions(self, hass, exception_type):
-        """Test the setup handles exceptions."""
-        nx584_client.Client.return_value.list_zones.side_effect = exception_type
-        await self._test_assert_graceful_fail(hass, {})
 
-    async def test_setup_version_too_old(self, hass):
-        """Test if version is too old."""
-        nx584_client.Client.return_value.get_version.return_value = "1.0"
-        await self._test_assert_graceful_fail(hass, {})
+async def _test_assert_graceful_fail(hass, config):
+    """Test the failing."""
+    assert not await async_setup_component(hass, "nx584", config)
 
-    @staticmethod
-    def test_setup_no_zones(hass):
-        """Test the setup with no zones."""
-        nx584_client.Client.return_value.list_zones.return_value = []
-        add_entities = mock.MagicMock()
-        assert nx584.setup_platform(hass, {}, add_entities)
-        assert not add_entities.called
+
+@pytest.mark.usefixtures("client")
+@pytest.mark.parametrize(
+    "config",
+    [
+        ({"exclude_zones": ["a"]}),
+        ({"zone_types": {"a": "b"}}),
+        ({"zone_types": {1: "notatype"}}),
+        ({"zone_types": {"notazone": "motion"}}),
+    ],
+)
+async def test_nx584_sensor_setup_bad_config(hass, config):
+    """Test the setup with bad configuration."""
+    await _test_assert_graceful_fail(hass, config)
+
+
+@pytest.mark.usefixtures("client")
+@pytest.mark.parametrize(
+    "exception_type",
+    [
+        pytest.param(requests.exceptions.ConnectionError, id="connect_failed"),
+        pytest.param(IndexError, id="no_partitions"),
+    ],
+)
+async def test_nx584_sensor_setup_with_exceptions(hass, exception_type):
+    """Test the setup handles exceptions."""
+    nx584_client.Client.return_value.list_zones.side_effect = exception_type
+    await _test_assert_graceful_fail(hass, {})
+
+
+@pytest.mark.usefixtures("client")
+async def test_nx584_sensor_setup_version_too_old(hass):
+    """Test if version is too old."""
+    nx584_client.Client.return_value.get_version.return_value = "1.0"
+    await _test_assert_graceful_fail(hass, {})
+
+
+@pytest.mark.usefixtures("client")
+def test_nx584_sensor_setup_no_zones(hass):
+    """Test the setup with no zones."""
+    nx584_client.Client.return_value.list_zones.return_value = []
+    add_entities = mock.MagicMock()
+    assert nx584.setup_platform(hass, {}, add_entities)
+    assert not add_entities.called
 
 
 def test_nx584_zone_sensor_normal():
@@ -148,81 +152,77 @@ def test_nx584_zone_sensor_normal():
     assert not sensor.is_on
 
 
-class TestNX584Watcher:
-    """Test the NX584 watcher."""
+@mock.patch.object(nx584.NX584ZoneSensor, "schedule_update_ha_state")
+def test_nx584_watcher_process_zone_event(mock_update):
+    """Test the processing of zone events."""
+    zone1 = {"number": 1, "name": "foo", "state": True}
+    zone2 = {"number": 2, "name": "bar", "state": True}
+    zones = {
+        1: nx584.NX584ZoneSensor(zone1, "motion"),
+        2: nx584.NX584ZoneSensor(zone2, "motion"),
+    }
+    watcher = nx584.NX584Watcher(None, zones)
+    watcher._process_zone_event({"zone": 1, "zone_state": False})
+    assert not zone1["state"]
+    assert mock_update.call_count == 1
 
-    @staticmethod
-    @mock.patch.object(nx584.NX584ZoneSensor, "schedule_update_ha_state")
-    def test_process_zone_event(mock_update):
-        """Test the processing of zone events."""
-        zone1 = {"number": 1, "name": "foo", "state": True}
-        zone2 = {"number": 2, "name": "bar", "state": True}
-        zones = {
-            1: nx584.NX584ZoneSensor(zone1, "motion"),
-            2: nx584.NX584ZoneSensor(zone2, "motion"),
-        }
-        watcher = nx584.NX584Watcher(None, zones)
-        watcher._process_zone_event({"zone": 1, "zone_state": False})
-        assert not zone1["state"]
-        assert mock_update.call_count == 1
 
-    @staticmethod
-    @mock.patch.object(nx584.NX584ZoneSensor, "schedule_update_ha_state")
-    def test_process_zone_event_missing_zone(mock_update):
-        """Test the processing of zone events with missing zones."""
-        watcher = nx584.NX584Watcher(None, {})
-        watcher._process_zone_event({"zone": 1, "zone_state": False})
-        assert not mock_update.called
+@mock.patch.object(nx584.NX584ZoneSensor, "schedule_update_ha_state")
+def test_nx584_watcher_process_zone_event_missing_zone(mock_update):
+    """Test the processing of zone events with missing zones."""
+    watcher = nx584.NX584Watcher(None, {})
+    watcher._process_zone_event({"zone": 1, "zone_state": False})
+    assert not mock_update.called
 
-    @staticmethod
-    def test_run_with_zone_events():
-        """Test the zone events."""
-        empty_me = [1, 2]
 
-        def fake_get_events():
-            """Return nothing twice, then some events."""
-            if empty_me:
-                empty_me.pop()
-            else:
-                return fake_events
+def test_nx584_watcher_run_with_zone_events():
+    """Test the zone events."""
+    empty_me = [1, 2]
 
-        client = mock.MagicMock()
-        fake_events = [
-            {"zone": 1, "zone_state": True, "type": "zone_status"},
-            {"zone": 2, "foo": False},
-        ]
-        client.get_events.side_effect = fake_get_events
-        watcher = nx584.NX584Watcher(client, {})
+    def fake_get_events():
+        """Return nothing twice, then some events."""
+        if empty_me:
+            empty_me.pop()
+        else:
+            return fake_events
 
-        @mock.patch.object(watcher, "_process_zone_event")
-        def run(fake_process):
-            """Run a fake process."""
-            fake_process.side_effect = StopMe
-            with pytest.raises(StopMe):
-                watcher._run()
-            assert fake_process.call_count == 1
-            assert fake_process.call_args == mock.call(fake_events[0])
+    client = mock.MagicMock()
+    fake_events = [
+        {"zone": 1, "zone_state": True, "type": "zone_status"},
+        {"zone": 2, "foo": False},
+    ]
+    client.get_events.side_effect = fake_get_events
+    watcher = nx584.NX584Watcher(client, {})
 
-        run()
-        assert 3 == client.get_events.call_count
+    @mock.patch.object(watcher, "_process_zone_event")
+    def run(fake_process):
+        """Run a fake process."""
+        fake_process.side_effect = StopMe
+        with pytest.raises(StopMe):
+            watcher._run()
+        assert fake_process.call_count == 1
+        assert fake_process.call_args == mock.call(fake_events[0])
 
-    @staticmethod
-    @mock.patch("time.sleep")
-    def test_run_retries_failures(mock_sleep):
-        """Test the retries with failures."""
-        empty_me = [1, 2]
+    run()
+    assert 3 == client.get_events.call_count
 
-        def fake_run():
-            """Fake runner."""
-            if empty_me:
-                empty_me.pop()
-                raise requests.exceptions.ConnectionError()
-            raise StopMe()
 
-        watcher = nx584.NX584Watcher(None, {})
-        with mock.patch.object(watcher, "_run") as mock_inner:
-            mock_inner.side_effect = fake_run
-            with pytest.raises(StopMe):
-                watcher.run()
-            assert 3 == mock_inner.call_count
-        mock_sleep.assert_has_calls([mock.call(10), mock.call(10)])
+@mock.patch("time.sleep")
+def test_nx584_watcher_run_retries_failures(mock_sleep):
+    """Test the retries with failures."""
+    empty_me = [1, 2]
+
+    def fake_run():
+        """Fake runner."""
+        if empty_me:
+            empty_me.pop()
+            raise requests.exceptions.ConnectionError()
+        raise StopMe()
+
+    watcher = nx584.NX584Watcher(None, {})
+    with mock.patch.object(watcher, "_run") as mock_inner:
+        mock_inner.side_effect = fake_run
+        with pytest.raises(StopMe):
+            watcher.run()
+        assert 3 == mock_inner.call_count
+    mock_sleep.assert_has_calls([mock.call(10), mock.call(10)])


### PR DESCRIPTION
## Proposed change
Removes classes from nx584 tests.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40873
- This PR is related to issue: #40873
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
