### PR TITLE
Fix missing/incorrect SimpliSafe entities

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 from uuid import UUID
 
 from simplipy import API
+from simplipy.entity import EntityTypes
 from simplipy.errors import EndpointUnavailable, InvalidCredentialsError, SimplipyError
 from simplipy.websocket import (
     EVENT_CAMERA_MOTION_DETECTED,
@@ -594,6 +595,13 @@ class SimpliSafeEntity(CoordinatorEntity):
         else:
             self._serial = system.serial
 
+        try:
+            sensor_type = EntityTypes(
+                simplisafe.initial_event_to_use[system.system_id].get("sensorType")
+            )
+        except ValueError:
+            sensor_type = EntityTypes.unknown
+
         self._attrs = {
             ATTR_LAST_EVENT_INFO: simplisafe.initial_event_to_use[system.system_id].get(
                 "info"
@@ -601,9 +609,7 @@ class SimpliSafeEntity(CoordinatorEntity):
             ATTR_LAST_EVENT_SENSOR_NAME: simplisafe.initial_event_to_use[
                 system.system_id
             ].get("sensorName"),
-            ATTR_LAST_EVENT_SENSOR_TYPE: simplisafe.initial_event_to_use[
-                system.system_id
-            ].get("sensorType"),
+            ATTR_LAST_EVENT_SENSOR_TYPE: sensor_type.name,
             ATTR_LAST_EVENT_TIMESTAMP: simplisafe.initial_event_to_use[
                 system.system_id
             ].get("eventTimestamp"),
@@ -740,3 +746,11 @@ class SimpliSafeBaseSensor(SimpliSafeEntity):
         self._device_info["model"] = sensor.type.name
         self._device_info["name"] = sensor.name
         self._sensor = sensor
+        self._sensor_type_human_name = " ".join(
+            [w.title() for w in self._sensor.type.name.split("_")]
+        )
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self._system.address} {self._name} {self._sensor_type_human_name}"

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -6,6 +6,8 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_GAS,
     DEVICE_CLASS_MOISTURE,
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
     BinarySensorEntity,
 )
@@ -18,7 +20,7 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
     EntityTypes.carbon_monoxide,
     EntityTypes.entry,
     EntityTypes.leak,
-    EntityTypes.lock,
+    EntityTypes.lock_keypad,
     EntityTypes.smoke,
     EntityTypes.temperature,
 ]
@@ -26,7 +28,9 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
 TRIGGERED_SENSOR_TYPES = {
     EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
     EntityTypes.entry: DEVICE_CLASS_DOOR,
+    EntityTypes.glass_break: DEVICE_CLASS_SAFETY,
     EntityTypes.leak: DEVICE_CLASS_MOISTURE,
+    EntityTypes.motion: DEVICE_CLASS_MOTION,
     EntityTypes.smoke: DEVICE_CLASS_SMOKE,
 }
 

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -6,8 +6,6 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_GAS,
     DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
     BinarySensorEntity,
 )
@@ -28,9 +26,7 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
 TRIGGERED_SENSOR_TYPES = {
     EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
     EntityTypes.entry: DEVICE_CLASS_DOOR,
-    EntityTypes.glass_break: DEVICE_CLASS_SAFETY,
     EntityTypes.leak: DEVICE_CLASS_MOISTURE,
-    EntityTypes.motion: DEVICE_CLASS_MOTION,
     EntityTypes.smoke: DEVICE_CLASS_SMOKE,
 }
 

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -6,6 +6,8 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_GAS,
     DEVICE_CLASS_MOISTURE,
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
     BinarySensorEntity,
 )
@@ -26,7 +28,9 @@ SUPPORTED_BATTERY_SENSOR_TYPES = [
 TRIGGERED_SENSOR_TYPES = {
     EntityTypes.carbon_monoxide: DEVICE_CLASS_GAS,
     EntityTypes.entry: DEVICE_CLASS_DOOR,
+    EntityTypes.glass_break: DEVICE_CLASS_SAFETY,
     EntityTypes.leak: DEVICE_CLASS_MOISTURE,
+    EntityTypes.motion: DEVICE_CLASS_MOTION,
     EntityTypes.smoke: DEVICE_CLASS_SMOKE,
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes missing SimpliSafe motion and glass breakage entities, as well as fixes incorrect lock keypad entity definitions. Lastly, it adds the entity type to the human-friendly entity name for easier identification.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/42814
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
