### PR TITLE
Improvement to allow parsing of station ID in vasttrafik integration

### DIFF
--- a/homeassistant/components/vasttrafik/sensor.py
+++ b/homeassistant/components/vasttrafik/sensor.py
@@ -80,13 +80,22 @@ class VasttrafikDepartureSensor(Entity):
         """Initialize the sensor."""
         self._planner = planner
         self._name = name or departure
-        self._departure = planner.location_name(departure)[0]
-        self._heading = planner.location_name(heading)[0] if heading else None
+        self._departure = self.get_station_id(departure)
+        self._heading = self.get_station_id(heading) if heading else None
         self._lines = lines if lines else None
         self._delay = timedelta(minutes=delay)
         self._departureboard = None
         self._state = None
         self._attributes = None
+
+    def get_station_id(self, location):
+        """Get the station ID."""
+        if location.isdecimal():
+            station_info = {"station_name": location, "station_id": location}
+        else:
+            station_id = self._planner.location_name(location)[0]["id"]
+            station_info = {"station_name": location, "station_id": station_id}
+        return station_info
 
     @property
     def name(self):
@@ -113,8 +122,8 @@ class VasttrafikDepartureSensor(Entity):
         """Get the departure board."""
         try:
             self._departureboard = self._planner.departureboard(
-                self._departure["id"],
-                direction=self._heading["id"] if self._heading else None,
+                self._departure["station_id"],
+                direction=self._heading["station_id"] if self._heading else None,
                 date=now() + self._delay,
             )
         except vasttrafik.Error:
@@ -123,9 +132,9 @@ class VasttrafikDepartureSensor(Entity):
 
         if not self._departureboard:
             _LOGGER.debug(
-                "No departures from %s heading %s",
-                self._departure["name"],
-                self._heading["name"] if self._heading else "ANY",
+                "No departures from departure station %s " "to destination station %s",
+                self._departure["station_name"],
+                self._heading["station_name"] if self._heading else "ANY",
             )
             self._state = None
             self._attributes = {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This change addresses an issue raised in #34851 where an incorrect station/bus/tram stop is selected. Currently it is only possible to provide the departure/destination names in the configuration. When this is sent to the Västtrafik API it will respond with the station of the highest weight (most popular), which is not always the correct one. This change allows for the user to instead provide the station ID in the configuration, which ensures the correct station will be selected. This change still allows the user to provide the station name if they wish. In order to utilize this functionality the documentation for this integration needs to be updated so the user knows how to retrieve the station ID. Documentation PR: [15623](https://github.com/home-assistant/home-assistant.io/pull/15623)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: vasttrafik
      key: redacted 
      secret: redacted
      departures:
        - name: mot Frölunda Torg
          from: 9021014002240000
          heading: 9021014002530000
          delay: 9

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34851
- This PR is related to issue: 
- Link to documentation pull request: [15623](https://github.com/home-assistant/home-assistant.io/pull/15623)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
