### PR TITLE
Cannot use vcgencmd in HassOS

### DIFF
--- a/homeassistant/components/sensehat/manifest.json
+++ b/homeassistant/components/sensehat/manifest.json
@@ -2,6 +2,6 @@
   "domain": "sensehat",
   "name": "Sense HAT",
   "documentation": "https://www.home-assistant.io/integrations/sensehat",
-  "requirements": ["sense-hat==2.2.0"],
+  "requirements": ["sense-hat==2.2.0", "rtimulib==7.2.1"],
   "codeowners": []
 }

--- a/homeassistant/components/sensehat/manifest.json
+++ b/homeassistant/components/sensehat/manifest.json
@@ -2,6 +2,6 @@
   "domain": "sensehat",
   "name": "Sense HAT",
   "documentation": "https://www.home-assistant.io/integrations/sensehat",
-  "requirements": ["sense-hat==2.2.0", "rtimulib==7.2.1"],
+  "requirements": ["sense-hat==2.2.0"],
   "codeowners": []
 }

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -43,9 +43,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_cpu_temp():
     """Get CPU temperature."""
-    res = os.popen("vcgencmd measure_temp").readline()
-    t_cpu = float(res.replace("temp=", "").replace("'C\n", ""))
-    return t_cpu
+    t_cpu = os.popen("cat /sys/class/thermal/thermal_zone0/temp").readline()
+    return float(t_cpu)
 
 
 def get_average(temp_base):

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def get_cpu_temp():
     """Get CPU temperature."""
     t_cpu = Path("/sys/class/thermal/thermal_zone0/temp").read_text().strip()
-    return (float(t_cpu)  * 0.001)
+    return (float(t_cpu) * 0.001)
 
 
 def get_average(temp_base):

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -3,6 +3,9 @@ from datetime import timedelta
 from pathlib import Path
 import logging
 
+from sense_hat import SenseHat
+import voluptuous as vol
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_DISPLAY_OPTIONS,

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -43,8 +43,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_cpu_temp():
     """Get CPU temperature."""
-    t_cpu = os.popen("cat /sys/class/thermal/thermal_zone0/temp").readline()
-    return float(t_cpu)
+    t_cpu = Path("/sys/class/thermal/thermal_zone0/temp").read_text().replace("\n", "")
+    return (float(t_cpu)  * 0.001)
 
 
 def get_average(temp_base):

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -1,7 +1,7 @@
 """Support for Sense HAT sensors."""
 from datetime import timedelta
-from pathlib import Path
 import logging
+from pathlib import Path
 
 from sense_hat import SenseHat
 import voluptuous as vol

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def get_cpu_temp():
     """Get CPU temperature."""
     t_cpu = Path("/sys/class/thermal/thermal_zone0/temp").read_text().strip()
-    return (float(t_cpu) * 0.001)
+    return float(t_cpu) * 0.001
 
 
 def get_average(temp_base):

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -1,10 +1,7 @@
 """Support for Sense HAT sensors."""
 from datetime import timedelta
+from pathlib import Path
 import logging
-import os
-
-from sense_hat import SenseHat
-import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_cpu_temp():
     """Get CPU temperature."""
-    t_cpu = Path("/sys/class/thermal/thermal_zone0/temp").read_text().replace("\n", "")
+    t_cpu = Path("/sys/class/thermal/thermal_zone0/temp").read_text().strip()
     return (float(t_cpu)  * 0.001)
 
 


### PR DESCRIPTION
Stop using native rpi _vcgencmd_ in favor of a more universal _cat_

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SenseHAT integration code still rely on vcgencmd to read CPU temperature. However this is unavailable in HassOS and breaks the integration. The more universal ``cat /sys/class/thermal/thermal_zone0/temp`` read the temperature in all RPi OSs.

If this PR is merged, a little change should be done to the example in the documentation, as I show here.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
  - platform: sensehat
    display_options:
      - temperature
      - humidity
      - pressure
  - platform: template
    sensors:
      sensehat_temperature:
        value_template: '{{ states("sensor.temperature") | round(1) }}'
        unit_of_measurement: '°C'
      sensehat_pressure:
        value_template: '{{ states("sensor.pressure") | round(1) }}'
        unit_of_measurement: 'mb'
      sensehat_humidity:
        value_template: '{{ states("sensor.humidity") | round(1) }}'
        unit_of_measurement: '%'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42708
- This PR is related to issue: NA
- Link to documentation pull request: NA, but willing to add the example as soon as this is accepted.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
