### PR TITLE
Make sure generated slugs are not empty

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -44,7 +44,8 @@ def sanitize_path(path: str) -> str:
 
 def slugify(text: str, *, separator: str = "_") -> str:
     """Slugify a given text."""
-    return unicode_slug.slugify(text, separator=separator)
+    slug = unicode_slug.slugify(text, separator=separator)
+    return "unknown" if slug == "" else slug
 
 
 def repr_helper(inp: Any) -> str:

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -44,6 +44,8 @@ def sanitize_path(path: str) -> str:
 
 def slugify(text: str, *, separator: str = "_") -> str:
     """Slugify a given text."""
+    if text == "":
+        return ""
     slug = unicode_slug.slugify(text, separator=separator)
     return "unknown" if slug == "" else slug
 

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -41,6 +41,8 @@ def test_slugify():
     assert util.slugify("影師嗎") == "ying_shi_ma"
     assert util.slugify("けいふぉんと") == "keihuonto"
     assert util.slugify("$") == "unknown"
+    assert util.slugify("Ⓐ") == "unknown"
+    assert util.slugify("ⓑ") == "unknown"
     assert util.slugify("$$$") == "unknown"
     assert util.slugify("$something") == "something"
     assert util.slugify("") == ""

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -43,6 +43,7 @@ def test_slugify():
     assert util.slugify("$") == "unknown"
     assert util.slugify("$$$") == "unknown"
     assert util.slugify("$something") == "something"
+    assert util.slugify("") == ""
 
 
 def test_repr_helper():

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -40,6 +40,9 @@ def test_slugify():
     assert util.slugify("Tèst_äöüß_ÄÖÜ") == "test_aouss_aou"
     assert util.slugify("影師嗎") == "ying_shi_ma"
     assert util.slugify("けいふぉんと") == "keihuonto"
+    assert util.slugify("$") == "unknown"
+    assert util.slugify("$$$") == "unknown"
+    assert util.slugify("$something") == "something"
 
 
 def test_repr_helper():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Make sure that slugs generated from names are always at least one character long. If they are not, things will break in interesting ways.

Reproduction: Create a new automation and name it `@`

Result:
```
2020-11-12 20:49:12 ERROR (MainThread) [homeassistant.components.automation] Error adding entities for domain automation with platform automation
Traceback (most recent call last):
  File "/workspaces/homeassistant/helpers/entity_platform.py", line 316, in async_add_entities
    await asyncio.gather(*tasks)
  File "/workspaces/homeassistant/helpers/entity_platform.py", line 467, in _async_add_entity
    raise HomeAssistantError(f"Invalid entity id: {entity.entity_id}")
homeassistant.exceptions.HomeAssistantError: Invalid entity id: automation.
2020-11-12 20:49:12 ERROR (MainThread) [homeassistant.core] Error executing service: <ServiceCall automation.reload (c:efcc91f322e715dcbe8bba8e73eb3a12)>
Traceback (most recent call last):
  File "/workspaces/homeassistant/core.py", line 1467, in catch_exceptions
    await coro_or_task
  File "/workspaces/homeassistant/core.py", line 1486, in _execute_service
    await handler.job.target(service_call)
  File "/workspaces/homeassistant/helpers/service.py", line 569, in admin_handler
    await result
  File "/workspaces/homeassistant/components/automation/__init__.py", line 196, in reload_service_handler
    await _async_process_config(hass, conf, component)
  File "/workspaces/homeassistant/components/automation/__init__.py", line 558, in _async_process_config
    await component.async_add_entities(entities)
  File "/workspaces/homeassistant/helpers/entity_platform.py", line 316, in async_add_entities
    await asyncio.gather(*tasks)
  File "/workspaces/homeassistant/helpers/entity_platform.py", line 467, in _async_add_entity
    raise HomeAssistantError(f"Invalid entity id: {entity.entity_id}")
homeassistant.exceptions.HomeAssistantError: Invalid entity id: automation.
```

This popped up while working on a custom component (see jheling/freeathome#81). The system in question would frequently name devices Ⓐ, ⓑ etc. if the user does not provide a meaningful name, which in turn would break HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None. Reproduction: Create a new automation and call it `@` or `$`

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: jheling/freeathome#81
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
