### PR TITLE
Add support for system health to AccuWeather integration

### DIFF
--- a/homeassistant/components/accuweather/strings.json
+++ b/homeassistant/components/accuweather/strings.json
@@ -31,5 +31,11 @@
         }
       }
     }
+  },
+  "system_health": {
+    "info": {
+      "can_reach_server": "Reach AccuWeather server",
+      "remaining_requests": "Remaining allowed requests"
+    }
   }
 }

--- a/homeassistant/components/accuweather/system_health.py
+++ b/homeassistant/components/accuweather/system_health.py
@@ -1,0 +1,28 @@
+"""Provide info to system health."""
+from accuweather.const import ENDPOINT
+
+from homeassistant.components import system_health
+from homeassistant.core import HomeAssistant, callback
+
+from .const import COORDINATOR, DOMAIN
+
+
+@callback
+def async_register(
+    hass: HomeAssistant, register: system_health.SystemHealthRegistration
+) -> None:
+    """Register system health callbacks."""
+    register.async_register_info(system_health_info)
+
+
+async def system_health_info(hass):
+    """Get info for the info page."""
+    remaining_requests = None
+
+    for entry in hass.data[DOMAIN].values():
+        remaining_requests = entry[COORDINATOR].accuweather.requests_remaining
+
+    return {
+        "can_reach_server": system_health.async_check_can_reach_url(hass, ENDPOINT),
+        "remaining_requests": remaining_requests,
+    }

--- a/homeassistant/components/accuweather/system_health.py
+++ b/homeassistant/components/accuweather/system_health.py
@@ -17,10 +17,9 @@ def async_register(
 
 async def system_health_info(hass):
     """Get info for the info page."""
-    remaining_requests = None
-
-    for entry in hass.data[DOMAIN].values():
-        remaining_requests = entry[COORDINATOR].accuweather.requests_remaining
+    remaining_requests = list(hass.data[DOMAIN].values())[0][
+        COORDINATOR
+    ].accuweather.requests_remaining
 
     return {
         "can_reach_server": system_health.async_check_can_reach_url(hass, ENDPOINT),

--- a/tests/components/accuweather/test_system_health.py
+++ b/tests/components/accuweather/test_system_health.py
@@ -1,4 +1,4 @@
-"""Test cloud system health."""
+"""Test AccuWeather system health."""
 import asyncio
 
 from aiohttp import ClientError
@@ -11,7 +11,7 @@ from tests.common import get_system_health_info
 
 
 async def test_accuweather_system_health(hass, aioclient_mock):
-    """Test cloud system health."""
+    """Test AccuWeather system health."""
     aioclient_mock.get("https://dataservice.accuweather.com/", text="")
     hass.config.components.add(DOMAIN)
     assert await async_setup_component(hass, "system_health", {})
@@ -35,7 +35,7 @@ async def test_accuweather_system_health(hass, aioclient_mock):
 
 
 async def test_accuweather_system_health_fail(hass, aioclient_mock):
-    """Test cloud system health."""
+    """Test AccuWeather system health."""
     aioclient_mock.get("https://dataservice.accuweather.com/", exc=ClientError)
     hass.config.components.add(DOMAIN)
     assert await async_setup_component(hass, "system_health", {})

--- a/tests/components/accuweather/test_system_health.py
+++ b/tests/components/accuweather/test_system_health.py
@@ -1,0 +1,58 @@
+"""Test cloud system health."""
+import asyncio
+
+from aiohttp import ClientError
+
+from homeassistant.components.accuweather.const import COORDINATOR, DOMAIN
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import Mock
+from tests.common import get_system_health_info
+
+
+async def test_accuweather_system_health(hass, aioclient_mock):
+    """Test cloud system health."""
+    aioclient_mock.get("https://dataservice.accuweather.com/", text="")
+    hass.config.components.add(DOMAIN)
+    assert await async_setup_component(hass, "system_health", {})
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN]["0123xyz"] = {}
+    hass.data[DOMAIN]["0123xyz"][COORDINATOR] = Mock(
+        accuweather=Mock(requests_remaining="42")
+    )
+
+    info = await get_system_health_info(hass, DOMAIN)
+
+    for key, val in info.items():
+        if asyncio.iscoroutine(val):
+            info[key] = await val
+
+    assert info == {
+        "can_reach_server": "ok",
+        "remaining_requests": "42",
+    }
+
+
+async def test_accuweather_system_health_fail(hass, aioclient_mock):
+    """Test cloud system health."""
+    aioclient_mock.get("https://dataservice.accuweather.com/", exc=ClientError)
+    hass.config.components.add(DOMAIN)
+    assert await async_setup_component(hass, "system_health", {})
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN]["0123xyz"] = {}
+    hass.data[DOMAIN]["0123xyz"][COORDINATOR] = Mock(
+        accuweather=Mock(requests_remaining="0")
+    )
+
+    info = await get_system_health_info(hass, DOMAIN)
+
+    for key, val in info.items():
+        if asyncio.iscoroutine(val):
+            info[key] = await val
+
+    assert info == {
+        "can_reach_server": {"type": "failed", "error": "unreachable"},
+        "remaining_requests": "0",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for system health to check if the AccuWeather server is reachable and how many allowed requests remain.

![image](https://user-images.githubusercontent.com/478555/99240770-41423800-27fd-11eb-8e4c-d7bd5ef7a451.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
