### PR TITLE
Add basic error handling and logging to Volumio

### DIFF
--- a/homeassistant/components/volumio/__init__.py
+++ b/homeassistant/components/volumio/__init__.py
@@ -56,9 +56,14 @@ def volumio_exception_handler(func):
             if self.available:
                 # Currently this always returns True.
                 # TO DO: Implement better handling of loss of connection.
-                # Combine this with better update handling, using DataUpdateCoordinator and CoordinatorEntity?
+                # Combine this with better update handling,
+                # using DataUpdateCoordinator and CoordinatorEntity?
                 # Look at Roku integration for example
-                _LOGGER.error("Error communicating with API in function %s: %s", func.__name__,error)
+                _LOGGER.error(
+                    "Error communicating with API in function %s: %s",
+                    func.__name__,
+                    error,
+                )
 
     return handler
 

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -35,6 +35,7 @@ from homeassistant.util import Throttle
 
 from .browse_media import browse_node, browse_top_level
 from .const import DATA_INFO, DATA_VOLUMIO, DOMAIN
+from . import volumio_exception_handler
 
 _CONFIGURING = {}
 
@@ -84,6 +85,7 @@ class Volumio(MediaPlayerEntity):
         self._playlists = []
         self._currentplaylist = None
 
+    @volumio_exception_handler
     async def async_update(self):
         """Update state."""
         self._state = await self._volumio.get_state()
@@ -190,18 +192,22 @@ class Volumio(MediaPlayerEntity):
         """Flag of media commands that are supported."""
         return SUPPORT_VOLUMIO
 
+    @volumio_exception_handler
     async def async_media_next_track(self):
         """Send media_next command to media player."""
         await self._volumio.next()
 
+    @volumio_exception_handler
     async def async_media_previous_track(self):
         """Send media_previous command to media player."""
         await self._volumio.previous()
 
+    @volumio_exception_handler
     async def async_media_play(self):
         """Send media_play command to media player."""
         await self._volumio.play()
 
+    @volumio_exception_handler
     async def async_media_pause(self):
         """Send media_pause command to media player."""
         if self._state["trackType"] == "webradio":
@@ -209,22 +215,27 @@ class Volumio(MediaPlayerEntity):
         else:
             await self._volumio.pause()
 
+    @volumio_exception_handler
     async def async_media_stop(self):
         """Send media_stop command to media player."""
         await self._volumio.stop()
 
+    @volumio_exception_handler
     async def async_set_volume_level(self, volume):
         """Send volume_up command to media player."""
         await self._volumio.set_volume_level(int(volume * 100))
 
+    @volumio_exception_handler
     async def async_volume_up(self):
         """Service to send the Volumio the command for volume up."""
         await self._volumio.volume_up()
 
+    @volumio_exception_handler
     async def async_volume_down(self):
         """Service to send the Volumio the command for volume down."""
         await self._volumio.volume_down()
 
+    @volumio_exception_handler
     async def async_mute_volume(self, mute):
         """Send mute command to media player."""
         if mute:
@@ -232,29 +243,35 @@ class Volumio(MediaPlayerEntity):
         else:
             await self._volumio.unmute()
 
+    @volumio_exception_handler
     async def async_set_shuffle(self, shuffle):
         """Enable/disable shuffle mode."""
         await self._volumio.set_shuffle(shuffle)
 
+    @volumio_exception_handler
     async def async_select_source(self, source):
         """Choose an available playlist and play it."""
         await self._volumio.play_playlist(source)
         self._currentplaylist = source
 
+    @volumio_exception_handler
     async def async_clear_playlist(self):
         """Clear players playlist."""
         await self._volumio.clear_playlist()
         self._currentplaylist = None
 
+    @volumio_exception_handler
     @Throttle(PLAYLIST_UPDATE_INTERVAL)
     async def _async_update_playlists(self, **kwargs):
         """Update available Volumio playlists."""
         self._playlists = await self._volumio.get_playlists()
 
+    @volumio_exception_handler
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Send the play_media command to the media player."""
         await self._volumio.replace_and_play(json.loads(media_id))
 
+    @volumio_exception_handler
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""
         if media_content_type in [None, "library"]:

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -33,9 +33,9 @@ from homeassistant.const import (
 )
 from homeassistant.util import Throttle
 
+from . import volumio_exception_handler
 from .browse_media import browse_node, browse_top_level
 from .const import DATA_INFO, DATA_VOLUMIO, DOMAIN
-from . import volumio_exception_handler
 
 _CONFIGURING = {}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Issue https://github.com/home-assistant/core/issues/42823 mentioned that the Volumio integration was not handling errors well in case of no response from the Volumio API. This PR aims to wrap all the calls to the api with proper error handling.

TO DO: the Volumio integration does not seem to fail very gracefully in case of lost connection. The media_player entity will remain available and the logs will fill with warnings about the state update. This could be improved but is not yet in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Not applicable
```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42823
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
