### PR TITLE
Bump hatasmota to 0.0.31

### DIFF
--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.0.30"],
+  "requirements": ["hatasmota==0.0.31"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -741,7 +741,7 @@ hass-nabucasa==0.37.2
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.0.30
+hatasmota==0.0.31
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -379,7 +379,7 @@ hangups==0.4.11
 hass-nabucasa==0.37.2
 
 # homeassistant.components.tasmota
-hatasmota==0.0.30
+hatasmota==0.0.31
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -51,12 +51,12 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == "unavailable"
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -64,35 +64,94 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"ON"}}'
     )
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
 
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"OFF"}}'
     )
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
 
     # Test periodic state update
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Switch1":"ON"}')
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Switch1":"OFF"}')
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
 
     # Test polled state update
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/STATUS10", '{"StatusSNS":{"Switch1":"ON"}}'
     )
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
 
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/STATUS10", '{"StatusSNS":{"Switch1":"OFF"}}'
     )
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
+    assert state.state == STATE_OFF
+
+
+async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasmota):
+    """Test state update via MQTT."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["swc"][0] = 1
+    config["swn"][0] = "Custom Name"
+    mac = config["mac"]
+
+    async_fire_mqtt_message(
+        hass,
+        f"{DEFAULT_PREFIX}/{mac}/config",
+        json.dumps(config),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.custom_name")
+    assert state.state == "unavailable"
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    state = hass.states.get("binary_sensor.custom_name")
+    assert state.state == STATE_OFF
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    # Test normal state update
+    async_fire_mqtt_message(
+        hass, "tasmota_49A3BC/stat/RESULT", '{"Custom Name":{"Action":"ON"}}'
+    )
+    state = hass.states.get("binary_sensor.custom_name")
+    assert state.state == STATE_ON
+
+    async_fire_mqtt_message(
+        hass, "tasmota_49A3BC/stat/RESULT", '{"Custom Name":{"Action":"OFF"}}'
+    )
+    state = hass.states.get("binary_sensor.custom_name")
+    assert state.state == STATE_OFF
+
+    # Test periodic state update
+    async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Custom Name":"ON"}')
+    state = hass.states.get("binary_sensor.custom_name")
+    assert state.state == STATE_ON
+
+    async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Custom Name":"OFF"}')
+    state = hass.states.get("binary_sensor.custom_name")
+    assert state.state == STATE_OFF
+
+    # Test polled state update
+    async_fire_mqtt_message(
+        hass, "tasmota_49A3BC/stat/STATUS10", '{"StatusSNS":{"Custom Name":"ON"}}'
+    )
+    state = hass.states.get("binary_sensor.custom_name")
+    assert state.state == STATE_ON
+
+    async_fire_mqtt_message(
+        hass, "tasmota_49A3BC/stat/STATUS10", '{"StatusSNS":{"Custom Name":"OFF"}}'
+    )
+    state = hass.states.get("binary_sensor.custom_name")
     assert state.state == STATE_OFF
 
 
@@ -109,12 +168,12 @@ async def test_pushon_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota)
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == "unavailable"
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -122,34 +181,34 @@ async def test_pushon_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota)
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"ON"}}'
     )
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
 
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"OFF"}}'
     )
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
 
     # Test periodic state update is ignored
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Switch1":"ON"}')
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
 
     # Test polled state update is ignored
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/STATUS10", '{"StatusSNS":{"Switch1":"ON"}}'
     )
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
 
 
 async def test_friendly_names(hass, mqtt_mock, setup_tasmota):
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
-    config["rl"][0] = 1
     config["swc"][0] = 1
     config["swc"][1] = 1
+    config["swn"][1] = "Beer"
     mac = config["mac"]
 
     async_fire_mqtt_message(
@@ -197,7 +256,7 @@ async def test_off_delay(hass, mqtt_mock, setup_tasmota):
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"ON"}}'
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
     assert events == ["off", "on"]
 
@@ -205,13 +264,13 @@ async def test_off_delay(hass, mqtt_mock, setup_tasmota):
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"ON"}}'
     )
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
     assert events == ["off", "on", "on"]
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test")
+    state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
     assert events == ["off", "on", "on", "off"]
 
@@ -222,6 +281,7 @@ async def test_availability_when_connection_lost(
     """Test availability after MQTT disconnection."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
+    config["swn"][0] = "Test"
     await help_test_availability_when_connection_lost(
         hass, mqtt_client_mock, mqtt_mock, binary_sensor.DOMAIN, config
     )
@@ -231,6 +291,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
+    config["swn"][0] = "Test"
     await help_test_availability(hass, mqtt_mock, binary_sensor.DOMAIN, config)
 
 
@@ -238,6 +299,7 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     """Test availability discovery update."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
+    config["swn"][0] = "Test"
     await help_test_availability_discovery_update(
         hass, mqtt_mock, binary_sensor.DOMAIN, config
     )
@@ -249,6 +311,7 @@ async def test_availability_poll_state(
     """Test polling after MQTT connection (re)established."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
+    config["swn"][0] = "Test"
     poll_topic = "tasmota_49A3BC/cmnd/STATUS"
     await help_test_availability_poll_state(
         hass,
@@ -267,6 +330,8 @@ async def test_discovery_removal_binary_sensor(hass, mqtt_mock, caplog, setup_ta
     config2 = copy.deepcopy(DEFAULT_CONFIG)
     config1["swc"][0] = 1
     config2["swc"][0] = 0
+    config1["swn"][0] = "Test"
+    config2["swn"][0] = "Test"
 
     await help_test_discovery_removal(
         hass, mqtt_mock, caplog, binary_sensor.DOMAIN, config1, config2
@@ -279,6 +344,7 @@ async def test_discovery_update_unchanged_binary_sensor(
     """Test update of discovered binary_sensor."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
+    config["swn"][0] = "Test"
     with patch(
         "homeassistant.components.tasmota.binary_sensor.TasmotaBinarySensor.discovery_update"
     ) as discovery_update:
@@ -301,6 +367,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
+    config["swn"][0] = "Test"
     topics = [
         get_topic_stat_result(config),
         get_topic_tele_sensor(config),
@@ -316,6 +383,7 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     """Test MQTT discovery update when entity_id is updated."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
+    config["swn"][0] = "Test"
     await help_test_entity_id_update_discovery_update(
         hass, mqtt_mock, binary_sensor.DOMAIN, config
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump hatasmota from 0.0.30 to 0.0.31

Changes:
 - 0.0.31 (https://github.com/emontnemery/hatasmota/releases/tag/0.0.31)
   - Tweak switch friendly names  [#45](https://github.com/emontnemery/hatasmota/pull/45) @emontnemery
   - Fix names for switches  [#44](https://github.com/emontnemery/hatasmota/pull/44) @effelle

https://github.com/emontnemery/hatasmota/compare/0.0.30...0.0.31

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
