### PR TITLE
Add an option to template delay_on/off in template binary sensor

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -29,7 +29,9 @@ from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
 from .template_entity import TemplateEntity
 
 CONF_DELAY_ON = "delay_on"
+CONF_DELAY_ON_TEMPLATE = "delay_on_template"
 CONF_DELAY_OFF = "delay_off"
+CONF_DELAY_OFF_TEMPLATE = "delay_off_template"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 
 SENSOR_SCHEMA = vol.All(
@@ -47,7 +49,9 @@ SENSOR_SCHEMA = vol.All(
             vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_DELAY_ON): cv.positive_time_period,
+            vol.Optional(CONF_DELAY_ON_TEMPLATE): cv.template,
             vol.Optional(CONF_DELAY_OFF): cv.positive_time_period,
+            vol.Optional(CONF_DELAY_OFF_TEMPLATE): cv.template,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
     ),
@@ -72,7 +76,9 @@ async def _async_create_entities(hass, config):
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         device_class = device_config.get(CONF_DEVICE_CLASS)
         delay_on = device_config.get(CONF_DELAY_ON)
+        delay_on_template = device_config.get(CONF_DELAY_ON_TEMPLATE)
         delay_off = device_config.get(CONF_DELAY_OFF)
+        delay_off_template = device_config.get(CONF_DELAY_OFF_TEMPLATE)
         unique_id = device_config.get(CONF_UNIQUE_ID)
 
         sensors.append(
@@ -86,7 +92,9 @@ async def _async_create_entities(hass, config):
                 entity_picture_template,
                 availability_template,
                 delay_on,
+                delay_on_template,
                 delay_off,
+                delay_off_template,
                 attribute_templates,
                 unique_id,
             )
@@ -116,7 +124,9 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
         entity_picture_template,
         availability_template,
         delay_on,
+        delay_on_template,
         delay_off,
+        delay_off_template,
         attribute_templates,
         unique_id,
     ):
@@ -134,13 +144,21 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
         self._state = None
         self._delay_cancel = None
         self._delay_on = delay_on
+        self._delay_on_template = delay_on_template
         self._delay_off = delay_off
+        self._delay_off_template = delay_off_template
         self._unique_id = unique_id
 
     async def async_added_to_hass(self):
         """Register callbacks."""
 
         self.add_template_attribute("_state", self._template, None, self._update_state)
+
+        if self._delay_on_template is not None:
+            self.add_template_attribute("_delay_on", self._delay_on_template, cv.positive_time_period)
+
+        if self._delay_off_template is not None:
+            self.add_template_attribute("_delay_off", self._delay_off_template, cv.positive_time_period)
 
         await super().async_added_to_hass()
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -19,12 +19,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import template as template_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.template import result_as_boolean
-from homeassistant.helpers import template as template_helper
 
 from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
 from .template_entity import TemplateEntity

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_call_later

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -155,10 +155,14 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
         self.add_template_attribute("_state", self._template, None, self._update_state)
 
         if self._delay_on_template is not None:
-            self.add_template_attribute("_delay_on", self._delay_on_template, cv.positive_time_period)
+            self.add_template_attribute(
+                "_delay_on", self._delay_on_template, cv.positive_time_period
+            )
 
         if self._delay_off_template is not None:
-            self.add_template_attribute("_delay_off", self._delay_off_template, cv.positive_time_period)
+            self.add_template_attribute(
+                "_delay_off", self._delay_off_template, cv.positive_time_period
+            )
 
         await super().async_added_to_hass()
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -144,18 +144,18 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
 
         self.add_template_attribute("_state", self._template, None, self._update_state)
 
-        try:
-            self._delay_on = cv.positive_time_period(self._delay_on_raw)
-        except vol.Invalid:
-            if self._delay_on_raw is not None:
+        if self._delay_on_raw is not None:
+            try:
+                self._delay_on = cv.positive_time_period(self._delay_on_raw)
+            except vol.Invalid:
                 self.add_template_attribute(
                     "_delay_on", self._delay_on_raw, cv.positive_time_period
                 )
 
-        try:
-            self._delay_off = cv.positive_time_period(self._delay_off_raw)
-        except vol.Invalid:
-            if self._delay_off_raw is not None:
+        if self._delay_off_raw is not None:
+            try:
+                self._delay_off = cv.positive_time_period(self._delay_off_raw)
+            except vol.Invalid:
                 self.add_template_attribute(
                     "_delay_off", self._delay_off_raw, cv.positive_time_period
                 )

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -24,14 +24,13 @@ from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.template import result_as_boolean
+from homeassistant.helpers import template as template_helper
 
 from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
 from .template_entity import TemplateEntity
 
 CONF_DELAY_ON = "delay_on"
-CONF_DELAY_ON_TEMPLATE = "delay_on_template"
 CONF_DELAY_OFF = "delay_off"
-CONF_DELAY_OFF_TEMPLATE = "delay_off_template"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 
 SENSOR_SCHEMA = vol.All(
@@ -48,10 +47,8 @@ SENSOR_SCHEMA = vol.All(
             vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
             vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-            vol.Optional(CONF_DELAY_ON): cv.positive_time_period,
-            vol.Optional(CONF_DELAY_ON_TEMPLATE): cv.template,
-            vol.Optional(CONF_DELAY_OFF): cv.positive_time_period,
-            vol.Optional(CONF_DELAY_OFF_TEMPLATE): cv.template,
+            vol.Optional(CONF_DELAY_ON): vol.Any(cv.positive_time_period, cv.template),
+            vol.Optional(CONF_DELAY_OFF): vol.Any(cv.positive_time_period, cv.template),
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
     ),
@@ -75,10 +72,8 @@ async def _async_create_entities(hass, config):
 
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         device_class = device_config.get(CONF_DEVICE_CLASS)
-        delay_on = device_config.get(CONF_DELAY_ON)
-        delay_on_template = device_config.get(CONF_DELAY_ON_TEMPLATE)
-        delay_off = device_config.get(CONF_DELAY_OFF)
-        delay_off_template = device_config.get(CONF_DELAY_OFF_TEMPLATE)
+        delay_on_raw = device_config.get(CONF_DELAY_ON)
+        delay_off_raw = device_config.get(CONF_DELAY_OFF)
         unique_id = device_config.get(CONF_UNIQUE_ID)
 
         sensors.append(
@@ -91,10 +86,8 @@ async def _async_create_entities(hass, config):
                 icon_template,
                 entity_picture_template,
                 availability_template,
-                delay_on,
-                delay_on_template,
-                delay_off,
-                delay_off_template,
+                delay_on_raw,
+                delay_off_raw,
                 attribute_templates,
                 unique_id,
             )
@@ -123,10 +116,8 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
         icon_template,
         entity_picture_template,
         availability_template,
-        delay_on,
-        delay_on_template,
-        delay_off,
-        delay_off_template,
+        delay_on_raw,
+        delay_off_raw,
         attribute_templates,
         unique_id,
     ):
@@ -143,10 +134,10 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
         self._template = value_template
         self._state = None
         self._delay_cancel = None
-        self._delay_on = delay_on
-        self._delay_on_template = delay_on_template
-        self._delay_off = delay_off
-        self._delay_off_template = delay_off_template
+        self._delay_on = None
+        self._delay_on_raw = delay_on_raw
+        self._delay_off = None
+        self._delay_off_raw = delay_off_raw
         self._unique_id = unique_id
 
     async def async_added_to_hass(self):
@@ -154,15 +145,21 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
 
         self.add_template_attribute("_state", self._template, None, self._update_state)
 
-        if self._delay_on_template is not None:
-            self.add_template_attribute(
-                "_delay_on", self._delay_on_template, cv.positive_time_period
-            )
+        try:
+            self._delay_on = cv.positive_time_period(self._delay_on_raw)
+        except vol.Invalid:
+            if self._delay_on_raw is not None:
+                self.add_template_attribute(
+                    "_delay_on", self._delay_on_raw, cv.positive_time_period
+                )
 
-        if self._delay_off_template is not None:
-            self.add_template_attribute(
-                "_delay_off", self._delay_off_template, cv.positive_time_period
-            )
+        try:
+            self._delay_off = cv.positive_time_period(self._delay_off_raw)
+        except vol.Invalid:
+            if self._delay_off_raw is not None:
+                self.add_template_attribute(
+                    "_delay_off", self._delay_off_raw, cv.positive_time_period
+                )
 
         await super().async_added_to_hass()
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -512,7 +512,7 @@ async def test_template_with_delay_on_based_on_input(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_on_template": '{{ ({ "seconds": states.input_number.delay.state }) }}',
+                    "delay_on_template": '{{ ({ "seconds": states("input_number.delay")|int }) }}',
                 }
             },
         }
@@ -550,7 +550,10 @@ async def test_template_with_delay_on_based_on_input(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    hass.states.async_set("input_number.delay", 2)
+    hass.states.async_set("input_number.delay", 4)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.test_state", "on")
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -563,7 +566,7 @@ async def test_template_with_delay_on_based_on_input(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "off"
 
-    future = dt_util.utcnow() + timedelta(seconds=2)
+    future = dt_util.utcnow() + timedelta(seconds=4)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
 
@@ -581,7 +584,7 @@ async def test_template_with_delay_off_based_on_input(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_off_template": '{{ ({ "seconds": states.input_number.delay.state }) }}',
+                    "delay_off_template": '{{ ({ "seconds": states("input_number.delay")|int }) }}',
                 }
             },
         }
@@ -619,7 +622,10 @@ async def test_template_with_delay_off_based_on_input(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    hass.states.async_set("input_number.delay", 2)
+    hass.states.async_set("input_number.delay", 4)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.test_state", "off")
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
@@ -632,7 +638,7 @@ async def test_template_with_delay_off_based_on_input(hass):
     state = hass.states.get("binary_sensor.test")
     assert state.state == "on"
 
-    future = dt_util.utcnow() + timedelta(seconds=2)
+    future = dt_util.utcnow() + timedelta(seconds=4)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -393,7 +393,7 @@ async def test_template_with_templated_delay_on(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_on_template": '{{ ({ "seconds": 6 / 2 }) }}',
+                    "delay_on": '{{ ({ "seconds": 6 / 2 }) }}',
                 }
             },
         }
@@ -452,7 +452,7 @@ async def test_template_with_templated_delay_off(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_off_template": '{{ ({ "seconds": 6 / 2 }) }}',
+                    "delay_off": '{{ ({ "seconds": 6 / 2 }) }}',
                 }
             },
         }
@@ -512,7 +512,7 @@ async def test_template_with_delay_on_based_on_input(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_on_template": '{{ ({ "seconds": states("input_number.delay")|int }) }}',
+                    "delay_on": '{{ ({ "seconds": states("input_number.delay")|int }) }}',
                 }
             },
         }
@@ -584,7 +584,7 @@ async def test_template_with_delay_off_based_on_input(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_off_template": '{{ ({ "seconds": states("input_number.delay")|int }) }}',
+                    "delay_off": '{{ ({ "seconds": states("input_number.delay")|int }) }}',
                 }
             },
         }

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -502,6 +502,144 @@ async def test_template_with_templated_delay_off(hass):
     assert state.state == "on"
 
 
+async def test_template_with_delay_on_based_on_input(hass):
+    """Test binary sensor template with template delay on based on input number."""
+    config = {
+        "binary_sensor": {
+            "platform": "template",
+            "sensors": {
+                "test": {
+                    "friendly_name": "virtual thingy",
+                    "value_template": "{{ states.sensor.test_state.state == 'on' }}",
+                    "device_class": "motion",
+                    "delay_on_template": '{{ ({ "seconds": states.input_number.delay.state }) }}',
+                }
+            },
+        }
+    }
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    hass.states.async_set("input_number.delay", 3)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=3)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    # set input to 4 seconds
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("input_number.delay", 2)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=2)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=2)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+
+async def test_template_with_delay_off_based_on_input(hass):
+    """Test binary sensor template with template delay off based on input number."""
+    config = {
+        "binary_sensor": {
+            "platform": "template",
+            "sensors": {
+                "test": {
+                    "friendly_name": "virtual thingy",
+                    "value_template": "{{ states.sensor.test_state.state == 'on' }}",
+                    "device_class": "motion",
+                    "delay_off_template": '{{ ({ "seconds": states.input_number.delay.state }) }}',
+                }
+            },
+        }
+    }
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    hass.states.async_set("input_number.delay", 3)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=3)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    # set input to 4 seconds
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("input_number.delay", 2)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=2)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=2)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+
 async def test_available_without_availability_template(hass):
     """Ensure availability is true without an availability_template."""
     config = {

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -383,6 +383,125 @@ async def test_template_delay_off(hass):
     assert state.state == "on"
 
 
+async def test_template_with_templated_delay_on(hass):
+    """Test binary sensor template with template delay on."""
+    config = {
+        "binary_sensor": {
+            "platform": "template",
+            "sensors": {
+                "test": {
+                    "friendly_name": "virtual thingy",
+                    "value_template": "{{ states.sensor.test_state.state == 'on' }}",
+                    "device_class": "motion",
+                    "delay_on_template": "{{ ({ "seconds": 6 / 2 }) }}",
+                }
+            },
+        }
+    }
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=3)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    # check with time changes
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    future = dt_util.utcnow() + timedelta(seconds=3)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+
+async def test_template_with_templated_delay_off(hass):
+    """Test binary sensor template with template delay off."""
+    config = {
+        "binary_sensor": {
+            "platform": "template",
+            "sensors": {
+                "test": {
+                    "friendly_name": "virtual thingy",
+                    "value_template": "{{ states.sensor.test_state.state == 'on' }}",
+                    "device_class": "motion",
+                    "delay_off_template": "{{ ({ "seconds": 6 / 2 }) }}",
+                }
+            },
+        }
+    }
+    hass.states.async_set("sensor.test_state", "on")
+    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=3)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "off"
+
+    # check with time changes
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", "off")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    hass.states.async_set("sensor.test_state", "on")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+    future = dt_util.utcnow() + timedelta(seconds=3)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == "on"
+
+
 async def test_available_without_availability_template(hass):
     """Ensure availability is true without an availability_template."""
     config = {

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -393,7 +393,7 @@ async def test_template_with_templated_delay_on(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_on_template": "{{ ({ "seconds": 6 / 2 }) }}",
+                    "delay_on_template": '{{ ({ "seconds": 6 / 2 }) }}',
                 }
             },
         }
@@ -452,7 +452,7 @@ async def test_template_with_templated_delay_off(hass):
                     "friendly_name": "virtual thingy",
                     "value_template": "{{ states.sensor.test_state.state == 'on' }}",
                     "device_class": "motion",
-                    "delay_off_template": "{{ ({ "seconds": 6 / 2 }) }}",
+                    "delay_off_template": '{{ ({ "seconds": 6 / 2 }) }}',
                 }
             },
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces the possibility to use templates in `delay_on` and `delay_off` parameters of a Template Binary Sensor. 

The returned value of such template can be a string, in a form of `hh:mm:ss`, or a dictionary, using the newly introduced rich template return types.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->


```yaml
input_number:
  delay:
    initial: 3
    min: 0
    max: 59
    step: 1

binary_sensor:
  - platform: template
    sensors:
      test_template:
        friendly_name: Delay template
        delay_off: >-
          {{ ({ "seconds": states('input_number.delay') }) }}
        value_template: >-
          {{ is_state('input_boolean.test', 'on') }}
```


```yaml
binary_sensor:
  - platform: template
    sensors:
      test_template:
        friendly_name: Delay template
        delay_off: >-
          {% if is_state('switch.night_mode', 'off') %}
              00:00:15
          {% else %}
              00:00:35
          {% endif %}
        value_template: >-
          {{ is_state('input_boolean.test', 'on') }}

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15654

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
