### PR TITLE
Improve Tasmota error handling when MQTT is missing

### DIFF
--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -40,6 +40,9 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistantType, config: dict):
     """Set up the Tasmota component."""
+    if "mqtt" not in hass.config.components:
+        _LOGGER.error("MQTT integration is not set up")
+        return False
     return True
 
 

--- a/homeassistant/components/tasmota/config_flow.py
+++ b/homeassistant/components/tasmota/config_flow.py
@@ -46,6 +46,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
+        if "mqtt" not in self.hass.config.components:
+            return self.async_abort(reason="mqtt_required")
+
         if self.show_advanced_options:
             return await self.async_step_config()
         return await self.async_step_confirm()

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
   "requirements": ["hatasmota==0.0.31"],
-  "dependencies": ["mqtt"],
+  "after_dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]
 }

--- a/homeassistant/components/tasmota/strings.json
+++ b/homeassistant/components/tasmota/strings.json
@@ -13,6 +13,7 @@
       }
     },
     "abort": {
+      "mqtt_required": "The MQTT integration is not set up",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "error": {

--- a/tests/components/tasmota/test_config_flow.py
+++ b/tests/components/tasmota/test_config_flow.py
@@ -106,6 +106,15 @@ async def test_user_setup_invalid_topic_prefix(hass, mqtt_mock):
     assert result["errors"]["base"] == "invalid_discovery_topic"
 
 
+async def test_user_setup_missing_mqtt(hass):
+    """Test abort if MQTT is not setup."""
+    result = await hass.config_entries.flow.async_init(
+        "tasmota", context={"source": "user", "show_advanced_options": True}
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "mqtt_required"
+
+
 async def test_user_single_instance(hass, mqtt_mock):
     """Test we only allow a single config flow."""
     MockConfigEntry(domain="tasmota").add_to_hass(hass)

--- a/tests/components/tasmota/test_init.py
+++ b/tests/components/tasmota/test_init.py
@@ -3,12 +3,20 @@ import copy
 import json
 
 from homeassistant.components import websocket_api
-from homeassistant.components.tasmota.const import DEFAULT_PREFIX
+from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
+from homeassistant.setup import async_setup_component
 
 from .test_common import DEFAULT_CONFIG
 
 from tests.async_mock import call
 from tests.common import MockConfigEntry, async_fire_mqtt_message
+
+
+async def test_missing_mqtt(hass, caplog):
+    """Test setup fails if MQTT is not setup."""
+    result = await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    assert not result
+    assert "MQTT integration is not set up" in caplog.text
 
 
 async def test_device_remove(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Tasmota error handling and user feedback when the MQTT integration is missing or not setup

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
