### PR TITLE
Preload config flow integrations to avoid executor overload

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -515,6 +515,7 @@ async def _async_set_up_integrations(
     asyncio.create_task(hass.helpers.device_registry.async_get_registry())
     asyncio.create_task(hass.helpers.entity_registry.async_get_registry())
     asyncio.create_task(hass.helpers.area_registry.async_get_registry())
+    asyncio.create_task(loader.async_preload_integrations_with_config_flows(hass))
 
     # Start setup
     if stage_1_domains:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -146,6 +146,22 @@ async def async_get_config_flows(hass: "HomeAssistant") -> Set[str]:
     return flows
 
 
+async def async_preload_integrations_with_config_flows(hass: "HomeAssistant") -> None:
+    """Preload integrations with config flows.
+
+    This function should not load the integration in
+    parallel.
+
+    Its current use case is to load each one in the background
+    to ensure the first time we load translations that we do
+    not fire off so many executor jobs that we overload
+    the executor in order to mitigate the impact of integrations
+    being converted to config flows.
+    """
+    for integration in await async_get_config_flows(hass):
+        await async_get_integration(hass, integration)
+
+
 async def async_get_zeroconf(hass: "HomeAssistant") -> Dict[str, List[Dict[str, str]]]:
     """Return cached list of zeroconf types."""
     zeroconf: Dict[str, List[Dict[str, str]]] = ZEROCONF.copy()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -394,3 +394,12 @@ async def test_get_custom_components_safe_mode(hass):
     """Test that we get empty custom components in safe mode."""
     hass.config.safe_mode = True
     assert await loader.async_get_custom_components(hass) == {}
+
+
+async def test_async_preload_integrations_with_config_flows(hass):
+    """Test integrations with config flows are loaded."""
+
+    with patch("homeassistant.loader.async_get_config_flows", return_value={"hue"}):
+        await loader.async_preload_integrations_with_config_flows(hass)
+
+    assert "hue" in hass.data[loader.DATA_INTEGRATIONS]


### PR DESCRIPTION
When looking at `py-spy`s I noticed there was a bunch of `SyncWorker` threads
created and then when the websocket reconnects and requests translations we
see the number of `SyncWorker` threads doubles or more.  It was noticeable because
other threads were spawned in between the original batch and the second batch.
With this change, the second batch is no longer created and the overall number
of `SyncWorker`s stays lower since we don't overload the executor anymore.

This solves the last known case of executor overload except for
async_get_integration waiting for disk which is done in
https://github.com/home-assistant/core/pull/43085

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As more integrations have been converted to config flow we have
to load their manifest.json when the UI is loaded. To avoid a
sudden bust of executor jobs, we preload the manifest.json files
one at a time in the background so they are ready when the UI
asks for translations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
