### PR TITLE
Bump pyheos to 0.7.2

### DIFF
--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denon HEOS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/heos",
-  "requirements": ["pyheos==0.6.0"],
+  "requirements": ["pyheos==0.7.2"],
   "ssdp": [
     {
       "st": "urn:schemas-denon-com:device:ACT-Denon:1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1422,7 +1422,7 @@ pygti==0.9.2
 pyhaversion==3.4.2
 
 # homeassistant.components.heos
-pyheos==0.6.0
+pyheos==0.7.2
 
 # homeassistant.components.hikvision
 pyhik==0.2.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -710,7 +710,7 @@ pygti==0.9.2
 pyhaversion==3.4.2
 
 # homeassistant.components.heos
-pyheos==0.6.0
+pyheos==0.7.2
 
 # homeassistant.components.homematic
 pyhomematic==0.1.70


### PR DESCRIPTION
## Proposed change
Update dependency `pyheos` for HEOS integration to latest version. https://github.com/andrewsayre/pyheos/releases/tag/0.7.2

## Type of change
- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)

If the code communicates with devices, web services, or third-party tools:

- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
