### PR TITLE
Add SmartThings Power Consumption Report

### DIFF
--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -19,6 +19,16 @@ DATA_MANAGER = "manager"
 DATA_BROKERS = "brokers"
 EVENT_BUTTON = "smartthings.button"
 
+POWER_CONSUMPTION_REPORT_NAMES = {
+    "power_consumption_start": "start",
+    "power_consumption_power": "power",
+    "power_consumption_end": "end",
+    "power_consumption_delta_energy": "delta_energy",
+    "power_consumption_power_energy": "power_energy",
+    "power_consumption_energy_saved": "energy_saved",
+    "power_consumption_persisted_energy": "persisted_energy",
+}
+
 SIGNAL_SMARTTHINGS_UPDATE = "smartthings_update"
 SIGNAL_SMARTAPP_PREFIX = "smartthings_smartap_"
 

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -302,7 +302,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 sensors.extend(
                     [
                         SmartThingsPowerConsumptionReportSensor(device, key)
-                        for key in POWER_CONSUMPTION_REPORT_NAMES.keys()
+                        for key in POWER_CONSUMPTION_REPORT_NAMES
                     ]
                 )
             elif capability == Capability.three_axis:

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -6,6 +6,7 @@ from pysmartthings import Attribute, Capability
 
 from homeassistant.const import (
     AREA_SQUARE_METERS,
+    ATTR_DATE,
     CONCENTRATION_PARTS_PER_MILLION,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
@@ -13,6 +14,7 @@ from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_TIMESTAMP,
     ENERGY_KILO_WATT_HOUR,
+    ENERGY_WATT_HOUR,
     LIGHT_LUX,
     MASS_KILOGRAMS,
     PERCENTAGE,
@@ -144,9 +146,7 @@ CAPABILITY_TO_SENSORS = {
     Capability.oven_setpoint: [
         Map(Attribute.oven_setpoint, "Oven Set Point", None, None)
     ],
-    Capability.power_consumption_report: [
-        Map(Attribute.power_consumption, "Power Consumption Report", None, None)
-    ],
+    Capability.power_consumption_report: [],
     Capability.power_meter: [Map(Attribute.power, "Power Meter", POWER_WATT, None)],
     Capability.power_source: [Map(Attribute.power_source, "Power Source", None, None)],
     Capability.refrigeration_setpoint: [
@@ -259,9 +259,37 @@ CAPABILITY_TO_SENSORS = {
     ],
 }
 
-UNITS = {"C": TEMP_CELSIUS, "F": TEMP_FAHRENHEIT}
+UNITS = {
+    "C": TEMP_CELSIUS,
+    "date": ATTR_DATE,
+    "F": TEMP_FAHRENHEIT,
+    "W": POWER_WATT,
+    "Wh": ENERGY_WATT_HOUR,
+}
 
 THREE_AXIS_NAMES = ["X Coordinate", "Y Coordinate", "Z Coordinate"]
+
+POWER_CONSUMPTION_REPORT_NAMES = {
+    "start": "Start Time",
+    "end": "End Time",
+    "energy": "Total Energy",
+    "power": "Instantaneous Power",
+    "deltaEnergy": "Load Energy",
+    "powerEnergy": "Power Watt-hours",
+    "energySaved": "Energy Saved",
+    "persistedEnergy": "Persisted Energy",
+}
+
+POWER_CONSUMPTION_REPORT_UNITS = {
+    "start": "date",
+    "end": "date",
+    "energy": "Wh",
+    "power": "W",
+    "deltaEnergy": "Wh",
+    "powerEnergy": "Wh",
+    "energySaved": "Wh",
+    "persistedEnergy": "Wh",
+}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -270,7 +298,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     sensors = []
     for device in broker.devices.values():
         for capability in broker.get_assigned(device.device_id, "sensor"):
-            if capability == Capability.three_axis:
+            if capability == Capability.power_consumption_report:
+                sensors.extend(
+                    [
+                        SmartThingsPowerConsumptionReportSensor(device, key)
+                        for key in POWER_CONSUMPTION_REPORT_NAMES.keys()
+                    ]
+                )
+            elif capability == Capability.three_axis:
                 sensors.extend(
                     [
                         SmartThingsThreeAxisSensor(device, index)
@@ -363,3 +398,41 @@ class SmartThingsThreeAxisSensor(SmartThingsEntity):
             return three_axis[self._index]
         except (TypeError, IndexError):
             return None
+
+
+class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
+    """Define a SmartTHings Power Consumption Report."""
+
+    def __init__(self, device, key):
+        """Init the class."""
+        super().__init__(device)
+        self._key = key
+
+    @property
+    def name(self) -> str:
+        """Return the name of the binary sensor."""
+        return "{} {}".format(
+            self._device.label, POWER_CONSUMPTION_REPORT_NAMES[self._key]
+        )
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return "{}.{}".format(
+            self._device.device_id, POWER_CONSUMPTION_REPORT_NAMES[self._key]
+        )
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        report = self._device.status.attributes[Attribute.power_consumption].value
+        try:
+            return report.get(self._key)
+        except TypeError:
+            return None
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        unit = POWER_CONSUMPTION_REPORT_UNITS[self._key]
+        return UNITS.get(unit, unit)

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -6,9 +6,9 @@ from pysmartthings import Attribute, Capability
 
 from homeassistant.const import (
     AREA_SQUARE_METERS,
-    ATTR_DATE,
     CONCENTRATION_PARTS_PER_MILLION,
     DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_TEMPERATURE,
@@ -259,37 +259,9 @@ CAPABILITY_TO_SENSORS = {
     ],
 }
 
-UNITS = {
-    "C": TEMP_CELSIUS,
-    "date": ATTR_DATE,
-    "F": TEMP_FAHRENHEIT,
-    "W": POWER_WATT,
-    "Wh": ENERGY_WATT_HOUR,
-}
+UNITS = {"C": TEMP_CELSIUS, "F": TEMP_FAHRENHEIT}
 
 THREE_AXIS_NAMES = ["X Coordinate", "Y Coordinate", "Z Coordinate"]
-
-POWER_CONSUMPTION_REPORT_NAMES = {
-    "start": "Start Time",
-    "end": "End Time",
-    "energy": "Total Energy",
-    "power": "Instantaneous Power",
-    "deltaEnergy": "Load Energy",
-    "powerEnergy": "Power Watt-hours",
-    "energySaved": "Energy Saved",
-    "persistedEnergy": "Persisted Energy",
-}
-
-POWER_CONSUMPTION_REPORT_UNITS = {
-    "start": "date",
-    "end": "date",
-    "energy": "Wh",
-    "power": "W",
-    "deltaEnergy": "Wh",
-    "powerEnergy": "Wh",
-    "energySaved": "Wh",
-    "persistedEnergy": "Wh",
-}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -299,12 +271,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device in broker.devices.values():
         for capability in broker.get_assigned(device.device_id, "sensor"):
             if capability == Capability.power_consumption_report:
-                sensors.extend(
-                    [
-                        SmartThingsPowerConsumptionReportSensor(device, key)
-                        for key in POWER_CONSUMPTION_REPORT_NAMES
-                    ]
-                )
+                sensors.append(SmartThingsPowerConsumptionReportSensor(device))
             elif capability == Capability.three_axis:
                 sensors.extend(
                     [
@@ -401,35 +368,44 @@ class SmartThingsThreeAxisSensor(SmartThingsEntity):
 
 
 class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
-    """Define a SmartTHings Power Consumption Report."""
+    """Define a SmartThings Power Consumption Report."""
 
-    def __init__(self, device, key):
+    def __init__(self, device):
         """Init the class."""
         super().__init__(device)
-        self._key = key
+        self._attribute = Attribute.power_consumption
+        self._name = "Energy"
+        self._primary_state_key = "energy"
+        self._device_class = DEVICE_CLASS_ENERGY
+        self._default_unit = ENERGY_WATT_HOUR
 
     @property
     def name(self) -> str:
         """Return the name of the binary sensor."""
-        return "{} {}".format(
-            self._device.label, POWER_CONSUMPTION_REPORT_NAMES[self._key]
-        )
+        return f"{self._device.label} {self._name}"
 
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return "{}.{}".format(
-            self._device.device_id, POWER_CONSUMPTION_REPORT_NAMES[self._key]
-        )
+        return f"{self._device.device_id}.{self._attribute}"
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        report = self._device.status.attributes[Attribute.power_consumption].value
-        return report.get(self._key)
+        report = self._device.status.attributes[self._attribute].value
+        return report.get(self._primary_state_key)
 
     @property
-    def unit_of_measurement(self):
+    def device_class(self) -> str:
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def unit_of_measurement(self) -> str:
         """Return the unit this state is expressed in."""
-        unit = POWER_CONSUMPTION_REPORT_UNITS[self._key]
-        return UNITS.get(unit, unit)
+        return self._default_unit
+
+    @property
+    def device_state_attributes(self):
+        """Return all attributes of the sensor."""
+        return self._device.status.attributes[self._attribute].value

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -374,8 +374,8 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
         """Init the class."""
         super().__init__(device)
         self._attribute = Attribute.power_consumption
-        self._name = "Energy"
-        self._primary_state_key = "energy"
+        self._name = "Power Consumption Report"
+        self._primary_attribute = "power_consumption_energy"
         self._device_class = DEVICE_CLASS_ENERGY
         self._default_unit = ENERGY_WATT_HOUR
 
@@ -392,8 +392,7 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        report = self._device.status.attributes[self._attribute].value
-        return report.get(self._primary_state_key)
+        return getattr(self._device.status, self._primary_attribute)
 
     @property
     def device_class(self) -> str:
@@ -407,5 +406,16 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
 
     @property
     def device_state_attributes(self):
-        """Return all attributes of the sensor."""
-        return self._device.status.attributes[self._attribute].value
+        """Return attributes of the sensor."""
+        attributes = [
+            "power_consumption_start",
+            "power_consumption_power",
+            "power_consumption_energy",
+            "power_consumption_end",
+        ]
+        state_attributes = {}
+        for attribute in attributes:
+            value = getattr(self._device.status, attribute)
+            if value is not None:
+                state_attributes[attribute] = value
+        return state_attributes

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -383,7 +383,7 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return f"{self._device.device_id}.{self._name}"
+        return f"{self._device.device_id}.powerConsumptionReport"
 
     @property
     def state(self):

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 )
 
 from . import SmartThingsEntity
-from .const import DATA_BROKERS, DOMAIN
+from .const import DATA_BROKERS, DOMAIN, POWER_CONSUMPTION_REPORT_NAMES
 
 Map = namedtuple("map", "attribute name default_unit device_class")
 
@@ -373,11 +373,7 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
     def __init__(self, device):
         """Init the class."""
         super().__init__(device)
-        self._attribute = Attribute.power_consumption
         self._name = "Power Consumption Report"
-        self._primary_attribute = "power_consumption_energy"
-        self._device_class = DEVICE_CLASS_ENERGY
-        self._default_unit = ENERGY_WATT_HOUR
 
     @property
     def name(self) -> str:
@@ -387,39 +383,29 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return f"{self._device.device_id}.{self._attribute}"
+        return f"{self._device.device_id}.{self._name}"
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        return getattr(self._device.status, self._primary_attribute)
+        return self._device.status.power_consumption_energy
 
     @property
     def device_class(self) -> str:
         """Return the device class of the sensor."""
-        return self._device_class
+        return DEVICE_CLASS_ENERGY
 
     @property
     def unit_of_measurement(self) -> str:
         """Return the unit this state is expressed in."""
-        return self._default_unit
+        return ENERGY_WATT_HOUR
 
     @property
     def device_state_attributes(self):
         """Return attributes of the sensor."""
-        attributes = [
-            "power_consumption_start",
-            "power_consumption_power",
-            "power_consumption_energy",
-            "power_consumption_end",
-            "power_consumption_delta_energy",
-            "power_consumption_power_energy",
-            "power_consumption_energy_saved",
-            "power_consumption_persisted_energy",
-        ]
         state_attributes = {}
-        for attribute in attributes:
+        for attribute, short_name in POWER_CONSUMPTION_REPORT_NAMES.items():
             value = getattr(self._device.status, attribute)
             if value is not None:
-                state_attributes[attribute] = value
+                state_attributes[short_name] = value
         return state_attributes

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -144,6 +144,9 @@ CAPABILITY_TO_SENSORS = {
     Capability.oven_setpoint: [
         Map(Attribute.oven_setpoint, "Oven Set Point", None, None)
     ],
+    Capability.power_consumption_report: [
+        Map(Attribute.power_consumption, "Power Consumption Report", None, None)
+    ],
     Capability.power_meter: [Map(Attribute.power, "Power Meter", POWER_WATT, None)],
     Capability.power_source: [Map(Attribute.power_source, "Power Source", None, None)],
     Capability.refrigeration_setpoint: [

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -426,10 +426,7 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
     def state(self):
         """Return the state of the sensor."""
         report = self._device.status.attributes[Attribute.power_consumption].value
-        try:
-            return report.get(self._key)
-        except TypeError:
-            return None
+        return report.get(self._key)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -412,6 +412,10 @@ class SmartThingsPowerConsumptionReportSensor(SmartThingsEntity):
             "power_consumption_power",
             "power_consumption_energy",
             "power_consumption_end",
+            "power_consumption_delta_energy",
+            "power_consumption_power_energy",
+            "power_consumption_energy_saved",
+            "power_consumption_persisted_energy",
         ]
         state_attributes = {}
         for attribute in attributes:

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -10,9 +10,12 @@ from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN as SENSOR_DOM
 from homeassistant.components.smartthings import sensor
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import (
+    ATTR_DATE,
     ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
+    ENERGY_WATT_HOUR,
     PERCENTAGE,
+    POWER_WATT,
     STATE_UNKNOWN,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -70,6 +73,84 @@ async def test_entity_three_axis_invalid_state(hass, device_factory):
     state = hass.states.get("sensor.three_axis_y_coordinate")
     assert state.state == STATE_UNKNOWN
     state = hass.states.get("sensor.three_axis_z_coordinate")
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_entity_power_consumption_report_state(hass, device_factory):
+    """Test the state attributes."""
+    test_attr_values = {
+        "start": "00110501T000000-0800",  # Nov 5 2020 America/Los Angeles
+        "end": "00110601T000000-0800",  # Nov 6 2020 America/Los Angeles
+        "energy": 10000,
+        "power": 90,
+        "deltaEnergy": 100,
+        "powerEnergy": 80,
+        "energySaved": 300,
+        "persistedEnergy": 20000,
+    }
+    device = device_factory(
+        "Power Consumption Report",
+        [Capability.power_consumption_report],
+        {Attribute.power_consumption: test_attr_values},
+    )
+    await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
+    state = hass.states.get("sensor.power_consumption_report_start_time")
+    assert state.state == "00110501T000000-0800"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Start Time"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ATTR_DATE
+    state = hass.states.get("sensor.power_consumption_report_end_time")
+    assert state.state == "00110601T000000-0800"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} End Time"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ATTR_DATE
+    state = hass.states.get("sensor.power_consumption_report_total_energy")
+    assert state.state == "10000"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Total Energy"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    state = hass.states.get("sensor.power_consumption_report_instantaneous_power")
+    assert state.state == "90"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Instantaneous Power"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == POWER_WATT
+    state = hass.states.get("sensor.power_consumption_report_load_energy")
+    assert state.state == "100"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Load Energy"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    state = hass.states.get("sensor.power_consumption_report_power_watt_hours")
+    assert state.state == "80"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Power Watt-hours"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    state = hass.states.get("sensor.power_consumption_report_energy_saved")
+    assert state.state == "300"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Energy Saved"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    state = hass.states.get("sensor.power_consumption_report_persisted_energy")
+    assert state.state == "20000"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Persisted Energy"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+
+
+async def test_entity_power_consumption_report_invalid_state(hass, device_factory):
+    """Test the state attributes."""
+    device = device_factory(
+        "Power Consumption Report",
+        [Capability.power_consumption_report],
+        {Attribute.power_consumption: {}},
+    )
+    await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
+    state = hass.states.get("sensor.power_consumption_report_start_time")
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.power_consumption_report_end_time")
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.power_consumption_report_total_energy")
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.power_consumption_report_instantaneous_power")
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.power_consumption_report_load_energy")
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.power_consumption_report_power_watt_hours")
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.power_consumption_report_energy_saved")
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get("sensor.power_consumption_report_persisted_energy")
     assert state.state == STATE_UNKNOWN
 
 

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -8,7 +8,11 @@ from pysmartthings import ATTRIBUTES, CAPABILITIES, Attribute, Capability
 
 from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.smartthings import sensor
-from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
+from homeassistant.components.smartthings.const import (
+    DOMAIN,
+    POWER_CONSUMPTION_REPORT_NAMES,
+    SIGNAL_SMARTTHINGS_UPDATE,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
@@ -78,10 +82,10 @@ async def test_entity_three_axis_invalid_state(hass, device_factory):
 
 async def test_entity_power_consumption_report_state(hass, device_factory):
     """Test the state attributes."""
-    test_attr_values = {
+    mock_report = {
         "start": "00110501T000000-0800",  # Nov 5 2020 America/Los Angeles
         "power": 90,
-        "energy": 10000.0,
+        "energy": 10000.0,  # primary attribute, reported by state of sensor
         "end": "00110601T000000-0800",  # Nov 6 2020 America/Los Angeles
         "deltaEnergy": 100.0,
         "powerEnergy": 80.0,
@@ -91,7 +95,7 @@ async def test_entity_power_consumption_report_state(hass, device_factory):
     device = device_factory(
         "Appliance",
         [Capability.power_consumption_report],
-        {Attribute.power_consumption: test_attr_values},
+        {Attribute.power_consumption: mock_report},
     )
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
     state = hass.states.get("sensor.appliance_power_consumption_report")
@@ -102,18 +106,10 @@ async def test_entity_power_consumption_report_state(hass, device_factory):
     )
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
-    attributes = [
-        "power_consumption_start",
-        "power_consumption_power",
-        "power_consumption_energy",
-        "power_consumption_end",
-        "power_consumption_delta_energy",
-        "power_consumption_power_energy",
-        "power_consumption_energy_saved",
-        "power_consumption_persisted_energy",
-    ]
-    for attribute, test_attr_value in zip(attributes, test_attr_values):
-        assert state.attributes[attribute] == test_attr_values[test_attr_value]
+    attributes = POWER_CONSUMPTION_REPORT_NAMES.values()
+    mock_report = {k: v for k, v in mock_report.items() if k != "energy"}
+    for attribute, mock_value in zip(attributes, mock_report.values()):
+        assert state.attributes[attribute] == mock_value
 
 
 async def test_entity_power_consumption_report_invalid_state(hass, device_factory):

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -80,13 +80,13 @@ async def test_entity_power_consumption_report_state(hass, device_factory):
     """Test the state attributes."""
     test_attr_values = {
         "start": "00110501T000000-0800",  # Nov 5 2020 America/Los Angeles
-        "end": "00110601T000000-0800",  # Nov 6 2020 America/Los Angeles
-        "energy": 10000,
         "power": 90,
-        "deltaEnergy": 100,
-        "powerEnergy": 80,
-        "energySaved": 300,
-        "persistedEnergy": 20000,
+        "energy": 10000.0,
+        "end": "00110601T000000-0800",  # Nov 6 2020 America/Los Angeles
+        "deltaEnergy": 100.0,
+        "powerEnergy": 80.0,
+        "energySaved": 300.0,
+        "persistedEnergy": 20000.0,
     }
     device = device_factory(
         "Appliance",
@@ -95,22 +95,25 @@ async def test_entity_power_consumption_report_state(hass, device_factory):
     )
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
     state = hass.states.get("sensor.appliance_power_consumption_report")
-    assert state.state == "10000"
+    assert state.state == "10000.0"
     assert (
         state.attributes[ATTR_FRIENDLY_NAME]
         == f"{device.label} Power Consumption Report"
     )
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
-    # Only check for currently supported values
     attributes = [
         "power_consumption_start",
         "power_consumption_power",
         "power_consumption_energy",
         "power_consumption_end",
+        "power_consumption_delta_energy",
+        "power_consumption_power_energy",
+        "power_consumption_energy_saved",
+        "power_consumption_persisted_energy",
     ]
-    for attribute in attributes:
-        assert state.attributes[attribute] == test_attr_values[attribute[18:]]
+    for attribute, test_attr_value in zip(attributes, test_attr_values):
+        assert state.attributes[attribute] == test_attr_values[test_attr_value]
 
 
 async def test_entity_power_consumption_report_invalid_state(hass, device_factory):

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -89,30 +89,39 @@ async def test_entity_power_consumption_report_state(hass, device_factory):
         "persistedEnergy": 20000,
     }
     device = device_factory(
-        "Power Consumption Report",
+        "Appliance",
         [Capability.power_consumption_report],
         {Attribute.power_consumption: test_attr_values},
     )
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
-    state = hass.states.get("sensor.power_consumption_report_energy")
+    state = hass.states.get("sensor.appliance_power_consumption_report")
     assert state.state == "10000"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Energy"
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME]
+        == f"{device.label} Power Consumption Report"
+    )
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
-
-    for key in test_attr_values:
-        assert state.attributes[key] == test_attr_values[key]
+    # Only check for currently supported values
+    attributes = [
+        "power_consumption_start",
+        "power_consumption_power",
+        "power_consumption_energy",
+        "power_consumption_end",
+    ]
+    for attribute in attributes:
+        assert state.attributes[attribute] == test_attr_values[attribute[18:]]
 
 
 async def test_entity_power_consumption_report_invalid_state(hass, device_factory):
     """Test the state attributes."""
     device = device_factory(
-        "Power Consumption Report",
+        "Appliance",
         [Capability.power_consumption_report],
         {Attribute.power_consumption: {}},
     )
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
-    state = hass.states.get("sensor.power_consumption_report_energy")
+    state = hass.states.get("sensor.appliance_power_consumption_report")
     assert state.state == STATE_UNKNOWN
 
 

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -10,12 +10,12 @@ from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN as SENSOR_DOM
 from homeassistant.components.smartthings import sensor
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import (
-    ATTR_DATE,
+    ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
+    DEVICE_CLASS_ENERGY,
     ENERGY_WATT_HOUR,
     PERCENTAGE,
-    POWER_WATT,
     STATE_UNKNOWN,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -94,38 +94,14 @@ async def test_entity_power_consumption_report_state(hass, device_factory):
         {Attribute.power_consumption: test_attr_values},
     )
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
-    state = hass.states.get("sensor.power_consumption_report_start_time")
-    assert state.state == "00110501T000000-0800"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Start Time"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ATTR_DATE
-    state = hass.states.get("sensor.power_consumption_report_end_time")
-    assert state.state == "00110601T000000-0800"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} End Time"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ATTR_DATE
-    state = hass.states.get("sensor.power_consumption_report_total_energy")
+    state = hass.states.get("sensor.power_consumption_report_energy")
     assert state.state == "10000"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Total Energy"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Energy"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
-    state = hass.states.get("sensor.power_consumption_report_instantaneous_power")
-    assert state.state == "90"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Instantaneous Power"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == POWER_WATT
-    state = hass.states.get("sensor.power_consumption_report_load_energy")
-    assert state.state == "100"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Load Energy"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
-    state = hass.states.get("sensor.power_consumption_report_power_watt_hours")
-    assert state.state == "80"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Power Watt-hours"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
-    state = hass.states.get("sensor.power_consumption_report_energy_saved")
-    assert state.state == "300"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Energy Saved"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
-    state = hass.states.get("sensor.power_consumption_report_persisted_energy")
-    assert state.state == "20000"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{device.label} Persisted Energy"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
+
+    for key in test_attr_values:
+        assert state.attributes[key] == test_attr_values[key]
 
 
 async def test_entity_power_consumption_report_invalid_state(hass, device_factory):
@@ -136,21 +112,7 @@ async def test_entity_power_consumption_report_invalid_state(hass, device_factor
         {Attribute.power_consumption: {}},
     )
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
-    state = hass.states.get("sensor.power_consumption_report_start_time")
-    assert state.state == STATE_UNKNOWN
-    state = hass.states.get("sensor.power_consumption_report_end_time")
-    assert state.state == STATE_UNKNOWN
-    state = hass.states.get("sensor.power_consumption_report_total_energy")
-    assert state.state == STATE_UNKNOWN
-    state = hass.states.get("sensor.power_consumption_report_instantaneous_power")
-    assert state.state == STATE_UNKNOWN
-    state = hass.states.get("sensor.power_consumption_report_load_energy")
-    assert state.state == STATE_UNKNOWN
-    state = hass.states.get("sensor.power_consumption_report_power_watt_hours")
-    assert state.state == STATE_UNKNOWN
-    state = hass.states.get("sensor.power_consumption_report_energy_saved")
-    assert state.state == STATE_UNKNOWN
-    state = hass.states.get("sensor.power_consumption_report_persisted_energy")
+    state = hass.states.get("sensor.power_consumption_report_energy")
     assert state.state == STATE_UNKNOWN
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for power consumption report as discussed: https://github.com/home-assistant/core/issues/42006

#### Names
Open to more intuitive naming of the sensors according to the results we get

#### Dates
This sensor will report a "start" and "end" date as attributes.  I could not find a "date" unit of measurement so used ATTR_DATE but I don't think I have this right.  

It would be possible to convert the start/end to an interval (end - start).  Importantly, the start/end date is *more relevant* to the user than *the time at which the sensor was updated* (which is merely the time that SmartThings provided the report to HA).

#### Units
Based on data gathered by @cobirnm https://github.com/home-assistant/core/issues/42006#issuecomment-723693610 I am not 100% confident on the units.  100Wh makes sense for an efficient washing machine.  65,000Wh makes sense for energy used over the lifetime of the unit (~650 loads) yet we see this reported by the energy attribute, which should rather be the cumulative energy during the reporting period.  Perhaps the reporting period defaults to the lifetime of the unit?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42006
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15792

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
