### PR TITLE
Revert "Remove YAML config for Tile (#43064)"

### DIFF
--- a/homeassistant/components/tile/config_flow.py
+++ b/homeassistant/components/tile/config_flow.py
@@ -9,10 +9,6 @@ from homeassistant.helpers import aiohttp_client
 
 from .const import DOMAIN  # pylint: disable=unused-import
 
-DATA_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
-)
-
 
 class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Tile config flow."""
@@ -20,10 +16,26 @@ class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    def __init__(self):
+        """Initialize the config flow."""
+        self.data_schema = vol.Schema(
+            {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+        )
+
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
+        return self.async_show_form(
+            step_id="user", data_schema=self.data_schema, errors=errors or {}
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow."""
         if not user_input:
-            return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
+            return await self._show_form()
 
         await self.async_set_unique_id(user_input[CONF_USERNAME])
         self._abort_if_unique_id_configured()
@@ -35,10 +47,6 @@ class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD], session=session
             )
         except TileError:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=DATA_SCHEMA,
-                errors={"base": "invalid_auth"},
-            )
+            return await self._show_form({"base": "invalid_auth"})
 
         return self.async_create_entry(title=user_input[CONF_USERNAME], data=user_input)

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -3,6 +3,8 @@ import logging
 
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_GPS
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
 from . import DATA_COORDINATOR, DOMAIN, TileEntity
@@ -26,8 +28,30 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         [
             TileDeviceTracker(coordinator, tile_uuid, tile)
             for tile_uuid, tile in coordinator.data.items()
-        ]
+        ],
+        True,
     )
+
+
+async def async_setup_scanner(hass, config, async_see, discovery_info=None):
+    """Detect a legacy configuration and import it."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_USERNAME: config[CONF_USERNAME],
+                CONF_PASSWORD: config[CONF_PASSWORD],
+            },
+        )
+    )
+
+    _LOGGER.info(
+        "Your Tile configuration has been imported into the UI; "
+        "please remove it from configuration.yaml"
+    )
+
+    return True
 
 
 class TileDeviceTracker(TileEntity, TrackerEntity):

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -3,7 +3,7 @@ from pytile.errors import TileError
 
 from homeassistant import data_entry_flow
 from homeassistant.components.tile import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from tests.async_mock import patch
@@ -12,7 +12,10 @@ from tests.common import MockConfigEntry
 
 async def test_duplicate_error(hass):
     """Test that errors are shown when duplicates are added."""
-    conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "123abc"}
+    conf = {
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
+    }
 
     MockConfigEntry(domain=DOMAIN, unique_id="user@host.com", data=conf).add_to_hass(
         hass
@@ -28,7 +31,10 @@ async def test_duplicate_error(hass):
 
 async def test_invalid_credentials(hass):
     """Test that invalid credentials key throws an error."""
-    conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "123abc"}
+    conf = {
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
+    }
 
     with patch(
         "homeassistant.components.tile.config_flow.async_login",
@@ -41,9 +47,33 @@ async def test_invalid_credentials(hass):
         assert result["errors"] == {"base": "invalid_auth"}
 
 
+async def test_step_import(hass):
+    """Test that the import step works."""
+    conf = {
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
+    }
+
+    with patch(
+        "homeassistant.components.tile.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.tile.config_flow.async_login"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "user@host.com"
+        assert result["data"] == {
+            CONF_USERNAME: "user@host.com",
+            CONF_PASSWORD: "123abc",
+        }
+
+
 async def test_step_user(hass):
     """Test that the user step works."""
-    conf = {CONF_USERNAME: "user@host.com", CONF_PASSWORD: "123abc"}
+    conf = {
+        CONF_USERNAME: "user@host.com",
+        CONF_PASSWORD: "123abc",
+    }
 
     with patch(
         "homeassistant.components.tile.async_setup_entry", return_value=True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reverts commit 19f48e180c7e6a34bd93d7a849147a8de491771c.

Removing the legacy import code for Tile (#43064) yielded https://github.com/home-assistant/core/issues/43192, so this PR reverts that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/43192
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
