### PR TITLE
Allow iZone Climate Device external temperature sensor

### DIFF
--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -1,8 +1,9 @@
 """Platform for the iZone AC."""
-import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.const import CONF_ENTITY_ID, CONF_EXCLUDE, CONF_SENSORS
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import DATA_CONFIG, IZONE

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -2,13 +2,15 @@
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import (CONF_DEVICE_ID, CONF_ENTITY_ID, CONF_EXCLUDE,
-                                 CONF_SENSORS)
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    CONF_EXCLUDE,
+    CONF_SENSORS,
+)
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import DATA_CONFIG, IZONE
-from .discovery import (async_start_discovery_service,
-                        async_stop_discovery_service)
+from .discovery import async_start_discovery_service, async_stop_discovery_service
 
 EXT_SENSOR_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -1,18 +1,14 @@
 """Platform for the iZone AC."""
-import voluptuous as vol
-
-from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_EXCLUDE,
-    CONF_ENTITY_ID,
-    CONF_DEVICE_ID,
-    CONF_SENSORS,
-)
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import (CONF_DEVICE_ID, CONF_ENTITY_ID, CONF_EXCLUDE,
+                                 CONF_SENSORS)
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import DATA_CONFIG, IZONE
-from .discovery import async_start_discovery_service, async_stop_discovery_service
+from .discovery import (async_start_discovery_service,
+                        async_stop_discovery_service)
 
 EXT_SENSOR_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -2,12 +2,23 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_EXCLUDE
+from homeassistant.const import (
+    CONF_EXCLUDE,
+    CONF_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_SENSORS,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import DATA_CONFIG, IZONE
 from .discovery import async_start_discovery_service, async_stop_discovery_service
+
+EXT_SENSOR_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    }
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -15,7 +26,8 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional(CONF_EXCLUDE, default=[]): vol.All(
                     cv.ensure_list, [cv.string]
-                )
+                ),
+                vol.Optional(CONF_SENSORS): vol.Schema({cv.string: EXT_SENSOR_SCHEMA}),
             }
         )
     },

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -2,15 +2,12 @@
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_ENTITY_ID,
-    CONF_EXCLUDE,
-    CONF_SENSORS,
-)
+from homeassistant.const import CONF_ENTITY_ID, CONF_EXCLUDE, CONF_SENSORS
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import DATA_CONFIG, IZONE
-from .discovery import async_start_discovery_service, async_stop_discovery_service
+from .discovery import (async_start_discovery_service,
+                        async_stop_discovery_service)
 
 EXT_SENSOR_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -6,8 +6,7 @@ from homeassistant.const import CONF_ENTITY_ID, CONF_EXCLUDE, CONF_SENSORS
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import DATA_CONFIG, IZONE
-from .discovery import (async_start_discovery_service,
-                        async_stop_discovery_service)
+from .discovery import async_start_discovery_service, async_stop_discovery_service
 
 EXT_SENSOR_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -84,7 +84,7 @@ async def async_setup_entry(
             for device_id, value in sensors.items():
                 if device_id == ctrl.device_uid:
                     entity_id = value.get(CONF_ENTITY_ID)
-                    _LOGGER.debug("Found external temperature sensor="+entity_id+", for device_id="+device_id)
+                    _LOGGER.debug("Found external temperature sensor=%s, for device_id=%s", entity_id, device_id)
                     device = ControllerDevice(ctrl, entity_id)
                     break
             else:

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -19,35 +19,37 @@ from homeassistant.components.climate.const import (
     PRESET_ECO,
     PRESET_NONE,
     SUPPORT_FAN_MODE,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-)
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_EXCLUDE,
-    CONF_ENTITY_ID,
-    CONF_SENSORS,
-    PRECISION_HALVES,
-    PRECISION_TENTHS,
-    TEMP_CELSIUS,
-    STATE_UNKNOWN,
-)
+import logging
+from typing import List, Optional
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (FAN_AUTO, FAN_HIGH,
+                                                    FAN_LOW, FAN_MEDIUM,
+                                                    HVAC_MODE_COOL,
+                                                    HVAC_MODE_DRY,
+                                                    HVAC_MODE_FAN_ONLY,
+                                                    HVAC_MODE_HEAT,
+                                                    HVAC_MODE_HEAT_COOL,
+                                                    HVAC_MODE_OFF, PRESET_ECO,
+                                                    PRESET_NONE,
+                                                    SUPPORT_FAN_MODE,
+                                                    SUPPORT_PRESET_MODE,
+                                                    SUPPORT_TARGET_TEMPERATURE)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_ENTITY_ID,
+                                 CONF_EXCLUDE, CONF_SENSORS, PRECISION_HALVES,
+                                 PRECISION_TENTHS, STATE_UNKNOWN, TEMP_CELSIUS)
 from homeassistant.core import callback
-from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from pizone import Controller, Zone
 
-from .const import (
-    DATA_CONFIG,
-    DATA_DISCOVERY_SERVICE,
-    DISPATCH_CONTROLLER_DISCONNECTED,
-    DISPATCH_CONTROLLER_DISCOVERED,
-    DISPATCH_CONTROLLER_RECONNECTED,
-    DISPATCH_CONTROLLER_UPDATE,
-    DISPATCH_ZONE_UPDATE,
-    IZONE,
-)
+from .const import (DATA_CONFIG, DATA_DISCOVERY_SERVICE,
+                    DISPATCH_CONTROLLER_DISCONNECTED,
+                    DISPATCH_CONTROLLER_DISCOVERED,
+                    DISPATCH_CONTROLLER_RECONNECTED,
+                    DISPATCH_CONTROLLER_UPDATE, DISPATCH_ZONE_UPDATE, IZONE)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -2,8 +2,6 @@
 import logging
 from typing import List, Optional
 
-from pizone import Controller, Zone
-
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     FAN_AUTO,
@@ -19,25 +17,19 @@ from homeassistant.components.climate.const import (
     PRESET_ECO,
     PRESET_NONE,
     SUPPORT_FAN_MODE,
-import logging
-from typing import List, Optional
-
-from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import (FAN_AUTO, FAN_HIGH,
-                                                    FAN_LOW, FAN_MEDIUM,
-                                                    HVAC_MODE_COOL,
-                                                    HVAC_MODE_DRY,
-                                                    HVAC_MODE_FAN_ONLY,
-                                                    HVAC_MODE_HEAT,
-                                                    HVAC_MODE_HEAT_COOL,
-                                                    HVAC_MODE_OFF, PRESET_ECO,
-                                                    PRESET_NONE,
-                                                    SUPPORT_FAN_MODE,
-                                                    SUPPORT_PRESET_MODE,
-                                                    SUPPORT_TARGET_TEMPERATURE)
-from homeassistant.const import (ATTR_TEMPERATURE, CONF_ENTITY_ID,
-                                 CONF_EXCLUDE, CONF_SENSORS, PRECISION_HALVES,
-                                 PRECISION_TENTHS, STATE_UNKNOWN, TEMP_CELSIUS)
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_ENTITY_ID,
+    CONF_EXCLUDE,
+    CONF_SENSORS,
+    PRECISION_HALVES,
+    PRECISION_TENTHS,
+    STATE_UNKNOWN,
+    TEMP_CELSIUS,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_state_change
@@ -45,11 +37,16 @@ from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from pizone import Controller, Zone
 
-from .const import (DATA_CONFIG, DATA_DISCOVERY_SERVICE,
-                    DISPATCH_CONTROLLER_DISCONNECTED,
-                    DISPATCH_CONTROLLER_DISCOVERED,
-                    DISPATCH_CONTROLLER_RECONNECTED,
-                    DISPATCH_CONTROLLER_UPDATE, DISPATCH_ZONE_UPDATE, IZONE)
+from .const import (
+    DATA_CONFIG,
+    DATA_DISCOVERY_SERVICE,
+    DISPATCH_CONTROLLER_DISCONNECTED,
+    DISPATCH_CONTROLLER_DISCOVERED,
+    DISPATCH_CONTROLLER_RECONNECTED,
+    DISPATCH_CONTROLLER_UPDATE,
+    DISPATCH_ZONE_UPDATE,
+    IZONE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,20 +68,22 @@ async def async_setup_entry(
     def init_controller(ctrl: Controller):
         """Register the controller device and the containing zones."""
         conf = hass.data.get(DATA_CONFIG)  # type: ConfigType
-
         # Filter out any entities excluded in the config file
         if conf and ctrl.device_uid in conf[CONF_EXCLUDE]:
             _LOGGER.info("Controller UID=%s ignored as excluded", ctrl.device_uid)
             return
         _LOGGER.info("Controller UID=%s discovered", ctrl.device_uid)
-
         # Find matching device ID's and pass in sensor entity_id
         if conf and conf.get(CONF_SENSORS):
             sensors = conf.get(CONF_SENSORS)
             for device_id, value in sensors.items():
                 if device_id == ctrl.device_uid:
                     entity_id = value.get(CONF_ENTITY_ID)
-                    _LOGGER.debug("Found external temperature sensor=%s, for device_id=%s", entity_id, device_id)
+                    _LOGGER.debug(
+                        "Found external temperature sensor=%s, for device_id=%s",
+                        entity_id,
+                        device_id,
+                    )
                     device = ControllerDevice(ctrl, entity_id)
                     break
             else:
@@ -127,7 +126,6 @@ class ControllerDevice(ClimateEntity):
         self._controller = controller
         self._temperature_sensor = entity_id
         self._current_temperature = None
-
         self._supported_features = SUPPORT_FAN_MODE
 
         if (
@@ -165,8 +163,9 @@ class ControllerDevice(ClimateEntity):
     async def async_added_to_hass(self):
         """Call on adding to hass."""
         if self._temperature_sensor:
-            async_track_state_change(self.hass, self._temperature_sensor,
-                                     self._async_temp_sensor_changed)
+            async_track_state_change(
+                self.hass, self._temperature_sensor, self._async_temp_sensor_changed
+            )
 
             temp_sensor_state = self.hass.states.get(self._temperature_sensor)
             if temp_sensor_state and temp_sensor_state.state != STATE_UNKNOWN:
@@ -444,6 +443,7 @@ class ControllerDevice(ClimateEntity):
                 self._current_temperature = float(state.state)
         except ValueError as ex:
             _LOGGER.error("Unable to update from temperature sensor: %s", ex)
+
 
 class ZoneDevice(ClimateEntity):
     """Representation of iZone Zone."""

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -2,6 +2,8 @@
 import logging
 from typing import List, Optional
 
+from pizone import Controller, Zone
+
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     FAN_AUTO,
@@ -35,7 +37,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-from pizone import Controller, Zone
 
 from .const import (
     DATA_CONFIG,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
On some iZone system's, the controller cannot read the in-vent temperature from the A/C system. This means the current_temperature value will always read 0.0. This breaks the lovelace climate component visually, but also causes issues with Google Assistant, whereby it says the Air-conditioner is not currently available when you ask it what the current temperature or mode is.

This change, allows overriding the inbuilt vent-sensor from the iZone controller, with another temperature sensor available in HA. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
izone:
  sensors: 
    "000036424":
      entity_id: sensor.living_room_temperature
```
The new fields shown are, the device id, and a nested entity_id of the replacement temperature sensor.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15694

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
