### PR TITLE
Add support for multiple event triggers in automation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -43,40 +43,35 @@ from homeassistant.helpers.script import (
     ATTR_MODE,
     CONF_MAX,
     CONF_MAX_EXCEEDED,
-    SCRIPT_MODE_SINGLE,
     Script,
-    make_script_schema,
 )
 from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.service import async_register_admin_service
-from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util.dt import parse_datetime
 
+from .config import async_validate_config_item
+from .const import (
+    CONF_ACTION,
+    CONF_CONDITION,
+    CONF_INITIAL_STATE,
+    CONF_TRIGGER,
+    DEFAULT_INITIAL_STATE,
+    DOMAIN,
+    LOGGER,
+)
+from .helpers import async_get_blueprints
+
 # mypy: allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs, no-warn-return-any
 
-DOMAIN = "automation"
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
-DATA_BLUEPRINTS = "automation_blueprints"
 
-CONF_DESCRIPTION = "description"
-CONF_HIDE_ENTITY = "hide_entity"
-
-CONF_CONDITION = "condition"
-CONF_ACTION = "action"
-CONF_TRIGGER = "trigger"
-CONF_CONDITION_TYPE = "condition_type"
-CONF_INITIAL_STATE = "initial_state"
 CONF_SKIP_CONDITION = "skip_condition"
 CONF_STOP_ACTIONS = "stop_actions"
-CONF_BLUEPRINT = "blueprint"
-CONF_INPUT = "input"
-
-DEFAULT_INITIAL_STATE = True
 DEFAULT_STOP_ACTIONS = True
 
 EVENT_AUTOMATION_RELOADED = "automation_reloaded"
@@ -87,37 +82,7 @@ ATTR_SOURCE = "source"
 ATTR_VARIABLES = "variables"
 SERVICE_TRIGGER = "trigger"
 
-_LOGGER = logging.getLogger(__name__)
-
 AutomationActionType = Callable[[HomeAssistant, TemplateVarsType], Awaitable[None]]
-
-_CONDITION_SCHEMA = vol.All(cv.ensure_list, [cv.CONDITION_SCHEMA])
-
-PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_HIDE_ENTITY, invalidation_version="0.110"),
-    make_script_schema(
-        {
-            # str on purpose
-            CONF_ID: str,
-            CONF_ALIAS: cv.string,
-            vol.Optional(CONF_DESCRIPTION): cv.string,
-            vol.Optional(CONF_INITIAL_STATE): cv.boolean,
-            vol.Optional(CONF_HIDE_ENTITY): cv.boolean,
-            vol.Required(CONF_TRIGGER): cv.TRIGGER_SCHEMA,
-            vol.Optional(CONF_CONDITION): _CONDITION_SCHEMA,
-            vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
-            vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
-        },
-        SCRIPT_MODE_SINGLE,
-    ),
-)
-
-
-@singleton(DATA_BLUEPRINTS)
-@callback
-def async_get_blueprints(hass: HomeAssistant) -> blueprint.DomainBlueprints:  # type: ignore
-    """Get automation blueprints."""
-    return blueprint.DomainBlueprints(hass, DOMAIN, _LOGGER)  # type: ignore
 
 
 @bind_hass
@@ -194,7 +159,7 @@ def devices_in_automation(hass: HomeAssistant, entity_id: str) -> List[str]:
 
 async def async_setup(hass, config):
     """Set up the automation."""
-    hass.data[DOMAIN] = component = EntityComponent(_LOGGER, DOMAIN, hass)
+    hass.data[DOMAIN] = component = EntityComponent(LOGGER, DOMAIN, hass)
 
     await _async_process_config(hass, config, component)
 
@@ -263,7 +228,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         self._is_enabled = False
         self._referenced_entities: Optional[Set[str]] = None
         self._referenced_devices: Optional[Set[str]] = None
-        self._logger = _LOGGER
+        self._logger = LOGGER
         self._variables: ScriptVariables = variables
 
     @property
@@ -536,10 +501,12 @@ async def _async_process_config(
                 try:
                     config_block = cast(
                         Dict[str, Any],
-                        PLATFORM_SCHEMA(blueprint_inputs.async_substitute()),
+                        await async_validate_config_item(
+                            hass, blueprint_inputs.async_substitute()
+                        ),
                     )
                 except vol.Invalid as err:
-                    _LOGGER.error(
+                    LOGGER.error(
                         "Blueprint %s generated invalid automation with inputs %s: %s",
                         blueprint_inputs.blueprint.name,
                         blueprint_inputs.inputs,
@@ -561,7 +528,7 @@ async def _async_process_config(
                 script_mode=config_block[CONF_MODE],
                 max_runs=config_block[CONF_MAX],
                 max_exceeded=config_block[CONF_MAX_EXCEEDED],
-                logger=_LOGGER,
+                logger=LOGGER,
                 # We don't pass variables here
                 # Automation will already render them to use them in the condition
                 # and so will pass them on to the script.
@@ -600,7 +567,7 @@ async def _async_process_if(hass, config, p_config):
         try:
             checks.append(await condition.async_from_config(hass, if_config, False))
         except HomeAssistantError as ex:
-            _LOGGER.warning("Invalid condition: %s", ex)
+            LOGGER.warning("Invalid condition: %s", ex)
             return None
 
     def if_action(variables=None):

--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -8,24 +8,47 @@ from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.config import async_log_exception, config_without_domain
+from homeassistant.const import CONF_ALIAS, CONF_ID, CONF_VARIABLES
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_per_platform
+from homeassistant.helpers import config_per_platform, config_validation as cv, script
 from homeassistant.helpers.condition import async_validate_condition_config
-from homeassistant.helpers.script import async_validate_actions_config
 from homeassistant.helpers.trigger import async_validate_trigger_config
 from homeassistant.loader import IntegrationNotFound
 
-from . import (
+from .const import (
     CONF_ACTION,
     CONF_CONDITION,
+    CONF_DESCRIPTION,
+    CONF_HIDE_ENTITY,
+    CONF_INITIAL_STATE,
     CONF_TRIGGER,
     DOMAIN,
-    PLATFORM_SCHEMA,
-    async_get_blueprints,
 )
+from .helpers import async_get_blueprints
 
 # mypy: allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs, no-warn-return-any
+
+_CONDITION_SCHEMA = vol.All(cv.ensure_list, [cv.CONDITION_SCHEMA])
+
+PLATFORM_SCHEMA = vol.All(
+    cv.deprecated(CONF_HIDE_ENTITY, invalidation_version="0.110"),
+    script.make_script_schema(
+        {
+            # str on purpose
+            CONF_ID: str,
+            CONF_ALIAS: cv.string,
+            vol.Optional(CONF_DESCRIPTION): cv.string,
+            vol.Optional(CONF_INITIAL_STATE): cv.boolean,
+            vol.Optional(CONF_HIDE_ENTITY): cv.boolean,
+            vol.Required(CONF_TRIGGER): cv.TRIGGER_SCHEMA,
+            vol.Optional(CONF_CONDITION): _CONDITION_SCHEMA,
+            vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
+            vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
+        },
+        script.SCRIPT_MODE_SINGLE,
+    ),
+)
 
 
 async def async_validate_config_item(hass, config, full_config=None):
@@ -48,7 +71,9 @@ async def async_validate_config_item(hass, config, full_config=None):
             ]
         )
 
-    config[CONF_ACTION] = await async_validate_actions_config(hass, config[CONF_ACTION])
+    config[CONF_ACTION] = await script.async_validate_actions_config(
+        hass, config[CONF_ACTION]
+    )
 
     return config
 

--- a/homeassistant/components/automation/const.py
+++ b/homeassistant/components/automation/const.py
@@ -1,0 +1,19 @@
+"""Constants for the automation integration."""
+import logging
+
+CONF_CONDITION = "condition"
+CONF_ACTION = "action"
+CONF_TRIGGER = "trigger"
+DOMAIN = "automation"
+
+CONF_DESCRIPTION = "description"
+CONF_HIDE_ENTITY = "hide_entity"
+
+CONF_CONDITION_TYPE = "condition_type"
+CONF_INITIAL_STATE = "initial_state"
+CONF_BLUEPRINT = "blueprint"
+CONF_INPUT = "input"
+
+DEFAULT_INITIAL_STATE = True
+
+LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/automation/helpers.py
+++ b/homeassistant/components/automation/helpers.py
@@ -1,0 +1,15 @@
+"""Helpers for automation integration."""
+from homeassistant.components import blueprint
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.singleton import singleton
+
+from .const import DOMAIN, LOGGER
+
+DATA_BLUEPRINTS = "automation_blueprints"
+
+
+@singleton(DATA_BLUEPRINTS)
+@callback
+def async_get_blueprints(hass: HomeAssistant) -> blueprint.DomainBlueprints:  # type: ignore
+    """Get automation blueprints."""
+    return blueprint.DomainBlueprints(hass, DOMAIN, LOGGER)  # type: ignore

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -2,8 +2,11 @@
 from collections import OrderedDict
 import uuid
 
-from homeassistant.components.automation import DOMAIN, PLATFORM_SCHEMA
-from homeassistant.components.automation.config import async_validate_config_item
+from homeassistant.components.automation.config import (
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    async_validate_config_item,
+)
 from homeassistant.config import AUTOMATION_CONFIG_PATH
 from homeassistant.const import CONF_ID, SERVICE_RELOAD
 from homeassistant.helpers import config_validation as cv, entity_registry

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -59,6 +59,33 @@ async def test_if_fires_on_event(hass, calls):
     assert len(calls) == 1
 
 
+async def test_if_fires_on_multiple_events(hass, calls):
+    """Test the firing of events."""
+    context = Context()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "event",
+                    "event_type": ["test_event", "test2_event"],
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event", context=context)
+    await hass.async_block_till_done()
+    hass.bus.async_fire("test2_event", context=context)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[0].context.parent_id == context.id
+    assert calls[1].context.parent_id == context.id
+
+
 async def test_if_fires_on_event_extra_data(hass, calls, context_with_user):
     """Test the firing of events still matches with event data and context."""
     assert await async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for listening to multiple events with a single trigger.
Not a big change, but helps to reduce YAML overload a little if you listen for multiple events with similar (or no) data/context.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
automation:
  trigger:
    platform: event
    event_type:
      - automation_reloaded
      - scene_reloaded
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15611

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
