### PR TITLE
Fix time_date interval for DST

### DIFF
--- a/homeassistant/components/time_date/sensor.py
+++ b/homeassistant/components/time_date/sensor.py
@@ -96,8 +96,8 @@ class TimeDateSensor(Entity):
         now = dt_util.utcnow()
 
         if self.type == "date":
-            now = dt_util.start_of_local_day(dt_util.as_local(now))
-            return now + timedelta(seconds=86400)
+            tomorrow = dt_util.as_local(now) + timedelta(days=1)
+            return dt_util.start_of_local_day(tomorrow)
 
         if self.type == "beat":
             interval = 86.4

--- a/tests/components/time_date/test_sensor.py
+++ b/tests/components/time_date/test_sensor.py
@@ -137,6 +137,32 @@ async def test_timezone_intervals(hass):
         next_time = device.get_next_interval()
     assert next_time.timestamp() == dt_util.as_timestamp("2017-11-14 00:00:00-07:00")
 
+    # Entering DST
+    new_tz = dt_util.get_time_zone("Europe/Prague")
+    assert new_tz is not None
+    dt_util.set_default_time_zone(new_tz)
+
+    now = dt_util.parse_datetime("2020-03-29 00:00+01:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-03-30 00:00+02:00")
+
+    now = dt_util.parse_datetime("2020-03-29 03:00+02:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-03-30 00:00+02:00")
+
+    # Leaving DST
+    now = dt_util.parse_datetime("2020-10-25 00:00+02:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-10-26 00:00:00+01:00")
+
+    now = dt_util.parse_datetime("2020-10-25 23:59+01:00")
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        next_time = device.get_next_interval()
+    assert next_time.timestamp() == dt_util.as_timestamp("2020-10-26 00:00:00+01:00")
+
 
 @patch(
     "homeassistant.util.dt.utcnow",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The date interval calculation failed with Daylight Savings Time:
* Entering DST would update the date on the following day at 01:00, an hour late
* Leaving DST would:
    * Schedule the next date update for the same day at 23:00, a no-op
    * Cause a 100% CPU busy loop between 23:00 and 00:00 because we would constantly schedule the next update for 23:00 which had already passed.
    * Miss a date when updates got back in sync at 00:00 (reported in #42465)

Both issues are fixed by moving `start_of_local_day()` to be _after_ the `timedelta(days=1)` adjustment.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42465
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
