### PR TITLE
Refactor how entities are created for homekit_controller services

### DIFF
--- a/homeassistant/components/homekit_controller/air_quality.py
+++ b/homeassistant/components/homekit_controller/air_quality.py
@@ -1,5 +1,6 @@
 """Support for HomeKit Controller air quality sensors."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.air_quality import AirQualityEntity
 from homeassistant.core import callback
@@ -85,10 +86,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        if service["stype"] != "air-quality":
+    def async_add_service(service):
+        if service.short_type != ServicesTypes.AIR_QUALITY_SENSOR:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeAirQualitySensor(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -1,5 +1,6 @@
 """Support for Homekit Alarm Control Panel."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntity
 from homeassistant.components.alarm_control_panel.const import (
@@ -43,10 +44,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        if service["stype"] != "security-system":
+    def async_add_service(service):
+        if service.short_type != ServicesTypes.SECURITY_SYSTEM:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitAlarmControlPanelEntity(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -1,5 +1,6 @@
 """Support for Homekit motion sensors."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_GAS,
@@ -124,12 +125,12 @@ class HomeKitLeakSensor(HomeKitEntity, BinarySensorEntity):
 
 
 ENTITY_TYPES = {
-    "motion": HomeKitMotionSensor,
-    "contact": HomeKitContactSensor,
-    "smoke": HomeKitSmokeSensor,
-    "carbon-monoxide": HomeKitCarbonMonoxideSensor,
-    "occupancy": HomeKitOccupancySensor,
-    "leak": HomeKitLeakSensor,
+    ServicesTypes.MOTION_SENSOR: HomeKitMotionSensor,
+    ServicesTypes.CONTACT_SENSOR: HomeKitContactSensor,
+    ServicesTypes.SMOKE_SENSOR: HomeKitSmokeSensor,
+    ServicesTypes.CARBON_MONOXIDE_SENSOR: HomeKitCarbonMonoxideSensor,
+    ServicesTypes.OCCUPANCY_SENSOR: HomeKitOccupancySensor,
+    ServicesTypes.LEAK_SENSOR: HomeKitLeakSensor,
 }
 
 
@@ -139,11 +140,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        entity_class = ENTITY_TYPES.get(service["stype"])
+    def async_add_service(service):
+        entity_class = ENTITY_TYPES.get(service.short_type)
         if not entity_class:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -10,6 +10,7 @@ from aiohomekit.model.characteristics import (
     SwingModeValues,
     TargetHeaterCoolerStateValues,
 )
+from aiohomekit.model.services import ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
 
 from homeassistant.components.climate import (
@@ -87,11 +88,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        entity_class = ENTITY_TYPES.get(service["stype"])
+    def async_add_service(service):
+        entity_class = ENTITY_TYPES.get(service.short_type)
         if not entity_class:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)
         return True
 
@@ -454,6 +455,6 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
 
 
 ENTITY_TYPES = {
-    "heater-cooler": HomeKitHeaterCoolerEntity,
-    "thermostat": HomeKitClimateEntity,
+    ServicesTypes.HEATER_COOLER: HomeKitHeaterCoolerEntity,
+    ServicesTypes.THERMOSTAT: HomeKitClimateEntity,
 }

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -317,19 +317,17 @@ class HKDevice:
         self._add_new_entities_for_accessory(self.accessory_factories)
 
     def _add_new_entities(self, callbacks):
-        for accessory in self.accessories:
-            aid = accessory["aid"]
-            for service in accessory["services"]:
-                iid = service["iid"]
-                stype = ServicesTypes.get_short(service["type"].upper())
-                service["stype"] = stype
+        for accessory in self.entity_map.accessories:
+            aid = accessory.aid
+            for service in accessory.services:
+                iid = service.iid
 
                 if (aid, iid) in self.entities:
                     # Don't add the same entity again
                     continue
 
                 for listener in callbacks:
-                    if listener(aid, service):
+                    if listener(service):
                         self.entities.append((aid, iid))
                         break
 

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -1,5 +1,6 @@
 """Support for Homekit covers."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -39,17 +40,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        info = {"aid": aid, "iid": service["iid"]}
-        if service["stype"] == "garage-door-opener":
-            async_add_entities([HomeKitGarageDoorCover(conn, info)], True)
-            return True
-
-        if service["stype"] in ("window-covering", "window"):
-            async_add_entities([HomeKitWindowCover(conn, info)], True)
-            return True
-
-        return False
+    def async_add_service(service):
+        entity_class = ENTITY_TYPES.get(service.short_type)
+        if not entity_class:
+            return False
+        info = {"aid": service.accessory.aid, "iid": service.iid}
+        async_add_entities([entity_class(conn, info)], True)
+        return True
 
     conn.add_listener(async_add_service)
 
@@ -246,3 +243,9 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         if not obstruction_detected:
             return {}
         return {"obstruction-detected": obstruction_detected}
+
+
+ENTITY_TYPES = {
+    ServicesTypes.GARAGE_DOOR_OPENER: HomeKitGarageDoorCover,
+    ServicesTypes.WINDOW_COVERING: HomeKitWindowCover,
+}

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -174,9 +174,9 @@ def enumerate_doorbell(service):
 
 
 TRIGGER_FINDERS = {
-    "service-label": enumerate_stateless_switch_group,
-    "stateless-programmable-switch": enumerate_stateless_switch,
-    "doorbell": enumerate_doorbell,
+    ServicesTypes.SERVICE_LABEL: enumerate_stateless_switch_group,
+    ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH: enumerate_stateless_switch,
+    ServicesTypes.DOORBELL: enumerate_doorbell,
 }
 
 
@@ -186,8 +186,9 @@ async def async_setup_triggers_for_entry(hass: HomeAssistant, config_entry):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service_dict):
-        service_type = service_dict["stype"]
+    def async_add_service(service):
+        aid = service.accessory.aid
+        service_type = service.short_type
 
         # If not a known service type then we can't handle any stateless events for it
         if service_type not in TRIGGER_FINDERS:
@@ -200,11 +201,6 @@ async def async_setup_triggers_for_entry(hass: HomeAssistant, config_entry):
         device_id = conn.devices[aid]
         if device_id in hass.data[TRIGGERS]:
             return False
-
-        # At the moment add_listener calls us with the raw service dict, rather than
-        # a service model. So turn it into a service ourselves.
-        accessory = conn.entity_map.aid(aid)
-        service = accessory.services.iid(service_dict["iid"])
 
         # Just because we recognise the service type doesn't mean we can actually
         # extract any triggers - so only proceed if we can

--- a/homeassistant/components/homekit_controller/fan.py
+++ b/homeassistant/components/homekit_controller/fan.py
@@ -1,5 +1,6 @@
 """Support for Homekit fans."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.fan import (
     DIRECTION_FORWARD,
@@ -161,8 +162,8 @@ class HomeKitFanV2(BaseHomeKitFan):
 
 
 ENTITY_TYPES = {
-    "fan": HomeKitFanV1,
-    "fanv2": HomeKitFanV2,
+    ServicesTypes.FAN: HomeKitFanV1,
+    ServicesTypes.FAN_V2: HomeKitFanV2,
 }
 
 
@@ -172,11 +173,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        entity_class = ENTITY_TYPES.get(service["stype"])
+    def async_add_service(service):
+        entity_class = ENTITY_TYPES.get(service.short_type)
         if not entity_class:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -1,5 +1,6 @@
 """Support for Homekit lights."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -21,10 +22,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        if service["stype"] != "lightbulb":
+    def async_add_service(service):
+        if service.short_type != ServicesTypes.LIGHTBULB:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitLight(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -1,5 +1,6 @@
 """Support for HomeKit Controller locks."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_LOCKED, STATE_UNLOCKED
@@ -20,10 +21,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        if service["stype"] != "lock-mechanism":
+    def async_add_service(service):
+        if service.short_type != ServicesTypes.LOCK_MECHANISM:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitLock(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/media_player.py
+++ b/homeassistant/components/homekit_controller/media_player.py
@@ -44,10 +44,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        if service["stype"] != "television":
+    def async_add_service(service):
+        if service.short_type != ServicesTypes.TELEVISION:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitTelevision(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -1,5 +1,6 @@
 """Support for Homekit sensors."""
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
@@ -216,11 +217,11 @@ class HomeKitBatterySensor(HomeKitEntity):
 
 
 ENTITY_TYPES = {
-    "humidity": HomeKitHumiditySensor,
-    "temperature": HomeKitTemperatureSensor,
-    "light": HomeKitLightSensor,
-    "carbon-dioxide": HomeKitCarbonDioxideSensor,
-    "battery": HomeKitBatterySensor,
+    ServicesTypes.HUMIDITY_SENSOR: HomeKitHumiditySensor,
+    ServicesTypes.TEMPERATURE_SENSOR: HomeKitTemperatureSensor,
+    ServicesTypes.LIGHT_SENSOR: HomeKitLightSensor,
+    ServicesTypes.CARBON_DIOXIDE_SENSOR: HomeKitCarbonDioxideSensor,
+    ServicesTypes.BATTERY_SERVICE: HomeKitBatterySensor,
 }
 
 
@@ -230,11 +231,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        entity_class = ENTITY_TYPES.get(service["stype"])
+    def async_add_service(service):
+        entity_class = ENTITY_TYPES.get(service.short_type)
         if not entity_class:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)
         return True
 

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -4,6 +4,7 @@ from aiohomekit.model.characteristics import (
     InUseValues,
     IsConfiguredValues,
 )
+from aiohomekit.model.services import ServicesTypes
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
@@ -96,9 +97,9 @@ class HomeKitValve(HomeKitEntity, SwitchEntity):
 
 
 ENTITY_TYPES = {
-    "switch": HomeKitSwitch,
-    "outlet": HomeKitSwitch,
-    "valve": HomeKitValve,
+    ServicesTypes.SWITCH: HomeKitSwitch,
+    ServicesTypes.OUTLET: HomeKitSwitch,
+    ServicesTypes.VALVE: HomeKitValve,
 }
 
 
@@ -108,11 +109,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     conn = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(aid, service):
-        entity_class = ENTITY_TYPES.get(service["stype"])
+    def async_add_service(service):
+        entity_class = ENTITY_TYPES.get(service.short_type)
         if not entity_class:
             return False
-        info = {"aid": aid, "iid": service["iid"]}
+        info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)
         return True
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#42676 and #43100 highlighted something i've been thinking about for a while. The way HomeKit services are enumerated and turned into entities is currently not only too limiting but also awkward because you have to directly parse the JSON data from HomeKit.

This PR allows the functions that create entities to instead operate on the aiohomekit entity map abstraction which is already used in the entity implementations themselves.

It turns something like this:

```python
    def get_accessory(conn, aid):
        for acc in conn.accessories:
            if acc.get("aid") == aid:
                return acc
        return None

    def get_service(acc, iid):
        for serv in acc.get("services"):
            if serv.get("iid") == iid:
                return serv
        return None

    def get_char(serv, iid):

        if len(iid) == 36:
            type_uuid = iid
        else:
            try:
                type_name = CharacteristicsTypes[iid]
                type_uuid = CharacteristicsTypes.get_uuid(type_name)
            except KeyError:
                return None

        for char in serv.get("characteristics"):
            if char.get("type") == type_uuid:
                return char
        return None

    @callback
    def async_add_service(aid, service):
        if service["stype"] != "humidifier-dehumidifier":
            return False
        info = {"aid": aid, "iid": service["iid"]}

        acc = get_accessory(conn, aid)
        serv = get_service(acc, service["iid"])


        if (
            get_char(serv, CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL)
            is not None
        ):
            async_add_entities([VocolincFlowerbud(conn, info)], True)
        else:
            if (
                get_char(
                    serv, CharacteristicsTypes.RELATIVE_HUMIDITY_HUMIDIFIER_THRESHOLD
                )
                is not None
            ):
                async_add_entities([HomeKitHumidifier(conn, info)], True)

            if (
                get_char(
                    serv, CharacteristicsTypes.RELATIVE_HUMIDITY_DEHUMIDIFIER_THRESHOLD
                )
                is not None
            ):
                async_add_entities([HomeKitDehumidifier(conn, info)], True)

        return True
```

Into:

```python
    @callback
    def async_add_service(service):
        if service.short_type != ServicesTypes.HUMIDIFIER_DEHUMIDIFIER:
            return False

        info = {"aid": service.accessory.aid, "iid": service.iid}
        entities = []

        if service.has(CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL):
            entities.append(VocolincFlowerbud(conn, info))
        else:
            if services.has(RELATIVE_HUMIDITY_HUMIDIFIER_THRESHOLD):
                entities.append(HomeKitHumidifier(conn, info))
            if services.has(RELATIVE_HUMIDITY_DEHUMIDIFIER_THRESHOLD):
                entities.append(HomeKitDehumidifier(conn, info))

        async_add_entities([entities], True)
        return True
```

It also means we can use the aiohomekit constants for service types.

No new tests - but this bit of code is already exercised quite well by the existing ones.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #42676 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
