### PR TITLE
Cleanup dispatchers when unloading rfxtrx

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -49,6 +49,9 @@ from .const import (
     CONF_OFF_DELAY,
     CONF_REMOVE_DEVICE,
     CONF_SIGNAL_REPETITIONS,
+    DATA_CLEANUP_CALLBACK,
+    DATA_LISTENER,
+    DATA_RFXOBJECT,
     DEVICE_PACKET_TYPE_LIGHTING4,
     EVENT_RFXTRX_EVENT,
     SERVICE_SEND,
@@ -93,8 +96,6 @@ DATA_TYPES = OrderedDict(
 )
 
 _LOGGER = logging.getLogger(__name__)
-DATA_RFXOBJECT = "rfxobject"
-DATA_LISTENER = "ha_stop"
 
 
 def _bytearray_string(data):
@@ -188,6 +189,8 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     """Set up the RFXtrx component."""
     hass.data.setdefault(DOMAIN, {})
 
+    hass.data[DATA_CLEANUP_CALLBACK] = []
+
     await async_setup_internal(hass, entry)
 
     for domain in DOMAINS:
@@ -211,6 +214,9 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
         return False
 
     hass.services.async_remove(DOMAIN, SERVICE_SEND)
+
+    for cleanup_callback in hass.data[DATA_CLEANUP_CALLBACK]:
+        cleanup_callback()
 
     listener = hass.data[DOMAIN][DATA_LISTENER]
     listener()

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -49,7 +49,7 @@ from .const import (
     CONF_OFF_DELAY,
     CONF_REMOVE_DEVICE,
     CONF_SIGNAL_REPETITIONS,
-    DATA_CLEANUP_CALLBACK,
+    DATA_CLEANUP_CALLBACKS,
     DATA_LISTENER,
     DATA_RFXOBJECT,
     DEVICE_PACKET_TYPE_LIGHTING4,
@@ -189,7 +189,7 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     """Set up the RFXtrx component."""
     hass.data.setdefault(DOMAIN, {})
 
-    hass.data[DATA_CLEANUP_CALLBACK] = []
+    hass.data[DATA_CLEANUP_CALLBACKS] = []
 
     await async_setup_internal(hass, entry)
 
@@ -215,7 +215,7 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
 
     hass.services.async_remove(DOMAIN, SERVICE_SEND)
 
-    for cleanup_callback in hass.data[DATA_CLEANUP_CALLBACK]:
+    for cleanup_callback in hass.data[DATA_CLEANUP_CALLBACKS]:
         cleanup_callback()
 
     listener = hass.data[DOMAIN][DATA_LISTENER]

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -434,11 +434,11 @@ def get_device_id(device, data_bits=None):
     return (f"{device.packettype:x}", f"{device.subtype:x}", id_string)
 
 
-async def async_connect_auto_add(hass, entry_data, callback):
+async def async_connect_auto_add(hass, entry_data, callback_fun):
     """Connect to dispatcher for automatic add."""
     if entry_data[CONF_AUTOMATIC_ADD]:
         hass.data[DATA_CLEANUP_CALLBACKS].append(
-            hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, callback)
+            hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, callback_fun)
         )
 
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -435,7 +435,7 @@ def get_device_id(device, data_bits=None):
 
 
 async def async_connect_auto_add(hass, entry_data, callback):
-    """Conncet to dispatcher for automatic add."""
+    """Connect to dispatcher for automatic add."""
     if entry_data[CONF_AUTOMATIC_ADD]:
         hass.data[DATA_CLEANUP_CALLBACKS].append(
             hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, callback)

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -189,7 +189,7 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     """Set up the RFXtrx component."""
     hass.data.setdefault(DOMAIN, {})
 
-    hass.data[DATA_CLEANUP_CALLBACKS] = []
+    hass.data[DOMAIN][DATA_CLEANUP_CALLBACKS] = []
 
     await async_setup_internal(hass, entry)
 
@@ -215,7 +215,7 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
 
     hass.services.async_remove(DOMAIN, SERVICE_SEND)
 
-    for cleanup_callback in hass.data[DATA_CLEANUP_CALLBACKS]:
+    for cleanup_callback in hass.data[DOMAIN][DATA_CLEANUP_CALLBACKS]:
         cleanup_callback()
 
     listener = hass.data[DOMAIN][DATA_LISTENER]
@@ -223,6 +223,8 @@ async def async_unload_entry(hass, entry: config_entries.ConfigEntry):
 
     rfx_object = hass.data[DOMAIN][DATA_RFXOBJECT]
     await hass.async_add_executor_job(rfx_object.close_connection)
+
+    hass.data.pop(DOMAIN)
 
     return True
 
@@ -437,7 +439,7 @@ def get_device_id(device, data_bits=None):
 def connect_auto_add(hass, entry_data, callback_fun):
     """Connect to dispatcher for automatic add."""
     if entry_data[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACKS].append(
+        hass.data[DOMAIN][DATA_CLEANUP_CALLBACKS].append(
             hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, callback_fun)
         )
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -434,6 +434,14 @@ def get_device_id(device, data_bits=None):
     return (f"{device.packettype:x}", f"{device.subtype:x}", id_string)
 
 
+async def async_connect_auto_add(hass, entry_data, callback):
+    """Conncet to dispatcher for automatic add."""
+    if entry_data[CONF_AUTOMATIC_ADD]:
+        hass.data[DATA_CLEANUP_CALLBACKS].append(
+            hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, callback)
+        )
+
+
 class RfxtrxEntity(RestoreEntity):
     """Represents a Rfxtrx device.
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -434,7 +434,7 @@ def get_device_id(device, data_bits=None):
     return (f"{device.packettype:x}", f"{device.subtype:x}", id_string)
 
 
-async def async_connect_auto_add(hass, entry_data, callback_fun):
+def connect_auto_add(hass, entry_data, callback_fun):
     """Connect to dispatcher for automatic add."""
     if entry_data[CONF_AUTOMATIC_ADD]:
         hass.data[DATA_CLEANUP_CALLBACKS].append(

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -22,7 +22,7 @@ from . import (
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
     RfxtrxEntity,
-    async_connect_auto_add,
+    connect_auto_add,
     find_possible_pt2262_device,
     get_device_id,
     get_pt2262_cmd,
@@ -146,7 +146,7 @@ async def async_setup_entry(
         async_add_entities([sensor])
 
     # Subscribe to main RFXtrx events
-    await async_connect_auto_add(hass, discovery_info, binary_sensor_update)
+    connect_auto_add(hass, discovery_info, binary_sensor_update)
 
 
 class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -19,12 +19,10 @@ from homeassistant.core import callback
 from homeassistant.helpers import event as evt
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
-    DATA_CLEANUP_CALLBACKS,
-    SIGNAL_EVENT,
     RfxtrxEntity,
+    async_connect_auto_add,
     find_possible_pt2262_device,
     get_device_id,
     get_pt2262_cmd,
@@ -148,12 +146,7 @@ async def async_setup_entry(
         async_add_entities([sensor])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACKS].append(
-            hass.helpers.dispatcher.async_dispatcher_connect(
-                SIGNAL_EVENT, binary_sensor_update
-            )
-        )
+    await async_connect_auto_add(hass, discovery_info, binary_sensor_update)
 
 
 class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -22,7 +22,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
-    DATA_CLEANUP_CALLBACK,
+    DATA_CLEANUP_CALLBACKS,
     SIGNAL_EVENT,
     RfxtrxEntity,
     find_possible_pt2262_device,
@@ -149,7 +149,7 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACK].append(
+        hass.data[DATA_CLEANUP_CALLBACKS].append(
             hass.helpers.dispatcher.async_dispatcher_connect(
                 SIGNAL_EVENT, binary_sensor_update
             )

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -22,6 +22,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
+    DATA_CLEANUP_CALLBACK,
     SIGNAL_EVENT,
     RfxtrxEntity,
     find_possible_pt2262_device,
@@ -148,8 +149,10 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(
-            SIGNAL_EVENT, binary_sensor_update
+        hass.data[DATA_CLEANUP_CALLBACK].append(
+            hass.helpers.dispatcher.async_dispatcher_connect(
+                SIGNAL_EVENT, binary_sensor_update
+            )
         )
 
 

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -33,3 +33,7 @@ SERVICE_SEND = "send"
 DEVICE_PACKET_TYPE_LIGHTING4 = 0x13
 
 EVENT_RFXTRX_EVENT = "rfxtrx_event"
+
+DATA_RFXOBJECT = "rfxobject"
+DATA_LISTENER = "ha_stop"
+DATA_CLEANUP_CALLBACKS = "cleanup_callbacks"

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -6,13 +6,11 @@ from homeassistant.const import CONF_DEVICES, STATE_OPEN
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
-    DATA_CLEANUP_CALLBACKS,
     DEFAULT_SIGNAL_REPETITIONS,
-    SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    async_connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -82,10 +80,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACKS].append(
-            hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, cover_update)
-        )
+    await async_connect_auto_add(hass, discovery_info, cover_update)
 
 
 class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -9,6 +9,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
+    DATA_CLEANUP_CALLBACK,
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxCommandEntity,
@@ -82,7 +83,9 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, cover_update)
+        hass.data[DATA_CLEANUP_CALLBACK].append(
+            hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, cover_update)
+        )
 
 
 class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -9,7 +9,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
-    DATA_CLEANUP_CALLBACK,
+    DATA_CLEANUP_CALLBACKS,
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxCommandEntity,
@@ -83,7 +83,7 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACK].append(
+        hass.data[DATA_CLEANUP_CALLBACKS].append(
             hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, cover_update)
         )
 

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -10,7 +10,7 @@ from . import (
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
     RfxtrxCommandEntity,
-    async_connect_auto_add,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -80,7 +80,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    await async_connect_auto_add(hass, discovery_info, cover_update)
+    connect_auto_add(hass, discovery_info, cover_update)
 
 
 class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -16,7 +16,7 @@ from . import (
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
     RfxtrxCommandEntity,
-    async_connect_auto_add,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -94,7 +94,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    await async_connect_auto_add(hass, discovery_info, light_update)
+    connect_auto_add(hass, discovery_info, light_update)
 
 
 class RfxtrxLight(RfxtrxCommandEntity, LightEntity):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -15,6 +15,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
+    DATA_CLEANUP_CALLBACK,
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxCommandEntity,
@@ -96,7 +97,9 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, light_update)
+        hass.data[DATA_CLEANUP_CALLBACK].append(
+            hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, light_update)
+        )
 
 
 class RfxtrxLight(RfxtrxCommandEntity, LightEntity):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -12,13 +12,11 @@ from homeassistant.const import CONF_DEVICES, STATE_ON
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
-    DATA_CLEANUP_CALLBACKS,
     DEFAULT_SIGNAL_REPETITIONS,
-    SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    async_connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -96,10 +94,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACKS].append(
-            hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, light_update)
-        )
+    await async_connect_auto_add(hass, discovery_info, light_update)
 
 
 class RfxtrxLight(RfxtrxCommandEntity, LightEntity):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -15,7 +15,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
-    DATA_CLEANUP_CALLBACK,
+    DATA_CLEANUP_CALLBACKS,
     DEFAULT_SIGNAL_REPETITIONS,
     SIGNAL_EVENT,
     RfxtrxCommandEntity,
@@ -97,7 +97,7 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACK].append(
+        hass.data[DATA_CLEANUP_CALLBACKS].append(
             hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, light_update)
         )
 

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.core import callback
 from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
+    DATA_CLEANUP_CALLBACK,
     DATA_TYPES,
     SIGNAL_EVENT,
     RfxtrxEntity,
@@ -128,7 +129,11 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, sensor_update)
+        hass.data[DATA_CLEANUP_CALLBACK].append(
+            hass.helpers.dispatcher.async_dispatcher_connect(
+                SIGNAL_EVENT, sensor_update
+            )
+        )
 
 
 class RfxtrxSensor(RfxtrxEntity):

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -23,7 +23,7 @@ from . import (
     CONF_DATA_BITS,
     DATA_TYPES,
     RfxtrxEntity,
-    async_connect_auto_add,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -126,7 +126,7 @@ async def async_setup_entry(
             async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    await async_connect_auto_add(hass, discovery_info, sensor_update)
+    connect_auto_add(hass, discovery_info, sensor_update)
 
 
 class RfxtrxSensor(RfxtrxEntity):

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.core import callback
 from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
-    DATA_CLEANUP_CALLBACK,
+    DATA_CLEANUP_CALLBACKS,
     DATA_TYPES,
     SIGNAL_EVENT,
     RfxtrxEntity,
@@ -129,7 +129,7 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACK].append(
+        hass.data[DATA_CLEANUP_CALLBACKS].append(
             hass.helpers.dispatcher.async_dispatcher_connect(
                 SIGNAL_EVENT, sensor_update
             )

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -20,12 +20,10 @@ from homeassistant.const import (
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
-    DATA_CLEANUP_CALLBACKS,
     DATA_TYPES,
-    SIGNAL_EVENT,
     RfxtrxEntity,
+    async_connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -128,12 +126,7 @@ async def async_setup_entry(
             async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACKS].append(
-            hass.helpers.dispatcher.async_dispatcher_connect(
-                SIGNAL_EVENT, sensor_update
-            )
-        )
+    await async_connect_auto_add(hass, discovery_info, sensor_update)
 
 
 class RfxtrxSensor(RfxtrxEntity):

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -8,14 +8,12 @@ from homeassistant.const import CONF_DEVICES, STATE_ON
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
-    DATA_CLEANUP_CALLBACKS,
     DEFAULT_SIGNAL_REPETITIONS,
     DOMAIN,
-    SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    async_connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -93,12 +91,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACKS].append(
-            hass.helpers.dispatcher.async_dispatcher_connect(
-                SIGNAL_EVENT, switch_update
-            )
-        )
+    await async_connect_auto_add(hass, discovery_info, switch_update)
 
 
 class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -13,7 +13,7 @@ from . import (
     DEFAULT_SIGNAL_REPETITIONS,
     DOMAIN,
     RfxtrxCommandEntity,
-    async_connect_auto_add,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -91,7 +91,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    await async_connect_auto_add(hass, discovery_info, switch_update)
+    connect_auto_add(hass, discovery_info, switch_update)
 
 
 class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -11,7 +11,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
-    DATA_CLEANUP_CALLBACK,
+    DATA_CLEANUP_CALLBACKS,
     DEFAULT_SIGNAL_REPETITIONS,
     DOMAIN,
     SIGNAL_EVENT,
@@ -94,7 +94,7 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_CLEANUP_CALLBACK].append(
+        hass.data[DATA_CLEANUP_CALLBACKS].append(
             hass.helpers.dispatcher.async_dispatcher_connect(
                 SIGNAL_EVENT, switch_update
             )

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -11,6 +11,7 @@ from . import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
+    DATA_CLEANUP_CALLBACK,
     DEFAULT_SIGNAL_REPETITIONS,
     DOMAIN,
     SIGNAL_EVENT,
@@ -93,7 +94,11 @@ async def async_setup_entry(
 
     # Subscribe to main RFXtrx events
     if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, switch_update)
+        hass.data[DATA_CLEANUP_CALLBACK].append(
+            hass.helpers.dispatcher.async_dispatcher_connect(
+                SIGNAL_EVENT, switch_update
+            )
+        )
 
 
 class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When unloading rfxtrx ConfigEntry, dispatchers are not cleaned up. As a result, without restarting Home Assistant, once they are registered. they will keep registering new devices and entities. These will be added in a kind of "broken" state as they will not be added to ConfigEntry data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42781
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
