### PR TITLE
Add support for multiple tags and devices in tag trigger

### DIFF
--- a/homeassistant/components/tag/trigger.py
+++ b/homeassistant/components/tag/trigger.py
@@ -40,11 +40,9 @@ async def async_attach_trigger(hass, config, action, automation_info):
     @callback
     def handle_event(event):
         """Listen for tag scan events and calls the action when data matches."""
-        print(event.data)
         try:
             tag_data_schema(event.data)
         except vol.Invalid:
-            print("OMG PUPPIES!")
             # If event doesn't match, skip tag event
             return
 

--- a/homeassistant/components/tag/trigger.py
+++ b/homeassistant/components/tag/trigger.py
@@ -3,6 +3,7 @@ import voluptuous as vol
 
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
 from .const import DEVICE_ID, DOMAIN, EVENT_TAG_SCANNED, TAG_ID
@@ -10,7 +11,7 @@ from .const import DEVICE_ID, DOMAIN, EVENT_TAG_SCANNED, TAG_ID
 TRIGGER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_PLATFORM): DOMAIN,
-        vol.Required(TAG_ID): cv.string,
+        vol.Required(TAG_ID): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(DEVICE_ID): cv.string,
     }
 )
@@ -18,20 +19,32 @@ TRIGGER_SCHEMA = vol.Schema(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for tag_scanned events based on configuration."""
-    tag_id = config.get(TAG_ID)
+    tag_ids = config.get(TAG_ID)
     device_id = config.get(DEVICE_ID)
-    event_data = {TAG_ID: tag_id}
+    removes = []
 
-    if device_id:
-        event_data[DEVICE_ID] = device_id
+    for tag_id in tag_ids:
+        event_data = {TAG_ID: tag_id}
+        if device_id:
+            event_data[DEVICE_ID] = device_id
 
-    event_config = {
-        event_trigger.CONF_PLATFORM: "event",
-        event_trigger.CONF_EVENT_TYPE: EVENT_TAG_SCANNED,
-        event_trigger.CONF_EVENT_DATA: event_data,
-    }
-    event_config = event_trigger.TRIGGER_SCHEMA(event_config)
+        event_config = {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: EVENT_TAG_SCANNED,
+            event_trigger.CONF_EVENT_DATA: event_data,
+        }
+        event_config = event_trigger.TRIGGER_SCHEMA(event_config)
 
-    return await event_trigger.async_attach_trigger(
-        hass, event_config, action, automation_info, platform_type=DOMAIN
-    )
+        removes.append(
+            await event_trigger.async_attach_trigger(
+                hass, event_config, action, automation_info, platform_type=DOMAIN
+            )
+        )
+
+    @callback
+    def remove_triggers():
+        """Remove event triggers."""
+        for remove in removes:
+            remove()
+
+    return remove_triggers

--- a/homeassistant/components/tag/trigger.py
+++ b/homeassistant/components/tag/trigger.py
@@ -26,7 +26,9 @@ async def async_attach_trigger(hass, config, action, automation_info):
     @callback
     def handle_event(event):
         """Listen for tag scan events and calls the action when data matches."""
-        if event.data.get(TAG_ID) not in device_ids or (device_ids and event.data.get(DEVICE_ID) not in device_ids):
+        if event.data.get(TAG_ID) not in tag_ids or (
+            device_ids and event.data.get(DEVICE_ID) not in device_ids
+        ):
             return
 
         hass.async_run_hass_job(

--- a/homeassistant/components/tag/trigger.py
+++ b/homeassistant/components/tag/trigger.py
@@ -1,9 +1,8 @@
 """Support for tag triggers."""
 import voluptuous as vol
 
-from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import CONF_PLATFORM
-from homeassistant.core import callback
+from homeassistant.core import HassJob, callback
 from homeassistant.helpers import config_validation as cv
 
 from .const import DEVICE_ID, DOMAIN, EVENT_TAG_SCANNED, TAG_ID
@@ -12,7 +11,7 @@ TRIGGER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_PLATFORM): DOMAIN,
         vol.Required(TAG_ID): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(DEVICE_ID): cv.string,
+        vol.Optional(DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 
@@ -20,31 +19,45 @@ TRIGGER_SCHEMA = vol.Schema(
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for tag_scanned events based on configuration."""
     tag_ids = config.get(TAG_ID)
-    device_id = config.get(DEVICE_ID)
-    removes = []
+    device_ids = config.get(DEVICE_ID)
 
-    for tag_id in tag_ids:
-        event_data = {TAG_ID: tag_id}
-        if device_id:
-            event_data[DEVICE_ID] = device_id
+    tag_data_schema = vol.Schema(
+        {
+            vol.Required(TAG_ID): vol.In(tag_ids),
+        },
+        extra=vol.ALLOW_EXTRA,
+    )
 
-        event_config = {
-            event_trigger.CONF_PLATFORM: "event",
-            event_trigger.CONF_EVENT_TYPE: EVENT_TAG_SCANNED,
-            event_trigger.CONF_EVENT_DATA: event_data,
-        }
-        event_config = event_trigger.TRIGGER_SCHEMA(event_config)
-
-        removes.append(
-            await event_trigger.async_attach_trigger(
-                hass, event_config, action, automation_info, platform_type=DOMAIN
-            )
+    if device_ids:
+        tag_data_schema = tag_data_schema.extend(
+            {
+                vol.Required(DEVICE_ID): vol.In(device_ids),
+            }
         )
 
-    @callback
-    def remove_triggers():
-        """Remove event triggers."""
-        for remove in removes:
-            remove()
+    job = HassJob(action)
 
-    return remove_triggers
+    @callback
+    def handle_event(event):
+        """Listen for tag scan events and calls the action when data matches."""
+        print(event.data)
+        try:
+            tag_data_schema(event.data)
+        except vol.Invalid:
+            print("OMG PUPPIES!")
+            # If event doesn't match, skip tag event
+            return
+
+        hass.async_run_hass_job(
+            job,
+            {
+                "trigger": {
+                    "platform": DOMAIN,
+                    "event": event,
+                    "description": "Tag scanned",
+                }
+            },
+            event.context,
+        )
+
+    return hass.bus.async_listen(EVENT_TAG_SCANNED, handle_event)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, defining tags in automation triggers can be daunting if you want to respond to multiple specific tags or multiple devices (requires duplication of triggers).

This PR removes that by allowing to specify multiple tag IDs and multiple device IDs in a single trigger.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
automation:
  trigger:
    platform: tag
    tag_id:
      - A7-6B-90-5F
      - A7-6B-44-AD
```


```yaml
# Example configuration.yaml
automation:
  trigger:
    platform: tag
    tag_id: A7-6B-90-5F
    device_id:
      - 0e19cd3cf2b311ea88f469a7512c307d
      - d0609cb25f4a13922bb27d8f86e4c821
```

```yaml
# Example configuration.yaml
automation:
  trigger:
    platform: tag
    tag_id:
      - A7-6B-90-5F
      - A7-6B-44-AD
    device_id:
      - 0e19cd3cf2b311ea88f469a7512c307d
      - d0609cb25f4a13922bb27d8f86e4c821
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15612

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
