### PR TITLE
Fix dimming for ISY994 Z-Wave devices using percent instead of 8-bit brightness values

### DIFF
--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -193,6 +193,7 @@ UOM_HVAC_MODE_INSTEON = "98"
 UOM_FAN_MODES = "99"
 UOM_INDEX = "25"
 UOM_ON_OFF = "2"
+UOM_PERCENTAGE = "51"
 
 # Do not use the Home Assistant consts for the states here - we're matching exact API
 # responses, not using them for Home Assistant states
@@ -369,7 +370,7 @@ UOM_FRIENDLY_NAME = {
     "48": SPEED_MILES_PER_HOUR,
     "49": SPEED_METERS_PER_SECOND,
     "50": "Ω",
-    "51": PERCENTAGE,
+    UOM_PERCENTAGE: PERCENTAGE,
     "52": MASS_POUNDS,
     "53": "pf",
     "54": CONCENTRATION_PARTS_PER_MILLION,

--- a/homeassistant/components/isy994/cover.py
+++ b/homeassistant/components/isy994/cover.py
@@ -53,7 +53,7 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
         if self._node.status == ISY_VALUE_UNKNOWN:
             return None
         if self._node.uom == UOM_8_BIT_RANGE:
-            return int(self._node.status * 100 / 255)
+            return round(self._node.status * 100.0 / 255.0)
         return sorted((0, self._node.status, 100))[1]
 
     @property
@@ -83,7 +83,7 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
         if self._node.uom == UOM_8_BIT_RANGE:
-            position = int(position * 255 / 100)
+            position = round(position * 255.0 / 100.0)
         if not self._node.turn_on(val=position):
             _LOGGER.error("Unable to set cover position")
 

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -80,11 +80,10 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
     def on_update(self, event: object) -> None:
         """Save brightness in the update event from the ISY994 Node."""
         if self._node.status not in (0, ISY_VALUE_UNKNOWN):
-            self._last_brightness = (
-                self._node.status
-                if self._node.uom != UOM_PERCENTAGE
-                else round(self._node.status * 255.0 / 100.0)
-            )
+            if self._node.uom == UOM_PERCENTAGE:
+                self._last_brightness = round(self._node.status * 255.0 / 100.0)
+            else:
+                self._last_brightness = self._node.status
         super().on_update(event)
 
     # pylint: disable=arguments-differ

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -68,7 +68,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
             return None
         # Special Case for ISY Z-Wave Devices using % instead of 0-255:
         if self._node.uom == UOM_PERCENTAGE:
-            return int(self._node.status * 255.0 / 100.0)
+            return round(self._node.status * 255.0 / 100.0)
         return int(self._node.status)
 
     def turn_off(self, **kwargs) -> None:
@@ -83,7 +83,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
             self._last_brightness = (
                 self._node.status
                 if self._node.uom != UOM_PERCENTAGE
-                else int(self._node.status * 255.0 / 100.0)
+                else round(self._node.status * 255.0 / 100.0)
             )
         super().on_update(event)
 
@@ -94,7 +94,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
             brightness = self._last_brightness
         # Special Case for ISY Z-Wave Devices using % instead of 0-255:
         if brightness is not None and self._node.uom == UOM_PERCENTAGE:
-            brightness = int(brightness * 100.0 / 255.0)
+            brightness = round(brightness * 100.0 / 255.0)
         if not self._node.turn_on(val=brightness):
             _LOGGER.debug("Unable to turn on light")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
On the ISY994, some dimmable Z-Wave devices use a 0-100% dimming value instead of the 8-bit 0-255 range used for the majority of other dimmable devices on the ISY. This fix uses the ISY's Unit of Measurement (UOM) identifiers to determine if dimmable light device is expecting a 0-100 or 0-255 value. This is implemented the same way (albeit inverted) as the ISY994 `cover` platform (which translates the 0-255 from the ISY to 0-100 for Home Assistant).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42745, fixes #4619, fixes shbatm/hacs-isy994#76, fixes automicus/pyisy#141
- This PR is related to issue: 
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] N/A

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
