### PR TITLE
Show media progress in sisyphus

### DIFF
--- a/homeassistant/components/sisyphus/light.py
+++ b/homeassistant/components/sisyphus/light.py
@@ -38,6 +38,10 @@ class SisyphusLight(LightEntity):
         """Add listeners after this object has been initialized."""
         self._table.add_listener(self.async_write_ha_state)
 
+    async def async_update(self):
+        """Force update the table state."""
+        await self._table.refresh()
+
     @property
     def available(self):
         """Return true if the table is responding to heartbeats."""

--- a/homeassistant/components/sisyphus/media_player.py
+++ b/homeassistant/components/sisyphus/media_player.py
@@ -65,6 +65,10 @@ class SisyphusPlayer(MediaPlayerEntity):
         """Add listeners after this object has been initialized."""
         self._table.add_listener(self.async_write_ha_state)
 
+    async def async_update(self):
+        """Force update table state."""
+        await self._table.refresh()
+
     @property
     def unique_id(self):
         """Return the UUID of the table."""
@@ -128,6 +132,24 @@ class SisyphusPlayer(MediaPlayerEntity):
     def media_content_id(self):
         """Return the track ID of the current track."""
         return self._table.active_track.id if self._table.active_track else None
+
+    @property
+    def media_duration(self):
+        """Return the total time it will take to run this track at the current speed."""
+        return self._table.active_track_total_time.total_seconds()
+
+    @property
+    def media_position(self):
+        """Return the current position within the track."""
+        return (
+            self._table.active_track_total_time
+            - self._table.active_track_remaining_time
+        ).total_seconds()
+
+    @property
+    def media_position_updated_at(self):
+        """Return the last time we got a position update."""
+        return self._table.active_track_remaining_time_as_of
 
     @property
     def supported_features(self):


### PR DESCRIPTION
## Proposed change
Adds support for media progress when communicating with a sisyphus table that supports it.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
No changes required to existing configuration

## Additional information
N/A

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
