### PR TITLE
Add show progress to ozw config flow

### DIFF
--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -121,6 +121,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_install_failed(self, user_input=None):
         """Add-on installation failed."""
+        _LOGGER.warning("DEBUG: Aborting flow after install failed")
         return self.async_abort(reason="addon_install_failed")
 
     async def async_step_start_addon(self, user_input=None):

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -99,7 +99,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not self.install_task:
             self.install_task = self.hass.async_create_task(self._async_install_addon())
 
-            return self.async_show_progress(step_id="install_addon")
+            return self.async_show_progress(
+                step_id="install_addon", progress_action="install_addon"
+            )
 
         try:
             await self.install_task

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -103,10 +103,17 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="install_addon", progress_action="install_addon"
             )
 
+        _LOGGER.warning(
+            "DEBUG: Awaiting finished task with done status: %s",
+            self.install_task.done(),
+        )
         try:
             await self.install_task
         except self.hass.components.hassio.HassioAPIError:
+            _LOGGER.warning("DEBUG: Caught error when awaiting finished task")
             return self.async_show_progress_done(next_step_id="install_failed")
+
+        _LOGGER.warning("DEBUG: Waited finished task ok")
 
         self.integration_created_addon = True
 
@@ -197,9 +204,16 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_install_addon(self):
         """Install the OpenZWave add-on."""
         try:
+            raise self.hass.components.hassio.HassioAPIError(
+                "Test raising add-on install error."
+            )
             await self.hass.components.hassio.async_install_addon("core_zwave")
         except self.hass.components.hassio.HassioAPIError as err:
             _LOGGER.error("Failed to install OpenZWave add-on: %s", err)
             raise
         finally:
-            await self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+            _LOGGER.warning("DEBUG: OpenZWave add-on finished install. Continuing flow")
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+            )
+            _LOGGER.warning("DEBUG: Continuing flow called ok")

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -6,6 +6,10 @@
         "description": "Do you want to use the OpenZWave Supervisor add-on?",
         "data": {"use_addon": "Use the OpenZWave Supervisor add-on"}
       },
+      "show_install_info": {
+        "title": "The OpenZWave add-on installation has started",
+        "description": "Please wait while the OpenZWave add-on installation finishes. This can take several minutes."
+      },
       "start_addon": {
         "title": "Enter the OpenZWave add-on configuration",
         "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -6,9 +6,8 @@
         "description": "Do you want to use the OpenZWave Supervisor add-on?",
         "data": {"use_addon": "Use the OpenZWave Supervisor add-on"}
       },
-      "show_install_info": {
-        "title": "The OpenZWave add-on installation has started",
-        "description": "Please wait while the OpenZWave add-on installation finishes. This can take several minutes."
+      "install_addon": {
+        "title": "The OpenZWave add-on installation has started"
       },
       "start_addon": {
         "title": "Enter the OpenZWave add-on configuration",
@@ -24,6 +23,9 @@
     },
     "error": {
       "addon_start_failed": "Failed to start the OpenZWave add-on. Check the configuration."
+    },
+    "progress": {
+      "install_addon": "Please wait while the OpenZWave add-on installation finishes. This can take several minutes."
     }
   }
 }

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -10,17 +10,19 @@
         "error": {
             "addon_start_failed": "Failed to start the OpenZWave add-on. Check the configuration."
         },
+        "progress": {
+            "install_addon": "Please wait while the OpenZWave add-on installation finishes. This can take several minutes."
+        },
         "step": {
+            "install_addon": {
+                "title": "The OpenZWave add-on installation has started"
+            },
             "on_supervisor": {
                 "data": {
                     "use_addon": "Use the OpenZWave Supervisor add-on"
                 },
                 "description": "Do you want to use the OpenZWave Supervisor add-on?",
                 "title": "Select connection method"
-            },
-            "show_install_info": {
-                "description": "Please wait while the OpenZWave add-on installation finishes. This can take several minutes.",
-                "title": "The OpenZWave add-on installation has started"
             },
             "start_addon": {
                 "data": {

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -18,6 +18,10 @@
                 "description": "Do you want to use the OpenZWave Supervisor add-on?",
                 "title": "Select connection method"
             },
+            "show_install_info": {
+                "description": "Please wait while the OpenZWave add-on installation finishes. This can take several minutes.",
+                "title": "The OpenZWave add-on installation has started"
+            },
             "start_addon": {
                 "data": {
                     "network_key": "Network Key",

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -305,6 +305,16 @@ async def test_addon_not_installed(
         result["flow_id"], {"use_addon": True}
     )
 
+    assert result["type"] == "progress"
+
+    # Make sure the flow continues when the progress task is done.
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "start_addon"
+
     with patch(
         "homeassistant.components.ozw.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -341,6 +351,13 @@ async def test_install_addon_failure(hass, supervisor, addon_installed, install_
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"use_addon": True}
     )
+
+    assert result["type"] == "progress"
+
+    # Make sure the flow continues when the progress task is done.
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == "abort"
     assert result["reason"] == "addon_install_failed"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add a show progress prompt that informs the user that the add-on install has started and will take some time.

## Todo

- [x] Wait for frontend fix: https://github.com/home-assistant/frontend/pull/7700

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
