### PR TITLE
Refactor ZHA sensor initialization

### DIFF
--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -208,7 +208,7 @@ class ZigbeeChannel(LogMixin):
         attributes = []
         for report_config in self._report_config:
             attributes.append(report_config["attr"])
-        if len(attributes) > 0:
+        if attributes:
             await self.get_attributes(attributes, from_cache=from_cache)
         self._status = ChannelStatus.INITIALIZED
 

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -20,7 +20,7 @@ from ..const import (
     SIGNAL_STATE_ATTR,
     SIGNAL_UPDATE_DEVICE,
 )
-from .base import ClientChannel, ZigbeeChannel, parse_and_log_command
+from .base import ChannelStatus, ClientChannel, ZigbeeChannel, parse_and_log_command
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.Alarms.cluster_id)
@@ -415,15 +415,6 @@ class PowerConfigurationChannel(ZigbeeChannel):
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""
-        await self.async_read_state(from_cache)
-        await super().async_initialize(from_cache)
-
-    async def async_update(self):
-        """Retrieve latest state."""
-        await self.async_read_state(True)
-
-    async def async_read_state(self, from_cache):
-        """Read data from the cluster."""
         attributes = [
             "battery_size",
             "battery_percentage_remaining",
@@ -431,6 +422,7 @@ class PowerConfigurationChannel(ZigbeeChannel):
             "battery_quantity",
         ]
         await self.get_attributes(attributes, from_cache=from_cache)
+        self._status = ChannelStatus.INITIALIZED
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.PowerProfile.cluster_id)

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -1,4 +1,6 @@
 """Smart energy channels module for Zigbee Home Automation."""
+from typing import Union
+
 import zigpy.zcl.clusters.smartenergy as smartenergy
 
 from homeassistant.const import (
@@ -82,43 +84,47 @@ class Metering(ZigbeeChannel):
     ) -> None:
         """Initialize Metering."""
         super().__init__(cluster, ch_pool)
-        self._divisor = 1
-        self._multiplier = 1
-        self._unit_enum = None
         self._format_spec = None
 
-    async def async_configure(self):
+    @property
+    def divisor(self) -> int:
+        """Return divisor for the value."""
+        return self.cluster.get("divisor")
+
+    @property
+    def multiplier(self) -> int:
+        """Return multiplier for the value."""
+        return self.cluster.get("multiplier")
+
+    async def async_configure(self) -> None:
         """Configure channel."""
         await self.fetch_config(False)
         await super().async_configure()
 
-    async def async_initialize(self, from_cache):
+    async def async_initialize(self, from_cache: bool) -> None:
         """Initialize channel."""
         await self.fetch_config(True)
         await super().async_initialize(from_cache)
 
     @callback
-    def attribute_updated(self, attrid, value):
+    def attribute_updated(self, attrid: int, value: int) -> None:
         """Handle attribute update from Metering cluster."""
-        if None in (self._multiplier, self._divisor, self._format_spec):
+        if None in (self.multiplier, self.divisor, self._format_spec):
             return
-        super().attribute_updated(attrid, value * self._multiplier / self._divisor)
+        super().attribute_updated(attrid, value)
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return unit of measurement."""
-        return self.unit_of_measure_map.get(self._unit_enum & 0x7F, "unknown")
+        uom = self.cluster.get("unit_of_measure", 0x7F)
+        return self.unit_of_measure_map.get(uom & 0x7F, "unknown")
 
-    async def fetch_config(self, from_cache):
+    async def fetch_config(self, from_cache: bool) -> None:
         """Fetch config from device and updates format specifier."""
         results = await self.get_attributes(
             ["divisor", "multiplier", "unit_of_measure", "demand_formatting"],
             from_cache=from_cache,
         )
-
-        self._divisor = results.get("divisor", self._divisor)
-        self._multiplier = results.get("multiplier", self._multiplier)
-        self._unit_enum = results.get("unit_of_measure", 0x7F)  # default to unknown
 
         fmting = results.get(
             "demand_formatting", 0xF9
@@ -135,8 +141,9 @@ class Metering(ZigbeeChannel):
         else:
             self._format_spec = "{:0" + str(width) + "." + str(r_digits) + "f}"
 
-    def formatter_function(self, value):
+    def formatter_function(self, value: int) -> Union[int, float]:
         """Return formatted value for display."""
+        value = value * self.multiplier / self.divisor
         if self.unit_of_measurement == POWER_WATT:
             # Zigbee spec power unit is kW, but we show the value in W
             value_watt = value * 1000

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -39,12 +39,13 @@ async def async_add_entities(
             Tuple[str, zha_typing.ZhaDeviceType, List[zha_typing.ChannelType]],
         ]
     ],
+    update_before_add: bool = True,
 ) -> None:
     """Add entities helper."""
     if not entities:
         return
     to_add = [ent_cls(*args) for ent_cls, args in entities]
-    _async_add_entities(to_add, update_before_add=True)
+    _async_add_entities(to_add, update_before_add=update_before_add)
     entities.clear()
 
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -192,10 +192,10 @@ class Battery(Sensor):
     async def async_state_attr_provider(self) -> Dict[str, Any]:
         """Return device state attrs for battery sensors."""
         state_attrs = {}
-        battery_size = self._channel.get("battery_size")
+        battery_size = self._channel.cluster.get("battery_size")
         if battery_size is not None:
             state_attrs["battery_size"] = BATTERY_SIZES.get(battery_size, "Unknown")
-        battery_quantity = self._channel.get("battery_quantity")
+        battery_quantity = self._channel.cluster.get("battery_quantity")
         if battery_quantity is not None:
             state_attrs["battery_quantity"] = battery_quantity
         return state_attrs

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -106,7 +106,11 @@ class Sensor(ZhaEntity):
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._channel: ChannelType = channels[0]
         if self.SENSOR_ATTR is not None:
-            self._state = self._channel.cluster.get(self.SENSOR_ATTR)
+            try:
+                self._state = self.formatter(self._channel.cluster[self.SENSOR_ATTR])
+            except KeyError:
+                # no cached value
+                pass
 
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -79,7 +79,10 @@ async def async_setup_entry(
         hass,
         SIGNAL_ADD_ENTITIES,
         functools.partial(
-            discovery.async_add_entities, async_add_entities, entities_to_create
+            discovery.async_add_entities,
+            async_add_entities,
+            entities_to_create,
+            update_before_add=False,
         ),
     )
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
@@ -202,6 +205,9 @@ class Battery(Sensor):
         battery_quantity = self._channel.cluster.get("battery_quantity")
         if battery_quantity is not None:
             state_attrs["battery_quantity"] = battery_quantity
+        battery_voltage = self._channel.cluster.get("battery_voltage")
+        if battery_voltage is not None:
+            state_attrs["battery_voltage"] = round(battery_voltage / 10, 1)
         return state_attrs
 
     @callback

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -93,6 +93,17 @@ async def async_test_electrical_measurement(hass, cluster, entity_id):
         assert_state(hass, entity_id, "9.9", POWER_WATT)
 
 
+async def async_test_powerconfiguration(hass, cluster, entity_id):
+    """Test powerconfiguration/battery sensor."""
+    await send_attributes_report(hass, cluster, {33: 98})
+    assert_state(hass, entity_id, "49", "%")
+    assert hass.states.get(entity_id).attributes["battery_voltage"] == 2.9
+    assert hass.states.get(entity_id).attributes["battery_quantity"] == 3
+    assert hass.states.get(entity_id).attributes["battery_size"] == "AAA"
+    await send_attributes_report(hass, cluster, {32: 20})
+    assert hass.states.get(entity_id).attributes["battery_voltage"] == 2.0
+
+
 @pytest.mark.parametrize(
     "cluster_id, test_func, report_count, read_plug",
     (
@@ -125,6 +136,16 @@ async def async_test_electrical_measurement(hass, cluster, entity_id):
             async_test_electrical_measurement,
             1,
             None,
+        ),
+        (
+            general.PowerConfiguration.cluster_id,
+            async_test_powerconfiguration,
+            2,
+            {
+                "battery_size": 4,  # AAA
+                "battery_voltage": 29,
+                "battery_quantity": 3,
+            },
         ),
     ),
 )

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -94,17 +94,37 @@ async def async_test_electrical_measurement(hass, cluster, entity_id):
 
 
 @pytest.mark.parametrize(
-    "cluster_id, test_func, report_count",
+    "cluster_id, test_func, report_count, read_plug",
     (
-        (measurement.RelativeHumidity.cluster_id, async_test_humidity, 1),
-        (measurement.TemperatureMeasurement.cluster_id, async_test_temperature, 1),
-        (measurement.PressureMeasurement.cluster_id, async_test_pressure, 1),
-        (measurement.IlluminanceMeasurement.cluster_id, async_test_illuminance, 1),
-        (smartenergy.Metering.cluster_id, async_test_metering, 1),
+        (measurement.RelativeHumidity.cluster_id, async_test_humidity, 1, None),
+        (
+            measurement.TemperatureMeasurement.cluster_id,
+            async_test_temperature,
+            1,
+            None,
+        ),
+        (measurement.PressureMeasurement.cluster_id, async_test_pressure, 1, None),
+        (
+            measurement.IlluminanceMeasurement.cluster_id,
+            async_test_illuminance,
+            1,
+            None,
+        ),
+        (
+            smartenergy.Metering.cluster_id,
+            async_test_metering,
+            1,
+            {
+                "demand_formatting": 0xF9,
+                "divisor": 1,
+                "multiplier": 1,
+            },
+        ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
             async_test_electrical_measurement,
             1,
+            None,
         ),
     ),
 )
@@ -115,6 +135,7 @@ async def test_sensor(
     cluster_id,
     test_func,
     report_count,
+    read_plug,
 ):
     """Test zha sensor platform."""
 
@@ -128,6 +149,10 @@ async def test_sensor(
         }
     )
     cluster = zigpy_device.endpoints[1].in_clusters[cluster_id]
+    if cluster_id == smartenergy.Metering.cluster_id:
+        # this one is mains powered
+        zigpy_device.node_desc.mac_capability_flags |= 0b_0000_0100
+    cluster.PLUGGED_ATTR_READS = read_plug
     zha_device = await zha_device_joined_restored(zigpy_device)
     entity_id = await find_entity_id(DOMAIN, zha_device, hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor ZHA sensor entities just to be the representation of the Zigpy cached attribute values. Removes an extra `async_update()` before entities are added to hass. Paves the way to support multiple entities per single Zigpy cluster. Should merge this PR after 0.118 release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
