### PR TITLE
Fix memory leak in script and automation loggers

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -238,6 +238,14 @@ async def async_setup(hass, config):
     return True
 
 
+class AutomationLoggerAdapter(logging.LoggerAdapter):
+    """Add automation name to script log messages."""
+
+    def process(self, msg, kwargs):
+        """Add automation name to script log messages."""
+        return f'[{self.extra["name"]}] {msg}', kwargs
+
+
 class AutomationEntity(ToggleEntity, RestoreEntity):
     """Entity to show status of entity."""
 
@@ -341,8 +349,8 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         """Startup with initial state or previous state."""
         await super().async_added_to_hass()
 
-        self._logger = logging.getLogger(
-            f"{__name__}.{split_entity_id(self.entity_id)[1]}"
+        self._logger = AutomationLoggerAdapter(
+            _LOGGER, {"name": split_entity_id(self.entity_id)[1]}
         )
         self.action_script.update_logger(self._logger)
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.script import (
     CONF_MAX_EXCEEDED,
     SCRIPT_MODE_SINGLE,
     Script,
+    ScriptLoggerAdapter,
     make_script_schema,
 )
 from homeassistant.helpers.service import async_set_service_schema
@@ -264,7 +265,7 @@ class ScriptEntity(ToggleEntity):
             script_mode=cfg[CONF_MODE],
             max_runs=cfg[CONF_MAX],
             max_exceeded=cfg[CONF_MAX_EXCEEDED],
-            logger=logging.getLogger(f"{__name__}.{object_id}"),
+            logger=ScriptLoggerAdapter(_LOGGER, {"name": object_id}),
             variables=cfg.get(CONF_VARIABLES),
         )
         self._changed = asyncio.Event()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -755,6 +755,14 @@ async def _async_stop_scripts_at_shutdown(hass, event):
 _VarsType = Union[Dict[str, Any], MappingProxyType]
 
 
+class ScriptLoggerAdapter(logging.LoggerAdapter):
+    """Add script name to script log messages."""
+
+    def process(self, msg, kwargs):
+        """Add script name to script log messages."""
+        return f'[{self.extra["name"]}] {msg}', kwargs
+
+
 class Script:
     """Representation of a script."""
 
@@ -771,7 +779,7 @@ class Script:
         script_mode: str = DEFAULT_SCRIPT_MODE,
         max_runs: int = DEFAULT_MAX,
         max_exceeded: str = DEFAULT_MAX_EXCEEDED,
-        logger: Optional[logging.Logger] = None,
+        logger: Optional[Union[ScriptLoggerAdapter, logging.Logger]] = None,
         log_exceptions: bool = True,
         top_level: bool = True,
         variables: Optional[ScriptVariables] = None,
@@ -837,13 +845,17 @@ class Script:
         ):
             self._change_listener_job = HassJob(change_listener)
 
-    def _set_logger(self, logger: Optional[logging.Logger] = None) -> None:
+    def _set_logger(
+        self, logger: Optional[Union[ScriptLoggerAdapter, logging.Logger]] = None
+    ) -> None:
         if logger:
             self._logger = logger
         else:
-            self._logger = logging.getLogger(f"{__name__}.{slugify(self.name)}")
+            self._logger = ScriptLoggerAdapter(_LOGGER, {"name": slugify(self.name)})
 
-    def update_logger(self, logger: Optional[logging.Logger] = None) -> None:
+    def update_logger(
+        self, logger: Optional[Union[ScriptLoggerAdapter, logging.Logger]] = None
+    ) -> None:
         """Update logger."""
         self._set_logger(logger)
         for script in self._repeat_script.values():

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -60,7 +60,7 @@ async def test_firing_event_basic(hass, caplog):
     assert len(events) == 1
     assert events[0].context is context
     assert events[0].data.get("hello") == "world"
-    assert ".test_name:" in caplog.text
+    assert "[test_name]" in caplog.text
     assert "Test Name: Running test script" in caplog.text
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Same fix as #42894 in another place.

This one is more about reducing the number of logger objects in memory, although renaming scripts or automations will leak over time.

New logging looks like

```
2020-11-06 18:51:26 WARNING (MainThread) [homeassistant.components.automation] [turn_on_new_office_aircon_from_pico] Turn on New Office Aircon from Pico: Already running
2020-11-06 18:49:58 INFO (MainThread) [homeassistant.components.script] [tv_lift_down] TV Lift Down: Running script sequence
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
