### PR TITLE
Catch unhandled exception in websocket_api

### DIFF
--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -222,7 +222,7 @@ class WebSocketHandler:
                 self._to_write.put_nowait(None)
                 # Make sure all error messages are written before closing
                 await self._writer_task
-            except:
+            except (asyncio.QueueFull, asyncio.exceptions.CancelledError):
                 self._writer_task.cancel()
 
             await wsock.close()

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -222,20 +222,20 @@ class WebSocketHandler:
                 self._to_write.put_nowait(None)
                 # Make sure all error messages are written before closing
                 await self._writer_task
-            except (asyncio.QueueFull, asyncio.CancelledError):
+                await wsock.close()
+            except asyncio.QueueFull:  # can be raised by put_nowait
                 self._writer_task.cancel()
 
-            await wsock.close()
+            finally:
+                if disconnect_warn is None:
+                    self._logger.debug("Disconnected")
+                else:
+                    self._logger.warning("Disconnected: %s", disconnect_warn)
 
-            if disconnect_warn is None:
-                self._logger.debug("Disconnected")
-            else:
-                self._logger.warning("Disconnected: %s", disconnect_warn)
-
-            if connection is not None:
-                self.hass.data[DATA_CONNECTIONS] -= 1
-            self.hass.helpers.dispatcher.async_dispatcher_send(
-                SIGNAL_WEBSOCKET_DISCONNECTED
-            )
+                if connection is not None:
+                    self.hass.data[DATA_CONNECTIONS] -= 1
+                self.hass.helpers.dispatcher.async_dispatcher_send(
+                    SIGNAL_WEBSOCKET_DISCONNECTED
+                )
 
         return wsock

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -222,7 +222,7 @@ class WebSocketHandler:
                 self._to_write.put_nowait(None)
                 # Make sure all error messages are written before closing
                 await self._writer_task
-            except asyncio.QueueFull:
+            except:
                 self._writer_task.cancel()
 
             await wsock.close()

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -222,7 +222,7 @@ class WebSocketHandler:
                 self._to_write.put_nowait(None)
                 # Make sure all error messages are written before closing
                 await self._writer_task
-            except (asyncio.QueueFull, asyncio.exceptions.CancelledError):
+            except (asyncio.QueueFull, asyncio.CancelledError):
                 self._writer_task.cancel()
 
             await wsock.close()


### PR DESCRIPTION
## Proposed change
Fix unhandled exception in websocket_api causing the connection counter to be wrong.


## Type of change
- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:


## Additional information
- This PR fixes or closes issue: fixes #42665
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
