### PR TITLE
Update cloud integration to 0.38.0

### DIFF
--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cloud",
   "name": "Home Assistant Cloud",
   "documentation": "https://www.home-assistant.io/integrations/cloud",
-  "requirements": ["hass-nabucasa==0.37.2"],
+  "requirements": ["hass-nabucasa==0.38.0"],
   "dependencies": ["http", "webhook", "alexa"],
   "after_dependencies": ["google_assistant"],
   "codeowners": ["@home-assistant/cloud"]

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -1,7 +1,7 @@
 """Support for the cloud for text to speech service."""
 
 from hass_nabucasa import Cloud
-from hass_nabucasa.voice import VoiceError
+from hass_nabucasa.voice import VOICE_MAP, VoiceError
 import voluptuous as vol
 
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
@@ -10,17 +10,29 @@ from .const import DOMAIN
 
 CONF_GENDER = "gender"
 
-SUPPORT_LANGUAGES = ["en-US", "de-DE", "es-ES", "nl-NL"]
-SUPPORT_GENDER = ["male", "female"]
+SUPPORT_LANGUAGES = list({key[0] for key in VOICE_MAP})
 
 DEFAULT_LANG = "en-US"
 DEFAULT_GENDER = "female"
 
+
+def validate_lang(value):
+    """Validate chosen gender or language."""
+    lang = value[CONF_LANG]
+    gender = value[CONF_GENDER]
+
+    if (lang, gender) not in VOICE_MAP:
+        raise vol.Invalid("Unsupported language and gender specified.")
+
+    return value
+
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
-        vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): vol.In(SUPPORT_GENDER),
-    }
+        vol.Optional(CONF_LANG, default=DEFAULT_LANG): str,
+        vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): str,
+    },
+    validate_lang,
 )
 
 

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -19,7 +19,12 @@ DEFAULT_GENDER = "female"
 def validate_lang(value):
     """Validate chosen gender or language."""
     lang = value[CONF_LANG]
-    gender = value[CONF_GENDER]
+    gender = value.get(CONF_GENDER)
+
+    if gender is None:
+        gender = value[CONF_GENDER] = next(
+            (chk_gender for chk_lang, chk_gender in MAP_VOICE if chk_lang == lang), None
+        )
 
     if (lang, gender) not in MAP_VOICE:
         raise vol.Invalid("Unsupported language and gender specified.")
@@ -31,7 +36,7 @@ PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend(
         {
             vol.Optional(CONF_LANG, default=DEFAULT_LANG): str,
-            vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): str,
+            vol.Optional(CONF_GENDER): str,
         }
     ),
     validate_lang,

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -1,7 +1,7 @@
 """Support for the cloud for text to speech service."""
 
 from hass_nabucasa import Cloud
-from hass_nabucasa.voice import VOICE_MAP, VoiceError
+from hass_nabucasa.voice import MAP_VOICE, VoiceError
 import voluptuous as vol
 
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
@@ -10,7 +10,7 @@ from .const import DOMAIN
 
 CONF_GENDER = "gender"
 
-SUPPORT_LANGUAGES = list({key[0] for key in VOICE_MAP})
+SUPPORT_LANGUAGES = list({key[0] for key in MAP_VOICE})
 
 DEFAULT_LANG = "en-US"
 DEFAULT_GENDER = "female"
@@ -21,7 +21,7 @@ def validate_lang(value):
     lang = value[CONF_LANG]
     gender = value[CONF_GENDER]
 
-    if (lang, gender) not in VOICE_MAP:
+    if (lang, gender) not in MAP_VOICE:
         raise vol.Invalid("Unsupported language and gender specified.")
 
     return value

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -10,7 +10,7 @@ from .const import DOMAIN
 
 CONF_GENDER = "gender"
 
-SUPPORT_LANGUAGES = ["en-US", "de-DE", "es-ES"]
+SUPPORT_LANGUAGES = ["en-US", "de-DE", "es-ES", "nl-NL"]
 SUPPORT_GENDER = ["male", "female"]
 
 DEFAULT_LANG = "en-US"

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -27,11 +27,13 @@ def validate_lang(value):
     return value
 
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_LANG, default=DEFAULT_LANG): str,
-        vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): str,
-    },
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend(
+        {
+            vol.Optional(CONF_LANG, default=DEFAULT_LANG): str,
+            vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): str,
+        }
+    ),
     validate_lang,
 )
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -12,7 +12,7 @@ cryptography==3.2
 defusedxml==0.6.0
 distro==1.5.0
 emoji==0.5.4
-hass-nabucasa==0.37.2
+hass-nabucasa==0.38.0
 home-assistant-frontend==20201111.1
 httpx==0.16.1
 importlib-metadata==1.6.0;python_version<'3.8'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -735,7 +735,7 @@ habitipy==0.2.0
 hangups==0.4.11
 
 # homeassistant.components.cloud
-hass-nabucasa==0.37.2
+hass-nabucasa==0.38.0
 
 # homeassistant.components.splunk
 hass_splunk==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -376,7 +376,7 @@ ha-ffmpeg==2.0
 hangups==0.4.11
 
 # homeassistant.components.cloud
-hass-nabucasa==0.37.2
+hass-nabucasa==0.38.0
 
 # homeassistant.components.tasmota
 hatasmota==0.0.30

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -1,0 +1,15 @@
+"""Tests for cloud tts."""
+from homeassistant.components.cloud import tts
+
+
+def test_schema():
+    """Test schema."""
+    assert "nl-NL" in tts.SUPPORT_LANGUAGES
+
+    processed = tts.PLATFORM_SCHEMA({"platform": "cloud", "language": "nl-NL"})
+    assert processed["gender"] == "female"
+
+    # Should not raise
+    processed = tts.PLATFORM_SCHEMA(
+        {"platform": "cloud", "language": "nl-NL", "gender": "female"}
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request ensures that you can now use new neural voices from the Nabu Casa TTS cloud integration. 
Related PR: https://github.com/NabuCasa/hass-nabucasa/pull/203

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
entity_id: media_player.test
message: "Will this work?"
language: nl-NL
options:
  gender: female
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
