### PR TITLE
Add config options for retry attempt to tplink integration

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -13,6 +13,8 @@ from .common import (
     CONF_DIMMER,
     CONF_DISCOVERY,
     CONF_LIGHT,
+    CONF_RETRY_DELAY,
+    CONF_RETRY_MAX_ATTEMPTS,
     CONF_STRIP,
     CONF_SWITCH,
     SmartDevices,
@@ -23,6 +25,8 @@ from .common import (
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "tplink"
+MAX_ATTEMPTS = 300
+SLEEP_TIME = 2
 
 TPLINK_HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): cv.string})
 
@@ -44,6 +48,10 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [TPLINK_HOST_SCHEMA]
                 ),
                 vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
+                vol.Optional(CONF_RETRY_DELAY, default=SLEEP_TIME): cv.positive_int,
+                vol.Optional(
+                    CONF_RETRY_MAX_ATTEMPTS, default=MAX_ATTEMPTS
+                ): cv.positive_int,
             }
         )
     },
@@ -83,6 +91,11 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigType):
 
         lights.extend(static_devices.lights)
         switches.extend(static_devices.switches)
+
+        hass.data[DOMAIN][CONF_RETRY_DELAY] = config_data[CONF_RETRY_DELAY]
+        hass.data[DOMAIN][CONF_RETRY_MAX_ATTEMPTS] = config_data[
+            CONF_RETRY_MAX_ATTEMPTS
+        ]
 
     # Add discovered devices
     if config_data is None or config_data[CONF_DISCOVERY]:

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -96,6 +96,7 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigType):
         hass.data[DOMAIN][CONF_RETRY_MAX_ATTEMPTS] = config_data[
             CONF_RETRY_MAX_ATTEMPTS
         ]
+        hass.data[DOMAIN]["add_attempt"] = 0
 
     # Add discovered devices
     if config_data is None or config_data[CONF_DISCOVERY]:

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -1,22 +1,10 @@
 """Component to embed TP-Link smart home devices."""
 import logging
 
-import voluptuous as vol
-
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .common import (
-    ATTR_CONFIG,
-    CONF_DIMMER,
-    CONF_DISCOVERY,
-    CONF_LIGHT,
-    CONF_RETRY_DELAY,
-    CONF_RETRY_MAX_ATTEMPTS,
-    CONF_STRIP,
-    CONF_SWITCH,
     SmartDevices,
     async_discover_devices,
     get_static_devices,
@@ -24,38 +12,14 @@ from .common import (
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "tplink"
-MAX_ATTEMPTS = 300
-SLEEP_TIME = 2
-
-TPLINK_HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): cv.string})
-
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_LIGHT, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_SWITCH, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_STRIP, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_DIMMER, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
-                vol.Optional(CONF_RETRY_DELAY, default=SLEEP_TIME): cv.positive_int,
-                vol.Optional(
-                    CONF_RETRY_MAX_ATTEMPTS, default=MAX_ATTEMPTS
-                ): cv.positive_int,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
+from .const import (
+    ATTR_CONFIG,
+    CONF_DISCOVERY,
+    CONF_LIGHT,
+    CONF_RETRY_DELAY,
+    CONF_RETRY_MAX_ATTEMPTS,
+    CONF_SWITCH,
+    DOMAIN,
 )
 
 
@@ -78,7 +42,8 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigType):
     """Set up TPLink from a config entry."""
-    config_data = hass.data[DOMAIN].get(ATTR_CONFIG)
+    # config_data = hass.data[DOMAIN].get(ATTR_CONFIG)
+    config_data = config_entry.data
 
     # These will contain the initialized devices
     lights = hass.data[DOMAIN][CONF_LIGHT] = []
@@ -96,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigType):
         hass.data[DOMAIN][CONF_RETRY_MAX_ATTEMPTS] = config_data[
             CONF_RETRY_MAX_ATTEMPTS
         ]
-        hass.data[DOMAIN]["add_attempt"] = 0
+    hass.data[DOMAIN]["add_attempt"] = 0
 
     # Add discovered devices
     if config_data is None or config_data[CONF_DISCOVERY]:

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -22,6 +22,8 @@ ATTR_CONFIG = "config"
 CONF_DIMMER = "dimmer"
 CONF_DISCOVERY = "discovery"
 CONF_LIGHT = "light"
+CONF_RETRY_DELAY = "retry_delay"
+CONF_RETRY_MAX_ATTEMPTS = "retry_max_attempts"
 CONF_STRIP = "strip"
 CONF_SWITCH = "switch"
 

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -13,19 +13,16 @@ from pyHS100 import (
 
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN as TPLINK_DOMAIN
+from .const import (
+    CONF_DIMMER,
+    CONF_LIGHT,
+    CONF_RETRY_MAX_ATTEMPTS,
+    CONF_STRIP,
+    CONF_SWITCH,
+    DOMAIN as TPLINK_DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-
-ATTR_CONFIG = "config"
-CONF_DIMMER = "dimmer"
-CONF_DISCOVERY = "discovery"
-CONF_LIGHT = "light"
-CONF_RETRY_DELAY = "retry_delay"
-CONF_RETRY_MAX_ATTEMPTS = "retry_max_attempts"
-CONF_STRIP = "strip"
-CONF_SWITCH = "switch"
 
 
 class SmartDevices:
@@ -113,7 +110,13 @@ def get_static_devices(config_data) -> SmartDevices:
     switches = []
 
     for type_ in [CONF_LIGHT, CONF_SWITCH, CONF_STRIP, CONF_DIMMER]:
-        for entry in config_data[type_]:
+        entry_list = []
+        if config_data[type_]:
+            if type(config_data[type_]) is list:
+                entry_list = config_data[type_].split(",").strip()
+            else:
+                entry_list = config_data[type_]
+        for entry in entry_list:
             host = entry["host"]
             try:
                 if type_ == CONF_LIGHT:

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -1,13 +1,106 @@
 """Config flow for TP-Link."""
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 
-from .common import async_get_discoverable_devices
-from .const import DOMAIN
-
-config_entry_flow.register_discovery_flow(
+from .const import (
+    CONF_DIMMER,
+    CONF_DISCOVERY,
+    CONF_LIGHT,
+    CONF_RETRY_DELAY,
+    CONF_RETRY_MAX_ATTEMPTS,
+    CONF_STRIP,
+    CONF_SWITCH,
+    DEFAULT_MAX_ATTEMPTS,
+    DEFAULT_RETRY_DELAY,
     DOMAIN,
-    "TP-Link Smart Home",
-    async_get_discoverable_devices,
-    config_entries.CONN_CLASS_LOCAL_POLL,
 )
+
+DATA_SCHEMA = {
+    vol.Optional(
+        CONF_LIGHT,
+        description={"suggested_value": "Comma separated list of Lights"},
+        default="",
+    ): str,
+    vol.Optional(CONF_SWITCH, default=""): str,
+    vol.Optional(CONF_STRIP, default=""): str,
+    vol.Optional(CONF_DIMMER, default=""): str,
+    vol.Optional(CONF_DISCOVERY, default=True): bool,
+    vol.Optional(CONF_RETRY_DELAY, default=DEFAULT_RETRY_DELAY): int,
+    vol.Optional(CONF_RETRY_MAX_ATTEMPTS, default=DEFAULT_MAX_ATTEMPTS): int,
+}
+
+
+class TplinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """TP-Link configuration flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return TpLinkOptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Step when user initializes a integration."""
+
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(step_id="user", data_schema=vol.Schema(DATA_SCHEMA))
+
+
+class TpLinkOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_LIGHT,
+                        default=self.config_entry.options.get(CONF_LIGHT, ""),
+                    ): str,
+                    vol.Optional(
+                        CONF_STRIP,
+                        default=self.config_entry.options.get(CONF_STRIP, ""),
+                    ): str,
+                    vol.Optional(
+                        CONF_SWITCH,
+                        default=self.config_entry.options.get(CONF_SWITCH, ""),
+                    ): str,
+                    vol.Optional(
+                        CONF_DISCOVERY,
+                        default=self.config_entry.options.get(CONF_DISCOVERY, True),
+                    ): bool,
+                    vol.Optional(
+                        CONF_RETRY_DELAY,
+                        default=self.config_entry.options.get(
+                            CONF_RETRY_DELAY, DEFAULT_RETRY_DELAY
+                        ),
+                    ): int,
+                    vol.Optional(
+                        CONF_RETRY_MAX_ATTEMPTS,
+                        default=self.config_entry.options.get(
+                            CONF_RETRY_MAX_ATTEMPTS, DEFAULT_MAX_ATTEMPTS
+                        ),
+                    ): int,
+                }
+            ),
+        )

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -2,4 +2,14 @@
 import datetime
 
 DOMAIN = "tplink"
+ATTR_CONFIG = "config"
+CONF_DIMMER = "dimmer"
+CONF_DISCOVERY = "discovery"
+CONF_LIGHT = "light"
+CONF_RETRY_DELAY = "retry_delay"
+CONF_RETRY_MAX_ATTEMPTS = "retry_max_attempts"
+CONF_STRIP = "strip"
+CONF_SWITCH = "switch"
+DEFAULT_MAX_ATTEMPTS = 300
+DEFAULT_RETRY_DELAY = 2
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=8)

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -25,7 +25,12 @@ from homeassistant.util.color import (
 )
 import homeassistant.util.dt as dt_util
 
-from . import CONF_LIGHT, DOMAIN as TPLINK_DOMAIN
+from . import (
+    CONF_LIGHT,
+    CONF_RETRY_DELAY,
+    CONF_RETRY_MAX_ATTEMPTS,
+    DOMAIN as TPLINK_DOMAIN,
+)
 from .common import add_available_devices
 
 PARALLEL_UPDATES = 0
@@ -54,9 +59,6 @@ LIGHT_SYSINFO_MODEL = "model"
 LIGHT_SYSINFO_IS_DIMMABLE = "is_dimmable"
 LIGHT_SYSINFO_IS_VARIABLE_COLOR_TEMP = "is_variable_color_temp"
 LIGHT_SYSINFO_IS_COLOR = "is_color"
-
-MAX_ATTEMPTS = 300
-SLEEP_TIME = 2
 
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
@@ -255,7 +257,7 @@ class TPLinkSmartBulb(LightEntity):
             if update_attempt == 0:
                 _LOGGER.debug(
                     "Retrying in %s seconds for %s|%s due to: %s",
-                    SLEEP_TIME,
+                    self.hass.data[TPLINK_DOMAIN][CONF_RETRY_DELAY],
                     self._host,
                     self._alias,
                     ex,
@@ -464,7 +466,9 @@ class TPLinkSmartBulb(LightEntity):
 
     async def async_update(self):
         """Update the TP-Link bulb's state."""
-        for update_attempt in range(MAX_ATTEMPTS):
+        for update_attempt in range(
+            self.hass.data[TPLINK_DOMAIN][CONF_RETRY_MAX_ATTEMPTS]
+        ):
             is_ready = await self.hass.async_add_executor_job(
                 self.attempt_update, update_attempt
             )
@@ -479,7 +483,7 @@ class TPLinkSmartBulb(LightEntity):
                         update_attempt,
                     )
                 break
-            await asyncio.sleep(SLEEP_TIME)
+            await asyncio.sleep(self.hass.data[TPLINK_DOMAIN][CONF_RETRY_DELAY])
         else:
             if self._is_available:
                 _LOGGER.warning(

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -1,8 +1,9 @@
 {
+  "title": "TP-Link Kasa Smart",
   "config": {
     "step": {
       "confirm": {
-        "description": "Do you want to setup TP-Link smart devices?"
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
       }
     },
     "abort": {

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -15,7 +15,12 @@ from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import CONF_SWITCH, DOMAIN as TPLINK_DOMAIN
+from . import (
+    CONF_RETRY_DELAY,
+    CONF_RETRY_MAX_ATTEMPTS,
+    CONF_SWITCH,
+    DOMAIN as TPLINK_DOMAIN,
+)
 from .common import add_available_devices
 
 PARALLEL_UPDATES = 0
@@ -24,9 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_TOTAL_ENERGY_KWH = "total_energy_kwh"
 ATTR_CURRENT_A = "current_a"
-
-MAX_ATTEMPTS = 300
-SLEEP_TIME = 2
 
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
@@ -163,7 +165,7 @@ class SmartPlugSwitch(SwitchEntity):
             if update_attempt == 0:
                 _LOGGER.debug(
                     "Retrying in %s seconds for %s|%s due to: %s",
-                    SLEEP_TIME,
+                    self.hass.data[TPLINK_DOMAIN][CONF_RETRY_DELAY],
                     self._host,
                     self._alias,
                     ex,
@@ -172,7 +174,9 @@ class SmartPlugSwitch(SwitchEntity):
 
     async def async_update(self):
         """Update the TP-Link switch's state."""
-        for update_attempt in range(MAX_ATTEMPTS):
+        for update_attempt in range(
+            self.hass.data[TPLINK_DOMAIN][CONF_RETRY_MAX_ATTEMPTS]
+        ):
             is_ready = await self.hass.async_add_executor_job(
                 self.attempt_update, update_attempt
             )
@@ -187,7 +191,7 @@ class SmartPlugSwitch(SwitchEntity):
                         update_attempt,
                     )
                 break
-            await asyncio.sleep(SLEEP_TIME)
+            await asyncio.sleep(self.hass.data[TPLINK_DOMAIN][CONF_RETRY_DELAY])
 
         else:
             if self._is_available:

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -577,7 +577,7 @@ async def test_update_failure(
     caplog.set_level(logging.DEBUG)
 
     await update_entity(hass, "light.light1")
-    assert f"Retrying in 0 seconds for 123.123.123.123|light1" in caplog.text
+    assert "Retrying in 0 seconds for 123.123.123.123|light1" in caplog.text
     assert "Device 123.123.123.123|light1 responded after " in caplog.text
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR will add the ability to define the max attempts and retry delay in the config for the tplink component to allow users to override the default values. This will allow people to determine if they even want the retries to occur at all or just for a few times.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
tplink:
  retry_max_attempts: 200
  retry_delay: 1
  discovery: true

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42669
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15657

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
