### PR TITLE
Ensure instances of async_add_entities can be garbage collected

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -199,7 +199,7 @@ class EntityPlatform:
                 await asyncio.shield(task)
 
             # Block till all entities are done
-            if self._tasks:
+            while self._tasks:
                 pending = [task for task in self._tasks if not task.done()]
                 self._tasks.clear()
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -163,7 +163,7 @@ class EntityPlatform:
         def async_create_setup_task():
             """Get task to set up platform."""
             return platform.async_setup_entry(  # type: ignore
-                self.hass, config_entry, self._async_schedule_add_entities
+                self.hass, config_entry, self._async_schedule_add_entities_nowait
             )
 
         return await self._async_setup_platform(async_create_setup_task)
@@ -259,11 +259,24 @@ class EntityPlatform:
     ) -> None:
         """Schedule adding entities for a single platform async."""
         self._tasks.append(
-            self.hass.async_create_task(
-                self.async_add_entities(
-                    new_entities, update_before_add=update_before_add
-                ),
+            self._async_schedule_add_entities_nowait(
+                new_entities, update_before_add=update_before_add
             )
+        )
+
+    @callback
+    def _async_schedule_add_entities_nowait(
+        self, new_entities: Iterable["Entity"], update_before_add: bool = False
+    ) -> asyncio.tasks.Task:
+        """Schedule adding entities for a single platform async.
+
+        Unlike _async_schedule_add_entities, these are not tracked
+        in self._tasks as _async_setup_platform will not be able to clear
+        them as these are setup from config entries where we use
+        async_forward_entry_setup.
+        """
+        return self.hass.async_create_task(
+            self.async_add_entities(new_entities, update_before_add=update_before_add),
         )
 
     def add_entities(

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -63,6 +63,8 @@ class EntityPlatform:
         self.config_entry: Optional[config_entries.ConfigEntry] = None
         self.entities: Dict[str, Entity] = {}  # pylint: disable=used-before-assignment
         self._tasks: List[asyncio.Future] = []
+        # Stop tracking tasks after setup is completed
+        self._setup_complete = False
         # Method to cancel the state change listener
         self._async_unsub_polling: Optional[CALLBACK_TYPE] = None
         # Method to cancel the retry of setup
@@ -163,7 +165,7 @@ class EntityPlatform:
         def async_create_setup_task():
             """Get task to set up platform."""
             return platform.async_setup_entry(  # type: ignore
-                self.hass, config_entry, self._async_schedule_add_entities_nowait
+                self.hass, config_entry, self._async_schedule_add_entities
             )
 
         return await self._async_setup_platform(async_create_setup_task)
@@ -205,6 +207,7 @@ class EntityPlatform:
                     await asyncio.gather(*pending)
 
             hass.config.components.add(full_name)
+            self._setup_complete = True
             return True
         except PlatformNotReady:
             tries += 1
@@ -258,26 +261,12 @@ class EntityPlatform:
         self, new_entities: Iterable["Entity"], update_before_add: bool = False
     ) -> None:
         """Schedule adding entities for a single platform async."""
-        self._tasks.append(
-            self._async_schedule_add_entities_nowait(
-                new_entities, update_before_add=update_before_add
-            )
-        )
-
-    @callback
-    def _async_schedule_add_entities_nowait(
-        self, new_entities: Iterable["Entity"], update_before_add: bool = False
-    ) -> asyncio.tasks.Task:
-        """Schedule adding entities for a single platform async.
-
-        Unlike _async_schedule_add_entities, these are not tracked
-        in self._tasks as _async_setup_platform will not be able to clear
-        them as these are setup from config entries where we use
-        async_forward_entry_setup.
-        """
-        return self.hass.async_create_task(
+        task = self.hass.async_create_task(
             self.async_add_entities(new_entities, update_before_add=update_before_add),
         )
+
+        if not self._setup_complete:
+            self._tasks.append(task)
 
     def add_entities(
         self, new_entities: Iterable["Entity"], update_before_add: bool = False
@@ -536,6 +525,7 @@ class EntityPlatform:
         if self._async_unsub_polling is not None:
             self._async_unsub_polling()
             self._async_unsub_polling = None
+        self._setup_complete = False
 
     async def async_destroy(self) -> None:
         """Destroy an entity platform.

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -102,7 +102,7 @@ async def async_setup_cast(hass, config=None):
     if config is None:
         config = {}
     with patch(
-        "homeassistant.helpers.entity_platform.EntityPlatform._async_schedule_add_entities_nowait"
+        "homeassistant.helpers.entity_platform.EntityPlatform._async_schedule_add_entities"
     ) as add_entities:
         MockConfigEntry(domain="cast").add_to_hass(hass)
         await async_setup_component(hass, "cast", {"cast": {"media_player": config}})

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -102,7 +102,7 @@ async def async_setup_cast(hass, config=None):
     if config is None:
         config = {}
     with patch(
-        "homeassistant.helpers.entity_platform.EntityPlatform._async_schedule_add_entities"
+        "homeassistant.helpers.entity_platform.EntityPlatform._async_schedule_add_entities_nowait"
     ) as add_entities:
         MockConfigEntry(domain="cast").add_to_hass(hass)
         await async_setup_component(hass, "cast", {"cast": {"media_player": config}})


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure instances of async_add_entities can be garbage collected 
when they are called from config entries

Integrations frequently call this after setup is complete.  If entities are dynamically added and removed, a Task would be leaked each time

Fixes these never going away:

`
<Task finished name='Task-1900' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1901' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1902' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1904' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1905' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1906' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1907' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1909' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1910' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1911' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1912' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1914' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1915' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1916' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1917' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1919' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1920' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1921' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1922' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1924' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1925' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1926' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1927' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1929' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1930' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1931' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1932' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1934' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1935' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1936' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1937' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1939' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1940' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1941' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1942' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1944' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1945' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1946' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1947' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1949' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1950' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1951' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1952' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1954' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1955' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1956' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1957' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285> result=None>, <Task finished name='Task-1959' coro=<EntityPlatform.async_add_entities() done, defined at /usr/src/homeassistant/homeassistant/helpers/entity_platform.py:285
`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42916
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
