### PR TITLE
Update nest SDM climate simplifying support for eco mode

### DIFF
--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -258,7 +258,7 @@ class ThermostatEntity(ClimateEntity):
     def fan_modes(self):
         """Return the list of available fan modes."""
         if FanTrait.NAME in self._device.traits:
-            return list(FAN_INV_MODE_MAP.keys())
+            return list(FAN_INV_MODE_MAP)
         return []
 
     @property
@@ -304,11 +304,11 @@ class ThermostatEntity(ClimateEntity):
         trait = self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
         if self.preset_mode == PRESET_ECO or self.hvac_mode == HVAC_MODE_HEAT_COOL:
             if low_temp and high_temp:
-                return await trait.set_range(low_temp, high_temp)
+                await trait.set_range(low_temp, high_temp)
         elif self.hvac_mode == HVAC_MODE_COOL and temp:
-            return await trait.set_cool(temp)
+            await trait.set_cool(temp)
         elif self.hvac_mode == HVAC_MODE_HEAT and temp:
-            return await trait.set_heat(temp)
+            await trait.set_heat(temp)
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -46,7 +46,6 @@ THERMOSTAT_MODE_MAP = {
     "HEAT": HVAC_MODE_HEAT,
     "COOL": HVAC_MODE_COOL,
     "HEATCOOL": HVAC_MODE_HEAT_COOL,
-    "MANUAL_ECO": HVAC_MODE_AUTO,
 }
 THERMOSTAT_INV_MODE_MAP = {v: k for k, v in THERMOSTAT_MODE_MAP.items()}
 
@@ -60,14 +59,6 @@ THERMOSTAT_HVAC_STATUS_MAP = {
     "COOLING": CURRENT_HVAC_COOL,
 }
 
-# Mapping to determine the trait that supports the target temperatures
-# based on the current HVAC mode
-THERMOSTAT_SETPOINT_TRAIT_MAP = {
-    HVAC_MODE_COOL: ThermostatTemperatureSetpointTrait.NAME,
-    HVAC_MODE_HEAT: ThermostatTemperatureSetpointTrait.NAME,
-    HVAC_MODE_HEAT_COOL: ThermostatTemperatureSetpointTrait.NAME,
-    HVAC_MODE_AUTO: ThermostatEcoTrait.NAME,
-}
 THERMOSTAT_RANGE_MODES = [HVAC_MODE_HEAT_COOL, HVAC_MODE_AUTO]
 
 PRESET_MODE_MAP = {
@@ -170,7 +161,7 @@ class ThermostatEntity(ClimateEntity):
     @property
     def target_temperature_high(self):
         """Return the upper bound target temperature."""
-        if self.hvac_mode not in THERMOSTAT_RANGE_MODES:
+        if self.hvac_mode != HVAC_MODE_HEAT_COOL:
             return None
         trait = self._target_temperature_trait
         if not trait:
@@ -180,7 +171,7 @@ class ThermostatEntity(ClimateEntity):
     @property
     def target_temperature_low(self):
         """Return the lower bound target temperature."""
-        if self.hvac_mode not in THERMOSTAT_RANGE_MODES:
+        if self.hvac_mode != HVAC_MODE_HEAT_COOL:
             return None
         trait = self._target_temperature_trait
         if not trait:
@@ -192,20 +183,16 @@ class ThermostatEntity(ClimateEntity):
         """Return the correct trait with a target temp depending on mode."""
         if not self.hvac_mode:
             return None
-        if self.hvac_mode not in THERMOSTAT_SETPOINT_TRAIT_MAP:
-            return None
-        trait_name = THERMOSTAT_SETPOINT_TRAIT_MAP[self.hvac_mode]
-        if trait_name not in self._device.traits:
-            return None
-        return self._device.traits[trait_name]
+        if self.preset_mode == PRESET_ECO:
+            if ThermostatEcoTrait.NAME in self._device.traits:
+                return self._device.traits[ThermostatEcoTrait.NAME]
+        if ThermostatTemperatureSetpointTrait.NAME in self._device.traits:
+            return self._device.traits[ThermostatTemperatureSetpointTrait.NAME]
+        return None
 
     @property
     def hvac_mode(self):
         """Return the current operation (e.g. heat, cool, idle)."""
-        if ThermostatEcoTrait.NAME in self._device.traits:
-            trait = self._device.traits[ThermostatEcoTrait.NAME]
-            if trait.mode == THERMOSTAT_ECO_MODE:
-                return HVAC_MODE_AUTO
         if ThermostatModeTrait.NAME in self._device.traits:
             trait = self._device.traits[ThermostatModeTrait.NAME]
             if trait.mode in THERMOSTAT_MODE_MAP:
@@ -227,9 +214,6 @@ class ThermostatEntity(ClimateEntity):
         modes = []
         if ThermostatModeTrait.NAME in self._device.traits:
             trait = self._device.traits[ThermostatModeTrait.NAME]
-            modes.extend(trait.available_modes)
-        if ThermostatEcoTrait.NAME in self._device.traits:
-            trait = self._device.traits[ThermostatEcoTrait.NAME]
             modes.extend(trait.available_modes)
         return set(modes)
 
@@ -285,7 +269,7 @@ class ThermostatEntity(ClimateEntity):
     def _get_supported_features(self):
         """Compute the bitmap of supported features from the current state."""
         features = 0
-        if HVAC_MODE_HEAT_COOL in self.hvac_modes or HVAC_MODE_AUTO in self.hvac_modes:
+        if HVAC_MODE_HEAT_COOL in self.hvac_modes:
             features |= SUPPORT_TARGET_TEMPERATURE_RANGE
         if HVAC_MODE_HEAT in self.hvac_modes or HVAC_MODE_COOL in self.hvac_modes:
             features |= SUPPORT_TARGET_TEMPERATURE

--- a/tests/components/nest/climate_sdm_test.py
+++ b/tests/components/nest/climate_sdm_test.py
@@ -23,7 +23,6 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_OFF,
     FAN_OFF,
     FAN_ON,
-    HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
@@ -267,7 +266,6 @@ async def test_thermostat_eco_off(hass):
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
-        HVAC_MODE_AUTO,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_TARGET_TEMP_LOW] == 22.0
@@ -308,19 +306,60 @@ async def test_thermostat_eco_on(hass):
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_AUTO
+    assert thermostat.state == HVAC_MODE_HEAT_COOL
     assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_COOL
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 29.9
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
-        HVAC_MODE_AUTO,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_TARGET_TEMP_LOW] == 21.0
     assert thermostat.attributes[ATTR_TARGET_TEMP_HIGH] == 29.0
     assert thermostat.attributes[ATTR_TEMPERATURE] is None
+    assert thermostat.attributes[ATTR_PRESET_MODE] == PRESET_ECO
+    assert thermostat.attributes[ATTR_PRESET_MODES] == [PRESET_ECO, PRESET_NONE]
+
+
+async def test_thermostat_eco_heat_only(hass):
+    """Test a thermostat in eco mode that only supports heat."""
+    await setup_climate(
+        hass,
+        {
+            "sdm.devices.traits.ThermostatHvac": {
+                "status": "OFF",
+            },
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "OFF"],
+                "mode": "HEAT",
+            },
+            "sdm.devices.traits.ThermostatEco": {
+                "availableModes": ["MANUAL_ECO", "OFF"],
+                "mode": "MANUAL_ECO",
+                "heatCelsius": 21.0,
+                "coolCelsius": 29.0,
+            },
+            "sdm.devices.traits.Temperature": {
+                "ambientTemperatureCelsius": 29.9,
+            },
+            "sdm.devices.traits.ThermostatTemperatureSetpoint": {},
+        },
+    )
+
+    assert len(hass.states.async_all()) == 1
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.state == HVAC_MODE_HEAT
+    assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_OFF
+    assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 29.9
+    assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
+        HVAC_MODE_HEAT,
+        HVAC_MODE_OFF,
+    }
+    assert thermostat.attributes[ATTR_TEMPERATURE] == 21.0
+    assert ATTR_TARGET_TEMP_LOW not in thermostat.attributes
+    assert ATTR_TARGET_TEMP_HIGH not in thermostat.attributes
     assert thermostat.attributes[ATTR_PRESET_MODE] == PRESET_ECO
     assert thermostat.attributes[ATTR_PRESET_MODES] == [PRESET_ECO, PRESET_NONE]
 
@@ -498,7 +537,7 @@ async def test_thermostat_set_eco_preset(hass):
 
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_AUTO
+    assert thermostat.state == HVAC_MODE_OFF
     assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_OFF
     assert thermostat.attributes[ATTR_PRESET_MODE] == PRESET_ECO
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update the nest SDM  climate support to better represent ECO mode.  Fist, instead of using HVAC_MODE_AUTO, just represents eco mode as a preset on top and not a separate mode.  Second, better support for thermostats that only support heat or cool only, rather than both.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42921
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
