### PR TITLE
Update nest subscriber to use a service account

### DIFF
--- a/homeassistant/components/nest/api.py
+++ b/homeassistant/components/nest/api.py
@@ -6,11 +6,13 @@ The auth object is used for two use cases:
       This relies on the logic in OAuth2Session to determine if the token is
       valid.  OAuth2Session manages the logic for checking expiration times
       and exchanging a refresh token for a new access token.  This is used when
-      directly talking to the API from the python library.
+      directly talking to the API from the python library, following:
+      https://developers.google.com/nest/device-access/api/authorization#oauth_flow
 
   async_get_creds:
-      This is used for the google pubsub subcriber, which supports its own
-      OAuth token refresh logic in a background thread.
+      This is used for the google pubsub subcsriber.  This uses a service
+      account, which is recommended by the guidance for using Events:
+      https://developers.google.com/nest/device-access/api/events#service_accounts
 """
 
 import logging

--- a/homeassistant/components/nest/api.py
+++ b/homeassistant/components/nest/api.py
@@ -1,10 +1,29 @@
-"""API for Google Nest Device Access bound to Home Assistant OAuth."""
+"""API for Google Nest Device Access bound to Home Assistant OAuth.
+
+The auth object is used for two use cases:
+
+  async_get_access_token:
+      This relies on the logic in OAuth2Session to determine if the token is
+      valid.  OAuth2Session manages the logic for checking expiration times
+      and exchanging a refresh token for a new access token.  This is used when
+      directly talking to the API from the python library.
+
+  async_get_creds:
+      This is used for the google pubsub subcriber, which supports its own
+      OAuth token refresh logic in a background thread.
+"""
+
+import logging
 
 from aiohttp import ClientSession
 from google.oauth2.credentials import Credentials
 from google_nest_sdm.auth import AbstractAuth
 
 from homeassistant.helpers import config_entry_oauth2_flow
+
+from .const import SDM_SCOPES
+
+_LOGGER = logging.getLogger(__name__)
 
 # See https://developers.google.com/nest/device-access/registration
 
@@ -15,12 +34,14 @@ class AsyncConfigEntryAuth(AbstractAuth):
     def __init__(
         self,
         websession: ClientSession,
-        oauth_session: config_entry_oauth2_flow.OAuth2Session,
         api_url: str,
+        oauth_session: config_entry_oauth2_flow.OAuth2Session,
+        local_oauth: config_entry_oauth2_flow.LocalOAuth2Implementation,
     ):
         """Initialize Google Nest Device Access auth."""
         super().__init__(websession, api_url)
         self._oauth_session = oauth_session
+        self._local_oauth = local_oauth
 
     async def async_get_access_token(self):
         """Return a valid access token."""
@@ -30,6 +51,17 @@ class AsyncConfigEntryAuth(AbstractAuth):
         return self._oauth_session.token["access_token"]
 
     async def async_get_creds(self):
-        """Return a minimal OAuth credential."""
-        token = await self.async_get_access_token()
-        return Credentials(token=token)
+        """Return an OAuth credential that supports refresh."""
+        if not self._oauth_session.valid_token:
+            await self._oauth_session.async_ensure_token_valid()
+
+        token = self._oauth_session.token
+        _LOGGER.debug("Credentials for token: %s", token)
+        return Credentials(
+            token=token["access_token"],
+            refresh_token=token["refresh_token"],
+            token_uri=self._local_oauth.token_url,
+            client_id=self._local_oauth.client_id,
+            client_secret=self._local_oauth.client_secret,
+            scopes=tuple(SDM_SCOPES),
+        )

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -12,6 +12,16 @@ from homeassistant.setup import async_setup_component
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
+SERVICE_ACCOUNT_INFO = """
+{
+  "type": "service_account_info",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "client_email": "example@service.iam.gserviceaccount.com",
+  "client_id": "some-client-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\\n-----END PRIVATE KEY-----\\n"
+}
+"""
+
 CONFIG = {
     "nest": {
         "client_id": "some-client-id",
@@ -19,6 +29,7 @@ CONFIG = {
         # Required fields for using SDM API
         "project_id": "some-project-id",
         "subscriber_id": "some-subscriber-id",
+        "subscriber_service_account": SERVICE_ACCOUNT_INFO,
     },
 }
 

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -12,15 +12,13 @@ from homeassistant.setup import async_setup_component
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
-SERVICE_ACCOUNT_INFO = """
-{
-  "type": "service_account_info",
-  "token_uri": "https://oauth2.googleapis.com/token",
-  "client_email": "example@service.iam.gserviceaccount.com",
-  "client_id": "some-client-id",
-  "private_key": "-----BEGIN PRIVATE KEY-----\\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\\n-----END PRIVATE KEY-----\\n"
+SERVICE_ACCOUNT_INFO = {
+    "type": "service_account_info",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "client_email": "example@service.iam.gserviceaccount.com",
+    "client_id": "some-client-id",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\n-----END PRIVATE KEY-----\n",
 }
-"""
 
 CONFIG = {
     "nest": {

--- a/tests/components/nest/test_api.py
+++ b/tests/components/nest/test_api.py
@@ -1,0 +1,22 @@
+"""Tests for the authentication library."""
+
+from homeassistant.components.nest import DATA_NEST_CONFIG, DOMAIN, async_get_auth
+
+from .common import CONFIG_ENTRY_ID, async_setup_sdm_platform
+
+
+async def test_auth_creds(hass):
+    """Tests the authentication library can create creds correctly."""
+    await async_setup_sdm_platform(hass, "")
+    config_entry = hass.config_entries.async_get_entry(CONFIG_ENTRY_ID)
+    auth = await async_get_auth(hass, hass.data[DOMAIN][DATA_NEST_CONFIG], config_entry)
+
+    access_token = await auth.async_get_access_token()
+    assert "some-token" == access_token
+
+    creds = await auth.async_get_creds()
+    assert "some-token" == creds.token
+    assert "some-refresh-token" == creds.refresh_token
+    assert "https://www.googleapis.com/oauth2/v4/token" == creds.token_uri
+    assert "some-client-id" == creds.client_id
+    assert "some-client-secret" == creds.client_secret

--- a/tests/components/nest/test_api.py
+++ b/tests/components/nest/test_api.py
@@ -15,8 +15,4 @@ async def test_auth_creds(hass):
     assert "some-token" == access_token
 
     creds = await auth.async_get_creds()
-    assert "some-token" == creds.token
-    assert "some-refresh-token" == creds.refresh_token
-    assert "https://www.googleapis.com/oauth2/v4/token" == creds.token_uri
-    assert "some-client-id" == creds.client_id
-    assert "some-client-secret" == creds.client_secret
+    assert "example@service.iam.gserviceaccount.com" == creds.service_account_email

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -4,6 +4,8 @@ from homeassistant.components.nest.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
+from .common import SERVICE_ACCOUNT_INFO
+
 from tests.async_mock import patch
 
 CLIENT_ID = "1234"
@@ -23,6 +25,7 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
                 "subscriber_id": SUBSCRIBER_ID,
                 CONF_CLIENT_ID: CLIENT_ID,
                 CONF_CLIENT_SECRET: CLIENT_SECRET,
+                "subscriber_service_account": SERVICE_ACCOUNT_INFO,
             },
             "http": {"base_url": "https://example.com"},
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Existing users of the `nest` SDM API integration will need to perform additional setup to make the Pub/Sub subscriber use a service account.
See [Device Access: Events: Service Accounts](https://developers.google.com/nest/device-access/api/events#service_accounts) for instructions, which basically consist of:

- [Create a service account](https://cloud.google.com/docs/authentication/production#create_service_account)
- Grant a *Pub/Sub Subscriber* role
- Download the service account key json file, and add include it in the configuration variable `subscriber_service_account`.  The simplest way is with `!include example.json`

See additional details in the linked documentation PR.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update `nest` integration Pub/Sub subscriber to use a service account, rather than OAuth credentials.  This is the recommended approach in the [Device Access: Events](https://developers.google.com/nest/device-access/api/events#service_accounts) documentation, and also fixes an issue where the subscriber loses access after 1 hour.

This requires some additional setup as described in the documentation which includes creating a service account and ensuring that it has the correct roles for a Pub/Sub subscriber.

This is considered a breaking change because existing users need to add some additional configuration, though technically, the existing subscriber is already broken after 1 hr.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml entry
nest:
  client_id: CLIENT_ID
  client_secret: CLIENT_SECRET
  project_id: PROJECT_ID   # ("Project ID" in the Device Access Console)
  subscriber_id: SUBSCRIBER_ID # ("Subscription ID" in Google Cloud Console)
  subscriber_service_account: !include SERVICE_ACCOUNT_JSON_FILE
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42947
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15571

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
