### PR TITLE
Decrease request volume in nsw fuel

### DIFF
--- a/homeassistant/components/nsw_fuel_station/__init__.py
+++ b/homeassistant/components/nsw_fuel_station/__init__.py
@@ -1,5 +1,6 @@
 """The nsw_fuel_station component."""
 import logging
+from typing import Optional
 
 from nsw_fuel import FuelCheckClient, FuelCheckError
 
@@ -15,46 +16,53 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup(hass, config):
     client = FuelCheckClient()
+    fuel_check_data = FuelCheckData(client)
+    fuel_check_data.update()
 
-    reference_data = SharedReferenceData(client)
-    reference_data.update()
-
-    hass.data[DATA_NSW_FUEL_STATION] = {
-        DATA_ATTR_CLIENT: client,
-        DATA_ATTR_REFERENCE_DATA: reference_data,
-    }
+    hass.data[DATA_NSW_FUEL_STATION] = fuel_check_data
 
     return True
 
 
-class SharedReferenceData():
+class FuelCheckData:
     def __init__(self, client: FuelCheckClient):
+        """An object to fetch and cache the latest fuel check data."""
         self._client = client
-        self._data = None
+        self._stations = None
+        self._prices = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        if self._data is None:
-            try:
-                self._data = self._client.get_reference_data()
-            except FuelCheckError as exc:
-                _LOGGER.error(
-                    "Failed to fetch NSW Fuel station reference data. %s", exc
-                )
-                return
-
-    def get_station_name(self, station_id: int) -> str:
-        """Return the name of the station."""
-        name = None
-        if self._data is not None:
-            name = next(
-                (
-                    station.name
-                    for station in self._data.stations
-                    if station.code == station_id
-                ),
-                None,
+        """Update the internal data using the API client."""
+        try:
+            raw_price_data = self._client.get_fuel_prices()
+            # Store prices and station details indexed by station code for
+            # O(1) lookup
+            self._stations = {s.code: s for s in raw_price_data.stations}
+            self._prices = {(str(p.station_code), p.fuel_type): p.price for p
+                            in
+                            raw_price_data.prices}
+        except FuelCheckError as exc:
+            _LOGGER.error(
+                "Failed to fetch NSW Fuel station price data. %s", exc
             )
+            return
 
-        return name or f"station {station_id}"
+    def get_fuel_price(self, station_code: int, fuel_type: str) -> Optional[
+        float]:
+        """Return the price of the given fuel type."""
+        if self._prices is None:
+            return None
 
+        return self._prices.get((str(station_code), fuel_type))
+
+    def get_station_name(self, station_code: int) -> str:
+        """Return the name of the station for a given station code."""
+
+        name = None
+        if self._stations:
+            station_info = self._stations.get(station_code)
+            if station_info:
+                name = station_info.name
+
+        return name or f"station {station_code}"

--- a/homeassistant/components/nsw_fuel_station/__init__.py
+++ b/homeassistant/components/nsw_fuel_station/__init__.py
@@ -1,4 +1,5 @@
 """The nsw_fuel_station component."""
+import datetime
 import logging
 from typing import Optional
 
@@ -6,15 +7,13 @@ from nsw_fuel import FuelCheckClient, FuelCheckError
 
 from homeassistant.components.nsw_fuel_station.const import (
     DATA_NSW_FUEL_STATION,
-    MIN_TIME_BETWEEN_UPDATES,
-    DATA_ATTR_CLIENT,
-    DATA_ATTR_REFERENCE_DATA,
 )
 from homeassistant.util import Throttle
 
-DOMAIN = "nsw_fuel_station"
-
 _LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "nsw_fuel_station"
+MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(hours=1)
 
 
 def setup(hass, config):

--- a/homeassistant/components/nsw_fuel_station/__init__.py
+++ b/homeassistant/components/nsw_fuel_station/__init__.py
@@ -15,6 +15,7 @@ MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(hours=1)
 
 
 def setup(hass, config):
+    """Set up the NSW Fuel Station platform."""
     client = FuelCheckClient()
     fuel_check_data = FuelCheckData(client)
     fuel_check_data.update()
@@ -25,15 +26,17 @@ def setup(hass, config):
 
 
 class FuelCheckData:
+    """An object to fetch and cache the latest fuel check data."""
+
     def __init__(self, client: FuelCheckClient):
-        """An object to fetch and cache the latest fuel check data."""
+        """Initialize the shared data cache."""
         self._client = client
         self._stations = None
         self._prices = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Update the internal data using the API client."""
+        """Updates the internal data using the API client."""
         try:
             raw_price_data = self._client.get_fuel_prices()
             # Store prices and station details indexed by station code for

--- a/homeassistant/components/nsw_fuel_station/__init__.py
+++ b/homeassistant/components/nsw_fuel_station/__init__.py
@@ -1,1 +1,60 @@
 """The nsw_fuel_station component."""
+import logging
+
+from nsw_fuel import FuelCheckClient, FuelCheckError
+
+from homeassistant.components.nsw_fuel_station.const import (
+    DATA_NSW_FUEL_STATION, MIN_TIME_BETWEEN_UPDATES, DATA_ATTR_CLIENT,
+    DATA_ATTR_REFERENCE_DATA)
+from homeassistant.util import Throttle
+
+DOMAIN = "nsw_fuel_station"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup(hass, config):
+    client = FuelCheckClient()
+
+    reference_data = SharedReferenceData(client)
+    reference_data.update()
+
+    hass.data[DATA_NSW_FUEL_STATION] = {
+        DATA_ATTR_CLIENT: client,
+        DATA_ATTR_REFERENCE_DATA: reference_data,
+    }
+
+    return True
+
+
+class SharedReferenceData():
+    def __init__(self, client: FuelCheckClient):
+        self._client = client
+        self._data = None
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        if self._data is None:
+            try:
+                self._data = self._client.get_reference_data()
+            except FuelCheckError as exc:
+                _LOGGER.error(
+                    "Failed to fetch NSW Fuel station reference data. %s", exc
+                )
+                return
+
+    def get_station_name(self, station_id: int) -> str:
+        """Return the name of the station."""
+        name = None
+        if self._data is not None:
+            name = next(
+                (
+                    station.name
+                    for station in self._data.stations
+                    if station.code == station_id
+                ),
+                None,
+            )
+
+        return name or f"station {station_id}"
+

--- a/homeassistant/components/nsw_fuel_station/__init__.py
+++ b/homeassistant/components/nsw_fuel_station/__init__.py
@@ -5,9 +5,7 @@ from typing import Optional
 
 from nsw_fuel import FuelCheckClient, FuelCheckError
 
-from homeassistant.components.nsw_fuel_station.const import (
-    DATA_NSW_FUEL_STATION,
-)
+from homeassistant.components.nsw_fuel_station.const import DATA_NSW_FUEL_STATION
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/nsw_fuel_station/__init__.py
+++ b/homeassistant/components/nsw_fuel_station/__init__.py
@@ -5,8 +5,11 @@ from typing import Optional
 from nsw_fuel import FuelCheckClient, FuelCheckError
 
 from homeassistant.components.nsw_fuel_station.const import (
-    DATA_NSW_FUEL_STATION, MIN_TIME_BETWEEN_UPDATES, DATA_ATTR_CLIENT,
-    DATA_ATTR_REFERENCE_DATA)
+    DATA_NSW_FUEL_STATION,
+    MIN_TIME_BETWEEN_UPDATES,
+    DATA_ATTR_CLIENT,
+    DATA_ATTR_REFERENCE_DATA,
+)
 from homeassistant.util import Throttle
 
 DOMAIN = "nsw_fuel_station"
@@ -39,17 +42,15 @@ class FuelCheckData:
             # Store prices and station details indexed by station code for
             # O(1) lookup
             self._stations = {s.code: s for s in raw_price_data.stations}
-            self._prices = {(str(p.station_code), p.fuel_type): p.price for p
-                            in
-                            raw_price_data.prices}
+            self._prices = {
+                (str(p.station_code), p.fuel_type): p.price
+                for p in raw_price_data.prices
+            }
         except FuelCheckError as exc:
-            _LOGGER.error(
-                "Failed to fetch NSW Fuel station price data. %s", exc
-            )
+            _LOGGER.error("Failed to fetch NSW Fuel station price data. %s", exc)
             return
 
-    def get_fuel_price(self, station_code: int, fuel_type: str) -> Optional[
-        float]:
+    def get_fuel_price(self, station_code: int, fuel_type: str) -> Optional[float]:
         """Return the price of the given fuel type."""
         if self._prices is None:
             return None

--- a/homeassistant/components/nsw_fuel_station/__init__.py
+++ b/homeassistant/components/nsw_fuel_station/__init__.py
@@ -36,7 +36,7 @@ class FuelCheckData:
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Updates the internal data using the API client."""
+        """Fetch updated data using the API client."""
         try:
             raw_price_data = self._client.get_fuel_prices()
             # Store prices and station details indexed by station code for

--- a/homeassistant/components/nsw_fuel_station/const.py
+++ b/homeassistant/components/nsw_fuel_station/const.py
@@ -1,0 +1,6 @@
+import datetime
+
+DATA_NSW_FUEL_STATION = "nsw_fuel_station"
+DATA_ATTR_CLIENT = "client"
+DATA_ATTR_REFERENCE_DATA = "reference_data"
+MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(hours=1)

--- a/homeassistant/components/nsw_fuel_station/const.py
+++ b/homeassistant/components/nsw_fuel_station/const.py
@@ -1,1 +1,3 @@
+"""Constants for the NSW Fuel Station integration."""
+
 DATA_NSW_FUEL_STATION = "nsw_fuel_station"

--- a/homeassistant/components/nsw_fuel_station/const.py
+++ b/homeassistant/components/nsw_fuel_station/const.py
@@ -1,6 +1,1 @@
-import datetime
-
 DATA_NSW_FUEL_STATION = "nsw_fuel_station"
-DATA_ATTR_CLIENT = "client"
-DATA_ATTR_REFERENCE_DATA = "reference_data"
-MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(hours=1)

--- a/homeassistant/components/nsw_fuel_station/sensor.py
+++ b/homeassistant/components/nsw_fuel_station/sensor.py
@@ -3,17 +3,14 @@ import logging
 from typing import Optional
 
 import voluptuous as vol
-from nsw_fuel import FuelCheckError, FuelCheckClient
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.nsw_fuel_station import (
     DATA_NSW_FUEL_STATION,
-    DATA_ATTR_CLIENT, DATA_ATTR_REFERENCE_DATA, SharedReferenceData,
-    MIN_TIME_BETWEEN_UPDATES)
+    FuelCheckData)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CURRENCY_CENT, VOLUME_LITERS
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,81 +51,41 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     station_id = config[CONF_STATION_ID]
     fuel_types = config[CONF_FUEL_TYPES]
 
-    client = hass.data[DATA_NSW_FUEL_STATION][DATA_ATTR_CLIENT]
-    reference_data = hass.data[DATA_NSW_FUEL_STATION][DATA_ATTR_REFERENCE_DATA]
-
-    station_data = StationPriceData(client, station_id)
-    station_data.update()
+    fuel_check_data = hass.data[DATA_NSW_FUEL_STATION]
 
     add_entities(
-        [StationPriceSensor(station_id, reference_data, station_data,
-                            fuel_type) for
+        [StationPriceSensor(fuel_check_data, station_id, fuel_type) for
          fuel_type in fuel_types])
-
-
-class StationPriceData:
-    """An object to store and fetch the latest data for a given station."""
-
-    def __init__(self, client: FuelCheckClient, station_id: int) -> None:
-        """Initialize the sensor."""
-        self._station_id = station_id
-        self._client = client
-        self._data = None
-
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
-        """Update the internal data using the API client."""
-        try:
-            self._data = self._client.get_fuel_prices_for_station(
-                self._station_id)
-        except FuelCheckError as exc:
-            _LOGGER.error("Failed to fetch NSW Fuel station price data. %s", exc)
-
-    def for_fuel_type(self, fuel_type: str):
-        """Return the price of the given fuel type."""
-        if self._data is None:
-            return None
-        return next(
-            (price for price in self._data if price.fuel_type == fuel_type), None
-        )
-
-    def get_available_fuel_types(self):
-        """Return the available fuel types for the station."""
-        return [price.fuel_type for price in self._data]
 
 
 class StationPriceSensor(Entity):
     """Implementation of a sensor that reports the fuel price for a station."""
 
-    def __init__(self, station_id: int, reference_data: SharedReferenceData,
-                 station_data: StationPriceData, fuel_type: str):
+    def __init__(self, fuel_check_data: FuelCheckData, station_id: int,
+                 fuel_type: str):
         """Initialize the sensor."""
         self._station_id = station_id
-        self._reference_data = reference_data
-        self._station_data = station_data
         self._fuel_type = fuel_type
+        self._fuel_check_data = fuel_check_data
 
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        station_name = self._reference_data.get_station_name(self._station_id)
+        station_name = self._fuel_check_data.get_station_name(self._station_id)
         return f"{station_name} {self._fuel_type}"
 
     @property
     def state(self) -> Optional[float]:
         """Return the state of the sensor."""
-        price_info = self._station_data.for_fuel_type(self._fuel_type)
-        if price_info:
-            return price_info.price
-
-        return None
+        return self._fuel_check_data.get_fuel_price(
+            self._station_id, self._fuel_type)
 
     @property
     def device_state_attributes(self) -> dict:
         """Return the state attributes of the device."""
         return {
             ATTR_STATION_ID: self._station_id,
-            ATTR_STATION_NAME: self._reference_data.get_station_name(
+            ATTR_STATION_NAME: self._fuel_check_data.get_station_name(
                 self._station_id),
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
@@ -140,5 +97,4 @@ class StationPriceSensor(Entity):
 
     def update(self):
         """Update current conditions."""
-        self._reference_data.update()
-        self._station_data.update()
+        self._fuel_check_data.update()

--- a/homeassistant/components/nsw_fuel_station/sensor.py
+++ b/homeassistant/components/nsw_fuel_station/sensor.py
@@ -7,7 +7,8 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.nsw_fuel_station import (
     DATA_NSW_FUEL_STATION,
-    FuelCheckData)
+    FuelCheckData,
+)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CURRENCY_CENT, VOLUME_LITERS
 from homeassistant.helpers.entity import Entity
@@ -54,15 +55,17 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     fuel_check_data = hass.data[DATA_NSW_FUEL_STATION]
 
     add_entities(
-        [StationPriceSensor(fuel_check_data, station_id, fuel_type) for
-         fuel_type in fuel_types])
+        [
+            StationPriceSensor(fuel_check_data, station_id, fuel_type)
+            for fuel_type in fuel_types
+        ]
+    )
 
 
 class StationPriceSensor(Entity):
     """Implementation of a sensor that reports the fuel price for a station."""
 
-    def __init__(self, fuel_check_data: FuelCheckData, station_id: int,
-                 fuel_type: str):
+    def __init__(self, fuel_check_data: FuelCheckData, station_id: int, fuel_type: str):
         """Initialize the sensor."""
         self._station_id = station_id
         self._fuel_type = fuel_type
@@ -77,16 +80,14 @@ class StationPriceSensor(Entity):
     @property
     def state(self) -> Optional[float]:
         """Return the state of the sensor."""
-        return self._fuel_check_data.get_fuel_price(
-            self._station_id, self._fuel_type)
+        return self._fuel_check_data.get_fuel_price(self._station_id, self._fuel_type)
 
     @property
     def device_state_attributes(self) -> dict:
         """Return the state attributes of the device."""
         return {
             ATTR_STATION_ID: self._station_id,
-            ATTR_STATION_NAME: self._fuel_check_data.get_station_name(
-                self._station_id),
+            ATTR_STATION_NAME: self._fuel_check_data.get_station_name(self._station_id),
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 

--- a/homeassistant/components/nsw_fuel_station/sensor.py
+++ b/homeassistant/components/nsw_fuel_station/sensor.py
@@ -4,13 +4,13 @@ from typing import Optional
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.nsw_fuel_station import (
     DATA_NSW_FUEL_STATION,
     FuelCheckData,
 )
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CURRENCY_CENT, VOLUME_LITERS
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -47,6 +47,7 @@ class FuelCheckClientMock:
     """Mock FuelCheckClient implementation."""
 
     def get_fuel_prices(self):
+        """Return a mock fuel prices response."""
         return MockGetFuelPricesResponse(
             prices=[
                 MockPrice(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is not a breaking change


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR aims to resolve https://github.com/home-assistant/core/issues/42246 by reducing the overall request volume being made against NSW Fuel Check's API.

Prior to this PR, a total of 8 requests were required to have 4 fuel station sensors:

```
# 2020-11-10 19:03:58 DEBUG (SyncWorker_0) [nsw_fuel.client] Fetching reference data
# 2020-11-10 19:03:58 DEBUG (SyncWorker_1) [nsw_fuel.client] Fetching reference data
# 2020-11-10 19:03:58 DEBUG (SyncWorker_5) [nsw_fuel.client] Fetching reference data
# 2020-11-10 19:03:58 DEBUG (SyncWorker_4) [nsw_fuel.client] Fetching reference data
# 2020-11-10 19:03:58 DEBUG (SyncWorker_1) [nsw_fuel.client] Fetching fuel prices for station 1441
# 2020-11-10 19:03:58 DEBUG (SyncWorker_0) [nsw_fuel.client] Fetching fuel prices for station 17126
# 2020-11-10 19:03:58 DEBUG (SyncWorker_4) [nsw_fuel.client] Fetching fuel prices for station 2141
# 2020-11-10 19:03:58 DEBUG (SyncWorker_5) [nsw_fuel.client] Fetching fuel prices for station 17114
```

This PR introduces a shared singleton `FuelCheckData` shared via `hass.data` which fetches price data (throttled) and caches it for the use of all defined sensors. Only a single request is required for this data to be fetched which is a nice bonus.

One trade-off in this approach is that the existence of fuel types for fuel stations aren't validated at boot, meaning it is possible for invalid config to be used to set-up sensors (i.e. fuel type for a station that does not stock it), but I think this is not a big deal as it is unlikely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

# Configure a default setup of Home Assistant (frontend, api, etc)
default_config:

# Uncomment this if you are using SSL/TLS, running in Docker container, etc.
# http:
#   base_url: example.duckdns.org:8123

# Text to speech
tts:
  - platform: google_translate

group: !include groups.yaml
automation: !include automations.yaml
script: !include scripts.yaml

sensor:
  - platform: nsw_fuel_station
    #station_name: 'Kissing Pt Rd'
    station_id: 17126
    fuel_types:
      - E10

  - platform: nsw_fuel_station
    #station_name: 'West Ryde'
    station_id: 1441
    fuel_types:
      - E10

  - platform: nsw_fuel_station
    #station_name: 'Granville'
    station_id: 17114
    fuel_types:
      - E10

  - platform: nsw_fuel_station
    #station_name: 'Granville2'
    station_id: 2141
    fuel_types:
      - E10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42246, #23280
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
