### PR TITLE
Rewrite the kira/test_init.py unittests to pytest style test functions

### DIFF
--- a/tests/components/kira/test_init.py
+++ b/tests/components/kira/test_init.py
@@ -3,13 +3,13 @@
 import os
 import shutil
 import tempfile
-import unittest
+
+import pytest
 
 import homeassistant.components.kira as kira
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.async_mock import MagicMock, patch
-from tests.common import get_test_home_assistant
 
 TEST_CONFIG = {
     kira.DOMAIN: {
@@ -31,57 +31,58 @@ KIRA_CODES = """
 """
 
 
-class TestKiraSetup(unittest.TestCase):
-    """Test class for kira."""
+@pytest.fixture(autouse=True)
+def setup_comp():
+    """Set up things to be run when tests are started."""
+    _base_mock = MagicMock()
+    pykira = _base_mock.pykira
+    pykira.__file__ = "test"
+    _module_patcher = patch.dict("sys.modules", {"pykira": pykira})
+    _module_patcher.start()
+    yield
+    _module_patcher.stop()
 
-    # pylint: disable=invalid-name
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        _base_mock = MagicMock()
-        pykira = _base_mock.pykira
-        pykira.__file__ = "test"
-        self._module_patcher = patch.dict("sys.modules", {"pykira": pykira})
-        self._module_patcher.start()
 
-        self.work_dir = tempfile.mkdtemp()
-        self.addCleanup(self.tear_down_cleanup)
+@pytest.fixture(scope="module")
+def work_dir():
+    """Set up temporary workdir."""
+    work_dir = tempfile.mkdtemp()
+    yield work_dir
+    shutil.rmtree(work_dir, ignore_errors=True)
 
-    def tear_down_cleanup(self):
-        """Stop everything that was started."""
-        self.hass.stop()
-        self._module_patcher.stop()
-        shutil.rmtree(self.work_dir, ignore_errors=True)
 
-    def test_kira_empty_config(self):
-        """Kira component should load a default sensor."""
-        setup_component(self.hass, kira.DOMAIN, {})
-        assert len(self.hass.data[kira.DOMAIN]["sensor"]) == 1
+async def test_kira_empty_config(hass):
+    """Kira component should load a default sensor."""
+    await async_setup_component(hass, kira.DOMAIN, {kira.DOMAIN: {}})
+    assert len(hass.data[kira.DOMAIN]["sensor"]) == 1
 
-    def test_kira_setup(self):
-        """Ensure platforms are loaded correctly."""
-        setup_component(self.hass, kira.DOMAIN, TEST_CONFIG)
-        assert len(self.hass.data[kira.DOMAIN]["sensor"]) == 2
-        assert sorted(self.hass.data[kira.DOMAIN]["sensor"].keys()) == [
-            "kira",
-            "kira_1",
-        ]
-        assert len(self.hass.data[kira.DOMAIN]["remote"]) == 2
-        assert sorted(self.hass.data[kira.DOMAIN]["remote"].keys()) == [
-            "kira",
-            "kira_1",
-        ]
 
-    def test_kira_creates_codes(self):
-        """Kira module should create codes file if missing."""
-        code_path = os.path.join(self.work_dir, "codes.yaml")
-        kira.load_codes(code_path)
-        assert os.path.exists(code_path), "Kira component didn't create codes file"
+async def test_kira_setup(hass):
+    """Ensure platforms are loaded correctly."""
+    await async_setup_component(hass, kira.DOMAIN, TEST_CONFIG)
+    assert len(hass.data[kira.DOMAIN]["sensor"]) == 2
+    assert sorted(hass.data[kira.DOMAIN]["sensor"].keys()) == [
+        "kira",
+        "kira_1",
+    ]
+    assert len(hass.data[kira.DOMAIN]["remote"]) == 2
+    assert sorted(hass.data[kira.DOMAIN]["remote"].keys()) == [
+        "kira",
+        "kira_1",
+    ]
 
-    def test_load_codes(self):
-        """Kira should ignore invalid codes."""
-        code_path = os.path.join(self.work_dir, "codes.yaml")
-        with open(code_path, "w") as code_file:
-            code_file.write(KIRA_CODES)
-        res = kira.load_codes(code_path)
-        assert len(res) == 1, "Expected exactly 1 valid Kira code"
+
+async def test_kira_creates_codes(work_dir):
+    """Kira module should create codes file if missing."""
+    code_path = os.path.join(work_dir, "codes.yaml")
+    kira.load_codes(code_path)
+    assert os.path.exists(code_path), "Kira component didn't create codes file"
+
+
+async def test_load_codes(work_dir):
+    """Kira should ignore invalid codes."""
+    code_path = os.path.join(work_dir, "codes.yaml")
+    with open(code_path, "w") as code_file:
+        code_file.write(KIRA_CODES)
+    res = kira.load_codes(code_path)
+    assert len(res) == 1, "Expected exactly 1 valid Kira code"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrites the tests of the kira/test_init.py module to pytest style functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #40859
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
