### PR TITLE
Remove temporary variable from supported_features

### DIFF
--- a/homeassistant/components/ads/light.py
+++ b/homeassistant/components/ads/light.py
@@ -68,10 +68,9 @@ class AdsLight(AdsEntity, LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        support = 0
         if self._ads_var_brightness is not None:
-            support = SUPPORT_BRIGHTNESS
-        return support
+            return SUPPORT_BRIGHTNESS
+        return 0
 
     @property
     def is_on(self):

--- a/homeassistant/components/bond/light.py
+++ b/homeassistant/components/bond/light.py
@@ -68,11 +68,9 @@ class BondLight(BondEntity, LightEntity):
     @property
     def supported_features(self) -> Optional[int]:
         """Flag supported features."""
-        features = 0
         if self._device.supports_set_brightness():
-            features |= SUPPORT_BRIGHTNESS
-
-        return features
+            return SUPPORT_BRIGHTNESS
+        return 0
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/control4/light.py
+++ b/homeassistant/components/control4/light.py
@@ -187,10 +187,9 @@ class Control4Light(Control4Entity, LightEntity):
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
-        flags = 0
         if self._is_dimmer:
-            flags |= SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
-        return flags
+            return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+        return 0
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -119,9 +119,10 @@ class PowerViewShade(ShadeEntity, CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
+        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
         if self._device_info[DEVICE_MODEL] != LEGACY_DEVICE_MODEL:
-            return SUPPORT_STOP | SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
-        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+            supported_features |= SUPPORT_STOP
+        return supported_features
 
     @property
     def is_closed(self):

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -119,10 +119,9 @@ class PowerViewShade(ShadeEntity, CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
         if self._device_info[DEVICE_MODEL] != LEGACY_DEVICE_MODEL:
-            supported_features |= SUPPORT_STOP
-        return supported_features
+            return SUPPORT_STOP | SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
 
     @property
     def is_closed(self):

--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -71,10 +71,9 @@ class LcnOutputLight(LcnDevice, LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        features = SUPPORT_TRANSITION
         if self.dimmable:
-            features |= SUPPORT_BRIGHTNESS
-        return features
+            return SUPPORT_TRANSITION | SUPPORT_BRIGHTNESS
+        return SUPPORT_TRANSITION
 
     @property
     def brightness(self):

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -80,10 +80,9 @@ class NestCamera(Camera):
     @property
     def supported_features(self):
         """Flag supported features."""
-        features = 0
         if CameraLiveStreamTrait.NAME in self._device.traits:
-            features = features | SUPPORT_STREAM
-        return features
+            return SUPPORT_STREAM
+        return 0
 
     async def stream_source(self):
         """Return the source of the stream."""

--- a/homeassistant/components/spider/climate.py
+++ b/homeassistant/components/spider/climate.py
@@ -44,12 +44,9 @@ class SpiderThermostat(ClimateEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        supports = SUPPORT_TARGET_TEMPERATURE
-
         if self.thermostat.has_fan_mode:
-            supports |= SUPPORT_FAN_MODE
-
-        return supports
+            return SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
+        return SUPPORT_TARGET_TEMPERATURE
 
     @property
     def unique_id(self):

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -68,10 +68,9 @@ class TuyaCover(TuyaDevice, CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
         if self._tuya.support_stop():
-            supported_features |= SUPPORT_STOP
-        return supported_features
+            return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
+        return SUPPORT_OPEN | SUPPORT_CLOSE
 
     @property
     def is_opening(self):

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -119,7 +119,6 @@ class TuyaFanDevice(TuyaDevice, FanEntity):
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
-        supports = SUPPORT_SET_SPEED
         if self._tuya.support_oscillate():
-            supports = supports | SUPPORT_OSCILLATE
-        return supports
+            return SUPPORT_SET_SPEED | SUPPORT_OSCILLATE
+        return SUPPORT_SET_SPEED

--- a/homeassistant/components/xbox/media_player.py
+++ b/homeassistant/components/xbox/media_player.py
@@ -111,10 +111,9 @@ class XboxMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        active_support = SUPPORT_XBOX
         if self.state not in [STATE_PLAYING, STATE_PAUSED]:
-            active_support &= ~SUPPORT_NEXT_TRACK & ~SUPPORT_PREVIOUS_TRACK
-        return active_support
+            return SUPPORT_XBOX & ~SUPPORT_NEXT_TRACK & ~SUPPORT_PREVIOUS_TRACK
+        return SUPPORT_XBOX
 
     @property
     def media_content_type(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
More clean up: removing temporary variable from supported_features.

Example:

```python
# Before
def supported_features(self):
    supported_features = 0
    if device.supports_feature():
        supported_features |= SUPPORT_FEATURE
    return supported_features

# After
def supported_features(self):
    if device.supports_feature():
        return SUPPORT_FEATURE
    return 0
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
n/a
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
