### PR TITLE
Add Hyperion options flow and tests

### DIFF
--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -59,14 +59,20 @@ def split_hyperion_unique_id(unique_id) -> Tuple[str, int]:
         return None
 
 
-async def async_create_connect_client(
-    host: str,
-    port: int,
-    instance: int = hyperion_const.DEFAULT_INSTANCE,
-    token: str = None,
+def create_hyperion_client(
+    *args: Any,
+    **kwargs: Any,
+) -> client.HyperionClient:
+    """Create a Hyperion Client."""
+    return client.HyperionClient(*args, **kwargs)
+
+
+async def async_create_connect_hyperion_client(
+    *args: Any,
+    **kwargs: Any,
 ):
     """Create and connect a Hyperion Client."""
-    hyperion_client = client.HyperionClient(host, port, token=token, instance=instance)
+    hyperion_client = create_hyperion_client(*args, **kwargs)
 
     if not await hyperion_client.async_client_connect():
         return None
@@ -85,7 +91,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     port = config_entry.data[CONF_PORT]
     token = config_entry.data.get(CONF_TOKEN)
 
-    hyperion_client = await async_create_connect_client(host, port, token=token)
+    hyperion_client = await async_create_connect_hyperion_client(
+        host, port, token=token
+    )
     if not hyperion_client:
         raise ConfigEntryNotReady
 

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -11,10 +11,18 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
 from homeassistant.const import CONF_BASE, CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
+from homeassistant.core import callback
 from homeassistant.helpers.typing import ConfigType
 
 # pylint: disable=unused-import
-from .const import CONF_AUTH_ID, CONF_CREATE_TOKEN, DEFAULT_ORIGIN, DOMAIN
+from .const import (
+    CONF_AUTH_ID,
+    CONF_CREATE_TOKEN,
+    CONF_PRIORITY,
+    DEFAULT_ORIGIN,
+    DEFAULT_PRIORITY,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.DEBUG)
@@ -388,4 +396,37 @@ class HyperionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # pylint: disable=no-member  # https://github.com/PyCQA/pylint/issues/3167
         return self.async_create_entry(
             title=f"{self._data[CONF_HOST]}:{self._data[CONF_PORT]}", data=self._data
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the Hyperion Options flow."""
+        return HyperionOptionsFlow(config_entry)
+
+
+class HyperionOptionsFlow(config_entries.OptionsFlow):
+    """Hyperion options flow."""
+
+    def __init__(self, config_entry):
+        """Initialize a Hyperion options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_PRIORITY,
+                        default=self._config_entry.options.get(
+                            CONF_PRIORITY, DEFAULT_PRIORITY
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+                }
+            ),
         )

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -9,6 +9,7 @@ from hyperion import client, const
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.hyperion import create_hyperion_client
 from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
 from homeassistant.const import CONF_BASE, CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.core import callback
@@ -103,7 +104,7 @@ class HyperionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _create_client(self, raw_connection=False) -> client.HyperionClient:
         """Create and connect a client instance."""
-        return client.HyperionClient(
+        return create_hyperion_client(
             self._data[CONF_HOST],
             self._data[CONF_PORT],
             token=self._data.get(CONF_TOKEN),

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -9,11 +9,12 @@ from hyperion import client, const
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.hyperion import create_hyperion_client
 from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
 from homeassistant.const import CONF_BASE, CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.core import callback
 from homeassistant.helpers.typing import ConfigType
+
+from . import create_hyperion_client
 
 # pylint: disable=unused-import
 from .const import (

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity_registry import async_get_registry
 import homeassistant.util.color as color_util
 
-from . import async_create_connect_client, get_hyperion_unique_id
+from . import async_create_connect_hyperion_client, get_hyperion_unique_id
 from .const import (
     CONF_ON_UNLOAD,
     CONF_PRIORITY,
@@ -117,7 +117,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     # First, connect to the server and get the server id (which will be unique_id on a config_entry
     # if there is one).
-    hyperion_client = await async_create_connect_client(host, port)
+    hyperion_client = await async_create_connect_hyperion_client(host, port)
     if not hyperion_client:
         raise PlatformNotReady
     hyperion_id = await hyperion_client.async_id()
@@ -229,7 +229,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             desired_unique_ids.add(unique_id)
             if unique_id in current_entities:
                 continue
-            hyperion_client = await async_create_connect_client(
+            hyperion_client = await async_create_connect_hyperion_client(
                 host, port, instance=instance_id, token=token
             )
             if not hyperion_client:

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -182,7 +182,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 "Could not automatically migrate Hyperion YAML to a config entry."
             )
             return
-        # At a later stage add options migration functionality.
+        config_entry = result.get("result")
+        options = {**config_entry.options, CONF_PRIORITY: config[CONF_PRIORITY]}
+        hass.config_entries.async_update_entry(config_entry, options=options)
+
         _LOGGER.info(
             "Successfully migrated Hyperion YAML configuration to a config entry."
         )

--- a/homeassistant/components/hyperion/strings.json
+++ b/homeassistant/components/hyperion/strings.json
@@ -39,5 +39,14 @@
       "auth_new_token_not_work_error": "Failed to authenticate using newly created token",
       "no_id": "The Hyperion Ambilight instance did not report its id"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "priority": "Hyperion priority to use for colors and effects"
+        }
+      }
+    }
   }
 }

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -102,7 +102,9 @@ async def setup_test_config_entry(hass, client=None):
     # pylint: disable=attribute-defined-outside-init
     client.instances = [TEST_INSTANCE_1]
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
     return config_entry

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -122,7 +122,9 @@ async def _create_mock_entry(hass):
 
     # Setup
     client = create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -170,7 +172,9 @@ async def test_user_existing_id_abort(hass):
 
     await _create_mock_entry(hass)
     client = create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
@@ -184,7 +188,9 @@ async def test_user_client_errors(hass):
 
     # Fail the connection.
     client.async_client_connect = CoroutineMock(return_value=False)
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"]["base"] == "cannot_connect"
@@ -192,7 +198,9 @@ async def test_user_client_errors(hass):
     # Fail the auth check call.
     client.async_client_connect = CoroutineMock(return_value=True)
     client.async_is_auth_required = CoroutineMock(return_value={"success": False})
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "auth_required_error"
@@ -208,7 +216,10 @@ async def test_user_confirm_cannot_connect(hass):
     bad_client.async_client_connect = CoroutineMock(return_value=False)
 
     # Confirmation sync_client_connect fails.
-    with patch("hyperion.client.HyperionClient", side_effect=[good_client, bad_client]):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient",
+        side_effect=[good_client, bad_client],
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "cannot_connect"
@@ -222,7 +233,9 @@ async def test_user_confirm_id_error(hass):
     client.async_id = CoroutineMock(return_value=None)
 
     # Confirmation sync_client_connect fails.
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "no_id"
@@ -233,7 +246,9 @@ async def test_user_noauth_flow_success(hass):
     result = await _init_flow(hass)
 
     client = create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -251,7 +266,9 @@ async def test_user_auth_required(hass):
     client = create_mock_client()
     client.async_is_auth_required = CoroutineMock(return_value=TEST_AUTH_REQUIRED_RESP)
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "auth"
@@ -263,7 +280,9 @@ async def test_auth_static_token_auth_required_fail(hass):
 
     client = create_mock_client()
     client.async_is_auth_required = CoroutineMock(return_value=None)
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "auth_required_error"
@@ -277,7 +296,9 @@ async def test_auth_static_token_success(hass):
     client = create_mock_client()
     client.async_is_auth_required = CoroutineMock(return_value=TEST_AUTH_REQUIRED_RESP)
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: False, CONF_TOKEN: TEST_TOKEN}
@@ -305,7 +326,9 @@ async def test_auth_static_token_login_fail(hass):
         return_value={"command": "authorize-login", "success": False, "tan": 0}
     )
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: False, CONF_TOKEN: TEST_TOKEN}
@@ -322,14 +345,19 @@ async def test_auth_create_token_approval_declined(hass):
     client = create_mock_client()
     client.async_is_auth_required = CoroutineMock(return_value=TEST_AUTH_REQUIRED_RESP)
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "auth"
 
     client.async_request_token = CoroutineMock(return_value=TEST_REQUEST_TOKEN_FAIL)
-    with patch("hyperion.client.HyperionClient", return_value=client), patch(
-        "hyperion.client.generate_random_auth_id", return_value=TEST_AUTH_ID
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ), patch(
+        "homeassistant.components.hyperion.config_flow.client.generate_random_auth_id",
+        return_value=TEST_AUTH_ID,
     ):
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: True}
@@ -360,14 +388,19 @@ async def test_auth_create_token_when_issued_token_fails(hass):
     client = create_mock_client()
     client.async_is_auth_required = CoroutineMock(return_value=TEST_AUTH_REQUIRED_RESP)
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "auth"
 
     client.async_request_token = CoroutineMock(return_value=TEST_REQUEST_TOKEN_SUCCESS)
-    with patch("hyperion.client.HyperionClient", return_value=client), patch(
-        "hyperion.client.generate_random_auth_id", return_value=TEST_AUTH_ID
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ), patch(
+        "homeassistant.components.hyperion.config_flow.client.generate_random_auth_id",
+        return_value=TEST_AUTH_ID,
     ):
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: True}
@@ -399,14 +432,19 @@ async def test_auth_create_token_success(hass):
     client = create_mock_client()
     client.async_is_auth_required = CoroutineMock(return_value=TEST_AUTH_REQUIRED_RESP)
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "auth"
 
     client.async_request_token = CoroutineMock(return_value=TEST_REQUEST_TOKEN_SUCCESS)
-    with patch("hyperion.client.HyperionClient", return_value=client), patch(
-        "hyperion.client.generate_random_auth_id", return_value=TEST_AUTH_ID
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ), patch(
+        "homeassistant.components.hyperion.config_flow.client.generate_random_auth_id",
+        return_value=TEST_AUTH_ID,
     ):
         result = await _configure_flow(
             hass, result, user_input={CONF_CREATE_TOKEN: True}
@@ -436,12 +474,16 @@ async def test_ssdp_success(hass):
     """Check an SSDP flow."""
 
     client = create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _init_flow(hass, source=SOURCE_SSDP, data=TEST_SSDP_SERVICE_INFO)
         await hass.async_block_till_done()
 
     # Accept the confirmation.
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _configure_flow(hass, result)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -459,7 +501,9 @@ async def test_ssdp_cannot_connect(hass):
     client = create_mock_client()
     client.async_client_connect = CoroutineMock(return_value=False)
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _init_flow(hass, source=SOURCE_SSDP, data=TEST_SSDP_SERVICE_INFO)
         await hass.async_block_till_done()
 
@@ -474,7 +518,9 @@ async def test_ssdp_missing_serial(hass):
     bad_data = {**TEST_SSDP_SERVICE_INFO}
     del bad_data["serialNumber"]
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _init_flow(hass, source=SOURCE_SSDP, data=bad_data)
         await hass.async_block_till_done()
 
@@ -489,7 +535,9 @@ async def test_ssdp_failure_bad_port_json(hass):
     bad_data = {**TEST_SSDP_SERVICE_INFO}
     bad_data["ports"]["jsonServer"] = "not_a_port"
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _init_flow(hass, source=SOURCE_SSDP, data=bad_data)
         result = await _configure_flow(hass, result)
         await hass.async_block_till_done()
@@ -507,8 +555,11 @@ async def test_ssdp_failure_bad_port_ui(hass):
     bad_data = {**TEST_SSDP_SERVICE_INFO}
     bad_data["ssdp_location"] = f"http://{TEST_HOST}:not_a_port/description.xml"
 
-    with patch("hyperion.client.HyperionClient", return_value=client), patch(
-        "hyperion.client.generate_random_auth_id", return_value=TEST_AUTH_ID
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ), patch(
+        "homeassistant.components.hyperion.config_flow.client.generate_random_auth_id",
+        return_value=TEST_AUTH_ID,
     ):
         result = await _init_flow(hass, source=SOURCE_SSDP, data=bad_data)
 
@@ -534,7 +585,9 @@ async def test_ssdp_abort_duplicates(hass):
     """Check an SSDP flow where no id is provided."""
 
     client = create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result_1 = await _init_flow(
             hass, source=SOURCE_SSDP, data=TEST_SSDP_SERVICE_INFO
         )
@@ -552,7 +605,9 @@ async def test_import_success(hass):
     """Check an import flow from the old-style YAML."""
 
     client = create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _init_flow(
             hass,
             source=SOURCE_IMPORT,
@@ -579,7 +634,9 @@ async def test_import_cannot_connect(hass):
     client = create_mock_client()
     client.async_client_connect = CoroutineMock(return_value=False)
 
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         result = await _init_flow(
             hass,
             source=SOURCE_IMPORT,
@@ -600,7 +657,9 @@ async def test_options(hass):
     config_entry = add_test_config_entry(hass)
 
     client = create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert hass.states.get(TEST_ENTITY_ID_1) is not None

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.entity_registry import async_get_registry
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
+    TEST_CONFIG_ENTRY_OPTIONS,
     TEST_ENTITY_ID_1,
     TEST_ENTITY_ID_2,
     TEST_ENTITY_ID_3,
@@ -123,7 +124,9 @@ async def test_setup_yaml_old_style_unique_id(hass: HomeAssistantType) -> None:
     assert registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, old_unique_id) is None
 
     # There should be a config entry with the correct server unique_id.
-    assert _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
+    entry = _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
+    assert entry
+    assert TEST_CONFIG_ENTRY_OPTIONS == entry.options
 
 
 async def test_setup_yaml_new_style_unique_id_wo_config(
@@ -157,7 +160,9 @@ async def test_setup_yaml_new_style_unique_id_wo_config(
     assert registry.async_get(entity_id_to_preserve).unique_id == new_unique_id
 
     # There should be a config entry with the correct server unique_id.
-    assert _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
+    entry = _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
+    assert entry
+    assert TEST_CONFIG_ENTRY_OPTIONS == entry.options
 
 
 async def test_setup_yaml_no_registry_entity(hass: HomeAssistantType) -> None:
@@ -180,7 +185,9 @@ async def test_setup_yaml_no_registry_entity(hass: HomeAssistantType) -> None:
     )
 
     # There should be a config entry with the correct server unique_id.
-    assert _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
+    entry = _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
+    assert entry
+    assert TEST_CONFIG_ENTRY_OPTIONS == entry.options
 
 
 async def test_setup_yaml_not_ready(hass: HomeAssistantType) -> None:

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -56,7 +56,9 @@ async def _setup_entity_yaml(
 ) -> None:
     """Add a test Hyperion entity to hass."""
     client = client or create_mock_client()
-    with patch("hyperion.client.HyperionClient", return_value=client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ):
         assert await setup.async_setup_component(
             hass,
             LIGHT_DOMAIN,
@@ -126,7 +128,7 @@ async def test_setup_yaml_old_style_unique_id(hass: HomeAssistantType) -> None:
     # There should be a config entry with the correct server unique_id.
     entry = _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
     assert entry
-    assert TEST_CONFIG_ENTRY_OPTIONS == entry.options
+    assert entry.options == TEST_CONFIG_ENTRY_OPTIONS
 
 
 async def test_setup_yaml_new_style_unique_id_wo_config(
@@ -162,7 +164,7 @@ async def test_setup_yaml_new_style_unique_id_wo_config(
     # There should be a config entry with the correct server unique_id.
     entry = _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
     assert entry
-    assert TEST_CONFIG_ENTRY_OPTIONS == entry.options
+    assert entry.options == TEST_CONFIG_ENTRY_OPTIONS
 
 
 async def test_setup_yaml_no_registry_entity(hass: HomeAssistantType) -> None:
@@ -187,7 +189,7 @@ async def test_setup_yaml_no_registry_entity(hass: HomeAssistantType) -> None:
     # There should be a config entry with the correct server unique_id.
     entry = _get_config_entry_from_unique_id(hass, TEST_SERVER_ID)
     assert entry
-    assert TEST_CONFIG_ENTRY_OPTIONS == entry.options
+    assert entry.options == TEST_CONFIG_ENTRY_OPTIONS
 
 
 async def test_setup_yaml_not_ready(hass: HomeAssistantType) -> None:
@@ -223,7 +225,7 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
     entity_client.instances = master_client.instances
 
     with patch(
-        "hyperion.client.HyperionClient",
+        "homeassistant.components.hyperion.client.HyperionClient",
         side_effect=[master_client, entity_client, entity_client],
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -237,7 +239,10 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
     instance_callback = master_client.set_callbacks.call_args[0][0][
         f"{const.KEY_INSTANCE}-{const.KEY_UPDATE}"
     ]
-    with patch("hyperion.client.HyperionClient", return_value=entity_client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient",
+        return_value=entity_client,
+    ):
         instance_callback(
             {
                 const.KEY_SUCCESS: True,
@@ -251,7 +256,10 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
     assert hass.states.get(TEST_ENTITY_ID_3) is not None
 
     # Inject a new instances update (re-add instance 1, but not running)
-    with patch("hyperion.client.HyperionClient", return_value=entity_client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient",
+        return_value=entity_client,
+    ):
         instance_callback(
             {
                 const.KEY_SUCCESS: True,
@@ -269,7 +277,10 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
     assert hass.states.get(TEST_ENTITY_ID_3) is not None
 
     # Inject a new instances update (re-add instance 1, running)
-    with patch("hyperion.client.HyperionClient", return_value=entity_client):
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient",
+        return_value=entity_client,
+    ):
         instance_callback(
             {
                 const.KEY_SUCCESS: True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add options flow to Hyperion config flow, supporting a single option (priority). This PR is to the 'add-hyperion-config-options-flow' branch which has been specifically created to combine the new config flow (https://github.com/home-assistant/core/pull/42104) with this PR to create new options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [home-assistant/home-assistant.io#15336](home-assistant/home-assistant.io#15336)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
