### PR TITLE
Fix missing sensor exceptions in SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -724,3 +724,15 @@ class SimpliSafeEntity(CoordinatorEntity):
     @callback
     def async_update_from_websocket_event(self, event):
         """Update the entity with the provided websocket event."""
+
+
+class SimpliSafeBaseSensor(SimpliSafeEntity):
+    """Define a SimpliSafe base (binary) sensor."""
+
+    def __init__(self, simplisafe, system, sensor):
+        """Initialize."""
+        super().__init__(simplisafe, system, sensor.name, serial=sensor.serial)
+        self._device_info["identifiers"] = {(DOMAIN, sensor.serial)}
+        self._device_info["model"] = sensor.type.name
+        self._device_info["name"] = sensor.name
+        self._sensor = sensor

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -6,8 +6,6 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_GAS,
     DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
     BinarySensorEntity,
 )
@@ -28,9 +26,7 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
 TRIGGERED_SENSOR_TYPES = {
     EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
     EntityTypes.entry: DEVICE_CLASS_DOOR,
-    EntityTypes.glass_break: DEVICE_CLASS_SAFETY,
     EntityTypes.leak: DEVICE_CLASS_MOISTURE,
-    EntityTypes.motion: DEVICE_CLASS_MOTION,
     EntityTypes.smoke: DEVICE_CLASS_SMOKE,
 }
 

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -6,6 +6,8 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_GAS,
     DEVICE_CLASS_MOISTURE,
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
     BinarySensorEntity,
 )
@@ -26,9 +28,9 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
 TRIGGERED_SENSOR_TYPES = {
     EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
     EntityTypes.entry: DEVICE_CLASS_DOOR,
-    EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
-    EntityTypes.entry: DEVICE_CLASS_DOOR,
+    EntityTypes.glass_break: DEVICE_CLASS_SAFETY,
     EntityTypes.leak: DEVICE_CLASS_MOISTURE,
+    EntityTypes.motion: DEVICE_CLASS_MOTION,
     EntityTypes.smoke: DEVICE_CLASS_SMOKE,
 }
 

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.core import callback
 
-from . import SimpliSafeEntity
+from . import SimpliSafeBaseSensor
 from .const import DATA_CLIENT, DOMAIN, LOGGER
 
 SUPPORTED_BATTERY_SENSOR_TYPES = [
@@ -23,25 +23,13 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
     EntityTypes.temperature,
 ]
 
-SUPPORTED_TRIGGERED_SENSOR_TYPES = [
-    EntityTypes.carbon_monoxide,
-    EntityTypes.entry,
-    EntityTypes.leak,
-    EntityTypes.smoke,
-]
-
-DEVICE_CLASSES = {
+TRIGGERED_SENSOR_TYPES = {
+    EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
+    EntityTypes.entry: DEVICE_CLASS_DOOR,
     EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
     EntityTypes.entry: DEVICE_CLASS_DOOR,
     EntityTypes.leak: DEVICE_CLASS_MOISTURE,
     EntityTypes.smoke: DEVICE_CLASS_SMOKE,
-}
-
-SENSOR_MODELS = {
-    EntityTypes.carbon_monoxide: "Carbon Monoxide Detector",
-    EntityTypes.entry: "Entry Sensor",
-    EntityTypes.leak: "Water Sensor",
-    EntityTypes.smoke: "Smoke Detector",
 }
 
 
@@ -56,39 +44,34 @@ async def async_setup_entry(hass, entry, async_add_entities):
             continue
 
         for sensor in system.sensors.values():
-            if sensor.type in SUPPORTED_TRIGGERED_SENSOR_TYPES:
-                sensors.append(TriggeredBinarySensor(simplisafe, system, sensor))
+            if sensor.type in TRIGGERED_SENSOR_TYPES:
+                sensors.append(
+                    TriggeredBinarySensor(
+                        simplisafe,
+                        system,
+                        sensor,
+                        TRIGGERED_SENSOR_TYPES[sensor.type],
+                    )
+                )
             if sensor.type in SUPPORTED_BATTERY_SENSOR_TYPES:
                 sensors.append(BatteryBinarySensor(simplisafe, system, sensor))
 
     async_add_entities(sensors)
 
 
-class SimpliSafeBinarySensor(SimpliSafeEntity, BinarySensorEntity):
-    """Define a SimpliSafe binary sensor entity."""
-
-    def __init__(self, simplisafe, system, sensor):
-        """Initialize."""
-        super().__init__(simplisafe, system, sensor.name, serial=sensor.serial)
-        self._device_info["identifiers"] = {(DOMAIN, sensor.serial)}
-        self._device_info["model"] = SENSOR_MODELS[sensor.type]
-        self._device_info["name"] = sensor.name
-
-
-class TriggeredBinarySensor(SimpliSafeBinarySensor):
+class TriggeredBinarySensor(SimpliSafeBaseSensor, BinarySensorEntity):
     """Define a binary sensor related to whether an entity has been triggered."""
 
-    def __init__(self, simplisafe, system, sensor):
+    def __init__(self, simplisafe, system, sensor, device_class):
         """Initialize."""
         super().__init__(simplisafe, system, sensor)
-        self._system = system
-        self._sensor = sensor
+        self._device_class = device_class
         self._is_on = False
 
     @property
     def device_class(self):
         """Return type of sensor."""
-        return DEVICE_CLASSES[self._sensor.type]
+        return self._device_class
 
     @property
     def is_on(self):
@@ -101,13 +84,12 @@ class TriggeredBinarySensor(SimpliSafeBinarySensor):
         self._is_on = self._sensor.triggered
 
 
-class BatteryBinarySensor(SimpliSafeEntity, BinarySensorEntity):
+class BatteryBinarySensor(SimpliSafeBaseSensor, BinarySensorEntity):
     """Define a SimpliSafe battery binary sensor entity."""
 
     def __init__(self, simplisafe, system, sensor):
         """Initialize."""
         super().__init__(simplisafe, system, sensor)
-        self._sensor = sensor
         self._is_low = False
 
     @property

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -4,7 +4,7 @@ from simplipy.entity import EntityTypes
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_FAHRENHEIT
 from homeassistant.core import callback
 
-from . import SimpliSafeEntity
+from . import SimpliSafeBaseSensor
 from .const import DATA_CLIENT, DOMAIN, LOGGER
 
 
@@ -25,18 +25,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(sensors)
 
 
-class SimplisafeFreezeSensor(SimpliSafeEntity):
+class SimplisafeFreezeSensor(SimpliSafeBaseSensor):
     """Define a SimpliSafe freeze sensor entity."""
 
     def __init__(self, simplisafe, system, sensor):
         """Initialize."""
-        super().__init__(simplisafe, system, sensor.name, serial=sensor.serial)
-        self._sensor = sensor
+        super().__init__(simplisafe, system, sensor)
         self._state = None
-
-        self._device_info["identifiers"] = {(DOMAIN, sensor.serial)}
-        self._device_info["model"] = "Freeze Sensor"
-        self._device_info["name"] = sensor.name
 
     @property
     def device_class(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously, SimpliSafe binary sensors were looking for supported data in too many places, leading to unhandled exceptions. This PR streamlines how sensor entities are defined and created to avoid this scenario now and in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/issues/42814
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
