### PR TITLE
Make MQTT climate return PRESET_NONE when no preset is set

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -640,7 +640,7 @@ class MqttClimate(
             return self._hold
         if self._away:
             return PRESET_AWAY
-        return None
+        return PRESET_NONE
 
     @property
     def preset_modes(self):

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -438,11 +438,11 @@ async def test_set_away_mode_pessimistic(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
     await common.async_set_preset_mode(hass, "away", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
     async_fire_mqtt_message(hass, "away-state", "ON")
     state = hass.states.get(ENTITY_CLIMATE)
@@ -450,11 +450,11 @@ async def test_set_away_mode_pessimistic(hass, mqtt_mock):
 
     async_fire_mqtt_message(hass, "away-state", "OFF")
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
     async_fire_mqtt_message(hass, "away-state", "nonsense")
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
 
 async def test_set_away_mode(hass, mqtt_mock):
@@ -467,7 +467,7 @@ async def test_set_away_mode(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
     await common.async_set_preset_mode(hass, "away", ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with("away-mode-topic", "AN", 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -477,7 +477,7 @@ async def test_set_away_mode(hass, mqtt_mock):
     await common.async_set_preset_mode(hass, PRESET_NONE, ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with("away-mode-topic", "AUS", 0, False)
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
     await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
     mqtt_mock.async_publish.reset_mock()
@@ -525,7 +525,7 @@ async def test_set_hold_pessimistic(hass, mqtt_mock):
 
     async_fire_mqtt_message(hass, "hold-state", "off")
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
 
 async def test_set_hold(hass, mqtt_mock):
@@ -534,7 +534,7 @@ async def test_set_hold(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
     await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with("hold-topic", "hold-on", 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -550,7 +550,7 @@ async def test_set_hold(hass, mqtt_mock):
     await common.async_set_preset_mode(hass, PRESET_NONE, ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with("hold-topic", "off", 0, False)
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
 
 async def test_set_preset_mode_twice(hass, mqtt_mock):
@@ -559,7 +559,7 @@ async def test_set_preset_mode_twice(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
     await common.async_set_preset_mode(hass, "hold-on", ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with("hold-topic", "hold-on", 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -735,7 +735,7 @@ async def test_set_with_templates(hass, mqtt_mock, caplog):
     assert state.attributes.get("temperature") == 1031
 
     # Away Mode
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
     async_fire_mqtt_message(hass, "away-state", '"ON"')
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") == "away"
@@ -743,7 +743,7 @@ async def test_set_with_templates(hass, mqtt_mock, caplog):
     # Away Mode with JSON values
     async_fire_mqtt_message(hass, "away-state", "false")
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
     async_fire_mqtt_message(hass, "away-state", "true")
     state = hass.states.get(ENTITY_CLIMATE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make MQTT climate return PRESET_NONE when no preset is set

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
