### PR TITLE
Extend WS API result when enabling an entity

### DIFF
--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -118,7 +118,7 @@ async def websocket_update_entity(hass, connection, msg):
         result = websocket_api.result_message(msg["id"], _entry_ext_dict(entry))
         if "disabled_by" in changes and changes["disabled_by"] is None:
             config_entry = hass.config_entries.async_get_entry(entry.config_entry_id)
-            if entry and not config_entry.supports_unload:
+            if config_entry and not config_entry.supports_unload:
                 result["result"]["requires_restart"] = True
             else:
                 result["result"][

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -114,19 +114,15 @@ async def websocket_update_entity(hass, connection, msg):
         connection.send_message(
             websocket_api.error_message(msg["id"], "invalid_info", str(err))
         )
-    else:
-        result = websocket_api.result_message(
-            msg["id"], {"entity_entry": _entry_ext_dict(entry)}
-        )
-        if "disabled_by" in changes and changes["disabled_by"] is None:
-            config_entry = hass.config_entries.async_get_entry(entry.config_entry_id)
-            if config_entry and not config_entry.supports_unload:
-                result["result"]["require_restart"] = True
-            else:
-                result["result"][
-                    "reload_delay"
-                ] = config_entries.RELOAD_AFTER_UPDATE_DELAY
-        connection.send_message(result)
+        return
+    result = {"entity_entry": _entry_ext_dict(entry)}
+    if "disabled_by" in changes and changes["disabled_by"] is None:
+        config_entry = hass.config_entries.async_get_entry(entry.config_entry_id)
+        if config_entry and not config_entry.supports_unload:
+            result["require_restart"] = True
+        else:
+            result["reload_delay"] = config_entries.RELOAD_AFTER_UPDATE_DELAY
+    connection.send_result(msg["id"], result)
 
 
 @require_admin

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -115,18 +115,18 @@ async def websocket_update_entity(hass, connection, msg):
             websocket_api.error_message(msg["id"], "invalid_info", str(err))
         )
     else:
-        result = websocket_api.result_message(msg["id"], _entry_ext_dict(entry))
+        result = websocket_api.result_message(
+            msg["id"], {"entity_entry": _entry_ext_dict(entry)}
+        )
         if "disabled_by" in changes and changes["disabled_by"] is None:
             config_entry = hass.config_entries.async_get_entry(entry.config_entry_id)
             if config_entry and not config_entry.supports_unload:
-                result["result"]["requires_restart"] = True
+                result["result"]["require_restart"] = True
             else:
                 result["result"][
                     "reload_delay"
                 ] = config_entries.RELOAD_AFTER_UPDATE_DELAY
-        connection.send_message(
-            websocket_api.result_message(msg["id"], _entry_ext_dict(entry))
-        )
+        connection.send_message(result)
 
 
 @require_admin

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -89,6 +89,8 @@ CONN_CLASS_LOCAL_POLL = "local_poll"
 CONN_CLASS_ASSUMED = "assumed"
 CONN_CLASS_UNKNOWN = "unknown"
 
+RELOAD_AFTER_UPDATE_DELAY = 30
+
 
 class ConfigError(HomeAssistantError):
     """Error while configuring an account."""
@@ -1109,8 +1111,6 @@ class SystemOptions:
 class EntityRegistryDisabledHandler:
     """Handler to handle when entities related to config entries updating disabled_by."""
 
-    RELOAD_AFTER_UPDATE_DELAY = 30
-
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the handler."""
         self.hass = hass
@@ -1167,7 +1167,7 @@ class EntityRegistryDisabledHandler:
             self._remove_call_later()
 
         self._remove_call_later = self.hass.helpers.event.async_call_later(
-            self.RELOAD_AFTER_UPDATE_DELAY, self._handle_reload
+            RELOAD_AFTER_UPDATE_DELAY, self._handle_reload
         )
 
     async def _handle_reload(self, _now: Any) -> None:

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -7,7 +7,7 @@ from homeassistant.components.config import entity_registry
 from homeassistant.const import ATTR_ICON
 from homeassistant.helpers.entity_registry import RegistryEntry
 
-from tests.common import MockEntity, MockEntityPlatform, mock_registry
+from tests.common import MockConfigEntry, MockEntity, MockEntityPlatform, mock_registry
 
 
 @pytest.fixture
@@ -162,18 +162,20 @@ async def test_update_entity(hass, client):
     msg = await client.receive_json()
 
     assert msg["result"] == {
-        "config_entry_id": None,
-        "device_id": None,
-        "area_id": "mock-area-id",
-        "disabled_by": None,
-        "platform": "test_platform",
-        "entity_id": "test_domain.world",
-        "name": "after update",
-        "icon": "icon:after update",
-        "original_name": None,
-        "original_icon": None,
-        "capabilities": None,
-        "unique_id": "1234",
+        "entity_entry": {
+            "config_entry_id": None,
+            "device_id": None,
+            "area_id": "mock-area-id",
+            "disabled_by": None,
+            "platform": "test_platform",
+            "entity_id": "test_domain.world",
+            "name": "after update",
+            "icon": "icon:after update",
+            "original_name": None,
+            "original_icon": None,
+            "capabilities": None,
+            "unique_id": "1234",
+        }
     }
 
     state = hass.states.get("test_domain.world")
@@ -208,18 +210,75 @@ async def test_update_entity(hass, client):
     msg = await client.receive_json()
 
     assert msg["result"] == {
-        "config_entry_id": None,
-        "device_id": None,
-        "area_id": "mock-area-id",
-        "disabled_by": None,
-        "platform": "test_platform",
-        "entity_id": "test_domain.world",
-        "name": "after update",
-        "icon": "icon:after update",
-        "original_name": None,
-        "original_icon": None,
-        "capabilities": None,
-        "unique_id": "1234",
+        "entity_entry": {
+            "config_entry_id": None,
+            "device_id": None,
+            "area_id": "mock-area-id",
+            "disabled_by": None,
+            "platform": "test_platform",
+            "entity_id": "test_domain.world",
+            "name": "after update",
+            "icon": "icon:after update",
+            "original_name": None,
+            "original_icon": None,
+            "capabilities": None,
+            "unique_id": "1234",
+        },
+        "reload_delay": 30,
+    }
+
+
+async def test_update_entity_require_restart(hass, client):
+    """Test updating entity."""
+    config_entry = MockConfigEntry(domain="test_platform")
+    config_entry.add_to_hass(hass)
+    mock_registry(
+        hass,
+        {
+            "test_domain.world": RegistryEntry(
+                config_entry_id=config_entry.entry_id,
+                entity_id="test_domain.world",
+                unique_id="1234",
+                # Using component.async_add_entities is equal to platform "domain"
+                platform="test_platform",
+            )
+        },
+    )
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(unique_id="1234")
+    await platform.async_add_entities([entity])
+
+    state = hass.states.get("test_domain.world")
+    assert state is not None
+
+    # UPDATE DISABLED_BY TO NONE
+    await client.send_json(
+        {
+            "id": 8,
+            "type": "config/entity_registry/update",
+            "entity_id": "test_domain.world",
+            "disabled_by": None,
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert msg["result"] == {
+        "entity_entry": {
+            "config_entry_id": config_entry.entry_id,
+            "device_id": None,
+            "area_id": None,
+            "disabled_by": None,
+            "platform": "test_platform",
+            "entity_id": "test_domain.world",
+            "name": None,
+            "icon": None,
+            "original_name": None,
+            "original_icon": None,
+            "capabilities": None,
+            "unique_id": "1234",
+        },
+        "require_restart": True,
     }
 
 
@@ -257,18 +316,20 @@ async def test_update_entity_no_changes(hass, client):
     msg = await client.receive_json()
 
     assert msg["result"] == {
-        "config_entry_id": None,
-        "device_id": None,
-        "area_id": None,
-        "disabled_by": None,
-        "platform": "test_platform",
-        "entity_id": "test_domain.world",
-        "name": "name of entity",
-        "icon": None,
-        "original_name": None,
-        "original_icon": None,
-        "capabilities": None,
-        "unique_id": "1234",
+        "entity_entry": {
+            "config_entry_id": None,
+            "device_id": None,
+            "area_id": None,
+            "disabled_by": None,
+            "platform": "test_platform",
+            "entity_id": "test_domain.world",
+            "name": "name of entity",
+            "icon": None,
+            "original_name": None,
+            "original_icon": None,
+            "capabilities": None,
+            "unique_id": "1234",
+        }
     }
 
     state = hass.states.get("test_domain.world")
@@ -335,18 +396,20 @@ async def test_update_entity_id(hass, client):
     msg = await client.receive_json()
 
     assert msg["result"] == {
-        "config_entry_id": None,
-        "device_id": None,
-        "area_id": None,
-        "disabled_by": None,
-        "platform": "test_platform",
-        "entity_id": "test_domain.planet",
-        "name": None,
-        "icon": None,
-        "original_name": None,
-        "original_icon": None,
-        "capabilities": None,
-        "unique_id": "1234",
+        "entity_entry": {
+            "config_entry_id": None,
+            "device_id": None,
+            "area_id": None,
+            "disabled_by": None,
+            "platform": "test_platform",
+            "entity_id": "test_domain.planet",
+            "name": None,
+            "icon": None,
+            "original_name": None,
+            "original_icon": None,
+            "capabilities": None,
+            "unique_id": "1234",
+        }
     }
 
     assert hass.states.get("test_domain.world") is None

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -412,11 +412,7 @@ async def test_enable_status_sensor(hass, mqtt_mock, setup_tasmota):
 
     async_fire_time_changed(
         hass,
-        dt.utcnow()
-        + timedelta(
-            seconds=config_entries.EntityRegistryDisabledHandler.RELOAD_AFTER_UPDATE_DELAY
-            + 1
-        ),
+        dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1156,11 +1156,7 @@ async def test_reload_entry_entity_registry_works(hass):
 
     async_fire_time_changed(
         hass,
-        dt.utcnow()
-        + timedelta(
-            seconds=config_entries.EntityRegistryDisabledHandler.RELOAD_AFTER_UPDATE_DELAY
-            + 1
-        ),
+        dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extend WS API result when enabling an entity.
The purpose is to improve user experience:
- Some entities won't be enabled until HA is restarted
- Entities won't be enabled until after a long delay

Note: A frontend PR is also needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
