### PR TITLE
Allow ZHA coordinator binding/unbinding

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -809,10 +809,10 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
 
     zdo = source_device.device.zdo
     bind_tasks = []
-    for cluster_pair in clusters_to_bind:
+    for binding_pair in clusters_to_bind:
         op_msg = "cluster: %s %s --> [%s]"
         op_params = (
-            cluster_pair.source_cluster.cluster_id,
+            binding_pair.source_cluster.cluster_id,
             operation.name,
             target_ieee,
         )
@@ -823,9 +823,9 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
                 zdo.request(
                     operation,
                     source_device.ieee,
-                    cluster_pair.source_cluster.endpoint.endpoint_id,
-                    cluster_pair.source_cluster.cluster_id,
-                    cluster_pair.destination_address,
+                    binding_pair.source_cluster.endpoint.endpoint_id,
+                    binding_pair.source_cluster.cluster_id,
+                    binding_pair.destination_address,
                 ),
                 op_msg,
                 op_params,

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -810,11 +810,6 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
     zdo = source_device.device.zdo
     bind_tasks = []
     for cluster_pair in clusters_to_bind:
-        destination_address = zdo_types.MultiAddress()
-        destination_address.addrmode = 3
-        destination_address.ieee = target_device.ieee
-        destination_address.endpoint = cluster_pair.target_cluster.endpoint.endpoint_id
-
         op_msg = "cluster: %s %s --> [%s]"
         op_params = (
             cluster_pair.source_cluster.cluster_id,
@@ -830,7 +825,7 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
                     source_device.ieee,
                     cluster_pair.source_cluster.endpoint.endpoint_id,
                     cluster_pair.source_cluster.cluster_id,
-                    destination_address,
+                    cluster_pair.destination_address,
                 ),
                 op_msg,
                 op_params,

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -807,14 +807,13 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
 
     clusters_to_bind = await get_matched_clusters(source_device, target_device)
 
+    zdo = source_device.device.zdo
     bind_tasks = []
     for cluster_pair in clusters_to_bind:
         destination_address = zdo_types.MultiAddress()
         destination_address.addrmode = 3
         destination_address.ieee = target_device.ieee
         destination_address.endpoint = cluster_pair.target_cluster.endpoint.endpoint_id
-
-        zdo = cluster_pair.source_cluster.endpoint.device.zdo
 
         op_msg = "cluster: %s %s --> [%s]"
         op_params = (

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -29,7 +29,7 @@ from .typing import ZhaDeviceType, ZigpyClusterType
 
 
 @dataclass
-class ClusterPair:
+class BindingPair:
     """Information for binding."""
 
     source_cluster: ZigpyClusterType
@@ -67,7 +67,7 @@ async def safe_read(
 
 async def get_matched_clusters(
     source_zha_device: ZhaDeviceType, target_zha_device: ZhaDeviceType
-) -> List[ClusterPair]:
+) -> List[BindingPair]:
     """Get matched input/output cluster pairs for 2 devices."""
     source_clusters = source_zha_device.async_get_std_clusters()
     target_clusters = target_zha_device.async_get_std_clusters()
@@ -78,7 +78,7 @@ async def get_matched_clusters(
             if cluster_id not in BINDABLE_CLUSTERS:
                 continue
             if target_zha_device.nwk == 0x0000:
-                cluster_pair = ClusterPair(
+                cluster_pair = BindingPair(
                     source_cluster=source_clusters[endpoint_id][CLUSTER_TYPE_OUT][
                         cluster_id
                     ],
@@ -91,7 +91,7 @@ async def get_matched_clusters(
                 continue
             for t_endpoint_id in target_clusters:
                 if cluster_id in target_clusters[t_endpoint_id][CLUSTER_TYPE_IN]:
-                    cluster_pair = ClusterPair(
+                    cluster_pair = BindingPair(
                         source_cluster=source_clusters[endpoint_id][CLUSTER_TYPE_OUT][
                             cluster_id
                         ],

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -61,7 +61,10 @@ async def get_matched_clusters(source_zha_device, target_zha_device):
                 continue
             if target_zha_device.nwk == 0x0000:
                 tgt_zigpy_dev = target_zha_device.device
-                tgt_ep = tgt_zigpy_dev.add_endpoint(1)
+                tgt_ep_id = tgt_zigpy_dev.application.get_endpoint_id(
+                    cluster_id, is_server_cluster=True
+                )
+                tgt_ep = tgt_zigpy_dev.add_endpoint(tgt_ep_id)
                 tgt_cluster = tgt_ep.add_input_cluster(cluster_id)
                 cluster_pair = ClusterPair(
                     source_cluster=source_clusters[endpoint_id][CLUSTER_TYPE_OUT][

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -59,6 +59,18 @@ async def get_matched_clusters(source_zha_device, target_zha_device):
         for cluster_id in source_clusters[endpoint_id][CLUSTER_TYPE_OUT]:
             if cluster_id not in BINDABLE_CLUSTERS:
                 continue
+            if target_zha_device.nwk == 0x0000:
+                tgt_zigpy_dev = target_zha_device.device
+                tgt_ep = tgt_zigpy_dev.add_endpoint(1)
+                tgt_cluster = tgt_ep.add_input_cluster(cluster_id)
+                cluster_pair = ClusterPair(
+                    source_cluster=source_clusters[endpoint_id][CLUSTER_TYPE_OUT][
+                        cluster_id
+                    ],
+                    target_cluster=tgt_cluster,
+                )
+                clusters_to_bind.append(cluster_pair)
+                continue
             for t_endpoint_id in target_clusters:
                 if cluster_id in target_clusters[t_endpoint_id][CLUSTER_TYPE_IN]:
                     cluster_pair = ClusterPair(
@@ -76,6 +88,9 @@ async def get_matched_clusters(source_zha_device, target_zha_device):
 @callback
 def async_is_bindable_target(source_zha_device, target_zha_device):
     """Determine if target is bindable to source."""
+    if target_zha_device.nwk == 0x0000:
+        return True
+
     source_clusters = source_zha_device.async_get_std_clusters()
     target_clusters = target_zha_device.async_get_std_clusters()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
By default ZHA bind remotes to coordinator, so coordinator could receive ZCL commands from the remotes and originate `zha_event`'s. However some remotes, like Philips RWL021 can only be bound to one destination and it is not possible to make this switch to bind to another destinations like Zigbee Groups. 
This PR allows unbinding of the coordinator, allowing the remote to be bound directly to another targets, like groups

![image](https://user-images.githubusercontent.com/5826160/98172146-d6206980-1ebe-11eb-8019-a9f75c56d50f.png)
This allows user to unbind the remote from ZHA coordinator and bind it directly to a group or any other device directly. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41665
- This PR fixes or closes issue: fixes https://github.com/zigpy/zha-device-handlers/issues/336
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
