### PR TITLE
Add "Live Override" service call to WLED integration

### DIFF
--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -10,6 +10,7 @@ ATTR_FADE = "fade"
 ATTR_IDENTIFIERS = "identifiers"
 ATTR_INTENSITY = "intensity"
 ATTR_LED_COUNT = "led_count"
+ATTR_LIVE = "live"
 ATTR_MANUFACTURER = "manufacturer"
 ATTR_MAX_POWER = "max_power"
 ATTR_MODEL = "model"
@@ -29,4 +30,5 @@ CURRENT_MA = "mA"
 
 # Services
 SERVICE_EFFECT = "effect"
+SERVICE_LIVE = "live"
 SERVICE_PRESET = "preset"

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -33,6 +33,7 @@ from . import WLEDDataUpdateCoordinator, WLEDDeviceEntity, wled_exception_handle
 from .const import (
     ATTR_COLOR_PRIMARY,
     ATTR_INTENSITY,
+    ATTR_LIVE,
     ATTR_ON,
     ATTR_PALETTE,
     ATTR_PLAYLIST,
@@ -42,6 +43,7 @@ from .const import (
     ATTR_SPEED,
     DOMAIN,
     SERVICE_EFFECT,
+    SERVICE_LIVE,
     SERVICE_PRESET,
 )
 
@@ -72,6 +74,16 @@ async def async_setup_entry(
             ),
         },
         "async_effect",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_LIVE,
+        {
+            vol.Required(ATTR_LIVE): vol.All(
+                vol.Coerce(int), vol.Range(min=-1, max=2)
+            ),
+        },
+        "async_live",
     )
 
     platform.async_register_entity_service(
@@ -382,6 +394,16 @@ class WLEDSegmentLight(LightEntity, WLEDDeviceEntity):
             data[ATTR_SPEED] = speed
 
         await self.coordinator.wled.segment(**data)
+
+    @wled_exception_handler
+    async def async_live(
+        self,
+        live: int,
+    ) -> None:
+        """Set the live override status on a WLED light."""
+        data = {ATTR_LIVE: live}
+
+        await self.coordinator.wled.live(**data)
 
     @wled_exception_handler
     async def async_preset(

--- a/homeassistant/components/wled/services.yaml
+++ b/homeassistant/components/wled/services.yaml
@@ -19,6 +19,15 @@ effect:
     reverse:
       description: Reverse the effect. Either true to reverse or false otherwise.
       example: false
+live:
+  description: Sets the live override status on a WLED light
+  fields:
+    entity_id:
+      description: Name of the WLED light entity.
+      example: "light.wled"
+    live:
+      description: 0 is off, 1 is override until live data ends, 2 is override until reboot
+      example: 1
 preset:
   description: Calls a preset on the WLED device
   fields:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a service call to WLED, in conjunction with this PR: https://github.com/frenck/python-wled/pull/186, that allows manually setting the "live override" (i.e. UDP or E1.31 control) status of a WLED light.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to pull request: https://github.com/frenck/python-wled/pull/186
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15567

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
