### PR TITLE
Migrate system health to use integration_platform

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -140,8 +140,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
         websocket.websocket_lovelace_dashboards
     )
 
-    hass.components.system_health.async_register_info(DOMAIN, system_health_info)
-
     hass.data[DOMAIN] = {
         # We store a dictionary mapping url_path: config. None is the default.
         "dashboards": {None: default_config},
@@ -231,14 +229,6 @@ async def create_yaml_resource_col(hass, yaml_resources):
                 yaml_resources = ll_conf[CONF_RESOURCES]
 
     return resources.ResourceYAMLCollection(yaml_resources or [])
-
-
-async def system_health_info(hass):
-    """Get info for the info page."""
-    health_info = {"dashboards": len(hass.data[DOMAIN]["dashboards"])}
-    health_info.update(await hass.data[DOMAIN]["dashboards"][None].async_get_info())
-    health_info.update(await hass.data[DOMAIN]["resources"].async_get_info())
-    return health_info
 
 
 @callback

--- a/homeassistant/components/lovelace/system_health.py
+++ b/homeassistant/components/lovelace/system_health.py
@@ -1,0 +1,21 @@
+"""Provide info to system health."""
+from homeassistant.components import system_health
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+
+
+@callback
+def async_register(
+    hass: HomeAssistant, register: system_health.RegisterSystemHealth
+) -> None:
+    """Register system health callbacks."""
+    register.async_register_info(system_health_info)
+
+
+async def system_health_info(hass):
+    """Get info for the info page."""
+    health_info = {"dashboards": len(hass.data[DOMAIN]["dashboards"])}
+    health_info.update(await hass.data[DOMAIN]["dashboards"][None].async_get_info())
+    health_info.update(await hass.data[DOMAIN]["resources"].async_get_info())
+    return health_info

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -6,11 +6,7 @@ from homeassistant.components.lovelace import const, dashboard
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import patch
-from tests.common import (
-    assert_setup_component,
-    async_capture_events,
-    get_system_health_info,
-)
+from tests.common import assert_setup_component, async_capture_events
 
 
 async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):
@@ -158,52 +154,6 @@ async def test_lovelace_from_yaml(hass, hass_ws_client):
     assert response["result"] == {"hello": "yo2"}
 
     assert len(events) == 1
-
-
-async def test_system_health_info_autogen(hass):
-    """Test system health info endpoint."""
-    assert await async_setup_component(hass, "lovelace", {})
-    assert await async_setup_component(hass, "system_health", {})
-    info = await get_system_health_info(hass, "lovelace")
-    assert info == {"dashboards": 1, "mode": "auto-gen", "resources": 0}
-
-
-async def test_system_health_info_storage(hass, hass_storage):
-    """Test system health info endpoint."""
-    assert await async_setup_component(hass, "system_health", {})
-    hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {
-        "key": "lovelace",
-        "version": 1,
-        "data": {"config": {"resources": [], "views": []}},
-    }
-    assert await async_setup_component(hass, "lovelace", {})
-    info = await get_system_health_info(hass, "lovelace")
-    assert info == {"dashboards": 1, "mode": "storage", "resources": 0, "views": 0}
-
-
-async def test_system_health_info_yaml(hass):
-    """Test system health info endpoint."""
-    assert await async_setup_component(hass, "system_health", {})
-    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
-    with patch(
-        "homeassistant.components.lovelace.dashboard.load_yaml",
-        return_value={"views": [{"cards": []}]},
-    ):
-        info = await get_system_health_info(hass, "lovelace")
-    assert info == {"dashboards": 1, "mode": "yaml", "resources": 0, "views": 1}
-
-
-async def test_system_health_info_yaml_not_found(hass):
-    """Test system health info endpoint."""
-    assert await async_setup_component(hass, "system_health", {})
-    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
-    info = await get_system_health_info(hass, "lovelace")
-    assert info == {
-        "dashboards": 1,
-        "mode": "yaml",
-        "error": "{} not found".format(hass.config.path("ui-lovelace.yaml")),
-        "resources": 0,
-    }
 
 
 @pytest.mark.parametrize("url_path", ("test-panel", "test-panel-no-sidebar"))

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -163,12 +163,14 @@ async def test_lovelace_from_yaml(hass, hass_ws_client):
 async def test_system_health_info_autogen(hass):
     """Test system health info endpoint."""
     assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, "system_health", {})
     info = await get_system_health_info(hass, "lovelace")
     assert info == {"dashboards": 1, "mode": "auto-gen", "resources": 0}
 
 
 async def test_system_health_info_storage(hass, hass_storage):
     """Test system health info endpoint."""
+    assert await async_setup_component(hass, "system_health", {})
     hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {
         "key": "lovelace",
         "version": 1,
@@ -181,6 +183,7 @@ async def test_system_health_info_storage(hass, hass_storage):
 
 async def test_system_health_info_yaml(hass):
     """Test system health info endpoint."""
+    assert await async_setup_component(hass, "system_health", {})
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
     with patch(
         "homeassistant.components.lovelace.dashboard.load_yaml",
@@ -192,6 +195,7 @@ async def test_system_health_info_yaml(hass):
 
 async def test_system_health_info_yaml_not_found(hass):
     """Test system health info endpoint."""
+    assert await async_setup_component(hass, "system_health", {})
     assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
     info = await get_system_health_info(hass, "lovelace")
     assert info == {

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -1,0 +1,52 @@
+"""Tests for Lovelace system health."""
+from homeassistant.components.lovelace import dashboard
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import patch
+from tests.common import get_system_health_info
+
+
+async def test_system_health_info_autogen(hass):
+    """Test system health info endpoint."""
+    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, "system_health", {})
+    info = await get_system_health_info(hass, "lovelace")
+    assert info == {"dashboards": 1, "mode": "auto-gen", "resources": 0}
+
+
+async def test_system_health_info_storage(hass, hass_storage):
+    """Test system health info endpoint."""
+    assert await async_setup_component(hass, "system_health", {})
+    hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT] = {
+        "key": "lovelace",
+        "version": 1,
+        "data": {"config": {"resources": [], "views": []}},
+    }
+    assert await async_setup_component(hass, "lovelace", {})
+    info = await get_system_health_info(hass, "lovelace")
+    assert info == {"dashboards": 1, "mode": "storage", "resources": 0, "views": 0}
+
+
+async def test_system_health_info_yaml(hass):
+    """Test system health info endpoint."""
+    assert await async_setup_component(hass, "system_health", {})
+    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    with patch(
+        "homeassistant.components.lovelace.dashboard.load_yaml",
+        return_value={"views": [{"cards": []}]},
+    ):
+        info = await get_system_health_info(hass, "lovelace")
+    assert info == {"dashboards": 1, "mode": "yaml", "resources": 0, "views": 1}
+
+
+async def test_system_health_info_yaml_not_found(hass):
+    """Test system health info endpoint."""
+    assert await async_setup_component(hass, "system_health", {})
+    assert await async_setup_component(hass, "lovelace", {"lovelace": {"mode": "YAML"}})
+    info = await get_system_health_info(hass, "lovelace")
+    assert info == {
+        "dashboards": 1,
+        "mode": "yaml",
+        "error": "{} not found".format(hass.config.path("ui-lovelace.yaml")),
+        "resources": 0,
+    }

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.setup import async_setup_component
 
 from tests.async_mock import AsyncMock, Mock
-from tests.common import mock_platform
+from tests.common import get_system_health_info, mock_platform
 
 
 @pytest.fixture
@@ -96,7 +96,7 @@ async def test_info_endpoint_register_callback_exc(
     assert data == {"error": "TEST ERROR"}
 
 
-async def test_platform_loading(hass, hass_ws_client):
+async def test_platform_loading(hass):
     """Test registering via platform."""
     hass.config.components.add("fake_integration")
     mock_platform(
@@ -110,12 +110,4 @@ async def test_platform_loading(hass, hass_ws_client):
     )
 
     assert await async_setup_component(hass, "system_health", {})
-    client = await hass_ws_client(hass)
-
-    resp = await client.send_json({"id": 6, "type": "system_health/info"})
-    resp = await client.receive_json()
-    assert resp["success"]
-    data = resp["result"]
-
-    assert len(data) == 2
-    assert data["fake_integration"] == {"hello": "info"}
+    assert await get_system_health_info(hass, "fake_integration") == {"hello": "info"}

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -1,19 +1,19 @@
 """Tests for the system health component init."""
 import asyncio
-from unittest.mock import Mock
 
 import pytest
 
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro
+from tests.async_mock import AsyncMock, Mock
+from tests.common import mock_platform
 
 
 @pytest.fixture
 def mock_system_info(hass):
     """Mock system info."""
-    hass.helpers.system_info.async_get_system_info = Mock(
-        return_value=mock_coro({"hello": True})
+    hass.helpers.system_info.async_get_system_info = AsyncMock(
+        return_value={"hello": True}
     )
 
 
@@ -94,3 +94,28 @@ async def test_info_endpoint_register_callback_exc(
     assert len(data) == 2
     data = data["lovelace"]
     assert data == {"error": "TEST ERROR"}
+
+
+async def test_platform_loading(hass, hass_ws_client):
+    """Test registering via platform."""
+    hass.config.components.add("fake_integration")
+    mock_platform(
+        hass,
+        "fake_integration.system_health",
+        Mock(
+            async_register=lambda hass, register: register.async_register_info(
+                AsyncMock(return_value={"hello": "info"})
+            )
+        ),
+    )
+
+    assert await async_setup_component(hass, "system_health", {})
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({"id": 6, "type": "system_health/info"})
+    resp = await client.receive_json()
+    assert resp["success"]
+    data = resp["result"]
+
+    assert len(data) == 2
+    assert data["fake_integration"] == {"hello": "info"}

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -51,6 +51,9 @@ async def test_info_endpoint_register_callback(hass, hass_ws_client, mock_system
     data = data["lovelace"]
     assert data == {"storage": "YAML"}
 
+    # Test our test helper works
+    assert await get_system_health_info(hass, "lovelace") == {"storage": "YAML"}
+
 
 async def test_info_endpoint_register_callback_timeout(
     hass, hass_ws_client, mock_system_info


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This migrates system health to be platform based instead of calling the system health integration. For integrations to opt-in to use system health, add a `system_health.py` to their integration.

Old way of registering system health is still available, but we print a warning notice. Keeping it around because I don't know if any custom component integrates with it. Marking it as a breaking change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
