### PR TITLE
Change Plugwise integration to plugwise module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -336,7 +336,7 @@ homeassistant/components/pi_hole/* @fabaff @johnluetke @shenxn
 homeassistant/components/pilight/* @trekky12
 homeassistant/components/plaato/* @JohNan
 homeassistant/components/plex/* @jjlawren
-homeassistant/components/plugwise/* @CoMPaTech @bouwew
+homeassistant/components/plugwise/* @CoMPaTech @bouwew @brefra
 homeassistant/components/plum_lightpad/* @ColinHarrington @prystupa
 homeassistant/components/point/* @fredrike
 homeassistant/components/poolsense/* @haemishkyd

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -1,14 +1,12 @@
 """Plugwise platform for Home Assistant Core."""
-import asyncio
-
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .const import ALL_PLATFORMS, DOMAIN, UNDO_UPDATE_LISTENER
-from .gateway import async_setup_entry_gw
+from .const import DOMAIN
+from .gateway import async_setup_entry_gw, async_unload_entry_gw
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -27,19 +25,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in ALL_PLATFORMS
-            ]
-        )
-    )
-
-    hass.data[DOMAIN][entry.entry_id][UNDO_UPDATE_LISTENER]()
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    """Unload the Plugwise components."""
+    if entry.data.get(CONF_HOST):
+        return await async_unload_entry_gw(hass, entry)
+    # PLACEHOLDER USB entry setup
+    return False

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -1,14 +1,10 @@
 """Plugwise platform for Home Assistant Core."""
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
 from .gateway import async_setup_entry_gw, async_unload_entry_gw
-
-CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from Plugwise_Smile.Smile import Smile
+from plugwise.exceptions import PlugwiseException
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
@@ -192,7 +192,7 @@ class PwThermostat(SmileGateway, ClimateEntity):
                 await self._api.set_temperature(self._loc_id, temperature)
                 self._setpoint = temperature
                 self.async_write_ha_state()
-            except Smile.PlugwiseError:
+            except PlugwiseException:
                 _LOGGER.error("Error while communicating to device")
         else:
             _LOGGER.error("Invalid temperature requested")
@@ -205,7 +205,7 @@ class PwThermostat(SmileGateway, ClimateEntity):
             try:
                 await self._api.set_temperature(self._loc_id, self._schedule_temp)
                 self._setpoint = self._schedule_temp
-            except Smile.PlugwiseError:
+            except PlugwiseException:
                 _LOGGER.error("Error while communicating to device")
         try:
             await self._api.set_schedule_state(
@@ -213,7 +213,7 @@ class PwThermostat(SmileGateway, ClimateEntity):
             )
             self._hvac_mode = hvac_mode
             self.async_write_ha_state()
-        except Smile.PlugwiseError:
+        except PlugwiseException:
             _LOGGER.error("Error while communicating to device")
 
     async def async_set_preset_mode(self, preset_mode):
@@ -223,7 +223,7 @@ class PwThermostat(SmileGateway, ClimateEntity):
             self._preset_mode = preset_mode
             self._setpoint = self._presets.get(self._preset_mode, "none")[0]
             self.async_write_ha_state()
-        except Smile.PlugwiseError:
+        except PlugwiseException:
             _LOGGER.error("Error while communicating to device")
 
     @callback

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -1,7 +1,8 @@
 """Config flow for Plugwise integration."""
 import logging
 
-from Plugwise_Smile.Smile import Smile
+from plugwise.exceptions import InvalidAuthentication, PlugwiseException
+from plugwise.smile import Smile
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
@@ -67,9 +68,9 @@ async def validate_gw_input(hass: core.HomeAssistant, data):
 
     try:
         await api.connect()
-    except Smile.InvalidAuthentication as err:
+    except InvalidAuthentication as err:
         raise InvalidAuth from err
-    except Smile.PlugwiseError as err:
+    except PlugwiseException as err:
         raise CannotConnect from err
 
     return api

--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -2,7 +2,9 @@
 DOMAIN = "plugwise"
 
 SENSOR_PLATFORMS = ["sensor", "switch"]
-ALL_PLATFORMS = ["binary_sensor", "climate", "sensor", "switch"]
+PLATFORMS_GATEWAY = ["binary_sensor", "climate", "sensor", "switch"]
+PW_TYPE = "plugwise_type"
+GATEWAY = "gateway"
 
 # Sensor mapping
 SENSOR_MAP_DEVICE_CLASS = 2

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,8 +2,8 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["Plugwise_Smile==1.6.0"],
-  "codeowners": ["@CoMPaTech", "@bouwew"],
+  "requirements": ["plugwise==0.8.1"],
+  "codeowners": ["@CoMPaTech", "@bouwew", "@brefra"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true
 }

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["plugwise==0.8.1"],
+  "requirements": ["plugwise==0.8.3"],
   "codeowners": ["@CoMPaTech", "@bouwew", "@brefra"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from Plugwise_Smile.Smile import Smile
+from plugwise.exceptions import PlugwiseException
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
@@ -14,6 +14,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Smile switches from a config entry."""
+    # PLACEHOLDER USB entry setup
+    return await async_setup_entry_gateway(hass, config_entry, async_add_entities)
+
+
+async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
     """Set up the Smile switches from a config entry."""
     api = hass.data[DOMAIN][config_entry.entry_id]["api"]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
@@ -37,7 +43,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 model = "Switch Group"
 
             entities.append(
-                PwSwitch(
+                GwSwitch(
                     api, coordinator, device_properties["name"], dev_id, members, model
                 )
             )
@@ -45,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(entities, True)
 
 
-class PwSwitch(SmileGateway, SwitchEntity):
+class GwSwitch(SmileGateway, SwitchEntity):
     """Representation of a Plugwise plug."""
 
     def __init__(self, api, coordinator, name, dev_id, members, model):
@@ -79,7 +85,7 @@ class PwSwitch(SmileGateway, SwitchEntity):
             if state_on:
                 self._is_on = True
                 self.async_write_ha_state()
-        except Smile.PlugwiseError:
+        except PlugwiseException:
             _LOGGER.error("Error while communicating to device")
 
     async def async_turn_off(self, **kwargs):
@@ -91,7 +97,7 @@ class PwSwitch(SmileGateway, SwitchEntity):
             if state_off:
                 self._is_on = False
                 self.async_write_ha_state()
-        except Smile.PlugwiseError:
+        except PlugwiseException:
             _LOGGER.error("Error while communicating to device")
 
     @callback

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1137,7 +1137,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.12
 
 # homeassistant.components.plugwise
-plugwise==0.8.1
+plugwise==0.8.3
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -25,9 +25,6 @@ Mastodon.py==1.5.1
 # homeassistant.components.orangepi_gpio
 OPi.GPIO==0.4.0
 
-# homeassistant.components.plugwise
-Plugwise_Smile==1.6.0
-
 # homeassistant.components.essent
 PyEssent==0.14
 
@@ -1138,6 +1135,9 @@ plexauth==0.0.6
 
 # homeassistant.components.plex
 plexwebsocket==0.0.12
+
+# homeassistant.components.plugwise
+plugwise==0.8.1
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -6,9 +6,6 @@
 # homeassistant.components.homekit
 HAP-python==3.0.0
 
-# homeassistant.components.plugwise
-Plugwise_Smile==1.6.0
-
 # homeassistant.components.flick_electric
 PyFlick==0.0.2
 
@@ -561,6 +558,9 @@ plexauth==0.0.6
 
 # homeassistant.components.plex
 plexwebsocket==0.0.12
+
+# homeassistant.components.plugwise
+plugwise==0.8.1
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -560,7 +560,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.12
 
 # homeassistant.components.plugwise
-plugwise==0.8.1
+plugwise==0.8.3
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/tests/components/plugwise/common.py
+++ b/tests/components/plugwise/common.py
@@ -1,6 +1,6 @@
 """Common initialisation for the Plugwise integration."""
 
-from homeassistant.components.plugwise import DOMAIN
+from homeassistant.components.plugwise.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -3,8 +3,13 @@
 from functools import partial
 import re
 
-from Plugwise_Smile.Smile import Smile
 import jsonpickle
+from plugwise.exceptions import (
+    ConnectionFailedError,
+    InvalidAuthentication,
+    PlugwiseException,
+    XMLDataMissingError,
+)
 import pytest
 
 from tests.async_mock import AsyncMock, Mock, patch
@@ -24,8 +29,8 @@ def mock_smile():
     with patch(
         "homeassistant.components.plugwise.config_flow.Smile",
     ) as smile_mock:
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.ConnectionFailedError = ConnectionFailedError
         smile_mock.return_value.connect.return_value = True
         yield smile_mock.return_value
 
@@ -48,9 +53,9 @@ def mock_smile_error(aioclient_mock: AiohttpClientMocker) -> None:
 def mock_smile_notconnect():
     """Mock the Plugwise Smile general connection failure for Home Assistant."""
     with patch("homeassistant.components.plugwise.gateway.Smile") as smile_mock:
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
-        smile_mock.PlugwiseError = Smile.PlugwiseError
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.ConnectionFailedError = ConnectionFailedError
+        smile_mock.PlugwiseException = PlugwiseException
         smile_mock.return_value.connect.side_effect = AsyncMock(return_value=False)
         yield smile_mock.return_value
 
@@ -65,9 +70,9 @@ def mock_smile_adam():
     """Create a Mock Adam environment for testing exceptions."""
     chosen_env = "adam_multiple_devices_per_zone"
     with patch("homeassistant.components.plugwise.gateway.Smile") as smile_mock:
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
-        smile_mock.XMLDataMissingError = Smile.XMLDataMissingError
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.ConnectionFailedError = ConnectionFailedError
+        smile_mock.XMLDataMissingError = XMLDataMissingError
 
         smile_mock.return_value.gateway_id = "fe799307f1624099878210aa0b9f1475"
         smile_mock.return_value.heater_id = "90986d591dcd426cae3ec3e8111ff730"
@@ -110,9 +115,9 @@ def mock_smile_anna():
     """Create a Mock Anna environment for testing exceptions."""
     chosen_env = "anna_heatpump"
     with patch("homeassistant.components.plugwise.gateway.Smile") as smile_mock:
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
-        smile_mock.XMLDataMissingError = Smile.XMLDataMissingError
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.ConnectionFailedError = ConnectionFailedError
+        smile_mock.XMLDataMissingError = XMLDataMissingError
 
         smile_mock.return_value.gateway_id = "015ae9ea3f964e668e490fa39da3870b"
         smile_mock.return_value.heater_id = "1cbf783bb11e4a7c8a6843dee3a86927"
@@ -155,9 +160,9 @@ def mock_smile_p1():
     """Create a Mock P1 DSMR environment for testing exceptions."""
     chosen_env = "p1v3_full_option"
     with patch("homeassistant.components.plugwise.gateway.Smile") as smile_mock:
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
-        smile_mock.XMLDataMissingError = Smile.XMLDataMissingError
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.ConnectionFailedError = ConnectionFailedError
+        smile_mock.XMLDataMissingError = XMLDataMissingError
 
         smile_mock.return_value.gateway_id = "e950c7d5e1ee407a858e2a8b5016c8b3"
         smile_mock.return_value.heater_id = None
@@ -191,9 +196,9 @@ def mock_stretch():
     """Create a Mock Stretch environment for testing exceptions."""
     chosen_env = "stretch_v31"
     with patch("homeassistant.components.plugwise.gateway.Smile") as smile_mock:
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
-        smile_mock.XMLDataMissingError = Smile.XMLDataMissingError
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.ConnectionFailedError = ConnectionFailedError
+        smile_mock.XMLDataMissingError = XMLDataMissingError
 
         smile_mock.return_value.gateway_id = "259882df3c05415b99c2d962534ce820"
         smile_mock.return_value.heater_id = None

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -1,5 +1,7 @@
 """Tests for the Plugwise Climate integration."""
 
+from plugwise.exceptions import PlugwiseException
+
 from homeassistant.config_entries import ENTRY_STATE_LOADED
 
 from tests.components.plugwise.common import async_init_integration
@@ -38,6 +40,34 @@ async def test_adam_climate_entity_attributes(hass, mock_smile_adam):
     assert attrs["current_temperature"] == 17.2
     assert attrs["temperature"] == 15.0
 
+    assert attrs["preset_mode"] == "asleep"
+
+
+async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
+    """Test exceptions of climate entities."""
+    mock_smile_adam.set_temperature.side_effect = PlugwiseException
+    mock_smile_adam.set_preset.side_effect = PlugwiseException
+    entry = await async_init_integration(hass, mock_smile_adam)
+    assert entry.state == ENTRY_STATE_LOADED
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": "climate.zone_lisa_wk", "temperature": 25},
+        blocking=True,
+    )
+    state = hass.states.get("climate.zone_lisa_wk")
+    attrs = state.attributes
+    assert attrs["temperature"] == 21.5
+
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": "climate.zone_thermostat_jessie", "preset_mode": "home"},
+        blocking=True,
+    )
+    state = hass.states.get("climate.zone_thermostat_jessie")
+    attrs = state.attributes
     assert attrs["preset_mode"] == "asleep"
 
 

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -44,7 +44,7 @@ async def test_adam_climate_entity_attributes(hass, mock_smile_adam):
     assert attrs["preset_mode"] == "asleep"
 
 
-async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
+async def test_adam_climate_adjust_negative_testing(hass, mock_smile_adam):
     """Test exceptions of climate entities."""
     mock_smile_adam.set_preset.side_effect = PlugwiseException
     mock_smile_adam.set_schedule_state.side_effect = PlugwiseException

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -1,5 +1,9 @@
 """Test the Plugwise config flow."""
-from Plugwise_Smile.Smile import Smile
+from plugwise.exceptions import (
+    ConnectionFailedError,
+    InvalidAuthentication,
+    PlugwiseException,
+)
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, setup
@@ -47,9 +51,9 @@ def mock_smile():
     with patch(
         "homeassistant.components.plugwise.config_flow.Smile",
     ) as smile_mock:
-        smile_mock.PlugwiseError = Smile.PlugwiseError
-        smile_mock.InvalidAuthentication = Smile.InvalidAuthentication
-        smile_mock.ConnectionFailedError = Smile.ConnectionFailedError
+        smile_mock.PlugwiseError = PlugwiseException
+        smile_mock.InvalidAuthentication = InvalidAuthentication
+        smile_mock.ConnectionFailedError = ConnectionFailedError
         smile_mock.return_value.connect.return_value = True
         yield smile_mock.return_value
 
@@ -207,7 +211,7 @@ async def test_form_invalid_auth(hass, mock_smile):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_smile.connect.side_effect = Smile.InvalidAuthentication
+    mock_smile.connect.side_effect = InvalidAuthentication
     mock_smile.gateway_id = "0a636a4fc1704ab4a24e4f7e37fb187a"
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -225,7 +229,7 @@ async def test_form_cannot_connect(hass, mock_smile):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_smile.connect.side_effect = Smile.ConnectionFailedError
+    mock_smile.connect.side_effect = ConnectionFailedError
     mock_smile.gateway_id = "0a636a4fc1704ab4a24e4f7e37fb187a"
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -243,7 +247,7 @@ async def test_form_cannot_connect_port(hass, mock_smile):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_smile.connect.side_effect = Smile.ConnectionFailedError
+    mock_smile.connect.side_effect = ConnectionFailedError
     mock_smile.gateway_id = "0a636a4fc1704ab4a24e4f7e37fb187a"
 
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -5,7 +5,6 @@ import asyncio
 from plugwise.exceptions import XMLDataMissingError
 
 from homeassistant.components.plugwise.const import DOMAIN
-from homeassistant.components.plugwise.gateway import async_unload_entry_gw
 from homeassistant.config_entries import (
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_ERROR,

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -2,9 +2,10 @@
 
 import asyncio
 
-from Plugwise_Smile.Smile import Smile
+from plugwise.exceptions import XMLDataMissingError
 
 from homeassistant.components.plugwise import DOMAIN
+from homeassistant.components.plugwise.gateway import async_unload_entry_gw
 from homeassistant.config_entries import (
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_ERROR,
@@ -43,7 +44,7 @@ async def test_smile_timeout(hass, mock_smile_notconnect):
 
 async def test_smile_adam_xmlerror(hass, mock_smile_adam):
     """Detect malformed XML by Smile in Adam environment."""
-    mock_smile_adam.full_update_device.side_effect = Smile.XMLDataMissingError
+    mock_smile_adam.full_update_device.side_effect = XMLDataMissingError
     entry = await async_init_integration(hass, mock_smile_adam)
     assert entry.state == ENTRY_STATE_SETUP_RETRY
 

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -4,7 +4,7 @@ import asyncio
 
 from plugwise.exceptions import XMLDataMissingError
 
-from homeassistant.components.plugwise import DOMAIN
+from homeassistant.components.plugwise.const import DOMAIN
 from homeassistant.components.plugwise.gateway import async_unload_entry_gw
 from homeassistant.config_entries import (
     ENTRY_STATE_NOT_LOADED,

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -1,5 +1,7 @@
 """Tests for the Plugwise switch integration."""
 
+from plugwise.exceptions import PlugwiseException
+
 from homeassistant.config_entries import ENTRY_STATE_LOADED
 
 from tests.components.plugwise.common import async_init_integration
@@ -13,6 +15,31 @@ async def test_adam_climate_switch_entities(hass, mock_smile_adam):
     state = hass.states.get("switch.cv_pomp")
     assert str(state.state) == "on"
 
+    state = hass.states.get("switch.fibaro_hc2")
+    assert str(state.state) == "on"
+
+
+async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
+    """Test exceptions of climate related switch entities."""
+    mock_smile_adam.set_relay_state.side_effect = PlugwiseException
+    entry = await async_init_integration(hass, mock_smile_adam)
+    assert entry.state == ENTRY_STATE_LOADED
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.cv_pomp"},
+        blocking=True,
+    )
+    state = hass.states.get("switch.cv_pomp")
+    assert str(state.state) == "on"
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.fibaro_hc2"},
+        blocking=True,
+    )
     state = hass.states.get("switch.fibaro_hc2")
     assert str(state.state) == "on"
 


### PR DESCRIPTION
## Proposed change
Final changes before we can draft the successor of #35713 - Some background to this PR. As requested in #35713 we joined forces but as a team decided to not only merge the HA-code but also our module! As such this PR swaps `Plugwise_Smile` for `plugwise`. To keep changes to a minimum this PR only adjusts the current integration for usage of the new module.

 - [Changelog of the new module](https://github.com/plugwise/python-plugwise/blob/main/CHANGELOG.md) (including predecessors)
 - Dependency (as per above) switched from lxml to defusedxml (improving security)
 - Final plumbing/placeholders for USB integration
 - Adding new tests (exceptions changed due to the merged new module, upsetting codecov - so tests specifically for the renamed exceptions were added).
 - Adding @brefra to CODEOWNERS

For reviewers, to clarify why we use `async_setup_entry` as a wrapper in `switch.py` will default to the current workings unless `PW_TYPE` is set to USB. (Hence the placeholder stub).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #35713
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.
