### PR TITLE
Refactor ZHA light state restoration after a restart

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -167,6 +167,11 @@ class LevelControlChannel(ZigbeeChannel):
     CURRENT_LEVEL = 0
     REPORT_CONFIG = ({"attr": "current_level", "config": REPORT_CONFIG_ASAP},)
 
+    @property
+    def current_level(self) -> Optional[int]:
+        """Return cached value of the current_level attribute."""
+        return self.cluster.get("current_level")
+
     @callback
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
@@ -247,6 +252,11 @@ class OnOffChannel(ZigbeeChannel):
         super().__init__(cluster, ch_pool)
         self._state = None
         self._off_listener = None
+
+    @property
+    def on_off(self) -> Optional[bool]:
+        """Return cached value of on/off attribute."""
+        return self.cluster.get("on_off")
 
     @callback
     def cluster_command(self, tsn, command_id, args):

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -1,4 +1,6 @@
 """Lighting channels module for Zigbee Home Automation."""
+from typing import Optional
+
 import zigpy.zcl.clusters.lighting as lighting
 
 from .. import registries, typing as zha_typing
@@ -41,14 +43,34 @@ class ColorChannel(ZigbeeChannel):
         self._max_mireds = 500
 
     @property
-    def min_mireds(self):
-        """Return the coldest color_temp that this channel supports."""
-        return self._min_mireds
+    def color_loop_active(self) -> Optional[int]:
+        """Return cached value of the color_loop_active attribute."""
+        return self.cluster.get("color_loop_active")
 
     @property
-    def max_mireds(self):
+    def color_temperature(self) -> Optional[int]:
+        """Return cached value of color temperature."""
+        return self.cluster.get("color_temperature")
+
+    @property
+    def current_x(self) -> Optional[int]:
+        """Return cached value of the current_x attribute."""
+        return self.cluster.get("current_x")
+
+    @property
+    def current_y(self) -> Optional[int]:
+        """Return cached value of the current_y attribute."""
+        return self.cluster.get("current_y")
+
+    @property
+    def min_mireds(self) -> int:
+        """Return the coldest color_temp that this channel supports."""
+        return self.cluster.get("color_temp_physical_min", self._min_mireds)
+
+    @property
+    def max_mireds(self) -> int:
         """Return the warmest color_temp that this channel supports."""
-        return self._max_mireds
+        return self.cluster.get("color_temp_physical_max", self._max_mireds)
 
     def get_color_capabilities(self):
         """Return the color capabilities."""
@@ -74,8 +96,6 @@ class ColorChannel(ZigbeeChannel):
         ]
         results = await self.get_attributes(attributes, from_cache=from_cache)
         capabilities = results.get("color_capabilities")
-        self._min_mireds = results.get("color_temp_physical_min", 153)
-        self._max_mireds = results.get("color_temp_physical_max", 500)
 
         if capabilities is None:
             # ZCL Version 4 devices don't support the color_capabilities

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -328,6 +328,7 @@ class Light(BaseLight, ZhaEntity):
         """Initialize the ZHA light."""
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._on_off_channel = self.cluster_channels.get(CHANNEL_ON_OFF)
+        self._state = bool(self._on_off_channel.on_off)
         self._level_channel = self.cluster_channels.get(CHANNEL_LEVEL)
         self._color_channel = self.cluster_channels.get(CHANNEL_COLOR)
         self._identify_channel = self.zha_device.channels.identify_ch
@@ -340,7 +341,7 @@ class Light(BaseLight, ZhaEntity):
         if self._level_channel:
             self._supported_features |= light.SUPPORT_BRIGHTNESS
             self._supported_features |= light.SUPPORT_TRANSITION
-            self._brightness = 0
+            self._brightness = self._level_channel.current_level
 
         if self._color_channel:
             color_capabilities = self._color_channel.get_color_capabilities()

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -347,14 +347,24 @@ class Light(BaseLight, ZhaEntity):
             color_capabilities = self._color_channel.get_color_capabilities()
             if color_capabilities & CAPABILITIES_COLOR_TEMP:
                 self._supported_features |= light.SUPPORT_COLOR_TEMP
+                self._color_temp = self._color_channel.color_temperature
 
             if color_capabilities & CAPABILITIES_COLOR_XY:
                 self._supported_features |= light.SUPPORT_COLOR
-                self._hs_color = (0, 0)
+                curr_x = self._color_channel.current_x
+                curr_y = self._color_channel.current_y
+                if curr_x is not None and curr_y is not None:
+                    self._hs_color = color_util.color_xy_to_hs(
+                        float(curr_x / 65535), float(curr_y / 65535)
+                    )
+                else:
+                    self._hs_color = (0, 0)
 
             if color_capabilities & CAPABILITIES_COLOR_LOOP:
                 self._supported_features |= light.SUPPORT_EFFECT
                 effect_list.append(light.EFFECT_COLORLOOP)
+                if self._color_channel.color_loop_active == 1:
+                    self._effect = light.EFFECT_COLORLOOP
 
         if self._identify_channel:
             self._supported_features |= light.SUPPORT_FLASH


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor the way ZHA restores light state after a restart. https://github.com/home-assistant/core/pull/39756 introduced a change, removing the `async_update()` method, causing ZHA lights not to have correct state upon restart, even though the "zigbee" channels were polled and contain up-to-date information cached. This PR used that cached information for the light initial state. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42554
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
