### PR TITLE
Fix time_date timestamp offsets

### DIFF
--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -100,10 +100,13 @@ class TimeDateSensor(Entity):
             return now + timedelta(seconds=86400)
 
         if self.type == "beat":
+            # Add 1 hour because @0 beats is at 23:00:00 UTC.
+            timestamp = dt_util.as_timestamp(now + timedelta(hours=1))
             interval = 86.4
         else:
+            timestamp = dt_util.as_timestamp(now)
             interval = 60
-        timestamp = int(dt_util.as_timestamp(now))
+
         delta = interval - (timestamp % interval)
         next_interval = now + timedelta(seconds=delta)
         _LOGGER.debug("%s + %s -> %s (%s)", now, delta, next_interval, self.type)

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -20,16 +20,16 @@ def restore_ts():
 async def test_intervals(hass):
     """Test timing intervals of sensors."""
     device = time_date.TimeDateSensor(hass, "time")
-    now = dt_util.utc_from_timestamp(45)
+    now = dt_util.utc_from_timestamp(45.5)
     with patch("homeassistant.util.dt.utcnow", return_value=now):
         next_time = device.get_next_interval()
     assert next_time == dt_util.utc_from_timestamp(60)
 
     device = time_date.TimeDateSensor(hass, "beat")
-    now = dt_util.utc_from_timestamp(29)
+    now = dt_util.parse_datetime("2020-11-13 00:00:29+01:00")
     with patch("homeassistant.util.dt.utcnow", return_value=now):
         next_time = device.get_next_interval()
-    assert next_time == dt_util.utc_from_timestamp(86.4)
+    assert next_time == dt_util.parse_datetime("2020-11-13 00:01:26.4+01:00")
 
     device = time_date.TimeDateSensor(hass, "date_time")
     now = dt_util.utc_from_timestamp(1495068899)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This fixes `time_date` sensors to schedule updates for exactly the time where the value changes:

* Swatch beats were updated an hour too late because the offset from UTC was not accounted for in the modulo calculation (of course, some other update would make the value update frequently enough, but not at the right 86.4 multiple).
* Other timestamps were updated a fraction of a second too late because an `int()` made microseconds be maintained from when the listener was attached. So we had:
    * `get_next_interval(45) => 60`
    * `get_next_interval(45.5) => 60.5`
    * `get_next_interval(46) => 60`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
