### PR TITLE
Add force_update property to opentherm_gw entities

### DIFF
--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
-from homeassistant.const import CONF_ID
+from homeassistant.const import CONF_FORCE_UPDATE, CONF_ID
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import async_generate_entity_id
@@ -45,12 +45,22 @@ class OpenThermBinarySensor(BinarySensorEntity):
         self._device_class = device_class
         self._friendly_name = friendly_name_format.format(gw_dev.name)
         self._unsub_updates = None
+        self._unsub_options = None
+        self._force_update = False
+
+    @callback
+    def update_options(self, entry):
+        """Update binary_sensor entity options."""
+        self._force_update = entry.options[CONF_FORCE_UPDATE]
 
     async def async_added_to_hass(self):
         """Subscribe to updates from the component."""
         _LOGGER.debug("Added OpenTherm Gateway binary sensor %s", self._friendly_name)
         self._unsub_updates = async_dispatcher_connect(
             self.hass, self._gateway.update_signal, self.receive_report
+        )
+        self._unsub_options = async_dispatcher_connect(
+            self.hass, self._gateway.options_update_signal, self.update_options
         )
 
     async def async_will_remove_from_hass(self):
@@ -59,6 +69,7 @@ class OpenThermBinarySensor(BinarySensorEntity):
             "Removing OpenTherm Gateway binary sensor %s", self._friendly_name
         )
         self._unsub_updates()
+        self._unsub_options()
 
     @property
     def available(self):
@@ -112,3 +123,8 @@ class OpenThermBinarySensor(BinarySensorEntity):
     def should_poll(self):
         """Return False because entity pushes its state."""
         return False
+
+    @property
+    def force_update(self) -> bool:
+        """Return force_update property."""
+        return self._force_update

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -8,7 +8,12 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import async_generate_entity_id
 
 from . import DOMAIN
-from .const import BINARY_SENSOR_INFO, DATA_GATEWAYS, DATA_OPENTHERM_GW
+from .const import (
+    BINARY_SENSOR_INFO,
+    DATA_GATEWAYS,
+    DATA_OPENTHERM_GW,
+    DEFAULT_FORCE_UPDATE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +30,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 var,
                 device_class,
                 friendly_name_format,
+                config_entry.options,
             )
         )
 
@@ -34,7 +40,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class OpenThermBinarySensor(BinarySensorEntity):
     """Represent an OpenTherm Gateway binary sensor."""
 
-    def __init__(self, gw_dev, var, device_class, friendly_name_format):
+    def __init__(self, gw_dev, var, device_class, friendly_name_format, options):
         """Initialize the binary sensor."""
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, f"{var}_{gw_dev.gw_id}", hass=gw_dev.hass
@@ -46,7 +52,7 @@ class OpenThermBinarySensor(BinarySensorEntity):
         self._friendly_name = friendly_name_format.format(gw_dev.name)
         self._unsub_updates = None
         self._unsub_options = None
-        self._force_update = False
+        self._force_update = options.get(CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE)
 
     @callback
     def update_options(self, entry):

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -17,6 +17,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
+    CONF_FORCE_UPDATE,
     CONF_ID,
     PRECISION_HALVES,
     PRECISION_TENTHS,
@@ -74,12 +75,14 @@ class OpenThermClimate(ClimateEntity):
         self._away_state_b = False
         self._unsub_options = None
         self._unsub_updates = None
+        self._force_update = False
 
     @callback
     def update_options(self, entry):
         """Update climate entity options."""
         self.floor_temp = entry.options[CONF_FLOOR_TEMP]
         self.temp_precision = entry.options[CONF_PRECISION]
+        self._force_update = entry.options[CONF_FORCE_UPDATE]
         self.async_write_ha_state()
 
     async def async_added_to_hass(self):
@@ -275,3 +278,8 @@ class OpenThermClimate(ClimateEntity):
     def max_temp(self):
         """Return the maximum temperature."""
         return 30
+
+    @property
+    def force_update(self) -> bool:
+        """Return force_update property."""
+        return self._force_update

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -29,7 +29,13 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import async_generate_entity_id
 
 from . import DOMAIN
-from .const import CONF_FLOOR_TEMP, CONF_PRECISION, DATA_GATEWAYS, DATA_OPENTHERM_GW
+from .const import (
+    CONF_FLOOR_TEMP,
+    CONF_PRECISION,
+    DATA_GATEWAYS,
+    DATA_OPENTHERM_GW,
+    DEFAULT_FORCE_UPDATE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,6 +69,7 @@ class OpenThermClimate(ClimateEntity):
         self.friendly_name = gw_dev.name
         self.floor_temp = options.get(CONF_FLOOR_TEMP, DEFAULT_FLOOR_TEMP)
         self.temp_precision = options.get(CONF_PRECISION)
+        self._force_update = options.get(CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE)
         self._available = False
         self._current_operation = None
         self._current_temperature = None
@@ -75,7 +82,6 @@ class OpenThermClimate(ClimateEntity):
         self._away_state_b = False
         self._unsub_options = None
         self._unsub_updates = None
-        self._force_update = False
 
     @callback
     def update_options(self, entry):

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_DEVICE,
+    CONF_FORCE_UPDATE,
     CONF_ID,
     CONF_NAME,
     PRECISION_HALVES,
@@ -132,6 +133,10 @@ class OpenThermGwOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_FLOOR_TEMP,
                         default=self.config_entry.options.get(CONF_FLOOR_TEMP, False),
+                    ): bool,
+                    vol.Optional(
+                        CONF_FORCE_UPDATE,
+                        default=self.config_entry.options.get(CONF_FORCE_UPDATE, False),
                     ): bool,
                 }
             ),

--- a/homeassistant/components/opentherm_gw/const.py
+++ b/homeassistant/components/opentherm_gw/const.py
@@ -23,6 +23,8 @@ CONF_PRECISION = "precision"
 DATA_GATEWAYS = "gateways"
 DATA_OPENTHERM_GW = "opentherm_gw"
 
+DEFAULT_FORCE_UPDATE = False
+
 DEVICE_CLASS_COLD = "cold"
 DEVICE_CLASS_HEAT = "heat"
 

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 
 from . import DOMAIN
-from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, SENSOR_INFO
+from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, DEFAULT_FORCE_UPDATE, SENSOR_INFO
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +27,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 device_class,
                 unit,
                 friendly_name_format,
+                config_entry.options,
             )
         )
 
@@ -36,7 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class OpenThermSensor(Entity):
     """Representation of an OpenTherm Gateway sensor."""
 
-    def __init__(self, gw_dev, var, device_class, unit, friendly_name_format):
+    def __init__(self, gw_dev, var, device_class, unit, friendly_name_format, options):
         """Initialize the OpenTherm Gateway sensor."""
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, f"{var}_{gw_dev.gw_id}", hass=gw_dev.hass
@@ -49,7 +50,7 @@ class OpenThermSensor(Entity):
         self._friendly_name = friendly_name_format.format(gw_dev.name)
         self._unsub_options = None
         self._unsub_updates = None
-        self._force_update = False
+        self._force_update = options.get(CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE)
 
     @callback
     def update_options(self, entry):

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
-from homeassistant.const import CONF_ID
+from homeassistant.const import CONF_FORCE_UPDATE, CONF_ID
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
@@ -47,7 +47,14 @@ class OpenThermSensor(Entity):
         self._device_class = device_class
         self._unit = unit
         self._friendly_name = friendly_name_format.format(gw_dev.name)
+        self._unsub_options = None
         self._unsub_updates = None
+        self._force_update = False
+
+    @callback
+    def update_options(self, entry):
+        """Update sensor entity options."""
+        self._force_update = entry.options[CONF_FORCE_UPDATE]
 
     async def async_added_to_hass(self):
         """Subscribe to updates from the component."""
@@ -55,11 +62,15 @@ class OpenThermSensor(Entity):
         self._unsub_updates = async_dispatcher_connect(
             self.hass, self._gateway.update_signal, self.receive_report
         )
+        self._unsub_options = async_dispatcher_connect(
+            self.hass, self._gateway.options_update_signal, self.update_options
+        )
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe from updates from the component."""
         _LOGGER.debug("Removing OpenTherm Gateway sensor %s", self._friendly_name)
         self._unsub_updates()
+        self._unsub_options()
 
     @property
     def available(self):
@@ -120,3 +131,8 @@ class OpenThermSensor(Entity):
     def should_poll(self):
         """Return False because entity pushes its state."""
         return False
+
+    @property
+    def force_update(self) -> bool:
+        """Return force_update property."""
+        return self._force_update

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -21,8 +21,9 @@
       "init": {
         "description": "Options for the OpenTherm Gateway",
         "data": {
+          "precision": "Precision",
           "floor_temperature": "Floor Temperature",
-          "precision": "Precision"
+          "force_update": "Force Update"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces PR https://github.com/home-assistant/core/pull/42564

For graphing in things such as Grafana it is useful to have data points even when there is no actual state change of the entity. For instance, when plotting a given time period, the data at the start of the period could be missing until the first state change. Grafana offers options to fill the missing time periods, but without information there is not a single correct way of filling those time periods.

Using force_update on an entity is a solution to get the desired data points into a data store such as InfluxDB. This PR is intended to allow the setting of the force_update property for the opentherm_gw entities.

Add the force_update property to opentherm_gw climate, sensor and binary_sensor entities.
Set the default to False.
Make the property editable via Options dialog of integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```
Not Applicable.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15458

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
