### PR TITLE
Support datetime sensor in time trigger

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -4,7 +4,14 @@ from functools import partial
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_AT, CONF_PLATFORM
+from homeassistant.components import sensor
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    CONF_AT,
+    CONF_PLATFORM,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HassJob, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import (
@@ -18,8 +25,8 @@ import homeassistant.util.dt as dt_util
 
 _TIME_TRIGGER_SCHEMA = vol.Any(
     cv.time,
-    vol.All(str, cv.entity_domain("input_datetime")),
-    msg="Expected HH:MM, HH:MM:SS or Entity ID from domain 'input_datetime'",
+    vol.All(str, cv.entity_domain(("input_datetime", "sensor"))),
+    msg="Expected HH:MM, HH:MM:SS or Entity ID with domain 'input_datetime' or 'sensor'",
 )
 
 TRIGGER_SCHEMA = vol.Schema(
@@ -60,14 +67,16 @@ async def async_attach_trigger(hass, config, action, automation_info):
     def update_entity_trigger(entity_id, new_state=None):
         """Update the entity trigger for the entity_id."""
         # If a listener was already set up for entity, remove it.
-        remove = entities.get(entity_id)
+        remove = entities.pop(entity_id, None)
         if remove:
             remove()
-            removes.remove(remove)
             remove = None
 
+        if not new_state:
+            return
+
         # Check state of entity. If valid, set up a listener.
-        if new_state:
+        if new_state.domain == "input_datetime":
             has_date = new_state.attributes["has_date"]
             if has_date:
                 year = new_state.attributes["year"]
@@ -111,16 +120,32 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     minute=minute,
                     second=second,
                 )
+        elif (
+            new_state.domain == "sensor"
+            and new_state.attributes.get(ATTR_DEVICE_CLASS)
+            == sensor.DEVICE_CLASS_TIMESTAMP
+            and new_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+        ):
+            trigger_dt = dt_util.parse_datetime(new_state.state)
+
+            if trigger_dt is not None and trigger_dt > dt_util.utcnow():
+                remove = async_track_point_in_time(
+                    hass,
+                    partial(
+                        time_automation_listener,
+                        f"time set in {entity_id}",
+                        entity_id=entity_id,
+                    ),
+                    trigger_dt,
+                )
 
         # Was a listener set up?
         if remove:
-            removes.append(remove)
-
-        entities[entity_id] = remove
+            entities[entity_id] = remove
 
     for at_time in config[CONF_AT]:
         if isinstance(at_time, str):
-            # input_datetime entity
+            # entity
             update_entity_trigger(at_time, new_state=hass.states.get(at_time))
         else:
             # datetime.time
@@ -144,6 +169,8 @@ async def async_attach_trigger(hass, config, action, automation_info):
     @callback
     def remove_track_time_changes():
         """Remove tracked time changes."""
+        for remove in entities.values():
+            remove()
         for remove in removes:
             remove()
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -282,25 +282,36 @@ comp_entity_ids = vol.Any(
 )
 
 
-def entity_domain(domain: str) -> Callable[[Any], str]:
+def entity_domain(domain: Union[str, List[str]]) -> Callable[[Any], str]:
     """Validate that entity belong to domain."""
+    ent_domain = entities_domain(domain)
 
     def validate(value: Any) -> str:
         """Test if entity domain is domain."""
-        ent_domain = entities_domain(domain)
         return ent_domain(value)[0]
 
     return validate
 
 
-def entities_domain(domain: str) -> Callable[[Union[str, List]], List[str]]:
+def entities_domain(
+    domain: Union[str, List[str]]
+) -> Callable[[Union[str, List]], List[str]]:
     """Validate that entities belong to domain."""
+    if isinstance(domain, str):
+
+        def check_invalid(val: str) -> bool:
+            return val != domain
+
+    else:
+
+        def check_invalid(val: str) -> bool:
+            return val not in domain
 
     def validate(values: Union[str, List]) -> List[str]:
         """Test if entity domain is domain."""
         values = entity_ids(values)
         for ent_id in values:
-            if split_entity_id(ent_id)[0] != domain:
+            if check_invalid(split_entity_id(ent_id)[0]):
                 raise vol.Invalid(
                     f"Entity ID '{ent_id}' does not belong to domain '{domain}'"
                 )

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 
 import pytest
 
-import homeassistant.components.automation as automation
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
+from homeassistant.components import automation, sensor
+from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ENTITY_ID, SERVICE_TURN_OFF
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -391,3 +391,104 @@ async def test_untrack_time_change(hass):
     )
 
     assert len(mock_track_time_change.mock_calls) == 3
+
+
+async def test_if_fires_using_at_sensor(hass, calls):
+    """Test for firing at sensor time."""
+    now = dt_util.now()
+
+    trigger_dt = now.replace(hour=5, minute=0, second=0, microsecond=0) + timedelta(2)
+
+    hass.states.async_set(
+        "sensor.next_alarm",
+        trigger_dt.isoformat(),
+        {ATTR_DEVICE_CLASS: sensor.DEVICE_CLASS_TIMESTAMP},
+    )
+
+    time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
+
+    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+    with patch(
+        "homeassistant.util.dt.utcnow",
+        return_value=dt_util.as_utc(time_that_will_not_match_right_away),
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {"platform": "time", "at": "sensor.next_alarm"},
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": some_data},
+                    },
+                }
+            },
+        )
+        await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-sensor.next_alarm"
+    )
+
+    trigger_dt += timedelta(days=1, hours=1)
+
+    hass.states.async_set(
+        "sensor.next_alarm",
+        trigger_dt.isoformat(),
+        {ATTR_DEVICE_CLASS: sensor.DEVICE_CLASS_TIMESTAMP},
+    )
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 2
+    assert (
+        calls[1].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-sensor.next_alarm"
+    )
+
+    for broken in ("unknown", "unavailable", "invalid-ts"):
+        hass.states.async_set(
+            "sensor.next_alarm",
+            trigger_dt.isoformat(),
+            {ATTR_DEVICE_CLASS: sensor.DEVICE_CLASS_TIMESTAMP},
+        )
+        await hass.async_block_till_done()
+        hass.states.async_set(
+            "sensor.next_alarm",
+            broken,
+            {ATTR_DEVICE_CLASS: sensor.DEVICE_CLASS_TIMESTAMP},
+        )
+        await hass.async_block_till_done()
+
+        async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+        await hass.async_block_till_done()
+
+        # We should not have listened to anything
+        assert len(calls) == 2
+
+    # Now without device class
+    hass.states.async_set(
+        "sensor.next_alarm",
+        trigger_dt.isoformat(),
+        {ATTR_DEVICE_CLASS: sensor.DEVICE_CLASS_TIMESTAMP},
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        "sensor.next_alarm",
+        trigger_dt.isoformat(),
+    )
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    # We should not have listened to anything
+    assert len(calls) == 2

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -179,14 +179,20 @@ def test_entity_domain():
     """Test entity domain validation."""
     schema = vol.Schema(cv.entity_domain("sensor"))
 
-    options = ("invalid_entity", "cover.demo")
-
-    for value in options:
+    for value in ("invalid_entity", "cover.demo"):
         with pytest.raises(vol.MultipleInvalid):
-            print(value)
             schema(value)
 
     assert schema("sensor.LIGHT") == "sensor.light"
+
+    schema = vol.Schema(cv.entity_domain(("sensor", "binary_sensor")))
+
+    for value in ("invalid_entity", "cover.demo"):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    assert schema("sensor.LIGHT") == "sensor.light"
+    assert schema("binary_sensor.LIGHT") == "binary_sensor.light"
 
 
 def test_entities_domain():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow specifying a datetime sensor as the `at` value for a time trigger. This will make it easy to automate on when your alarm is going to ring.

CC @dshokouhi 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
