### PR TITLE
Improve restore of deleted devices

### DIFF
--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -145,6 +145,9 @@ async def test_loading_from_storage(hass, hass_storage):
                     "connections": [["Zigbee", "01.23.45.67.89"]],
                     "id": "abcdefghijklm",
                     "identifiers": [["serial", "12:34:56:AB:CD:EF"]],
+                    "inactive_config_entries": ["2345"],
+                    "inactive_connections": [["mac", "56:ab:cd:ef:12:34"]],
+                    "inactive_identifiers": [["other", "34:56:AB:CD:EF:12"]],
                     "manufacturer": "manufacturer",
                     "model": "model",
                     "name": "name",
@@ -183,6 +186,21 @@ async def test_loading_from_storage(hass, hass_storage):
     assert isinstance(entry.config_entries, set)
     assert isinstance(entry.connections, set)
     assert isinstance(entry.identifiers, set)
+    assert isinstance(entry.inactive_config_entries, set)
+    assert isinstance(entry.inactive_connections, set)
+    assert isinstance(entry.inactive_identifiers, set)
+
+    entry = registry.async_get_or_create(
+        config_entry_id="2345",
+        connections={("mac", "56:AB:CD:EF:12:34")},
+        identifiers={("other", "34:56:AB:CD:EF:12")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+    assert entry.id == "abcdefghijklm"
+    assert entry.inactive_config_entries == set()
+    assert entry.inactive_connections == set()
+    assert entry.inactive_identifiers == set()
 
     entry = registry.async_get_or_create(
         config_entry_id="1234",
@@ -458,7 +476,38 @@ async def test_loading_saving_data(hass, registry):
 
     registry.async_remove_device(orig_light2.id)
 
-    assert len(registry.devices) == 2
+    orig_light3 = registry.async_get_or_create(
+        config_entry_id="789",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
+        identifiers={("hue", "abc")},
+        manufacturer="manufacturer",
+        model="light",
+    )
+
+    registry.async_get_or_create(
+        config_entry_id="abc",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
+        identifiers={("abc", "123")},
+        manufacturer="manufacturer",
+        model="light",
+    )
+
+    registry.async_remove_device(orig_light3.id)
+
+    orig_light4 = registry.async_get_or_create(
+        config_entry_id="789",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
+        identifiers={("hue", "abc")},
+        manufacturer="manufacturer",
+        model="light",
+    )
+
+    assert orig_light4.id == orig_light3.id
+    assert orig_light4.inactive_config_entries == {"abc"}
+    assert orig_light4.inactive_connections == set()
+    assert orig_light4.inactive_identifiers == {("abc", "123")}
+
+    assert len(registry.devices) == 3
     assert len(registry.deleted_devices) == 1
 
     orig_via = registry.async_update_device(
@@ -476,9 +525,11 @@ async def test_loading_saving_data(hass, registry):
 
     new_via = registry2.async_get_device({("hue", "0123")}, set())
     new_light = registry2.async_get_device({("hue", "456")}, set())
+    new_light4 = registry2.async_get_device({("hue", "abc")}, set())
 
     assert orig_via == new_via
     assert orig_light == new_light
+    assert orig_light4 == new_light4
 
 
 async def test_no_unnecessary_changes(registry):
@@ -839,6 +890,122 @@ async def test_restore_simple_device(hass, registry, update_events):
     assert update_events[2]["device_id"] == entry2.id
     assert update_events[3]["action"] == "create"
     assert update_events[3]["device_id"] == entry3.id
+
+
+async def test_restore_shared_device(hass, registry, update_events):
+    """Make sure device id is stable for shared devices."""
+    entry = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("entry_123", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 0
+
+    registry.async_get_or_create(
+        config_entry_id="234",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("entry_234", "2345")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 0
+
+    registry.async_remove_device(entry.id)
+
+    assert len(registry.devices) == 0
+    assert len(registry.deleted_devices) == 1
+
+    entry2 = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("entry_123", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert entry.id == entry2.id
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 0
+
+    assert isinstance(entry2.config_entries, set)
+    assert isinstance(entry2.connections, set)
+    assert isinstance(entry2.identifiers, set)
+    assert isinstance(entry2.inactive_config_entries, set)
+    assert isinstance(entry2.inactive_connections, set)
+    assert isinstance(entry2.inactive_identifiers, set)
+    assert entry2.inactive_config_entries == {"234"}
+    assert entry2.inactive_connections == set()
+    assert entry2.inactive_identifiers == {("entry_234", "2345")}
+
+    registry.async_remove_device(entry.id)
+
+    entry3 = registry.async_get_or_create(
+        config_entry_id="234",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("entry_234", "2345")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert entry.id == entry3.id
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 0
+
+    assert isinstance(entry3.config_entries, set)
+    assert isinstance(entry3.connections, set)
+    assert isinstance(entry3.identifiers, set)
+    assert isinstance(entry3.inactive_config_entries, set)
+    assert isinstance(entry3.inactive_connections, set)
+    assert isinstance(entry3.inactive_identifiers, set)
+    assert entry3.inactive_config_entries == {"123"}
+    assert entry3.inactive_connections == set()
+    assert entry3.inactive_identifiers == {("entry_123", "0123")}
+
+    entry4 = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("entry_123", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert entry.id == entry4.id
+    assert len(registry.devices) == 1
+    assert len(registry.deleted_devices) == 0
+
+    assert isinstance(entry4.config_entries, set)
+    assert isinstance(entry4.connections, set)
+    assert isinstance(entry4.identifiers, set)
+    assert isinstance(entry4.inactive_config_entries, set)
+    assert isinstance(entry4.inactive_connections, set)
+    assert isinstance(entry4.inactive_identifiers, set)
+    assert entry4.inactive_config_entries == set()
+    assert entry4.inactive_connections == set()
+    assert entry4.inactive_identifiers == set()
+
+    await hass.async_block_till_done()
+
+    assert len(update_events) == 7
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["device_id"] == entry.id
+    assert update_events[1]["action"] == "update"
+    assert update_events[1]["device_id"] == entry.id
+    assert update_events[2]["action"] == "remove"
+    assert update_events[2]["device_id"] == entry.id
+    assert update_events[3]["action"] == "create"
+    assert update_events[3]["device_id"] == entry.id
+    assert update_events[4]["action"] == "remove"
+    assert update_events[4]["device_id"] == entry.id
+    assert update_events[5]["action"] == "create"
+    assert update_events[5]["device_id"] == entry.id
+    assert update_events[1]["action"] == "update"
+    assert update_events[1]["device_id"] == entry.id
 
 
 async def test_get_or_create_empty_then_set_default_values(hass, registry):

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -145,9 +145,6 @@ async def test_loading_from_storage(hass, hass_storage):
                     "connections": [["Zigbee", "01.23.45.67.89"]],
                     "id": "abcdefghijklm",
                     "identifiers": [["serial", "12:34:56:AB:CD:EF"]],
-                    "inactive_config_entries": ["2345"],
-                    "inactive_connections": [["mac", "56:ab:cd:ef:12:34"]],
-                    "inactive_identifiers": [["other", "34:56:AB:CD:EF:12"]],
                     "manufacturer": "manufacturer",
                     "model": "model",
                     "name": "name",
@@ -186,21 +183,6 @@ async def test_loading_from_storage(hass, hass_storage):
     assert isinstance(entry.config_entries, set)
     assert isinstance(entry.connections, set)
     assert isinstance(entry.identifiers, set)
-    assert isinstance(entry.inactive_config_entries, set)
-    assert isinstance(entry.inactive_connections, set)
-    assert isinstance(entry.inactive_identifiers, set)
-
-    entry = registry.async_get_or_create(
-        config_entry_id="2345",
-        connections={("mac", "56:AB:CD:EF:12:34")},
-        identifiers={("other", "34:56:AB:CD:EF:12")},
-        manufacturer="manufacturer",
-        model="model",
-    )
-    assert entry.id == "abcdefghijklm"
-    assert entry.inactive_config_entries == set()
-    assert entry.inactive_connections == set()
-    assert entry.inactive_identifiers == set()
 
     entry = registry.async_get_or_create(
         config_entry_id="1234",
@@ -503,9 +485,6 @@ async def test_loading_saving_data(hass, registry):
     )
 
     assert orig_light4.id == orig_light3.id
-    assert orig_light4.inactive_config_entries == {"abc"}
-    assert orig_light4.inactive_connections == set()
-    assert orig_light4.inactive_identifiers == {("abc", "123")}
 
     assert len(registry.devices) == 3
     assert len(registry.deleted_devices) == 1
@@ -936,12 +915,6 @@ async def test_restore_shared_device(hass, registry, update_events):
     assert isinstance(entry2.config_entries, set)
     assert isinstance(entry2.connections, set)
     assert isinstance(entry2.identifiers, set)
-    assert isinstance(entry2.inactive_config_entries, set)
-    assert isinstance(entry2.inactive_connections, set)
-    assert isinstance(entry2.inactive_identifiers, set)
-    assert entry2.inactive_config_entries == {"234"}
-    assert entry2.inactive_connections == set()
-    assert entry2.inactive_identifiers == {("entry_234", "2345")}
 
     registry.async_remove_device(entry.id)
 
@@ -960,12 +933,6 @@ async def test_restore_shared_device(hass, registry, update_events):
     assert isinstance(entry3.config_entries, set)
     assert isinstance(entry3.connections, set)
     assert isinstance(entry3.identifiers, set)
-    assert isinstance(entry3.inactive_config_entries, set)
-    assert isinstance(entry3.inactive_connections, set)
-    assert isinstance(entry3.inactive_identifiers, set)
-    assert entry3.inactive_config_entries == {"123"}
-    assert entry3.inactive_connections == set()
-    assert entry3.inactive_identifiers == {("entry_123", "0123")}
 
     entry4 = registry.async_get_or_create(
         config_entry_id="123",
@@ -982,12 +949,6 @@ async def test_restore_shared_device(hass, registry, update_events):
     assert isinstance(entry4.config_entries, set)
     assert isinstance(entry4.connections, set)
     assert isinstance(entry4.identifiers, set)
-    assert isinstance(entry4.inactive_config_entries, set)
-    assert isinstance(entry4.inactive_connections, set)
-    assert isinstance(entry4.inactive_identifiers, set)
-    assert entry4.inactive_config_entries == set()
-    assert entry4.inactive_connections == set()
-    assert entry4.inactive_identifiers == set()
 
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve restore of deleted devices

When a device is deleted, certain information about the device is retained to ensure a stable device ID if it's later re-added:
- config entries to which the device belonged
- connections
- identifiers
- device ID

All of this information was restored, if a deleted device was re-added.

This PR modifies the restore functionality, such that only the config_entry, connections and identifiers present when re-adding the device will be visible. Any remaining config_entries , connections or identifiers will still be retained but marked as inactive until they are also actively re-added.
This fixes unwanted behavior when a device identified by a connection, e.g. MAC address, can be claimed by multiple integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42565

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
