### PR TITLE
Bypass the slow update warning for group updates

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -1,4 +1,5 @@
 """Provide the functionality to group entities."""
+from abc import abstractmethod
 import asyncio
 from contextvars import ContextVar
 import logging
@@ -398,7 +399,8 @@ class GroupEntity(Entity):
         assert self.hass is not None
 
         async def _update_at_start(_):
-            await self.async_update_ha_state(True)
+            await self.async_update()
+            self.async_write_ha_state()
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _update_at_start)
 
@@ -409,7 +411,12 @@ class GroupEntity(Entity):
         if self.hass.state != CoreState.running:
             return
 
-        await self.async_update_ha_state(True)
+        await self.async_update()
+        self.async_write_ha_state()
+
+    @abstractmethod
+    async def async_update(self) -> None:
+        """Abstract method to update the entity."""
 
 
 class Group(Entity):

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -150,6 +150,8 @@ class CoverGroup(GroupEntity, CoverEntity):
         """Register listeners."""
         for entity_id in self._entities:
             new_state = self.hass.states.get(entity_id)
+            if new_state is None:
+                continue
             await self.async_update_supported_features(
                 entity_id, new_state, update_state=False
             )
@@ -307,6 +309,8 @@ class CoverGroup(GroupEntity, CoverEntity):
             self._cover_position = 0 if self.is_closed else 100
             for entity_id in self._covers[KEY_POSITION]:
                 state = self.hass.states.get(entity_id)
+                if state is None:
+                    continue
                 pos = state.attributes.get(ATTR_CURRENT_POSITION)
                 if position == -1:
                     position = pos
@@ -323,6 +327,8 @@ class CoverGroup(GroupEntity, CoverEntity):
             self._tilt_position = 100
             for entity_id in self._tilts[KEY_POSITION]:
                 state = self.hass.states.get(entity_id)
+                if state is None:
+                    continue
                 pos = state.attributes.get(ATTR_CURRENT_TILT_POSITION)
                 if position == -1:
                     position = pos
@@ -351,6 +357,8 @@ class CoverGroup(GroupEntity, CoverEntity):
         if not self._assumed_state:
             for entity_id in self._entities:
                 state = self.hass.states.get(entity_id)
+                if state is None:
+                    continue
                 if state and state.attributes.get(ATTR_ASSUMED_STATE):
                     self._assumed_state = True
                     break

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -63,6 +63,16 @@ CONFIG_POS = {
     ]
 }
 
+CONFIG_TILT_ONLY = {
+    DOMAIN: [
+        {"platform": "demo"},
+        {
+            "platform": "group",
+            CONF_ENTITIES: [DEMO_COVER_TILT, DEMO_TILT],
+        },
+    ]
+}
+
 CONFIG_ATTRIBUTES = {
     DOMAIN: {
         "platform": "group",
@@ -209,6 +219,34 @@ async def test_attributes(hass, setup_comp):
 
     state = hass.states.get(COVER_GROUP)
     assert state.attributes[ATTR_ASSUMED_STATE] is True
+
+
+@pytest.mark.parametrize("config_count", [(CONFIG_TILT_ONLY, 2)])
+async def test_cover_that_only_supports_tilt_removed(hass, setup_comp):
+    """Test removing a cover that support tilt."""
+    hass.states.async_set(
+        DEMO_COVER_TILT,
+        STATE_OPEN,
+        {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 60},
+    )
+    hass.states.async_set(
+        DEMO_TILT,
+        STATE_OPEN,
+        {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 60},
+    )
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPEN
+    assert state.attributes[ATTR_FRIENDLY_NAME] == DEFAULT_NAME
+    assert state.attributes[ATTR_ENTITY_ID] == [
+        DEMO_COVER_TILT,
+        DEMO_TILT,
+    ]
+    assert ATTR_ASSUMED_STATE not in state.attributes
+    assert ATTR_CURRENT_TILT_POSITION in state.attributes
+
+    hass.states.async_remove(DEMO_COVER_TILT)
+    hass.states.async_set(DEMO_TILT, STATE_CLOSED)
+    await hass.async_block_till_done()
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])


### PR DESCRIPTION
Noticed this while reviewing a profile in https://github.com/home-assistant/core/issues/40292#issuecomment-727144386

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bypass the slow update warning for group updates

This change also exposed some bugs the handling of
of covers being removed from the state machine since
all exceptions were being suppressed.

The overhead of the slow update checks when there are
a lot of groups seems unnecessary since they should
never be slow to update as they never do I/O.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
