### PR TITLE
Add a config flow for Recollect Waste

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -708,6 +708,7 @@ omit =
     homeassistant/components/rainforest_eagle/sensor.py
     homeassistant/components/raspihats/*
     homeassistant/components/raspyrfm/*
+    homeassistant/components/recollect_waste/__init__.py
     homeassistant/components/recollect_waste/sensor.py
     homeassistant/components/recswitch/switch.py
     homeassistant/components/reddit/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -360,6 +360,7 @@ homeassistant/components/raincloud/* @vanstinator
 homeassistant/components/rainforest_eagle/* @gtdiehl @jcalbert
 homeassistant/components/rainmachine/* @bachya
 homeassistant/components/random/* @fabaff
+homeassistant/components/recollect_waste/* @bachya
 homeassistant/components/rejseplanen/* @DarkFox
 homeassistant/components/repetier/* @MTrab
 homeassistant/components/rfxtrx/* @danielhiversen @elupus @RobBie1221

--- a/homeassistant/components/recollect_waste/__init__.py
+++ b/homeassistant/components/recollect_waste/__init__.py
@@ -1,1 +1,87 @@
-"""The recollect_waste component."""
+"""The Recollect Waste integration."""
+import asyncio
+from datetime import date, timedelta
+from typing import List
+
+from aiorecollect.client import Client, PickupEvent
+from aiorecollect.errors import RecollectError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DATA_COORDINATOR, DOMAIN, LOGGER
+
+DATA_LISTENER = "listener"
+
+DEFAULT_NAME = "recollect_waste"
+DEFAULT_UPDATE_INTERVAL = timedelta(days=1)
+
+PLATFORMS = ["sensor"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the RainMachine component."""
+    hass.data[DOMAIN] = {DATA_COORDINATOR: {}, DATA_LISTENER: {}}
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up RainMachine as config entry."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = Client(
+        entry.data[CONF_PLACE_ID], entry.data[CONF_SERVICE_ID], session=session
+    )
+
+    try:
+        await client.async_get_next_pickup_event()
+    except RecollectError as err:
+        LOGGER.error("Error setting up Recollect sensor platform: %s", err)
+        return False
+
+    async def async_get_pickup_events() -> List[PickupEvent]:
+        """Get the next pickup."""
+        try:
+            return await client.async_get_pickup_events(
+                start_date=date.today(), end_date=date.today() + timedelta(weeks=4)
+            )
+        except RecollectError as err:
+            raise UpdateFailed(
+                f"Error while requesting data from Recollect: {err}"
+            ) from err
+
+    coordinator = hass.data[DOMAIN][DATA_COORDINATOR][
+        entry.entry_id
+    ] = DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        name=f"Place {entry.data[CONF_PLACE_ID]}, Service {entry.data[CONF_SERVICE_ID]}",
+        update_interval=DEFAULT_UPDATE_INTERVAL,
+        update_method=async_get_pickup_events,
+    )
+
+    await coordinator.async_refresh()
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload an RainMachine config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -19,7 +19,7 @@ DATA_SCHEMA = vol.Schema(
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Elexa Guardian."""
+    """Handle a config flow for Recollect Waste."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -1,0 +1,64 @@
+"""Config flow for Recollect Waste integration."""
+from aiorecollect.client import Client
+from aiorecollect.errors import RecollectError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.helpers import aiohttp_client
+
+from .const import (  # pylint:disable=unused-import
+    CONF_PLACE_ID,
+    CONF_SERVICE_ID,
+    DOMAIN,
+    LOGGER,
+)
+
+DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_PLACE_ID): str, vol.Required(CONF_SERVICE_ID): str}
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Elexa Guardian."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_import(self, import_config: dict = None) -> dict:
+        """Handle configuration via YAML import."""
+        return await self.async_step_user(import_config)
+
+    async def async_step_user(self, user_input: dict = None) -> dict:
+        """Handle configuration via the UI."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=DATA_SCHEMA, errors={}
+            )
+
+        unique_id = f"{user_input[CONF_PLACE_ID]}, {user_input[CONF_SERVICE_ID]}"
+
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        session = aiohttp_client.async_get_clientsession(self.hass)
+        client = Client(
+            user_input[CONF_PLACE_ID], user_input[CONF_SERVICE_ID], session=session
+        )
+
+        try:
+            await client.async_get_next_pickup_event()
+        except RecollectError as err:
+            LOGGER.error("Error during setup of integration: %s", err)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=DATA_SCHEMA,
+                errors={"base": "invalid_place_or_service_id"},
+            )
+
+        return self.async_create_entry(
+            title=unique_id,
+            data={
+                CONF_PLACE_ID: user_input[CONF_PLACE_ID],
+                CONF_SERVICE_ID: user_input[CONF_SERVICE_ID],
+            },
+        )

--- a/homeassistant/components/recollect_waste/const.py
+++ b/homeassistant/components/recollect_waste/const.py
@@ -1,0 +1,11 @@
+"""Define Recollect Waste constants."""
+import logging
+
+DOMAIN = "recollect_waste"
+
+LOGGER = logging.getLogger(__package__)
+
+CONF_PLACE_ID = "place_id"
+CONF_SERVICE_ID = "service_id"
+
+DATA_COORDINATOR = "coordinator"

--- a/homeassistant/components/recollect_waste/manifest.json
+++ b/homeassistant/components/recollect_waste/manifest.json
@@ -1,7 +1,12 @@
 {
   "domain": "recollect_waste",
   "name": "ReCollect Waste",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/recollect_waste",
-  "requirements": ["aiorecollect==0.2.1"],
-  "codeowners": []
+  "requirements": [
+    "aiorecollect==0.2.1"
+  ],
+  "codeowners": [
+    "@bachya"
+  ]
 }

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -75,22 +75,22 @@ class RecollectWasteSensor(CoordinatorEntity):
         self._state = None
 
     @property
-    def device_state_attributes(self):
+    def device_state_attributes(self) -> dict:
         """Return the state attributes."""
         return self._attributes
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Icon to use in the frontend."""
         return DEFAULT_ICON
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return DEFAULT_NAME
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the sensor."""
         return self._state
 
@@ -100,12 +100,12 @@ class RecollectWasteSensor(CoordinatorEntity):
         return f"{self._place_id}{self._service_id}"
 
     @callback
-    def _handle_coordinator_update(self):
+    def _handle_coordinator_update(self) -> None:
         """Respond to a DataUpdateCoordinator update."""
         self.update_from_latest_data()
         self.async_write_ha_state()
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
         self.update_from_latest_data()

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -1,27 +1,30 @@
-"""Support for Recollect Waste curbside collection pickup."""
-from datetime import date, timedelta
-import logging
+"""Support for Recollect Waste sensors."""
+from typing import Callable
 
-from aiorecollect import Client
-from aiorecollect.errors import RecollectError
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME
-from homeassistant.helpers import aiohttp_client, config_validation as cv
-from homeassistant.helpers.entity import Entity
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
-_LOGGER = logging.getLogger(__name__)
+from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DATA_COORDINATOR, DOMAIN, LOGGER
+
 ATTR_PICKUP_TYPES = "pickup_types"
 ATTR_AREA_NAME = "area_name"
 ATTR_NEXT_PICKUP_TYPES = "next_pickup_types"
 ATTR_NEXT_PICKUP_DATE = "next_pickup_date"
-CONF_PLACE_ID = "place_id"
-CONF_SERVICE_ID = "service_id"
-DEFAULT_NAME = "recollect_waste"
-ICON = "mdi:trash-can-outline"
-SCAN_INTERVAL = timedelta(days=1)
 
+DEFAULT_ATTRIBUTION = "Pickup data provided by Recollect Waste"
+DEFAULT_NAME = "recollect_waste"
+DEFAULT_ICON = "mdi:trash-can-outline"
+
+CONF_NAME = "name"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -32,46 +35,44 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Recollect Waste platform."""
-    session = aiohttp_client.async_get_clientsession(hass)
-    client = Client(config[CONF_PLACE_ID], config[CONF_SERVICE_ID], session=session)
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: dict,
+    async_add_entities: Callable,
+    discovery_info: dict = None,
+):
+    """Import Awair configuration from YAML."""
+    LOGGER.warning(
+        "Loading Recollect Waste via platform setup is deprecated. "
+        "Please remove it from your configuration."
+    )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=config,
+        )
+    )
 
-    # Ensure the client can connect to the API successfully
-    # with given place_id and service_id.
-    try:
-        await client.async_get_next_pickup_event()
-    except RecollectError as err:
-        _LOGGER.error("Error setting up Recollect sensor platform: %s", err)
-        return
 
-    async_add_entities([RecollectWasteSensor(config.get(CONF_NAME), client)], True)
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: Callable
+) -> None:
+    """Set up Recollect Waste sensors based on a config entry."""
+    coordinator = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id]
+    async_add_entities([RecollectWasteSensor(coordinator, entry)])
 
 
-class RecollectWasteSensor(Entity):
+class RecollectWasteSensor(CoordinatorEntity):
     """Recollect Waste Sensor."""
 
-    def __init__(self, name, client):
+    def __init__(self, coordinator: DataUpdateCoordinator, entry: ConfigEntry) -> None:
         """Initialize the sensor."""
-        self._attributes = {}
-        self._name = name
+        super().__init__(coordinator)
+        self._attributes = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._place_id = entry.data[CONF_PLACE_ID]
+        self._service_id = entry.data[CONF_SERVICE_ID]
         self._state = None
-        self.client = client
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return f"{self.client.place_id}{self.client.service_id}"
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
 
     @property
     def device_state_attributes(self):
@@ -81,21 +82,41 @@ class RecollectWasteSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON
+        return DEFAULT_ICON
 
-    async def async_update(self):
-        """Update device state."""
-        try:
-            pickup_event_array = await self.client.async_get_pickup_events(
-                start_date=date.today(), end_date=date.today() + timedelta(weeks=4)
-            )
-        except RecollectError as err:
-            _LOGGER.error("Error while requesting data from Recollect: %s", err)
-            return
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return DEFAULT_NAME
 
-        pickup_event = pickup_event_array[0]
-        next_pickup_event = pickup_event_array[1]
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"{self._place_id}{self._service_id}"
+
+    @callback
+    def _handle_coordinator_update(self):
+        """Respond to a DataUpdateCoordinator update."""
+        self.update_from_latest_data()
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        self.update_from_latest_data()
+
+    @callback
+    def update_from_latest_data(self) -> None:
+        """Update the state."""
+        pickup_event = self.coordinator.data[0]
+        next_pickup_event = self.coordinator.data[1]
         next_date = str(next_pickup_event.date)
+
         self._state = pickup_event.date
         self._attributes.update(
             {

--- a/homeassistant/components/recollect_waste/strings.json
+++ b/homeassistant/components/recollect_waste/strings.json
@@ -1,0 +1,19 @@
+{
+  "title": "Recollect Waste",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "place_id": "Place ID",
+          "service_id": "Service ID"
+        }
+      }
+    },
+    "error": {
+      "invalid_place_or_service_id": "Invalid Place or Service ID"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/recollect_waste/strings.json
+++ b/homeassistant/components/recollect_waste/strings.json
@@ -1,5 +1,4 @@
 {
-  "title": "Recollect Waste",
   "config": {
     "step": {
       "user": {

--- a/homeassistant/components/recollect_waste/translations/en.json
+++ b/homeassistant/components/recollect_waste/translations/en.json
@@ -14,6 +14,5 @@
                 }
             }
         }
-    },
-    "title": "Recollect Waste"
+    }
 }

--- a/homeassistant/components/recollect_waste/translations/en.json
+++ b/homeassistant/components/recollect_waste/translations/en.json
@@ -1,0 +1,19 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "invalid_place_or_service_id": "Invalid Place or Service ID"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "place_id": "Place ID",
+                    "service_id": "Service ID"
+                }
+            }
+        }
+    },
+    "title": "Recollect Waste"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -156,6 +156,7 @@ FLOWS = [
     "pvpc_hourly_pricing",
     "rachio",
     "rainmachine",
+    "recollect_waste",
     "rfxtrx",
     "ring",
     "risco",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -136,6 +136,9 @@ aiopvpc==2.0.2
 # homeassistant.components.webostv
 aiopylgtv==0.3.3
 
+# homeassistant.components.recollect_waste
+aiorecollect==0.2.1
+
 # homeassistant.components.shelly
 aioshelly==0.5.1
 

--- a/tests/components/recollect_waste/__init__.py
+++ b/tests/components/recollect_waste/__init__.py
@@ -1,0 +1,1 @@
+"""Define tests for the Recollet Waste integration."""

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -67,7 +67,7 @@ async def test_step_import(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
         )
-
+        await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == "12345, 12345"
         assert result["data"] == {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
@@ -85,7 +85,7 @@ async def test_step_user(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=conf
         )
-
+        await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == "12345, 12345"
         assert result["data"] == {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -1,0 +1,91 @@
+"""Define tests for the Recollect Waste config flow."""
+from aiorecollect.errors import RecollectError
+
+from homeassistant import data_entry_flow
+from homeassistant.components.recollect_waste import (
+    CONF_PLACE_ID,
+    CONF_SERVICE_ID,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+
+async def test_duplicate_error(hass):
+    """Test that errors are shown when duplicates are added."""
+    conf = {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
+
+    MockConfigEntry(domain=DOMAIN, unique_id="12345, 12345", data=conf).add_to_hass(
+        hass
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=conf
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_invalid_place_or_service_id(hass):
+    """Test that an invalid Place or Service ID throws an error."""
+    conf = {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
+
+    with patch(
+        "aiorecollect.client.Client.async_get_next_pickup_event",
+        side_effect=RecollectError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=conf
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "invalid_place_or_service_id"}
+
+
+async def test_show_form(hass):
+    """Test that the form is served with no input."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_step_import(hass):
+    """Test that the user step works."""
+    conf = {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
+
+    with patch(
+        "homeassistant.components.recollect_waste.async_setup_entry", return_value=True
+    ), patch(
+        "aiorecollect.client.Client.async_get_next_pickup_event", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "12345, 12345"
+        assert result["data"] == {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
+
+
+async def test_step_user(hass):
+    """Test that the user step works."""
+    conf = {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
+
+    with patch(
+        "homeassistant.components.recollect_waste.async_setup_entry", return_value=True
+    ), patch(
+        "aiorecollect.client.Client.async_get_next_pickup_event", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=conf
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "12345, 12345"
+        assert result["data"] == {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on https://github.com/home-assistant/core/pull/43022, this PR adds a config flow for Recollect Waste. In doing so, it transitions the API interaction to a `DataUpdateCoordinator`.

I don't believe this is a breaking change for a few reasons:

1. I've left the existing platform-based YAML config in place so that existing users will have their configuration automatically migrated without any action. I'll deprecate YAML config in a future PR.
2. I've removed references to the `name` YAML configuration parameter, as it is unnecessary in a world where Lovelace can change the human-friendly name. Its removal does not alter the presence of entities, automations, etc.

...but am open to others' thoughts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15624

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
