### PR TITLE
0.117.4

### DIFF
--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -34,6 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await coordinator.async_refresh()
 
     if not coordinator.last_update_success:
+        coordinator.shutdown()
         raise ConfigEntryNotReady
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/gree/manifest.json
+++ b/homeassistant/components/gree/manifest.json
@@ -3,6 +3,6 @@
   "name": "Gree Climate",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gree",
-  "requirements": ["greeclimate==0.9.2"],
+  "requirements": ["greeclimate==0.9.5"],
   "codeowners": ["@cmroche"]
 }

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -19,11 +19,10 @@ from homeassistant.core import callback
 from homeassistant.helpers import event as evt
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
-    SIGNAL_EVENT,
     RfxtrxEntity,
+    connect_auto_add,
     find_possible_pt2262_device,
     get_device_id,
     get_pt2262_cmd,
@@ -147,10 +146,7 @@ async def async_setup_entry(
         async_add_entities([sensor])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(
-            SIGNAL_EVENT, binary_sensor_update
-        )
+    connect_auto_add(hass, discovery_info, binary_sensor_update)
 
 
 class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -33,3 +33,7 @@ SERVICE_SEND = "send"
 DEVICE_PACKET_TYPE_LIGHTING4 = 0x13
 
 EVENT_RFXTRX_EVENT = "rfxtrx_event"
+
+DATA_RFXOBJECT = "rfxobject"
+DATA_LISTENER = "ha_stop"
+DATA_CLEANUP_CALLBACKS = "cleanup_callbacks"

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -6,12 +6,11 @@ from homeassistant.const import CONF_DEVICES, STATE_OPEN
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
-    SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -81,8 +80,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, cover_update)
+    connect_auto_add(hass, discovery_info, cover_update)
 
 
 class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -12,12 +12,11 @@ from homeassistant.const import CONF_DEVICES, STATE_ON
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
-    SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -95,8 +94,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, light_update)
+    connect_auto_add(hass, discovery_info, light_update)
 
 
 class RfxtrxLight(RfxtrxCommandEntity, LightEntity):

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -20,11 +20,10 @@ from homeassistant.const import (
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     DATA_TYPES,
-    SIGNAL_EVENT,
     RfxtrxEntity,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -127,8 +126,7 @@ async def async_setup_entry(
             async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, sensor_update)
+    connect_auto_add(hass, discovery_info, sensor_update)
 
 
 class RfxtrxSensor(RfxtrxEntity):

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -8,13 +8,12 @@ from homeassistant.const import CONF_DEVICES, STATE_ON
 from homeassistant.core import callback
 
 from . import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_SIGNAL_REPETITIONS,
     DEFAULT_SIGNAL_REPETITIONS,
     DOMAIN,
-    SIGNAL_EVENT,
     RfxtrxCommandEntity,
+    connect_auto_add,
     get_device_id,
     get_rfx_object,
 )
@@ -92,8 +91,7 @@ async def async_setup_entry(
         async_add_entities([entity])
 
     # Subscribe to main RFXtrx events
-    if discovery_info[CONF_AUTOMATIC_ADD]:
-        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_EVENT, switch_update)
+    connect_auto_add(hass, discovery_info, switch_update)
 
 
 class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 117
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -696,7 +696,7 @@ gpiozero==1.5.1
 gps3==0.33.3
 
 # homeassistant.components.gree
-greeclimate==0.9.2
+greeclimate==0.9.5
 
 # homeassistant.components.greeneye_monitor
 greeneye_monitor==2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -352,7 +352,7 @@ google-cloud-pubsub==0.39.1
 google-nest-sdm==0.1.6
 
 # homeassistant.components.gree
-greeclimate==0.9.2
+greeclimate==0.9.5
 
 # homeassistant.components.griddy
 griddypower==0.1.0


### PR DESCRIPTION
- Update greeclimate to 0.9.5 ([@cmroche] - [#42796]) ([gree docs])
- Cleanup dispatchers when unloading rfxtrx ([@RobBie1221] - [#42803]) ([rfxtrx docs])
- Call coordinator.shutdown() when ConfigEntryNotReady ([@bieniu] - [#42833]) ([brother docs])

[#42796]: https://github.com/home-assistant/core/pull/42796
[#42803]: https://github.com/home-assistant/core/pull/42803
[#42833]: https://github.com/home-assistant/core/pull/42833
[@RobBie1221]: https://github.com/RobBie1221
[@bieniu]: https://github.com/bieniu
[@cmroche]: https://github.com/cmroche
[brother docs]: https://www.home-assistant.io/integrations/brother/
[gree docs]: https://www.home-assistant.io/integrations/gree/
[rfxtrx docs]: https://www.home-assistant.io/integrations/rfxtrx/