### PR TITLE
Time/date sensor fixes

### DIFF
--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -100,10 +100,13 @@ class TimeDateSensor(Entity):
             return now + timedelta(seconds=86400)
 
         if self.type == "beat":
+            # Add 1 hour because 23:00:00 UTC marks @0 beats.
+            timestamp = dt_util.as_timestamp(now + timedelta(hours=1))
             interval = 86.4
         else:
+            timestamp = dt_util.as_timestamp(now)
             interval = 60
-        timestamp = int(dt_util.as_timestamp(now))
+
         delta = interval - (timestamp % interval)
         next_interval = now + timedelta(seconds=delta)
         _LOGGER.debug("%s + %s -> %s (%s)", now, delta, next_interval, self.type)

--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -96,8 +96,8 @@ class TimeDateSensor(Entity):
         now = dt_util.utcnow()
 
         if self.type == "date":
-            now = dt_util.start_of_local_day(dt_util.as_local(now))
-            return now + timedelta(seconds=86400)
+            tomorrow = dt_util.as_local(now) + timedelta(days=1)
+            return dt_util.start_of_local_day(tomorrow)
 
         if self.type == "beat":
             # Add 1 hour because 23:00:00 UTC marks @0 beats.

--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -119,16 +119,6 @@ class TimeDateSensor(Entity):
         date = dt_util.as_local(time_date).date().isoformat()
         date_utc = time_date.date().isoformat()
 
-        # Calculate Swatch Internet Time.
-        time_bmt = time_date + timedelta(hours=1)
-        delta = timedelta(
-            hours=time_bmt.hour,
-            minutes=time_bmt.minute,
-            seconds=time_bmt.second,
-            microseconds=time_bmt.microsecond,
-        )
-        beat = int((delta.seconds + delta.microseconds / 1000000.0) / 86.4)
-
         if self.type == "time":
             self._state = time
         elif self.type == "date":
@@ -142,6 +132,19 @@ class TimeDateSensor(Entity):
         elif self.type == "time_utc":
             self._state = time_utc
         elif self.type == "beat":
+            # Calculate Swatch Internet Time.
+            time_bmt = time_date + timedelta(hours=1)
+            delta = timedelta(
+                hours=time_bmt.hour,
+                minutes=time_bmt.minute,
+                seconds=time_bmt.second,
+                microseconds=time_bmt.microsecond,
+            )
+
+            # Use integers to better handle rounding. For example,
+            # int(63763.2/86.4) = 737 but 637632//864 = 738.
+            beat = int(delta.total_seconds() * 10) // 864
+
             self._state = f"@{beat:03d}"
         elif self.type == "date_time_iso":
             self._state = dt_util.parse_datetime(f"{date} {time}").isoformat()

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -21,17 +21,20 @@ async def test_intervals(hass):
     """Test timing intervals of sensors."""
     device = time_date.TimeDateSensor(hass, "time")
     now = dt_util.utc_from_timestamp(45)
-    next_time = device.get_next_interval(now)
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
     assert next_time == dt_util.utc_from_timestamp(60)
 
     device = time_date.TimeDateSensor(hass, "beat")
     now = dt_util.utc_from_timestamp(29)
-    next_time = device.get_next_interval(now)
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
     assert next_time == dt_util.utc_from_timestamp(86.4)
 
     device = time_date.TimeDateSensor(hass, "date_time")
     now = dt_util.utc_from_timestamp(1495068899)
-    next_time = device.get_next_interval(now)
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
     assert next_time == dt_util.utc_from_timestamp(1495068900)
 
     now = dt_util.utcnow()
@@ -117,7 +120,8 @@ async def test_timezone_intervals(hass):
 
     device = time_date.TimeDateSensor(hass, "date")
     now = dt_util.utc_from_timestamp(50000)
-    next_time = device.get_next_interval(now)
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
     # start of local day in EST was 18000.0
     # so the second day was 18000 + 86400
     assert next_time.timestamp() == 104400
@@ -127,7 +131,8 @@ async def test_timezone_intervals(hass):
     dt_util.set_default_time_zone(new_tz)
     now = dt_util.parse_datetime("2017-11-13 19:47:19-07:00")
     device = time_date.TimeDateSensor(hass, "date")
-    next_time = device.get_next_interval(now)
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
     assert next_time.timestamp() == dt_util.as_timestamp("2017-11-14 00:00:00-07:00")
 
 

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -69,6 +69,8 @@ async def test_states(hass):
     device = time_date.TimeDateSensor(hass, "beat")
     device._update_internal_state(now)
     assert device.state == "@079"
+    device._update_internal_state(dt_util.utc_from_timestamp(1602952963.2))
+    assert device.state == "@738"
 
     device = time_date.TimeDateSensor(hass, "date_time_iso")
     device._update_internal_state(now)

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -137,6 +137,32 @@ async def test_timezone_intervals(hass):
         next_time = device.get_next_interval()
     assert next_time.timestamp() == dt_util.as_timestamp("2017-11-14 00:00:00-07:00")
 
+    # Entering DST
+    new_tz = dt_util.get_time_zone("Europe/Prague")
+    assert new_tz is not None
+    dt_util.set_default_time_zone(new_tz)
+
+    now = dt_util.parse_datetime("2020-03-29 00:00+01:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-03-30 00:00+02:00")
+
+    now = dt_util.parse_datetime("2020-03-29 03:00+02:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-03-30 00:00+02:00")
+
+    # Leaving DST
+    now = dt_util.parse_datetime("2020-10-25 00:00+02:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-10-26 00:00:00+01:00")
+
+    now = dt_util.parse_datetime("2020-10-25 23:59+01:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-10-26 00:00:00+01:00")
+
 
 @patch(
     "homeassistant.util.dt.utcnow",

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -20,16 +20,16 @@ def restore_ts():
 async def test_intervals(hass):
     """Test timing intervals of sensors."""
     device = time_date.TimeDateSensor(hass, "time")
-    now = dt_util.utc_from_timestamp(45)
+    now = dt_util.utc_from_timestamp(45.5)
     with patch("homeassistant.util.dt.utcnow", return_value=now):
         next_time = device.get_next_interval()
     assert next_time == dt_util.utc_from_timestamp(60)
 
     device = time_date.TimeDateSensor(hass, "beat")
-    now = dt_util.utc_from_timestamp(29)
+    now = dt_util.utc_from_timestamp(86400 - 3600 + 29)
     with patch("homeassistant.util.dt.utcnow", return_value=now):
         next_time = device.get_next_interval()
-    assert next_time == dt_util.utc_from_timestamp(86.4)
+    assert next_time == dt_util.utc_from_timestamp(86400 - 3600 + 86.4)
 
     device = time_date.TimeDateSensor(hass, "date_time")
     now = dt_util.utc_from_timestamp(1495068899)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes a number of issues with the `time_date` sensor. It's small enough that I did not make four PRs but I did put each change in a separate commit for easier reviewing:
* Swatch beats were updated at the wrong times because the 1-hour offset from UTC was not accounted for in the modulo calculation.
* Timestamps were updated a fraction of a second too late because microseconds were not reset. So we had:
    * `get_next_interval(45) => 60`
    * `get_next_interval(45.5) => 60.5`
    * `get_next_interval(46) => 60`
* Some Swatch beats were rounded wrongly due to float precision.
* The date interval calculation failed with Daylight Savings Time:
    * Entering DST would update the date on the following day at 01:00
    * Leaving DST would:
        * Schedule the next date update for the same day at 23:00, a no-op
        * Cause a 100% CPU busy loop from 23:00-00:00 because we would constantly schedule the next update for 23:00 which had already passed.
        * Completely miss a date when updates got back in sync at 00:00 (reported in #42465)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42465
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
