### PR TITLE
Unregister webhook if it can't be established successfully

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -113,10 +113,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 hass.config_entries.async_forward_entry_setup(entry, "light")
             )
 
-    async def unload_light_platform():
-        """Unload light platform when webhook is unregistered."""
-        await hass.config_entries.async_forward_entry_unload(entry, "light")
-
     data_handler.listeners.append(
         async_dispatcher_connect(
             hass,
@@ -135,7 +131,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             return
         _LOGGER.debug("Unregister Netatmo webhook (%s)", entry.data[CONF_WEBHOOK_ID])
         webhook_unregister(hass, entry.data[CONF_WEBHOOK_ID])
-        await unload_light_platform()
+        await hass.config_entries.async_forward_entry_unload(entry, "light")
 
     async def register_webhook(event):
         if CONF_WEBHOOK_ID not in entry.data:

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -21,7 +21,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.event import async_call_later
 
 from . import api, config_flow
 from .const import (
@@ -55,18 +59,19 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS = ["camera", "climate", "sensor"]
+PLATFORMS = ["camera", "climate", "light", "sensor"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Netatmo component."""
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][DATA_PERSONS] = {}
-    hass.data[DOMAIN][DATA_DEVICE_IDS] = {}
-    hass.data[DOMAIN][DATA_SCHEDULES] = {}
-    hass.data[DOMAIN][DATA_HOMES] = {}
-    hass.data[DOMAIN][DATA_EVENTS] = {}
-    hass.data[DOMAIN][DATA_CAMERAS] = {}
+    hass.data[DOMAIN] = {
+        DATA_PERSONS: {},
+        DATA_DEVICE_IDS: {},
+        DATA_SCHEDULES: {},
+        DATA_HOMES: {},
+        DATA_EVENTS: {},
+        DATA_CAMERAS: {},
+    }
 
     if DOMAIN not in config:
         return True
@@ -106,21 +111,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await data_handler.async_setup()
     hass.data[DOMAIN][entry.entry_id][DATA_HANDLER] = data_handler
 
-    async def handle_event(event):
-        """Handle webhook events."""
-        if event["data"]["push_type"] == "webhook_activation":
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, "light")
-            )
-
-    data_handler.listeners.append(
-        async_dispatcher_connect(
-            hass,
-            f"signal-{DOMAIN}-webhook-None",
-            handle_event,
-        )
-    )
-
     for component in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
@@ -130,6 +120,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         if CONF_WEBHOOK_ID not in entry.data:
             return
         _LOGGER.debug("Unregister Netatmo webhook (%s)", entry.data[CONF_WEBHOOK_ID])
+        async_dispatcher_send(
+            hass,
+            f"signal-{DOMAIN}-webhook-None",
+            {"type": "None", "data": {"push_type": "webhook_deactivation"}},
+        )
         webhook_unregister(hass, entry.data[CONF_WEBHOOK_ID])
         await hass.config_entries.async_forward_entry_unload(entry, "light")
 
@@ -165,6 +160,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             webhook_register(
                 hass, DOMAIN, "Netatmo", entry.data[CONF_WEBHOOK_ID], handle_webhook
             )
+
+            async def handle_event(event):
+                """Handle webhook events."""
+                if event["data"]["push_type"] == "webhook_activation":
+                    if sub is not None:
+                        _LOGGER.debug("sub called")
+                        sub()
+
+                    if unsub is not None:
+                        _LOGGER.debug("Unsub called")
+                        unsub()
+
+            sub = async_dispatcher_connect(
+                hass,
+                f"signal-{DOMAIN}-webhook-None",
+                handle_event,
+            )
+
+            unsub = async_call_later(hass, 10, unregister_webhook)
+
             await hass.async_add_executor_job(
                 hass.data[DOMAIN][entry.entry_id][AUTH].addwebhook, webhook_url
             )

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -113,6 +113,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 hass.config_entries.async_forward_entry_setup(entry, "light")
             )
 
+    async def unload_light_platform():
+        """Unload light platform when webhook is unregistered."""
+        await hass.config_entries.async_forward_entry_unload(entry, "light")
+
     data_handler.listeners.append(
         async_dispatcher_connect(
             hass,
@@ -131,6 +135,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             return
         _LOGGER.debug("Unregister Netatmo webhook (%s)", entry.data[CONF_WEBHOOK_ID])
         webhook_unregister(hass, entry.data[CONF_WEBHOOK_ID])
+        await unload_light_platform()
 
     async def register_webhook(event):
         if CONF_WEBHOOK_ID not in entry.data:

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -126,7 +126,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             {"type": "None", "data": {"push_type": "webhook_deactivation"}},
         )
         webhook_unregister(hass, entry.data[CONF_WEBHOOK_ID])
-        await hass.config_entries.async_forward_entry_unload(entry, "light")
 
     async def register_webhook(event):
         if CONF_WEBHOOK_ID not in entry.data:
@@ -164,21 +163,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             async def handle_event(event):
                 """Handle webhook events."""
                 if event["data"]["push_type"] == "webhook_activation":
-                    if sub is not None:
+                    if activation_listener is not None:
                         _LOGGER.debug("sub called")
-                        sub()
+                        activation_listener()
 
-                    if unsub is not None:
+                    if activation_timeout is not None:
                         _LOGGER.debug("Unsub called")
-                        unsub()
+                        activation_timeout()
 
-            sub = async_dispatcher_connect(
+            activation_listener = async_dispatcher_connect(
                 hass,
                 f"signal-{DOMAIN}-webhook-None",
                 handle_event,
             )
 
-            unsub = async_call_later(hass, 10, unregister_webhook)
+            activation_timeout = async_call_later(hass, 10, unregister_webhook)
 
             await hass.async_add_executor_job(
                 hass.data[DOMAIN][entry.entry_id][AUTH].addwebhook, webhook_url

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -107,6 +107,10 @@ class NetatmoDataHandler:
             _LOGGER.info("%s webhook successfully registered", MANUFACTURER)
             self._webhook = True
 
+        elif event["data"]["push_type"] == "webhook_deactivation":
+            _LOGGER.info("%s webhook unregistered", MANUFACTURER)
+            self._webhook = False
+
         elif event["data"]["push_type"] == "NACamera-connection":
             _LOGGER.debug("%s camera reconnected", MANUFACTURER)
             self._data_classes[CAMERA_DATA_CLASS_NAME][NEXT_SCAN] = time()
@@ -118,6 +122,7 @@ class NetatmoDataHandler:
                 partial(data_class, **kwargs),
                 self._auth,
             )
+
             for update_callback in self._data_classes[data_class_entry][
                 "subscriptions"
             ]:

--- a/homeassistant/components/netatmo/light.py
+++ b/homeassistant/components/netatmo/light.py
@@ -53,9 +53,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
         for camera in all_cameras:
             if camera["type"] == "NOC":
-                if not data_handler.webhook:
-                    raise PlatformNotReady
-
                 _LOGGER.debug("Adding camera light %s %s", camera["id"], camera["name"])
                 entities.append(
                     NetatmoLight(
@@ -125,6 +122,11 @@ class NetatmoLight(NetatmoBase, LightEntity):
 
             self.async_write_ha_state()
             return
+
+    @property
+    def available(self) -> bool:
+        """If the webhook is not established, mark as unavailable."""
+        return bool(self.data_handler.webhook)
 
     @property
     def is_on(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Unregister the Netatmo webhook if it can't be established successfully within a reasonable time. This is supposed to prevent webhook banning when the instance does not conform to Netatmos requirements (e.g. exposed via port 443).

Subsequently the light platform will only be available when the webhook is successfully established as it is a strong requirement for its functionality.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
