### PR TITLE
Upgrade sisyphus-control dependency to 3.0

### DIFF
--- a/homeassistant/components/sisyphus/manifest.json
+++ b/homeassistant/components/sisyphus/manifest.json
@@ -2,6 +2,10 @@
   "domain": "sisyphus",
   "name": "Sisyphus",
   "documentation": "https://www.home-assistant.io/integrations/sisyphus",
-  "requirements": ["sisyphus-control==2.2.1"],
-  "codeowners": ["@jkeljo"]
+  "requirements": [
+    "sisyphus-control==3.0"
+  ],
+  "codeowners": [
+    "@jkeljo"
+  ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2024,7 +2024,7 @@ simplepush==1.1.4
 simplisafe-python==9.6.0
 
 # homeassistant.components.sisyphus
-sisyphus-control==2.2.1
+sisyphus-control==3.0
 
 # homeassistant.components.skybell
 skybellpy==0.6.1


### PR DESCRIPTION
This has a small chance of breaking tables with older firmwares; if your table has issues, make sure it is running at least firmware v1.10.73.

From the release notes for the new version:

[3.0] - 2020-11-08
==================
Added
-----
* Track remaining/total time support (requires recent firmware)
* Test shell program

Changed
-------
* Reworked the data model to match how Sisyphus itself does it. This fixes crashes that were occurring working with tables that have the latest firmware, but may break things with older firmwares.
* Switched to `python-socketio` for Socket.IO support, as it is more actively maintained than `SocketIO-client-nexus`.
* Switched to VSCode for development

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
This release contains updates to improve stability and support newer Sisyphus table firmwares. There is a small chance that older firmwares will have issues with this release; if you have trouble with the Sisyphus integration after this update, make sure your table is running at least firmware 1.10.73.

## Proposed change
Updates the `sisyphus-control` dependency to the latest version, which includes improvements in stability (due to a better SocketIO implementation) and fixes crashes that the previous version encountered when communicating with tables running newer firmware versions.

Release notes: <https://github.com/jkeljo/sisyphus-control/releases/tag/v3.0>

## Type of change
- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
