### PR TITLE
Limit concurrency of async_get_integration to avoid creating extra threads

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -28,6 +28,7 @@ from homeassistant.setup import (
     async_set_domains_to_be_loaded,
     async_setup_component,
 )
+from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.logging import async_activate_log_queue_handler
 from homeassistant.util.package import async_get_user_site, is_virtual_env
 from homeassistant.util.yaml import clear_secret_cache
@@ -48,6 +49,8 @@ STAGE_1_TIMEOUT = 120
 STAGE_2_TIMEOUT = 300
 WRAP_UP_TIMEOUT = 300
 COOLDOWN_TIME = 60
+
+MAX_LOAD_CONCURRENTLY = 6
 
 DEBUGGER_INTEGRATIONS = {"debugpy", "ptvsd"}
 CORE_INTEGRATIONS = ("homeassistant", "persistent_notification")
@@ -442,7 +445,8 @@ async def _async_set_up_integrations(
 
         integrations_to_process = [
             int_or_exc
-            for int_or_exc in await asyncio.gather(
+            for int_or_exc in await gather_with_concurrency(
+                loader.MAX_LOAD_CONCURRENTLY,
                 *(
                     loader.async_get_integration(hass, domain)
                     for domain in old_to_resolve

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -38,7 +38,13 @@ from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType, TemplateVarsType
-from homeassistant.loader import Integration, async_get_integration, bind_hass
+from homeassistant.loader import (
+    MAX_LOAD_CONCURRENTLY,
+    Integration,
+    async_get_integration,
+    bind_hass,
+)
+from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.yaml import load_yaml
 from homeassistant.util.yaml.loader import JSON_TYPE
 
@@ -307,8 +313,9 @@ async def async_get_all_descriptions(
     loaded = {}
 
     if missing:
-        integrations = await asyncio.gather(
-            *(async_get_integration(hass, domain) for domain in missing)
+        integrations = await gather_with_concurrency(
+            MAX_LOAD_CONCURRENTLY,
+            *(async_get_integration(hass, domain) for domain in missing),
         )
 
         contents = await hass.async_add_executor_job(

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -6,11 +6,13 @@ from typing import Any, Dict, List, Optional, Set
 
 from homeassistant.core import callback
 from homeassistant.loader import (
+    MAX_LOAD_CONCURRENTLY,
     Integration,
     async_get_config_flows,
     async_get_integration,
     bind_hass,
 )
+from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.json import load_json
 
 from .typing import HomeAssistantType
@@ -151,8 +153,9 @@ async def async_get_component_strings(
     integrations = dict(
         zip(
             domains,
-            await asyncio.gather(
-                *[async_get_integration(hass, domain) for domain in domains]
+            await gather_with_concurrency(
+                MAX_LOAD_CONCURRENTLY,
+                *[async_get_integration(hass, domain) for domain in domains],
             ),
         )
     )

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -50,6 +50,8 @@ CUSTOM_WARNING = (
 )
 _UNDEF = object()
 
+MAX_LOAD_CONCURRENTLY = 4
+
 
 def manifest_from_legacy_module(domain: str, module: ModuleType) -> Dict:
     """Generate a manifest from a legacy module."""

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -1,12 +1,12 @@
-"""Asyncio backports for Python 3.6 compatibility."""
-from asyncio import coroutines, ensure_future, get_running_loop
+"""Asyncio utilities."""
+from asyncio import Semaphore, coroutines, ensure_future, gather, get_running_loop
 from asyncio.events import AbstractEventLoop
 import concurrent.futures
 import functools
 import logging
 import threading
 from traceback import extract_stack
-from typing import Any, Callable, Coroutine, TypeVar
+from typing import Any, Awaitable, Callable, Coroutine, TypeVar
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,3 +121,21 @@ def protect_loop(func: Callable) -> Callable:
         return func(*args, **kwargs)
 
     return protected_loop_func
+
+
+async def gather_with_concurrency(
+    n: int, *tasks: Any, return_exceptions: bool = False
+) -> Any:
+    """Wrap asyncio.gather to limit the number of concurrent tasks.
+
+    From: https://stackoverflow.com/a/61478547/9127614
+    """
+    semaphore = Semaphore(n)
+
+    async def sem_task(task: Awaitable[Any]) -> Any:
+        async with semaphore:
+            return await task
+
+    return await gather(
+        *(sem_task(task) for task in tasks), return_exceptions=return_exceptions
+    )

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -124,13 +124,13 @@ def protect_loop(func: Callable) -> Callable:
 
 
 async def gather_with_concurrency(
-    n: int, *tasks: Any, return_exceptions: bool = False
+    limit: int, *tasks: Any, return_exceptions: bool = False
 ) -> Any:
     """Wrap asyncio.gather to limit the number of concurrent tasks.
 
     From: https://stackoverflow.com/a/61478547/9127614
     """
-    semaphore = Semaphore(n)
+    semaphore = Semaphore(limit)
 
     async def sem_task(task: Awaitable[Any]) -> Any:
         async with semaphore:


### PR DESCRIPTION
Similar to https://github.com/home-assistant/core/pull/43079. Follow up to https://github.com/home-assistant/core/pull/42172#issuecomment-713806645. Thanks for @elupus for providing the link to `gather_with_concurrency`


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since async_get_integration is waiting on the disk most of the time
it would end up creating many new executor threads because the disk could
not deliver the data in time.

After this change and, the prior reductions in #42172, and #43079 at least one production instance I was testing with went from 48 (0.117.x) => 25 (after #42172) => 19 (after #43079) => 7 (after #43085) SyncWorker threads. 
```
bash-5.0# ./py-spy dump --pid 208|grep Sync
Thread 236 (idle): "SyncWorker_0"
Thread 237 (idle): "SyncWorker_1"
Thread 238 (idle): "SyncWorker_2"
Thread 241 (idle): "SyncWorker_3"
Thread 242 (idle): "SyncWorker_4"
Thread 250 (idle): "SyncWorker_5"
Thread 251 (idle): "SyncWorker_6"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
