### PR TITLE
Add type name to Hyperion unique ids for future extensibility

### DIFF
--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -37,8 +37,8 @@ _LOGGER = logging.getLogger(__name__)
 # Each server connection may create multiple entities. The unique_id for each entity is
 # <server id>_<instance #>_<name>, where <server_id> will be the unique_id on the
 # relevant config entry (as above), <instance #> will be the server instance # and
-# <name> will be a unique identifying key for each entity associated with this
-# server/instance (e.g. "light").
+# <name> will be a unique identifying type name for each entity associated with this
+# server/instance (e.g. "hyperion_light").
 #
 # The get_hyperion_unique_id method will create a per-entity unique id when given the
 # server id, an instance number and a name.

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from hyperion import client, const as hyperion_const
 from pkg_resources import parse_version
@@ -34,13 +34,14 @@ _LOGGER = logging.getLogger(__name__)
 # unique_id is the server id returned from the Hyperion instance (a unique ID per
 # server).
 #
-# Each server connection may create multiple entities, 1 per "instance" on the Hyperion
-# server. The unique_id for each entity is <server id>_<instance #>, where <server_id>
-# will be the unique_id on the relevant config entry (as above).
+# Each server connection may create multiple entities. The unique_id for each entity is
+# <server id>_<instance #>_<name>, where <server_id> will be the unique_id on the
+# relevant config entry (as above), <instance #> will be the server instance # and
+# <name> will be a unique identifying key for each entity associated with this
+# server/instance (e.g. "light").
 #
 # The get_hyperion_unique_id method will create a per-entity unique id when given the
-# server id and the instance number. The split_hyperion_unique_id will reverse the
-# operation.
+# server id, an instance number and a name.
 
 # hass.data format
 # ================
@@ -53,18 +54,9 @@ _LOGGER = logging.getLogger(__name__)
 # }
 
 
-def get_hyperion_unique_id(server_id: str, instance: int) -> str:
+def get_hyperion_unique_id(server_id: str, instance: int, name: str) -> str:
     """Get a unique_id for a Hyperion instance."""
-    return f"{server_id}_{instance}"
-
-
-def split_hyperion_unique_id(unique_id: str) -> Optional[Tuple[str, int]]:
-    """Split a unique_id for a Hyperion instance."""
-    try:
-        server_id, instance = unique_id.rsplit("_", 1)
-        return server_id, int(instance)
-    except ValueError:
-        return None
+    return f"{server_id}_{instance}_{name}"
 
 
 def create_hyperion_client(

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -20,3 +20,5 @@ SOURCE_IMPORT = "import"
 
 HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.9"
 HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/releases"
+
+TYPE_HYPERION_LIGHT = "hyperion_light"

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -18,5 +18,5 @@ SIGNAL_INSTANCE_REMOVED = f"{DOMAIN}_instance_removed_signal." "{}"
 
 SOURCE_IMPORT = "import"
 
-HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.8"
+HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.9"
 HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/releases"

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -138,7 +138,7 @@ async def async_setup_platform(
     if not hyperion_id:
         raise PlatformNotReady
 
-    future_unique_id = get_hyperion_unique_id(hyperion_id, instance)
+    future_unique_id = get_hyperion_unique_id(hyperion_id, instance, LIGHT_DOMAIN)
 
     # Possibility 1: Already converted.
     # There is already a config entry with the unique id reporting by the
@@ -243,7 +243,7 @@ async def async_setup_entry(
             instance_id = instance.get(const.KEY_INSTANCE)
             if instance_id is None or not instance.get(const.KEY_RUNNING, False):
                 continue
-            unique_id = get_hyperion_unique_id(server_id, instance_id)
+            unique_id = get_hyperion_unique_id(server_id, instance_id, LIGHT_DOMAIN)
             desired_unique_ids.add(unique_id)
             if unique_id in current_entities:
                 continue

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -48,6 +48,7 @@ from .const import (
     SIGNAL_INSTANCE_REMOVED,
     SIGNAL_INSTANCES_UPDATED,
     SOURCE_IMPORT,
+    TYPE_HYPERION_LIGHT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -138,7 +139,9 @@ async def async_setup_platform(
     if not hyperion_id:
         raise PlatformNotReady
 
-    future_unique_id = get_hyperion_unique_id(hyperion_id, instance, LIGHT_DOMAIN)
+    future_unique_id = get_hyperion_unique_id(
+        hyperion_id, instance, TYPE_HYPERION_LIGHT
+    )
 
     # Possibility 1: Already converted.
     # There is already a config entry with the unique id reporting by the
@@ -227,7 +230,7 @@ async def async_setup_entry(
 
     async def async_instances_to_entities_raw(instances: List[Dict[str, Any]]) -> None:
         registry = await async_get_registry(hass)
-        entities_to_add: List[Hyperion] = []
+        entities_to_add: List[HyperionLight] = []
         desired_unique_ids: Set[str] = set()
         server_id = cast(str, config_entry.unique_id)
 
@@ -243,7 +246,9 @@ async def async_setup_entry(
             instance_id = instance.get(const.KEY_INSTANCE)
             if instance_id is None or not instance.get(const.KEY_RUNNING, False):
                 continue
-            unique_id = get_hyperion_unique_id(server_id, instance_id, LIGHT_DOMAIN)
+            unique_id = get_hyperion_unique_id(
+                server_id, instance_id, TYPE_HYPERION_LIGHT
+            )
             desired_unique_ids.add(unique_id)
             if unique_id in current_entities:
                 continue
@@ -254,7 +259,7 @@ async def async_setup_entry(
                 continue
             current_entities.add(unique_id)
             entities_to_add.append(
-                Hyperion(
+                HyperionLight(
                     unique_id,
                     instance.get(const.KEY_FRIENDLY_NAME, DEFAULT_NAME),
                     config_entry.options,
@@ -289,7 +294,7 @@ async def async_setup_entry(
     return True
 
 
-class Hyperion(LightEntity):
+class HyperionLight(LightEntity):
     """Representation of a Hyperion remote."""
 
     def __init__(

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -5,7 +5,6 @@ import logging
 from types import TracebackType
 from typing import Any, Dict, Optional, Type
 
-from asynctest import CoroutineMock, Mock, patch
 from hyperion import const
 
 from homeassistant.components.hyperion.const import CONF_PRIORITY, DOMAIN
@@ -14,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.typing import HomeAssistantType
 
+from tests.async_mock import AsyncMock, Mock, patch  # type: ignore[attr-defined]
 from tests.common import MockConfigEntry
 
 TEST_HOST = "test"
@@ -75,9 +75,9 @@ def create_mock_client() -> Mock:
     """Create a mock Hyperion client."""
     mock_client = AsyncContextManagerMock()
     # pylint: disable=attribute-defined-outside-init
-    mock_client.async_client_connect = CoroutineMock(return_value=True)
-    mock_client.async_client_disconnect = CoroutineMock(return_value=True)
-    mock_client.async_is_auth_required = CoroutineMock(
+    mock_client.async_client_connect = AsyncMock(return_value=True)
+    mock_client.async_client_disconnect = AsyncMock(return_value=True)
+    mock_client.async_is_auth_required = AsyncMock(
         return_value={
             "command": "authorize-tokenRequired",
             "info": {"required": False},
@@ -85,12 +85,12 @@ def create_mock_client() -> Mock:
             "tan": 1,
         }
     )
-    mock_client.async_login = CoroutineMock(
+    mock_client.async_login = AsyncMock(
         return_value={"command": "authorize-login", "success": True, "tan": 0}
     )
 
-    mock_client.async_sysinfo_id = CoroutineMock(return_value=TEST_SYSINFO_ID)
-    mock_client.async_sysinfo_version = CoroutineMock(return_value=TEST_SYSINFO_ID)
+    mock_client.async_sysinfo_id = AsyncMock(return_value=TEST_SYSINFO_ID)
+    mock_client.async_sysinfo_version = AsyncMock(return_value=TEST_SYSINFO_ID)
     mock_client.adjustment = None
     mock_client.effects = None
     mock_client.instances = [

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -121,7 +121,7 @@ async def test_setup_yaml_old_style_unique_id(hass: HomeAssistantType) -> None:
     # The unique_id should have been updated in the registry (rather than the one
     # specified above).
     assert registry.async_get(TEST_YAML_ENTITY_ID).unique_id == get_hyperion_unique_id(
-        TEST_SYSINFO_ID, 0
+        TEST_SYSINFO_ID, 0, LIGHT_DOMAIN
     )
     assert registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, old_unique_id) is None
 
@@ -139,7 +139,7 @@ async def test_setup_yaml_new_style_unique_id_wo_config(
     # Assistant should this combination, but verify correct behavior for defense in
     # depth.
 
-    new_unique_id = get_hyperion_unique_id(TEST_SYSINFO_ID, 0)
+    new_unique_id = get_hyperion_unique_id(TEST_SYSINFO_ID, 0, LIGHT_DOMAIN)
     entity_id_to_preserve = "light.magic_entity"
 
     # Add a pre-existing registry entry.
@@ -183,7 +183,7 @@ async def test_setup_yaml_no_registry_entity(hass: HomeAssistantType) -> None:
     # The unique_id should have been updated in the registry (rather than the one
     # specified above).
     assert registry.async_get(TEST_YAML_ENTITY_ID).unique_id == get_hyperion_unique_id(
-        TEST_SYSINFO_ID, 0
+        TEST_SYSINFO_ID, 0, LIGHT_DOMAIN
     )
 
     # There should be a config entry with the correct server unique_id.

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -10,7 +10,7 @@ from homeassistant.components.hyperion import (
     get_hyperion_unique_id,
     light as hyperion_light,
 )
-from homeassistant.components.hyperion.const import DOMAIN
+from homeassistant.components.hyperion.const import DOMAIN, TYPE_HYPERION_LIGHT
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_EFFECT,
@@ -121,7 +121,7 @@ async def test_setup_yaml_old_style_unique_id(hass: HomeAssistantType) -> None:
     # The unique_id should have been updated in the registry (rather than the one
     # specified above).
     assert registry.async_get(TEST_YAML_ENTITY_ID).unique_id == get_hyperion_unique_id(
-        TEST_SYSINFO_ID, 0, LIGHT_DOMAIN
+        TEST_SYSINFO_ID, 0, TYPE_HYPERION_LIGHT
     )
     assert registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, old_unique_id) is None
 
@@ -139,7 +139,7 @@ async def test_setup_yaml_new_style_unique_id_wo_config(
     # Assistant should this combination, but verify correct behavior for defense in
     # depth.
 
-    new_unique_id = get_hyperion_unique_id(TEST_SYSINFO_ID, 0, LIGHT_DOMAIN)
+    new_unique_id = get_hyperion_unique_id(TEST_SYSINFO_ID, 0, TYPE_HYPERION_LIGHT)
     entity_id_to_preserve = "light.magic_entity"
 
     # Add a pre-existing registry entry.
@@ -183,7 +183,7 @@ async def test_setup_yaml_no_registry_entity(hass: HomeAssistantType) -> None:
     # The unique_id should have been updated in the registry (rather than the one
     # specified above).
     assert registry.async_get(TEST_YAML_ENTITY_ID).unique_id == get_hyperion_unique_id(
-        TEST_SYSINFO_ID, 0, LIGHT_DOMAIN
+        TEST_SYSINFO_ID, 0, TYPE_HYPERION_LIGHT
     )
 
     # There should be a config entry with the correct server unique_id.

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -703,7 +703,7 @@ async def test_version_log_warning(caplog, hass: HomeAssistantType) -> None:
 async def test_version_no_log_warning(caplog, hass: HomeAssistantType) -> None:
     """Test no warning on acceptable version."""
     client = create_mock_client()
-    client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.8")
+    client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.9")
     await setup_test_config_entry(hass, hyperion_client=client)
     assert hass.states.get(TEST_ENTITY_ID_1) is not None
     assert "Please consider upgrading" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A small change to add support for an arbitrary name to Hyperion entity unique_ids. This is a harmless change, as this is being merged into a special branch ("add-hyperion-config-options"), and the underlying code has never been merged to 'dev', i.e. there are no entities in the wild using the old unique_ids. 

Motivation: I may need to add multiple switches per Hyperion server/instance, and so now is the time to add extensibility to the unique_ids, before this special branch is merged/retired.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
