### PR TITLE
Add services to log and dump objects to the profiler to help track down memory leaks

### DIFF
--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -1,14 +1,19 @@
 """The profiler integration."""
 import asyncio
 import cProfile
+from datetime import timedelta
+import logging
 import time
 
 from guppy import hpy
+import objgraph
 from pyprof2calltree import convert
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 
@@ -16,7 +21,27 @@ from .const import DOMAIN
 
 SERVICE_START = "start"
 SERVICE_MEMORY = "memory"
+SERVICE_START_LOG_OBJECTS = "start_log_objects"
+SERVICE_STOP_LOG_OBJECTS = "stop_log_objects"
+SERVICE_DUMP_LOG_OBJECTS = "dump_log_objects"
+
+SERVICES = (
+    SERVICE_START,
+    SERVICE_MEMORY,
+    SERVICE_START_LOG_OBJECTS,
+    SERVICE_STOP_LOG_OBJECTS,
+    SERVICE_DUMP_LOG_OBJECTS,
+)
+
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+
 CONF_SECONDS = "seconds"
+CONF_SCAN_INTERVAL = "scan_interval"
+CONF_TYPE = "type"
+
+LOG_INTERVAL_SUB = "log_interval_subscription"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -28,6 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Profiler from a config entry."""
 
     lock = asyncio.Lock()
+    domain_data = hass.data[DOMAIN] = {}
 
     async def _async_run_profile(call: ServiceCall):
         async with lock:
@@ -36,6 +62,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     async def _async_run_memory_profile(call: ServiceCall):
         async with lock:
             await _async_generate_memory_profile(hass, call)
+
+    async def _async_start_log_objects(call: ServiceCall):
+        if LOG_INTERVAL_SUB in domain_data:
+            domain_data[LOG_INTERVAL_SUB]()
+
+        hass.components.persistent_notification.async_create(
+            "Object growth logging has started. See [the logs](/config/logs) for to track the growth of new objects.",
+            title="Object growth logging started",
+            notification_id="profile_object_logging",
+        )
+        await hass.async_add_executor_job(_log_objects)
+        domain_data[LOG_INTERVAL_SUB] = async_track_time_interval(
+            hass, _log_objects, call.data[CONF_SCAN_INTERVAL]
+        )
+
+    async def _async_stop_log_objects(call: ServiceCall):
+        if LOG_INTERVAL_SUB not in domain_data:
+            return
+
+        hass.components.persistent_notification.async_dismiss("profile_object_logging")
+        domain_data[LOG_INTERVAL_SUB]()
+        domain_data.pop(LOG_INTERVAL_SUB)
+
+    def _dump_log_objects(call: ServiceCall):
+        obj_type = call.data[CONF_TYPE]
+
+        _LOGGER.critical(
+            "%s objects in memory: %s",
+            obj_type,
+            objgraph.by_type(obj_type),
+        )
+
+        hass.components.persistent_notification.create(
+            f"Objects with type {obj_type} have been dumped to the log. See [the logs](/config/logs) to review the repr of the objects.",
+            title="Object dump completed",
+            notification_id="profile_object_dump",
+        )
 
     async_register_admin_service(
         hass,
@@ -57,12 +120,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         ),
     )
 
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_START_LOG_OBJECTS,
+        _async_start_log_objects,
+        schema=vol.Schema(
+            {
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                ): cv.time_period
+            }
+        ),
+    )
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_STOP_LOG_OBJECTS,
+        _async_stop_log_objects,
+        schema=vol.Schema({}),
+    )
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_DUMP_LOG_OBJECTS,
+        _dump_log_objects,
+        schema=vol.Schema({vol.Required(CONF_TYPE): str}),
+    )
+
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    hass.services.async_remove(domain=DOMAIN, service=SERVICE_START)
+    for service in SERVICES:
+        hass.services.async_remove(domain=DOMAIN, service=service)
+    if LOG_INTERVAL_SUB in hass.data[DOMAIN]:
+        hass.data[DOMAIN][LOG_INTERVAL_SUB]()
+    hass.data.pop(DOMAIN)
     return True
 
 
@@ -119,3 +216,7 @@ def _write_profile(profiler, cprofile_path, callgrind_path):
 
 def _write_memory_profile(heap, heap_path):
     heap.byrcs.dump(heap_path)
+
+
+def _log_objects(*_):
+    _LOGGER.critical("Memory Growth: %s", objgraph.growth(limit=100))

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             domain_data[LOG_INTERVAL_SUB]()
 
         hass.components.persistent_notification.async_create(
-            "Object growth logging has started. See [the logs](/config/logs) for to track the growth of new objects.",
+            "Object growth logging has started. See [the logs](/config/logs) to track the growth of new objects.",
             title="Object growth logging started",
             notification_id="profile_object_logging",
         )

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -82,8 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             return
 
         hass.components.persistent_notification.async_dismiss("profile_object_logging")
-        domain_data[LOG_INTERVAL_SUB]()
-        domain_data.pop(LOG_INTERVAL_SUB)
+        domain_data.pop(LOG_INTERVAL_SUB)()
 
     def _dump_log_objects(call: ServiceCall):
         obj_type = call.data[CONF_TYPE]

--- a/homeassistant/components/profiler/manifest.json
+++ b/homeassistant/components/profiler/manifest.json
@@ -2,7 +2,7 @@
   "domain": "profiler",
   "name": "Profiler",
   "documentation": "https://www.home-assistant.io/integrations/profiler",
-  "requirements": ["pyprof2calltree==1.4.5", "guppy3==3.1.0"],
+  "requirements": ["pyprof2calltree==1.4.5", "guppy3==3.1.0", "objgraph==3.4.1"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",
   "config_flow": true

--- a/homeassistant/components/profiler/services.yaml
+++ b/homeassistant/components/profiler/services.yaml
@@ -10,3 +10,17 @@ memory:
     seconds:
       description: The number of seconds to run the memory profiler.
       example: 60.0
+start_log_objects:
+  description: Start logging growth of objects in memory
+  fields:
+    scan_interval:
+      description: The number of seconds between logging objects.
+      example: 60.0
+stop_log_objects:
+  description: Stop logging growth of objects in memory
+dump_log_objects:
+  description: Dump the repr of all matching objects to the log.
+  fields:
+    type:
+      description: The type of objects to dump to the log
+      example: State

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1024,6 +1024,9 @@ oasatelematics==0.3
 # homeassistant.components.google
 oauth2client==4.0.0
 
+# homeassistant.components.profiler
+objgraph==3.4.1
+
 # homeassistant.components.oem
 oemthermostat==1.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -504,6 +504,9 @@ numpy==1.19.2
 # homeassistant.components.google
 oauth2client==4.0.0
 
+# homeassistant.components.profiler
+objgraph==3.4.1
+
 # homeassistant.components.omnilogic
 omnilogic==0.4.2
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add services to the profiler to help track down memory leaks

profiler.start_log_objects:
profiler.stop_log_objects:
  Logs object growth over time

profiler.dump_log_objects:
  Dump the repr of objects to the log

To help track down #42752

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15566

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
