### PR TITLE
Allow members of allowed groups to talk to telegram_bot

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -744,7 +744,7 @@ class BaseTelegramBotEntity:
             _LOGGER.error("Incoming message does not have required data (%s)", msg_data)
             return False, None
 
-        if msg_data["from"].get("id") not in self.allowed_chat_ids or (
+        if msg_data["from"].get("id") not in self.allowed_chat_ids and (
             "chat" in msg_data
             and msg_data["chat"].get("id") not in self.allowed_chat_ids
         ):

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -744,11 +744,12 @@ class BaseTelegramBotEntity:
             _LOGGER.error("Incoming message does not have required data (%s)", msg_data)
             return False, None
 
-        if msg_data["from"].get("id") not in self.allowed_chat_ids and (
-            "chat" in msg_data
+        if (
+            msg_data["from"].get("id") not in self.allowed_chat_ids
             and msg_data["chat"].get("id") not in self.allowed_chat_ids
         ):
-            # Origin is not allowed.
+            # Neither from id nor chat id was in allowed_chat_ids,
+            # origin is not allowed.
             _LOGGER.error("Incoming message is not allowed (%s)", msg_data)
             return True, None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking Change

The telegram bot integration now allows/accepts messages when either the allowed group (Chat ID) OR the User ID of the sender matches.

This is a different behavior compared to before as before both Group (Chat ID) AND User ID needed to be allowed. This allows members of a group to talk to the bot, even if they are not specifically listed as a user. 

If you use Telegram groups, make sure you adjust your configuration accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`telegram_bot` doesn't allow messages from group chats declared in `allowed_chat_ids` unless the user sending the message is also allowed - resulting in "Incoming message is not allowed". As described in #43009.
My proposal is to change the `or`  to `and` (see diff) - so instead of:
> User ID `or` Chat ID missing in `allowed_chat_ids` -> Denied

We would get:
> User ID `and` Chat ID missing in `allowed_chat_ids` -> Denied

I have tried this with my bot and it successfully allows members of allowed chat groups to talk to the bot even though the users are not explicitly added to `allowed_chat_ids`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
telegram_bot:
  - platform: webhooks
    api_key: API_KEY
    allowed_chat_ids:
      - AAA # me
      - -BBB # A group
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43009
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
