### PR TITLE
Increase timeout for setup of rfxtrx

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -191,7 +191,11 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
 
     hass.data[DOMAIN][DATA_CLEANUP_CALLBACKS] = []
 
-    await async_setup_internal(hass, entry)
+    try:
+        await async_setup_internal(hass, entry)
+    except ConfigEntryNotReady:
+        # Library currently doesn't support reload
+        return False        
 
     for domain in DOMAINS:
         hass.async_create_task(
@@ -264,7 +268,7 @@ async def async_setup_internal(hass, entry: config_entries.ConfigEntry):
 
     # Initialize library
     try:
-        async with async_timeout.timeout(5):
+        async with async_timeout.timeout(30):
             rfx_object = await hass.async_add_executor_job(_create_rfx, config)
     except asyncio.TimeoutError as err:
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -194,6 +194,7 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
         await async_setup_internal(hass, entry)
     except asyncio.TimeoutError:
         # Library currently doesn't support reload
+        _LOGGER.exception("Connection timeout: failed to receive response from RFXCom device")
         return False
 
     for domain in DOMAINS:

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -193,9 +193,9 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
 
     try:
         await async_setup_internal(hass, entry)
-    except ConfigEntryNotReady:
+    except asyncio.TimeoutError:
         # Library currently doesn't support reload
-        return False        
+        return False
 
     for domain in DOMAINS:
         hass.async_create_task(
@@ -267,11 +267,8 @@ async def async_setup_internal(hass, entry: config_entries.ConfigEntry):
     config = entry.data
 
     # Initialize library
-    try:
-        async with async_timeout.timeout(30):
-            rfx_object = await hass.async_add_executor_job(_create_rfx, config)
-    except asyncio.TimeoutError as err:
-        raise ConfigEntryNotReady from err
+    async with async_timeout.timeout(30):
+        rfx_object = await hass.async_add_executor_job(_create_rfx, config)
 
     # Setup some per device config
     devices = _get_device_lookup(config[CONF_DEVICES])

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -194,7 +194,7 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
         await async_setup_internal(hass, entry)
     except asyncio.TimeoutError:
         # Library currently doesn't support reload
-        _LOGGER.exception(
+        _LOGGER.error(
             "Connection timeout: failed to receive response from RFXtrx device"
         )
         return False

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -194,7 +194,9 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
         await async_setup_internal(hass, entry)
     except asyncio.TimeoutError:
         # Library currently doesn't support reload
-        _LOGGER.exception("Connection timeout: failed to receive response from RFXtrx device")
+        _LOGGER.exception(
+            "Connection timeout: failed to receive response from RFXtrx device"
+        )
         return False
 
     for domain in DOMAINS:

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -194,7 +194,7 @@ async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
         await async_setup_internal(hass, entry)
     except asyncio.TimeoutError:
         # Library currently doesn't support reload
-        _LOGGER.exception("Connection timeout: failed to receive response from RFXCom device")
+        _LOGGER.exception("Connection timeout: failed to receive response from RFXtrx device")
         return False
 
     for domain in DOMAINS:

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -36,7 +36,6 @@ from homeassistant.const import (
     VOLT,
 )
 from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Increases timeout on connect from 5 to 30 seconds. Also disable for the time being reload, because the library doesn't cleanup resources. This will make it impossible to reload without restarting HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42687
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
