### PR TITLE
Cloud: Recover when internet is not available yet

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -14,6 +14,7 @@ from homeassistant.components.google_assistant import const as gc, smart_home as
 from homeassistant.const import HTTP_OK
 from homeassistant.core import Context, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.aiohttp import MockRequest
 
@@ -106,19 +107,34 @@ class CloudClient(Interface):
         """When user logs in."""
         await self.prefs.async_set_username(self.cloud.username)
 
-        if self.alexa_config.enabled and self.alexa_config.should_report_state:
+        async def enable_alexa(_):
+            """Enable Alexa."""
             try:
                 await self.alexa_config.async_enable_proactive_mode()
+            except aiohttp.ClientError:  # If no internet available yet
+                async_call_later(self._hass, 30, enable_alexa)
             except alexa_errors.NoTokenAvailable:
                 pass
 
-        if self._prefs.google_enabled:
+        async def enable_google(_):
+            """Enable Google."""
             gconf = await self.get_google_config()
 
             gconf.async_enable_local_sdk()
 
             if gconf.should_report_state:
                 gconf.async_enable_report_state()
+
+        tasks = []
+
+        if self.alexa_config.enabled and self.alexa_config.should_report_state:
+            tasks.append(enable_alexa)
+
+        if self._prefs.google_enabled:
+            tasks.append(enable_google)
+
+        for task in tasks:
+            await task(None)
 
     async def cleanups(self) -> None:
         """Cleanup some stuff after logout."""

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -113,10 +113,11 @@ class CloudClient(Interface):
             try:
                 await self.alexa_config.async_enable_proactive_mode()
             except aiohttp.ClientError as err:  # If no internet available yet
-                logging.getLogger(__package__).warning(
-                    "Unable to activate Alexa Report State: %s. Retrying in 30 seconds",
-                    err,
-                )
+                if self._hass.is_running:
+                    logging.getLogger(__package__).warning(
+                        "Unable to activate Alexa Report State: %s. Retrying in 30 seconds",
+                        err,
+                    )
                 async_call_later(self._hass, 30, enable_alexa)
             except alexa_errors.NoTokenAvailable:
                 pass

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -1,4 +1,7 @@
 """Test the cloud.iot module."""
+from datetime import timedelta
+
+import aiohttp
 from aiohttp import web
 import pytest
 
@@ -8,10 +11,12 @@ from homeassistant.components.cloud.const import PREF_ENABLE_ALEXA, PREF_ENABLE_
 from homeassistant.const import CONTENT_TYPE_JSON
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from . import mock_cloud, mock_cloud_prefs
 
-from tests.async_mock import AsyncMock, MagicMock, patch
+from tests.async_mock import AsyncMock, MagicMock, Mock, patch
+from tests.common import async_fire_time_changed
 from tests.components.alexa import test_smart_home as test_alexa
 
 
@@ -260,3 +265,24 @@ async def test_set_username(hass):
 
     assert len(prefs.async_set_username.mock_calls) == 1
     assert prefs.async_set_username.mock_calls[0][1][0] == "mock-username"
+
+
+async def test_login_recovers_bad_internet(hass):
+    """Test Alexa can recover bad auth."""
+    prefs = Mock(
+        alexa_enabled=True,
+        google_enabled=False,
+        async_set_username=AsyncMock(return_value=None),
+    )
+    client = CloudClient(hass, prefs, None, {}, {})
+    client.cloud = Mock()
+    client._alexa_config = Mock(
+        async_enable_proactive_mode=Mock(side_effect=aiohttp.ClientError)
+    )
+    await client.logged_in()
+    assert len(client._alexa_config.async_enable_proactive_mode.mock_calls) == 1
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    assert len(client._alexa_config.async_enable_proactive_mode.mock_calls) == 2

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -267,7 +267,7 @@ async def test_set_username(hass):
     assert prefs.async_set_username.mock_calls[0][1][0] == "mock-username"
 
 
-async def test_login_recovers_bad_internet(hass):
+async def test_login_recovers_bad_internet(hass, caplog):
     """Test Alexa can recover bad auth."""
     prefs = Mock(
         alexa_enabled=True,
@@ -281,6 +281,7 @@ async def test_login_recovers_bad_internet(hass):
     )
     await client.logged_in()
     assert len(client._alexa_config.async_enable_proactive_mode.mock_calls) == 1
+    assert "Unable to activate Alexa Report State" in caplog.text
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cloud set up would fail if Alexa report state was unable to contact the internet. Now it retries.

Fixes #42698

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
