### PR TITLE
New methods for input_select component

### DIFF
--- a/homeassistant/components/input_select/services.yaml
+++ b/homeassistant/components/input_select/services.yaml
@@ -4,6 +4,9 @@ select_next:
     entity_id:
       description: Entity id of the input select to select the next value for.
       example: input_select.my_select
+    cycle:
+      description: If the option should cycle from the last to the first (defaults to true).
+      example: true
 select_option:
   description: Select an option of an input select entity.
   fields:
@@ -18,6 +21,21 @@ select_previous:
   fields:
     entity_id:
       description: Entity id of the input select to select the previous value for.
+      example: input_select.my_select
+    cycle:
+      description: If the option should cycle from the first to the last (defaults to true).
+      example: true
+select_first:
+  description: Select the first option of an input select entity.
+  fields:
+    entity_id:
+      description: Entity id of the input select to select the first value for.
+      example: input_select.my_select
+select_last:
+  description: Select the last option of an input select entity.
+  fields:
+    entity_id:
+      description: Entity id of the input select to select the last value for.
       example: input_select.my_select
 set_options:
   description: Set the options of an input select entity.

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -6,6 +6,8 @@ from homeassistant.components.input_select import (
     ATTR_OPTIONS,
     CONF_INITIAL,
     DOMAIN,
+    SERVICE_SELECT_FIRST,
+    SERVICE_SELECT_LAST,
     SERVICE_SELECT_NEXT,
     SERVICE_SELECT_OPTION,
     SERVICE_SELECT_PREVIOUS,
@@ -99,6 +101,32 @@ def select_previous(hass, entity_id):
     hass.async_create_task(
         hass.services.async_call(
             DOMAIN, SERVICE_SELECT_PREVIOUS, {ATTR_ENTITY_ID: entity_id}
+        )
+    )
+
+
+@bind_hass
+def select_first(hass, entity_id):
+    """Set first value of input_select.
+
+    This is a legacy helper method. Do not use it for new tests.
+    """
+    hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN, SERVICE_SELECT_FIRST, {ATTR_ENTITY_ID: entity_id}
+        )
+    )
+
+
+@bind_hass
+def select_last(hass, entity_id):
+    """Set last value of input_select.
+
+    This is a legacy helper method. Do not use it for new tests.
+    """
+    hass.async_create_task(
+        hass.services.async_call(
+            DOMAIN, SERVICE_SELECT_LAST, {ATTR_ENTITY_ID: entity_id}
         )
     )
 
@@ -200,6 +228,38 @@ async def test_select_previous(hass):
     assert "first option" == state.state
 
     select_previous(hass, entity_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert "last option" == state.state
+
+
+async def test_select_first_last(hass):
+    """Test select_first and _last methods."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test_1": {
+                    "options": ["first option", "middle option", "last option"],
+                    "initial": "middle option",
+                }
+            }
+        },
+    )
+    entity_id = "input_select.test_1"
+
+    state = hass.states.get(entity_id)
+    assert "middle option" == state.state
+
+    select_first(hass, entity_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert "first option" == state.state
+
+    select_last(hass, entity_id)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)


### PR DESCRIPTION
This adds a `cycle` attribute to `input_select.next/previous`,
as well as `select_first` and `select_last` services.

This is quite useful for streamlining using `input_select` in
automations, such as when they represent a list of states to step
through; if the first option is the dimmest and the last the brightest,
one may not want to accidentally cycle from the first to the last, for
example.

Similarly, being able to directly select the first or last removes
adjustment in related automations.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15568

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
