### PR TITLE
0.117.6

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -362,6 +362,7 @@ homeassistant/components/rmvtransport/* @cgtobi
 homeassistant/components/roku/* @ctalkington
 homeassistant/components/roomba/* @pschmitt @cyr-ius @shenxn
 homeassistant/components/roon/* @pavoni
+homeassistant/components/rpi_gpio_pwm/* @soldag
 homeassistant/components/rpi_power/* @shenxn @swetoast
 homeassistant/components/ruckus_unleashed/* @gabe565
 homeassistant/components/safe_mode/* @home-assistant/core

--- a/homeassistant/components/google_translate/manifest.json
+++ b/homeassistant/components/google_translate/manifest.json
@@ -2,6 +2,6 @@
   "domain": "google_translate",
   "name": "Google Translate Text-to-Speech",
   "documentation": "https://www.home-assistant.io/integrations/google_translate",
-  "requirements": ["gTTS-token==1.1.3"],
+  "requirements": ["gTTS-token==1.1.4"],
   "codeowners": []
 }

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -289,6 +289,8 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_plex_website_auth(self):
         """Begin external auth flow on Plex website."""
         self.hass.http.register_view(PlexAuthorizationCallbackView)
+        hass_url = get_url(self.hass)
+        headers = {"Origin": hass_url}
         payload = {
             "X-Plex-Device-Name": X_PLEX_DEVICE_NAME,
             "X-Plex-Version": X_PLEX_VERSION,
@@ -298,9 +300,9 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             "X-Plex-Model": "Plex OAuth",
         }
         session = async_get_clientsession(self.hass)
-        self.plexauth = PlexAuth(payload, session)
+        self.plexauth = PlexAuth(payload, session, headers)
         await self.plexauth.initiate_auth()
-        forward_url = f"{get_url(self.hass)}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
+        forward_url = f"{hass_url}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
         auth_url = self.plexauth.auth_url(forward_url)
         return self.async_external_step(step_id="obtain_token", url=auth_url)
 

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -4,9 +4,9 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/plex",
   "requirements": [
-      "plexapi==4.1.1",
-      "plexauth==0.0.5",
-      "plexwebsocket==0.0.12"
+    "plexapi==4.1.1",
+    "plexauth==0.0.6",
+    "plexwebsocket==0.0.12"
   ],
   "dependencies": ["http"],
   "after_dependencies": ["sonos"],

--- a/homeassistant/components/rpi_gpio_pwm/light.py
+++ b/homeassistant/components/rpi_gpio_pwm/light.py
@@ -123,9 +123,6 @@ class PwmSimpleLed(LightEntity, RestoreEntity):
             self._brightness = last_state.attributes.get(
                 "brightness", DEFAULT_BRIGHTNESS
             )
-            self._led.set(
-                is_on=self._is_on, brightness=_from_hass_brightness(self._brightness)
-            )
 
     @property
     def should_poll(self):
@@ -199,7 +196,6 @@ class PwmRgbLed(PwmSimpleLed):
         last_state = await self.async_get_last_state()
         if last_state:
             self._color = last_state.attributes.get("hs_color", DEFAULT_COLOR)
-            self._led.set(color=_from_hass_color(self._color))
 
     @property
     def hs_color(self):

--- a/homeassistant/components/rpi_gpio_pwm/manifest.json
+++ b/homeassistant/components/rpi_gpio_pwm/manifest.json
@@ -3,5 +3,5 @@
   "name": "pigpio Daemon PWM LED",
   "documentation": "https://www.home-assistant.io/integrations/rpi_gpio_pwm",
   "requirements": ["pwmled==1.6.6"],
-  "codeowners": []
+  "codeowners": ["@soldag"]
 }

--- a/homeassistant/components/rpi_gpio_pwm/manifest.json
+++ b/homeassistant/components/rpi_gpio_pwm/manifest.json
@@ -2,6 +2,6 @@
   "domain": "rpi_gpio_pwm",
   "name": "pigpio Daemon PWM LED",
   "documentation": "https://www.home-assistant.io/integrations/rpi_gpio_pwm",
-  "requirements": ["pwmled==1.6.6"],
+  "requirements": ["pwmled==1.6.7"],
   "codeowners": ["@soldag"]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 117
-PATCH_VERSION = "5"
+PATCH_VERSION = "6"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1182,7 +1182,7 @@ pushbullet.py==0.11.0
 pushover_complete==1.1.1
 
 # homeassistant.components.rpi_gpio_pwm
-pwmled==1.6.6
+pwmled==1.6.7
 
 # homeassistant.components.august
 py-august==0.25.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1124,7 +1124,7 @@ pizzapi==0.0.3
 plexapi==4.1.1
 
 # homeassistant.components.plex
-plexauth==0.0.5
+plexauth==0.0.6
 
 # homeassistant.components.plex
 plexwebsocket==0.0.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -619,7 +619,7 @@ freesms==0.1.2
 fritzconnection==1.2.0
 
 # homeassistant.components.google_translate
-gTTS-token==1.1.3
+gTTS-token==1.1.4
 
 # homeassistant.components.garmin_connect
 garminconnect==0.1.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -302,7 +302,7 @@ fnvhash==0.1.0
 foobot_async==0.3.2
 
 # homeassistant.components.google_translate
-gTTS-token==1.1.3
+gTTS-token==1.1.4
 
 # homeassistant.components.garmin_connect
 garminconnect==0.1.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -541,7 +541,7 @@ pillow==7.2.0
 plexapi==4.1.1
 
 # homeassistant.components.plex
-plexauth==0.0.5
+plexauth==0.0.6
 
 # homeassistant.components.plex
 plexwebsocket==0.0.12


### PR DESCRIPTION
- Remove unneeded state restoration of the physical device in rpi_gpio_pwm integration ([@soldag] - [#42804]) ([rpi_gpio_pwm docs])
- Bump pwmled to v1.6.7 ([@soldag] - [#42903]) ([rpi_gpio_pwm docs])
- Bump gTTS-token to 1.1.4 ([@hmmbob] - [#43015]) ([google_translate docs])
- Fix Plex auth issues by setting header ([@jjlawren] - [#43081]) ([plex docs])

[#42804]: https://github.com/home-assistant/core/pull/42804
[#42903]: https://github.com/home-assistant/core/pull/42903
[#43015]: https://github.com/home-assistant/core/pull/43015
[#43081]: https://github.com/home-assistant/core/pull/43081
[@hmmbob]: https://github.com/hmmbob
[@jjlawren]: https://github.com/jjlawren
[@soldag]: https://github.com/soldag
[google_translate docs]: https://www.home-assistant.io/integrations/google_translate/
[plex docs]: https://www.home-assistant.io/integrations/plex/
[rpi_gpio_pwm docs]: https://www.home-assistant.io/integrations/rpi_gpio_pwm/