### PR TITLE
Move to Launch Library 2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -460,6 +460,7 @@ omit =
     homeassistant/components/lametric/*
     homeassistant/components/lannouncer/notify.py
     homeassistant/components/lastfm/sensor.py
+    homeassistant/components/launch_library/const.py
     homeassistant/components/launch_library/sensor.py
     homeassistant/components/lcn/*
     homeassistant/components/lg_netcast/media_player.py

--- a/homeassistant/components/launch_library/const.py
+++ b/homeassistant/components/launch_library/const.py
@@ -1,0 +1,10 @@
+"""Constants for launch_library."""
+
+ATTR_AGENCY = "agency"
+ATTR_AGENCY_COUNTRY_CODE = "agency_country_code"
+ATTR_LAUNCH_TIME = "launch_time"
+ATTR_STREAM = "stream"
+
+ATTRIBUTION = "Data provided by Launch Library."
+
+DEFAULT_NAME = "Next launch"

--- a/homeassistant/components/launch_library/manifest.json
+++ b/homeassistant/components/launch_library/manifest.json
@@ -2,6 +2,6 @@
   "domain": "launch_library",
   "name": "Launch Library",
   "documentation": "https://www.home-assistant.io/integrations/launch_library",
-  "requirements": ["pylaunches==0.2.0"],
+  "requirements": ["pylaunches==1.0.0"],
   "codeowners": ["@ludeeus"]
 }

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -13,11 +13,11 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 from .const import (
-    ATTRIBUTION,
     ATTR_AGENCY,
     ATTR_AGENCY_COUNTRY_CODE,
     ATTR_LAUNCH_TIME,
     ATTR_STREAM,
+    ATTRIBUTION,
     DEFAULT_NAME,
 )
 

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -1,8 +1,9 @@
 """A sensor platform that give you information about the next space launch."""
 from datetime import timedelta
 import logging
+from typing import Optional
 
-from pylaunches.api import Launches
+from pylaunches import PyLaunches, PyLaunchesException
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -11,11 +12,16 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
+from .const import (
+    ATTRIBUTION,
+    ATTR_AGENCY,
+    ATTR_AGENCY_COUNTRY_CODE,
+    ATTR_LAUNCH_TIME,
+    ATTR_STREAM,
+    DEFAULT_NAME,
+)
+
 _LOGGER = logging.getLogger(__name__)
-
-ATTRIBUTION = "Data provided by Launch Library."
-
-DEFAULT_NAME = "Next launch"
 
 SCAN_INTERVAL = timedelta(hours=1)
 
@@ -26,59 +32,55 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Create the launch sensor."""
-
     name = config[CONF_NAME]
-
     session = async_get_clientsession(hass)
-    launches = Launches(hass.loop, session)
-    sensor = [LaunchLibrarySensor(launches, name)]
-    async_add_entities(sensor, True)
+    launches = PyLaunches(session)
+
+    async_add_entities([LaunchLibrarySensor(launches, name)], True)
 
 
 class LaunchLibrarySensor(Entity):
     """Representation of a launch_library Sensor."""
 
-    def __init__(self, launches, name):
+    def __init__(self, launches: PyLaunches, name: str) -> None:
         """Initialize the sensor."""
         self.launches = launches
-        self._attributes = {}
+        self.next_launch = None
         self._name = name
-        self._state = None
 
-    async def async_update(self):
+    async def async_update(self) -> None:
         """Get the latest data."""
-        await self.launches.get_launches()
-        if self.launches.launches is None:
-            _LOGGER.error("No data received")
-            return
         try:
-            data = self.launches.launches[0]
-            self._state = data["name"]
-            self._attributes["launch_time"] = data["start"]
-            self._attributes["agency"] = data["agency"]
-            agency_country_code = data["agency_country_code"]
-            self._attributes["agency_country_code"] = agency_country_code
-            self._attributes["stream"] = data["stream"]
-            self._attributes[ATTR_ATTRIBUTION] = ATTRIBUTION
-        except (KeyError, IndexError) as error:
-            _LOGGER.debug("Error getting data, %s", error)
+            launches = await self.launches.upcoming_launches()
+            if launches:
+                self.next_launch = launches[0]
+        except PyLaunchesException as exception:
+            _LOGGER.error("Error getting data, %s", exception)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def state(self):
+    def state(self) -> Optional[str]:
         """Return the state of the sensor."""
-        return self._state
+        if self.next_launch:
+            return self.next_launch.name
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon of the sensor."""
         return "mdi:rocket"
 
     @property
-    def device_state_attributes(self):
+    def device_state_attributes(self) -> Optional[dict]:
         """Return attributes for the sensor."""
-        return self._attributes
+        if self.next_launch:
+            return {
+                ATTR_LAUNCH_TIME: self.next_launch.net,
+                ATTR_AGENCY: self.next_launch.launch_service_provider.name,
+                ATTR_AGENCY_COUNTRY_CODE: self.next_launch.pad.location.country_code,
+                ATTR_STREAM: self.next_launch.webcast_live,
+                ATTR_ATTRIBUTION: ATTRIBUTION,
+            }

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -52,10 +52,11 @@ class LaunchLibrarySensor(Entity):
         """Get the latest data."""
         try:
             launches = await self.launches.upcoming_launches()
-            if launches:
-                self.next_launch = launches[0]
         except PyLaunchesException as exception:
             _LOGGER.error("Error getting data, %s", exception)
+        else:
+            if launches:
+                self.next_launch = launches[0]
 
     @property
     def name(self) -> str:
@@ -67,6 +68,7 @@ class LaunchLibrarySensor(Entity):
         """Return the state of the sensor."""
         if self.next_launch:
             return self.next_launch.name
+        return None
 
     @property
     def icon(self) -> str:
@@ -84,3 +86,4 @@ class LaunchLibrarySensor(Entity):
                 ATTR_STREAM: self.next_launch.webcast_live,
                 ATTR_ATTRIBUTION: ATTRIBUTION,
             }
+        return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1476,7 +1476,7 @@ pylacrosse==0.4
 pylast==3.3.0
 
 # homeassistant.components.launch_library
-pylaunches==0.2.0
+pylaunches==1.0.0
 
 # homeassistant.components.lg_netcast
 pylgnetcast-homeassistant==0.2.0.dev0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Technically this is a dependency upgrade, but it's also a bug-fix (since the current API is no longer working), and some refactor.

I did not use GitHub releases when I made the current version of the library, so a version diff is not possible.
But I tracked down the commit that triggered the [Travis build for 0.2.0](https://travis-ci.com/github/ludeeus/pylaunches/builds/95644908).

<details>
<summary>1.0.0 Release notes</summary>

[1.0.0 Release notes](https://github.com/ludeeus/pylaunches/releases/tag/1.0.0)

## Changes

* Move to V2 of Launch Library (#2) @ludeeus

This is a breaking release, it has moved to [Launch Library 2](https://thespacedevs.com/llapi), see the updated example.py file for a reference.


</details>

[Changes between 0.2.0 and 1.0.0](https://github.com/ludeeus/pylaunches/compare/6cc449a9f734cbf789e561564b500a5dca93fe82...1.0.0)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #42754
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
