### PR TITLE
Add Hyperion version warning for old servers

### DIFF
--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Optional, Tuple
 
 from hyperion import client, const as hyperion_const
-from semver import VersionInfo
+from pkg_resources import parse_version
 
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -107,9 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     version = await hyperion_client.async_sysinfo_version()
     if version is not None:
         try:
-            if VersionInfo.parse(version) < VersionInfo.parse(
-                HYPERION_VERSION_WARN_CUTOFF
-            ):
+            if parse_version(version) < parse_version(HYPERION_VERSION_WARN_CUTOFF):
                 _LOGGER.warning(
                     "Using a Hyperion server version < %s is not recommended -- "
                     "some features may be unavailable or may not function correctly. "

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -178,5 +178,5 @@ async def async_unload_entry(
         for func in config_data[CONF_ON_UNLOAD]:
             func()
         root_client = config_data[CONF_ROOT_CLIENT]
-        await root_client.async_client_connect()
+        await root_client.async_client_disconnect()
     return unload_ok

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -396,7 +396,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
         async with self._create_client() as hyperion_client:
             if not hyperion_client:
                 return self.async_abort(reason="cannot_connect")
-            hyperion_id = await hyperion_client.async_id()
+            hyperion_id = await hyperion_client.async_sysinfo_id()
 
         if not hyperion_id:
             return self.async_abort(reason="no_id")

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -17,3 +17,6 @@ SIGNAL_INSTANCES_UPDATED = f"{DOMAIN}_instances_updated_signal." "{}"
 SIGNAL_INSTANCE_REMOVED = f"{DOMAIN}_instance_removed_signal." "{}"
 
 SOURCE_IMPORT = "import"
+
+HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.8"
+HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/releases"

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -134,7 +134,7 @@ async def async_setup_platform(
     hyperion_client = await async_create_connect_hyperion_client(host, port)
     if not hyperion_client:
         raise PlatformNotReady
-    hyperion_id = await hyperion_client.async_id()
+    hyperion_id = await hyperion_client.async_sysinfo_id()
     if not hyperion_id:
         raise PlatformNotReady
 

--- a/homeassistant/components/hyperion/manifest.json
+++ b/homeassistant/components/hyperion/manifest.json
@@ -7,7 +7,8 @@
   "domain": "hyperion",
   "name": "Hyperion",
   "requirements": [
-    "hyperion-py==0.4.2"
+    "hyperion-py==0.5.0",
+    "semver==2.13.0"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/hyperion/manifest.json
+++ b/homeassistant/components/hyperion/manifest.json
@@ -7,8 +7,7 @@
   "domain": "hyperion",
   "name": "Hyperion",
   "requirements": [
-    "hyperion-py==0.5.0",
-    "semver==2.13.0"
+    "hyperion-py==0.6.0"
   ],
   "ssdp": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -790,7 +790,7 @@ huawei-lte-api==1.4.12
 hydrawiser==0.2
 
 # homeassistant.components.hyperion
-hyperion-py==0.5.0
+hyperion-py==0.6.0
 
 # homeassistant.components.bh1750
 # homeassistant.components.bme280
@@ -1991,9 +1991,6 @@ schiene==0.23
 
 # homeassistant.components.scsgate
 scsgate==0.1.0
-
-# homeassistant.components.hyperion
-semver==2.13.0
 
 # homeassistant.components.sendgrid
 sendgrid==6.4.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -790,7 +790,7 @@ huawei-lte-api==1.4.12
 hydrawiser==0.2
 
 # homeassistant.components.hyperion
-hyperion-py==0.4.2
+hyperion-py==0.5.0
 
 # homeassistant.components.bh1750
 # homeassistant.components.bme280
@@ -1991,6 +1991,9 @@ schiene==0.23
 
 # homeassistant.components.scsgate
 scsgate==0.1.0
+
+# homeassistant.components.hyperion
+semver==2.13.0
 
 # homeassistant.components.sendgrid
 sendgrid==6.4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -410,7 +410,7 @@ httplib2==0.10.3
 huawei-lte-api==1.4.12
 
 # homeassistant.components.hyperion
-hyperion-py==0.5.0
+hyperion-py==0.6.0
 
 # homeassistant.components.iaqualink
 iaqualink==0.3.4
@@ -951,9 +951,6 @@ samsungctl[websocket]==0.7.1
 
 # homeassistant.components.samsungtv
 samsungtvws==1.4.0
-
-# homeassistant.components.hyperion
-semver==2.13.0
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -410,7 +410,7 @@ httplib2==0.10.3
 huawei-lte-api==1.4.12
 
 # homeassistant.components.hyperion
-hyperion-py==0.4.2
+hyperion-py==0.5.0
 
 # homeassistant.components.iaqualink
 iaqualink==0.3.4
@@ -951,6 +951,9 @@ samsungctl[websocket]==0.7.1
 
 # homeassistant.components.samsungtv
 samsungtvws==1.4.0
+
+# homeassistant.components.hyperion
+semver==2.13.0
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -20,7 +20,8 @@ TEST_HOST = "test"
 TEST_PORT = const.DEFAULT_PORT_JSON + 1
 TEST_PORT_UI = const.DEFAULT_PORT_UI + 1
 TEST_INSTANCE = 1
-TEST_SERVER_ID = "f9aab089-f85a-55cf-b7c1-222a72faebe9"
+TEST_SYSINFO_ID = "f9aab089-f85a-55cf-b7c1-222a72faebe9"
+TEST_SYSINFO_VERSION = "2.0.0-alpha.8"
 TEST_PRIORITY = 180
 TEST_YAML_NAME = f"{TEST_HOST}_{TEST_PORT}_{TEST_INSTANCE}"
 TEST_YAML_ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_YAML_NAME}"
@@ -88,7 +89,8 @@ def create_mock_client() -> Mock:
         return_value={"command": "authorize-login", "success": True, "tan": 0}
     )
 
-    mock_client.async_id = CoroutineMock(return_value=TEST_SERVER_ID)
+    mock_client.async_sysinfo_id = CoroutineMock(return_value=TEST_SYSINFO_ID)
+    mock_client.async_sysinfo_version = CoroutineMock(return_value=TEST_SYSINFO_ID)
     mock_client.adjustment = None
     mock_client.effects = None
     mock_client.instances = [
@@ -107,8 +109,8 @@ def add_test_config_entry(hass: HomeAssistantType) -> ConfigEntry:
             CONF_HOST: TEST_HOST,
             CONF_PORT: TEST_PORT,
         },
-        title=f"Hyperion {TEST_SERVER_ID}",
-        unique_id=TEST_SERVER_ID,
+        title=f"Hyperion {TEST_SYSINFO_ID}",
+        unique_id=TEST_SYSINFO_ID,
         options=TEST_CONFIG_ENTRY_OPTIONS,
     )
     config_entry.add_to_hass(hass)  # type: ignore[no-untyped-call]

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -31,7 +31,7 @@ from . import (
     TEST_INSTANCE,
     TEST_PORT,
     TEST_PORT_UI,
-    TEST_SERVER_ID,
+    TEST_SYSINFO_ID,
     TEST_TITLE,
     TEST_TOKEN,
     add_test_config_entry,
@@ -82,8 +82,8 @@ TEST_SSDP_SERVICE_INFO = {
     "modelName": "Hyperion",
     "modelNumber": "2.0.0-alpha.8",
     "modelURL": "https://www.hyperion-project.org",
-    "serialNumber": f"{TEST_SERVER_ID}",
-    "UDN": f"uuid:{TEST_SERVER_ID}",
+    "serialNumber": f"{TEST_SYSINFO_ID}",
+    "UDN": f"uuid:{TEST_SYSINFO_ID}",
     "ports": {
         "jsonServer": f"{TEST_PORT}",
         "sslServer": "8092",
@@ -100,7 +100,7 @@ TEST_SSDP_SERVICE_INFO = {
             "url": "img/hyperion/ssdp_icon.png",
         }
     },
-    "ssdp_usn": f"uuid:{TEST_SERVER_ID}",
+    "ssdp_usn": f"uuid:{TEST_SYSINFO_ID}",
     "ssdp_ext": "",
     "ssdp_server": "Raspbian GNU/Linux 10 (buster)/10 UPnP/1.0 Hyperion/2.0.0-alpha.8",
 }
@@ -111,7 +111,7 @@ async def _create_mock_entry(hass: HomeAssistantType) -> MockConfigEntry:
     entry: MockConfigEntry = MockConfigEntry(  # type: ignore[no-untyped-call]
         entry_id=TEST_CONFIG_ENTRY_ID,
         domain=DOMAIN,
-        unique_id=TEST_SERVER_ID,
+        unique_id=TEST_SYSINFO_ID,
         title=TEST_TITLE,
         data={
             "host": TEST_HOST,
@@ -237,7 +237,7 @@ async def test_user_confirm_id_error(hass: HomeAssistantType) -> None:
     result = await _init_flow(hass)
 
     client = create_mock_client()
-    client.async_id = AsyncMock(return_value=None)
+    client.async_sysinfo_id = AsyncMock(return_value=None)
 
     # Confirmation sync_client_connect fails.
     with patch(

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -695,7 +695,7 @@ async def test_version_log_warning(caplog, hass: HomeAssistantType) -> None:
     """Test warning on old version."""
     client = create_mock_client()
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.7")
-    await setup_test_config_entry(hass, client=client)
+    await setup_test_config_entry(hass, hyperion_client=client)
     assert hass.states.get(TEST_ENTITY_ID_1) is not None
     assert any(["Please consider upgrading" in m for _, _, m in caplog.record_tuples])
 
@@ -704,7 +704,7 @@ async def test_version_no_log_warning(caplog, hass: HomeAssistantType) -> None:
     """Test no warning on acceptable version."""
     client = create_mock_client()
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.8")
-    await setup_test_config_entry(hass, client=client)
+    await setup_test_config_entry(hass, hyperion_client=client)
     assert hass.states.get(TEST_ENTITY_ID_1) is not None
     assert not any(
         ["Please consider upgrading" in m for _, _, m in caplog.record_tuples]

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -688,7 +688,7 @@ async def test_unload_entry(hass: HomeAssistantType) -> None:
     assert entry
 
     await hass.config_entries.async_unload(entry.entry_id)
-    assert client.async_client_disconnect.called
+    assert client.async_client_disconnect.call_count == 2
 
 
 async def test_version_log_warning(caplog, hass: HomeAssistantType) -> None:

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -697,7 +697,7 @@ async def test_version_log_warning(caplog, hass: HomeAssistantType) -> None:
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.7")
     await setup_test_config_entry(hass, hyperion_client=client)
     assert hass.states.get(TEST_ENTITY_ID_1) is not None
-    assert any(["Please consider upgrading" in m for _, _, m in caplog.record_tuples])
+    assert "Please consider upgrading" in caplog.text
 
 
 async def test_version_no_log_warning(caplog, hass: HomeAssistantType) -> None:
@@ -706,6 +706,4 @@ async def test_version_no_log_warning(caplog, hass: HomeAssistantType) -> None:
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.8")
     await setup_test_config_entry(hass, hyperion_client=client)
     assert hass.states.get(TEST_ENTITY_ID_1) is not None
-    assert not any(
-        ["Please consider upgrading" in m for _, _, m in caplog.record_tuples]
-    )
+    assert "Please consider upgrading" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a warning if an older Hyperion server is used, encouraging an upgrade.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
