### PR TITLE
Support openRelativePercent for google assistant covers

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1629,7 +1629,9 @@ class OpenCloseTrait(_Trait):
                 service = cover.SERVICE_OPEN_COVER
                 should_verify = True
             else:
-                raise SmartHomeError(ERR_NOT_SUPPORTED, "No support for open close")
+                raise SmartHomeError(
+                    ERR_NOT_SUPPORTED, "No support for partial open close"
+                )
 
             if (
                 should_verify

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -68,7 +68,6 @@ from .const import (
     ERR_ALREADY_ARMED,
     ERR_ALREADY_DISARMED,
     ERR_CHALLENGE_NOT_SETUP,
-    ERR_FUNCTION_NOT_SUPPORTED,
     ERR_NOT_SUPPORTED,
     ERR_UNSUPPORTED_INPUT,
     ERR_VALUE_OUT_OF_RANGE,
@@ -120,6 +119,7 @@ COMMAND_INPUT = f"{PREFIX_COMMANDS}SetInput"
 COMMAND_NEXT_INPUT = f"{PREFIX_COMMANDS}NextInput"
 COMMAND_PREVIOUS_INPUT = f"{PREFIX_COMMANDS}PreviousInput"
 COMMAND_OPENCLOSE = f"{PREFIX_COMMANDS}OpenClose"
+COMMAND_OPENCLOSE_RELATIVE = f"{PREFIX_COMMANDS}OpenCloseRelative"
 COMMAND_SET_VOLUME = f"{PREFIX_COMMANDS}setVolume"
 COMMAND_VOLUME_RELATIVE = f"{PREFIX_COMMANDS}volumeRelative"
 COMMAND_MUTE = f"{PREFIX_COMMANDS}mute"
@@ -1519,7 +1519,7 @@ class OpenCloseTrait(_Trait):
     )
 
     name = TRAIT_OPENCLOSE
-    commands = [COMMAND_OPENCLOSE]
+    commands = [COMMAND_OPENCLOSE, COMMAND_OPENCLOSE_RELATIVE]
 
     @staticmethod
     def supported(domain, features, device_class):
@@ -1543,9 +1543,20 @@ class OpenCloseTrait(_Trait):
     def sync_attributes(self):
         """Return opening direction."""
         response = {}
+        features = self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+
         if self.state.domain == binary_sensor.DOMAIN:
             response["queryOnlyOpenClose"] = True
             response["discreteOnlyOpenClose"] = True
+        elif self.state.domain == cover.DOMAIN:
+            if features & cover.SUPPORT_SET_POSITION == 0:
+                response["discreteOnlyOpenClose"] = True
+
+                if (
+                    features & cover.SUPPORT_OPEN == 0
+                    and features & cover.SUPPORT_CLOSE == 0
+                ):
+                    response["queryOnlyOpenClose"] = True
 
         if self.state.attributes.get(ATTR_ASSUMED_STATE):
             response["commandOnlyOpenClose"] = True
@@ -1590,27 +1601,35 @@ class OpenCloseTrait(_Trait):
     async def execute(self, command, data, params, challenge):
         """Execute an Open, close, Set position command."""
         domain = self.state.domain
+        features = self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         if domain == cover.DOMAIN:
             svc_params = {ATTR_ENTITY_ID: self.state.entity_id}
+            should_verify = False
+            if command == COMMAND_OPENCLOSE_RELATIVE:
+                position = self.state.attributes.get(cover.ATTR_CURRENT_POSITION)
+                if position is None:
+                    raise SmartHomeError(
+                        ERR_NOT_SUPPORTED,
+                        "Current position not know for relative command",
+                    )
+                position = max(0, min(100, position + params["openRelativePercent"]))
+            else:
+                position = params["openPercent"]
 
-            if params["openPercent"] == 0:
+            if features & cover.SUPPORT_SET_POSITION:
+                service = cover.SERVICE_SET_COVER_POSITION
+                if position > 0:
+                    should_verify = True
+                svc_params[cover.ATTR_POSITION] = position
+            elif position == 0:
                 service = cover.SERVICE_CLOSE_COVER
                 should_verify = False
-            elif params["openPercent"] == 100:
+            elif position == 100:
                 service = cover.SERVICE_OPEN_COVER
                 should_verify = True
-            elif (
-                self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-                & cover.SUPPORT_SET_POSITION
-            ):
-                service = cover.SERVICE_SET_COVER_POSITION
-                should_verify = True
-                svc_params[cover.ATTR_POSITION] = params["openPercent"]
             else:
-                raise SmartHomeError(
-                    ERR_FUNCTION_NOT_SUPPORTED, "Setting a position is not supported"
-                )
+                raise SmartHomeError(ERR_NOT_SUPPORTED, "No support for open close")
 
             if (
                 should_verify

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -839,7 +839,7 @@ async def test_device_class_cover(hass, device_class, google_type):
             "agentUserId": "test-agent",
             "devices": [
                 {
-                    "attributes": {},
+                    "attributes": {"discreteOnlyOpenClose": True},
                     "id": "cover.demo_sensor",
                     "name": {"name": "Demo Sensor"},
                     "traits": ["action.devices.traits.OpenClose"],

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1928,27 +1928,57 @@ async def test_openclose_cover_assumed_state(hass):
     assert calls[0].data == {ATTR_ENTITY_ID: "cover.bla", cover.ATTR_POSITION: 40}
 
 
-async def test_openclose_cover_no_position(hass):
+async def test_openclose_cover_query_only(hass):
     """Test OpenClose trait support for cover domain."""
     assert helpers.get_google_type(cover.DOMAIN, None) is not None
-    assert trait.OpenCloseTrait.supported(
-        cover.DOMAIN, cover.SUPPORT_SET_POSITION, None
+    assert trait.OpenCloseTrait.supported(cover.DOMAIN, 0, None)
+
+    state = State(
+        "cover.bla",
+        cover.STATE_OPEN,
     )
 
     trt = trait.OpenCloseTrait(
         hass,
-        State(
-            "cover.bla",
-            cover.STATE_OPEN,
-            {
-                ATTR_SUPPORTED_FEATURES: cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE,
-            },
-        ),
+        state,
+        BASIC_CONFIG,
+    )
+
+    assert trt.sync_attributes() == {
+        "discreteOnlyOpenClose": True,
+        "queryOnlyOpenClose": True,
+    }
+    assert trt.query_attributes() == {"openPercent": 100}
+
+
+async def test_openclose_cover_no_position(hass):
+    """Test OpenClose trait support for cover domain."""
+    assert helpers.get_google_type(cover.DOMAIN, None) is not None
+    assert trait.OpenCloseTrait.supported(
+        cover.DOMAIN, cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE, None
+    )
+
+    state = State(
+        "cover.bla",
+        cover.STATE_OPEN,
+        {
+            ATTR_SUPPORTED_FEATURES: cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE,
+        },
+    )
+
+    trt = trait.OpenCloseTrait(
+        hass,
+        state,
         BASIC_CONFIG,
     )
 
     assert trt.sync_attributes() == {"discreteOnlyOpenClose": True}
     assert trt.query_attributes() == {"openPercent": 100}
+
+    state.state = cover.STATE_CLOSED
+
+    assert trt.sync_attributes() == {"discreteOnlyOpenClose": True}
+    assert trt.query_attributes() == {"openPercent": 0}
 
     calls = async_mock_service(hass, cover.DOMAIN, cover.SERVICE_CLOSE_COVER)
     await trt.execute(trait.COMMAND_OPENCLOSE, BASIC_DATA, {"openPercent": 0}, {})
@@ -1959,6 +1989,19 @@ async def test_openclose_cover_no_position(hass):
     await trt.execute(trait.COMMAND_OPENCLOSE, BASIC_DATA, {"openPercent": 100}, {})
     assert len(calls) == 1
     assert calls[0].data == {ATTR_ENTITY_ID: "cover.bla"}
+
+    with pytest.raises(
+        SmartHomeError, match=r"Current position not know for relative command"
+    ):
+        await trt.execute(
+            trait.COMMAND_OPENCLOSE_RELATIVE,
+            BASIC_DATA,
+            {"openRelativePercent": 100},
+            {},
+        )
+
+    with pytest.raises(SmartHomeError, match=r"No support for partial open close"):
+        await trt.execute(trait.COMMAND_OPENCLOSE, BASIC_DATA, {"openPercent": 50}, {})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Support relative percentage requests for covers
* Mark discrete open/close covers as such

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This will properly mark devices that only support discrete open/close commands as being such type of devices to google. It doesn't solve the case of relative open for a command only device completely, since home assistant internal API have no notion open a little bit, nor does GA have notion of stopping the opening/closing process for a cover.

If we want to fully support relative commands, we'd need to issue a OPEN service call, followed by a delayed STOP service call. The delay involved would have to be integration dependant.

- This PR is related to issue: #43178

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
