### PR TITLE
Default some entities to disabled

### DIFF
--- a/homeassistant/components/onewire/onewire_entities.py
+++ b/homeassistant/components/onewire/onewire_entities.py
@@ -22,6 +22,7 @@ class OneWire(Entity):
         sensor_type: str,
         sensor_name: str = None,
         device_info=None,
+        default_disabled: bool = False,
     ):
         """Initialize the sensor."""
         self._name = f"{name} {sensor_name or sensor_type.capitalize()}"
@@ -32,6 +33,7 @@ class OneWire(Entity):
         self._device_info = device_info
         self._state = None
         self._value_raw = None
+        self._default_disabled = default_disabled
 
     @property
     def name(self) -> Optional[str]:
@@ -68,6 +70,11 @@ class OneWire(Entity):
         """Return device specific attributes."""
         return self._device_info
 
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return not self._default_disabled
+
 
 class OneWireProxy(OneWire):
     """Implementation of a 1-Wire sensor through owserver."""
@@ -79,10 +86,13 @@ class OneWireProxy(OneWire):
         sensor_type: str,
         sensor_name: str,
         device_info: Dict[str, Any],
+        disable_startup: bool,
         owproxy: protocol._Proxy,
     ):
         """Initialize the sensor."""
-        super().__init__(name, device_file, sensor_type, sensor_name, device_info)
+        super().__init__(
+            name, device_file, sensor_type, sensor_name, device_info, disable_startup
+        )
         self._owproxy = owproxy
 
     def _read_value_ownet(self):

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -45,8 +45,14 @@ DEVICE_SENSORS = {
             "path": "TAI8570/temperature",
             "name": "Temperature",
             "type": SENSOR_TYPE_TEMPERATURE,
+            "default_disabled": True,
         },
-        {"path": "TAI8570/pressure", "name": "Pressure", "type": SENSOR_TYPE_PRESSURE},
+        {
+            "path": "TAI8570/pressure",
+            "name": "Pressure",
+            "type": SENSOR_TYPE_PRESSURE,
+            "default_disabled": True,
+        },
     ],
     "22": [
         {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE}
@@ -58,21 +64,25 @@ DEVICE_SENSORS = {
             "path": "HIH3600/humidity",
             "name": "Humidity HIH3600",
             "type": SENSOR_TYPE_HUMIDITY,
+            "default_disabled": True,
         },
         {
             "path": "HIH4000/humidity",
             "name": "Humidity HIH4000",
             "type": SENSOR_TYPE_HUMIDITY,
+            "default_disabled": True,
         },
         {
             "path": "HIH5030/humidity",
             "name": "Humidity HIH5030",
             "type": SENSOR_TYPE_HUMIDITY,
+            "default_disabled": True,
         },
         {
             "path": "HTM1735/humidity",
             "name": "Humidity HTM1735",
             "type": SENSOR_TYPE_HUMIDITY,
+            "default_disabled": True,
         },
         {"path": "B1-R1-A/pressure", "name": "Pressure", "type": SENSOR_TYPE_PRESSURE},
         {
@@ -247,6 +257,7 @@ def get_entities(onewirehub: OneWireHub, config):
                         device_sensor["type"],
                         device_sensor["name"],
                         device_info,
+                        device_sensor.get("default_disabled", False),
                         onewirehub.owproxy,
                     )
                 )

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -59,7 +59,12 @@ DEVICE_SENSORS = {
     ],
     "26": [
         {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE},
-        {"path": "humidity", "name": "Humidity", "type": SENSOR_TYPE_HUMIDITY},
+        {
+            "path": "humidity",
+            "name": "Humidity",
+            "type": SENSOR_TYPE_HUMIDITY,
+            "default_disabled": True,
+        },
         {
             "path": "HIH3600/humidity",
             "name": "Humidity HIH3600",
@@ -84,15 +89,36 @@ DEVICE_SENSORS = {
             "type": SENSOR_TYPE_HUMIDITY,
             "default_disabled": True,
         },
-        {"path": "B1-R1-A/pressure", "name": "Pressure", "type": SENSOR_TYPE_PRESSURE},
+        {
+            "path": "B1-R1-A/pressure",
+            "name": "Pressure",
+            "type": SENSOR_TYPE_PRESSURE,
+            "default_disabled": True,
+        },
         {
             "path": "S3-R1-A/illuminance",
             "name": "Illuminance",
             "type": SENSOR_TYPE_ILLUMINANCE,
+            "default_disabled": True,
         },
-        {"path": "VAD", "name": "Voltage VAD", "type": SENSOR_TYPE_VOLTAGE},
-        {"path": "VDD", "name": "Voltage VDD", "type": SENSOR_TYPE_VOLTAGE},
-        {"path": "IAD", "name": "Current", "type": SENSOR_TYPE_CURRENT},
+        {
+            "path": "VAD",
+            "name": "Voltage VAD",
+            "type": SENSOR_TYPE_VOLTAGE,
+            "default_disabled": True,
+        },
+        {
+            "path": "VDD",
+            "name": "Voltage VDD",
+            "type": SENSOR_TYPE_VOLTAGE,
+            "default_disabled": True,
+        },
+        {
+            "path": "IAD",
+            "name": "Current",
+            "type": SENSOR_TYPE_CURRENT,
+            "default_disabled": True,
+        },
     ],
     "28": [
         {"path": "temperature", "name": "Temperature", "type": SENSOR_TYPE_TEMPERATURE}

--- a/tests/components/onewire/test_entity_owserver.py
+++ b/tests/components/onewire/test_entity_owserver.py
@@ -7,6 +7,7 @@ from homeassistant.components.onewire.const import (
     DOMAIN,
     PRESSURE_CBAR,
 )
+from homeassistant.components.onewire.sensor import DEVICE_SENSORS
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     DEVICE_CLASS_CURRENT,
@@ -423,13 +424,9 @@ async def test_owserver_setup_valid_device(hass, device_id):
     # Ensure enough read side effect
     read_side_effect.extend([ProtocolError("Missing injected value")] * 10)
 
-    with patch.dict(
-        "homeassistant.components.onewire.sensor.DEVICE_SENSORS"
-    ) as device_specs, patch(
-        "homeassistant.components.onewire.onewirehub.protocol.proxy"
-    ) as owproxy:
-        # Ignore disable_startup for testing
-        device_specs["26"][2]["default_disabled"] = False
+    # Ignore default_disabled for testing
+    DEVICE_SENSORS["26"][2]["default_disabled"] = False
+    with patch("homeassistant.components.onewire.onewirehub.protocol.proxy") as owproxy:
         owproxy.return_value.dir.return_value = dir_return_value
         owproxy.return_value.read.side_effect = read_side_effect
 

--- a/tests/components/onewire/test_entity_owserver.py
+++ b/tests/components/onewire/test_entity_owserver.py
@@ -174,6 +174,7 @@ MOCK_DEVICE_SENSORS = {
                 "result": "72.8",
                 "unit": PERCENTAGE,
                 "class": DEVICE_CLASS_HUMIDITY,
+                "disabled": True,
             },
             {
                 "entity_id": "sensor.26_111111111111_humidity_hih3600",
@@ -217,6 +218,7 @@ MOCK_DEVICE_SENSORS = {
                 "result": "969.3",
                 "unit": PRESSURE_MBAR,
                 "class": DEVICE_CLASS_PRESSURE,
+                "disabled": True,
             },
             {
                 "entity_id": "sensor.26_111111111111_illuminance",
@@ -225,6 +227,7 @@ MOCK_DEVICE_SENSORS = {
                 "result": "65.9",
                 "unit": LIGHT_LUX,
                 "class": DEVICE_CLASS_ILLUMINANCE,
+                "disabled": True,
             },
             {
                 "entity_id": "sensor.26_111111111111_voltage_vad",
@@ -233,6 +236,7 @@ MOCK_DEVICE_SENSORS = {
                 "result": "3.0",
                 "unit": VOLT,
                 "class": DEVICE_CLASS_VOLTAGE,
+                "disabled": True,
             },
             {
                 "entity_id": "sensor.26_111111111111_voltage_vdd",
@@ -241,6 +245,7 @@ MOCK_DEVICE_SENSORS = {
                 "result": "4.7",
                 "unit": VOLT,
                 "class": DEVICE_CLASS_VOLTAGE,
+                "disabled": True,
             },
             {
                 "entity_id": "sensor.26_111111111111_current",
@@ -249,6 +254,7 @@ MOCK_DEVICE_SENSORS = {
                 "result": "1.0",
                 "unit": ELECTRICAL_CURRENT_AMPERE,
                 "class": DEVICE_CLASS_CURRENT,
+                "disabled": True,
             },
         ],
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This shouldn't have any impact on the users already migrated to the config-flow (existing entities will stay activated).
However, users coming from a YAML config may need to activate the entities manually.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set some of the entities to be disabled by default:
- device family 12 (`TAI8570/temperature` and `TAI8570/pressure`)
- device family 26 (`humidity`,`HIH3600/humidity`, `HIH4000/humidity`, `HIH5030/humidity`, `HTM1735/humidity`, `B1-R1-A/pressure`, `S3-R1-A/illuminance`, `VAD`, `VDD`, `IAD`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15528

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
