### PR TITLE
Update devolo-home-control-api to 0.16.0

### DIFF
--- a/homeassistant/components/devolo_home_control/__init__.py
+++ b/homeassistant/components/devolo_home_control/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTAN
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import CONF_HOMECONTROL, CONF_MYDEVOLO, DOMAIN, PLATFORMS
+from .const import CONF_MYDEVOLO, DOMAIN, PLATFORMS
 
 
 async def async_setup(hass, config):
@@ -24,11 +24,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     """Set up the devolo account from a config entry."""
     conf = entry.data
     hass.data.setdefault(DOMAIN, {})
-    try:
-        mydevolo = Mydevolo.get_instance()
-    except SyntaxError:
-        mydevolo = Mydevolo()
 
+    mydevolo = Mydevolo()
     mydevolo.user = conf[CONF_USERNAME]
     mydevolo.password = conf[CONF_PASSWORD]
     mydevolo.url = conf[CONF_MYDEVOLO]
@@ -52,8 +49,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
                     partial(
                         HomeControl,
                         gateway_id=gateway_id,
+                        mydevolo_instance=mydevolo,
                         zeroconf_instance=zeroconf_instance,
-                        url=conf[CONF_HOMECONTROL],
                     )
                 )
             )

--- a/homeassistant/components/devolo_home_control/config_flow.py
+++ b/homeassistant/components/devolo_home_control/config_flow.py
@@ -9,9 +9,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
 from .const import (  # pylint:disable=unused-import
-    CONF_HOMECONTROL,
     CONF_MYDEVOLO,
-    DEFAULT_MPRM,
     DEFAULT_MYDEVOLO,
     DOMAIN,
 )
@@ -39,24 +37,18 @@ class DevoloHomeControlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
                 vol.Required(CONF_MYDEVOLO, default=DEFAULT_MYDEVOLO): str,
-                vol.Required(CONF_HOMECONTROL, default=DEFAULT_MPRM): str,
             }
         if user_input is None:
             return self._show_form(user_input)
         user = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
-        try:
-            mydevolo = Mydevolo.get_instance()
-        except SyntaxError:
-            mydevolo = Mydevolo()
+        mydevolo = Mydevolo()
         mydevolo.user = user
         mydevolo.password = password
         if self.show_advanced_options:
             mydevolo.url = user_input[CONF_MYDEVOLO]
-            mprm = user_input[CONF_HOMECONTROL]
         else:
             mydevolo.url = DEFAULT_MYDEVOLO
-            mprm = DEFAULT_MPRM
         credentials_valid = await self.hass.async_add_executor_job(
             mydevolo.credentials_valid
         )
@@ -73,7 +65,6 @@ class DevoloHomeControlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: password,
                 CONF_USERNAME: user,
                 CONF_MYDEVOLO: mydevolo.url,
-                CONF_HOMECONTROL: mprm,
             },
         )
 

--- a/homeassistant/components/devolo_home_control/const.py
+++ b/homeassistant/components/devolo_home_control/const.py
@@ -2,7 +2,5 @@
 
 DOMAIN = "devolo_home_control"
 DEFAULT_MYDEVOLO = "https://www.mydevolo.com"
-DEFAULT_MPRM = "https://homecontrol.mydevolo.com"
 PLATFORMS = ["binary_sensor", "climate", "cover", "light", "sensor", "switch"]
 CONF_MYDEVOLO = "mydevolo_url"
-CONF_HOMECONTROL = "home_control_url"

--- a/homeassistant/components/devolo_home_control/manifest.json
+++ b/homeassistant/components/devolo_home_control/manifest.json
@@ -2,7 +2,7 @@
   "domain": "devolo_home_control",
   "name": "devolo Home Control",
   "documentation": "https://www.home-assistant.io/integrations/devolo_home_control",
-  "requirements": ["devolo-home-control-api==0.15.1"],
+  "requirements": ["devolo-home-control-api==0.16.0"],
   "after_dependencies": ["zeroconf"],
   "config_flow": true,
   "codeowners": ["@2Fake", "@Shutgun"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -484,7 +484,7 @@ deluge-client==1.7.1
 denonavr==0.9.5
 
 # homeassistant.components.devolo_home_control
-devolo-home-control-api==0.15.1
+devolo-home-control-api==0.16.0
 
 # homeassistant.components.directv
 directv==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -257,7 +257,7 @@ defusedxml==0.6.0
 denonavr==0.9.5
 
 # homeassistant.components.devolo_home_control
-devolo-home-control-api==0.15.1
+devolo-home-control-api==0.16.0
 
 # homeassistant.components.directv
 directv==0.3.0

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -40,7 +40,6 @@ async def test_form(hass):
     assert result2["data"] == {
         "username": "test-username",
         "password": "test-password",
-        "home_control_url": "https://homecontrol.mydevolo.com",
         "mydevolo_url": "https://www.mydevolo.com",
     }
 
@@ -114,7 +113,6 @@ async def test_form_advanced_options(hass):
             {
                 "username": "test-username",
                 "password": "test-password",
-                "home_control_url": "https://test_url.test",
                 "mydevolo_url": "https://test_mydevolo_url.test",
             },
         )
@@ -125,7 +123,6 @@ async def test_form_advanced_options(hass):
     assert result2["data"] == {
         "username": "test-username",
         "password": "test-password",
-        "home_control_url": "https://test_url.test",
         "mydevolo_url": "https://test_mydevolo_url.test",
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This bump will enable us a couple of new feature. However, the usage of the API changed a little and makes a config flow entry (CONF_HOMECONTROL) unnecessary. I'm not sure if removing is allowed without increasing the version. If it is not I would restore it and add the removal to https://github.com/home-assistant/core/pull/42219 to avoid wasting version numbers.

Changelog: https://github.com/2Fake/devolo_home_control_api/releases/tag/v0.16.0
Commit compare: https://github.com/2Fake/devolo_home_control_api/compare/v0.15.1...v0.16.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
