### PR TITLE
Disable legacy templates by default

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1533,7 +1533,7 @@ class Config:
         self.safe_mode: bool = False
 
         # Use legacy template behavior
-        self.legacy_templates: bool = True
+        self.legacy_templates: bool = False
 
     def distance(self, lat: float, lon: float) -> Optional[float]:
         """Calculate distance from Home Assistant.

--- a/tests/common.py
+++ b/tests/common.py
@@ -207,7 +207,6 @@ async def async_test_home_assistant(loop):
     hass.config.units = METRIC_SYSTEM
     hass.config.media_dirs = {"local": get_test_config_dir("media")}
     hass.config.skip_pip = True
-    hass.config.legacy_templates = False
 
     hass.config_entries = config_entries.ConfigEntries(hass, {})
     hass.config_entries._entries = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -906,7 +906,7 @@ def test_config_defaults():
     assert config.allowlist_external_urls == set()
     assert config.media_dirs == {}
     assert config.safe_mode is False
-    assert config.legacy_templates is True
+    assert config.legacy_templates is False
 
 
 def test_config_path_with_file():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This feature was introduced as a opt-in beta feature in Home Assistant Core 0.117, and is now enabled by default.

A template would always result in a string (text). This made it hard to use things like lists, or numbers as a result of a template. For example, returning a list of entities or an RGB/HS/XY color.

This change may impact your existing templates, as templates now can return other types; For example, string, float, integer, boolean, lists or dictionaries.

The following templates can be impacted by this:

- Entities with templated attributes. Attributes keep their native Python type, thus if the attribute is used/processed in a template again later, the type might be different.
- Templates working with lists or mappings (dictionaries). Previously, such collection would be returned as a text, for example [1, 2, 3, 4, 5]. We’ve seen examples where such results are decoded using text processing again (e.g., by splitting the result on a, to get the separate values). The additional processing is no longer needed, as the returned value will be a collection now.
- Note: The entity state in Home Assistant is always a text (string). Even with native types being supported in Templates now if a result is stored as an entity state, they will be converted to a string.

In case this new feature causes a problem for you, you can enable the old-style template rendering again, by setting the following configuration:

```yaml
homeassistant:
  legacy_templates: true
```

Please note, this option is a temporary/transitional option, that will be removed in the future. Adjusting your templates to the new situation is therefore advised.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR enabled the native template types by default, by disabling the legacy template option by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
