### PR TITLE
Use source-reported names if available in Yamaha

### DIFF
--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -1,6 +1,5 @@
 """The tests for the Yamaha Media player platform."""
 import pytest
-
 import rxv
 
 import homeassistant.components.media_player as mp
@@ -192,6 +191,7 @@ async def test_select_scene(hass, device, main_zone, caplog):
 
 
 async def test_sources(hass, device):
+    """Test that the source list from the device is reported back."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
     await hass.async_block_till_done()
 
@@ -209,6 +209,7 @@ async def test_sources(hass, device):
 
 
 async def test_sources_ignored(hass, device):
+    """Test that sources explicitly ignored are *not* reported back."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG_WITH_IGNORED_SOURCES)
     await hass.async_block_till_done()
 
@@ -226,6 +227,7 @@ async def test_sources_ignored(hass, device):
 
 
 async def test_sources_renamed(hass, device):
+    """Test that sources with an explicit configured alias are reported with it."""
     assert await async_setup_component(hass, mp.DOMAIN, CONFIG_WITH_RENAMED_SOURCES)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
Yamaha receivers report back the source's own name (from CEC) as
"Osdname". If the source has had no explicit alias in the configuration,
use that name to show to the user.

Note that this still doesn't use the input names as configured in the
receiver itself, because the rxv library doesn't expose them (yet).

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Instead of just showing HDMI1/HDMI2/HDMI3/… by default, it's possible to let (some) of the devices announce themselves to the user. For instance, PlayStation 3 and 4 set their CEC name to "PlayStation {N}", which means they can be shown exactly as that.

I would like to also respect the named configuration, but for that I'll have to propose a breaking change to rxv — if that goes through, I'll come back to update this integration.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
