### PR TITLE
Add support for checking minimum HA version

### DIFF
--- a/homeassistant/components/blueprint/const.py
+++ b/homeassistant/components/blueprint/const.py
@@ -6,5 +6,7 @@ CONF_USE_BLUEPRINT = "use_blueprint"
 CONF_INPUT = "input"
 CONF_SOURCE_URL = "source_url"
 CONF_DESCRIPTION = "description"
+CONF_HOMEASSISTANT = "homeassistant"
+CONF_MIN_VERSION = "min_version"
 
 DOMAIN = "blueprint"

--- a/homeassistant/components/blueprint/schemas.py
+++ b/homeassistant/components/blueprint/schemas.py
@@ -93,7 +93,7 @@ BLUEPRINT_INSTANCE_FIELDS = vol.Schema(
         vol.Required(CONF_USE_BLUEPRINT): vol.Schema(
             {
                 vol.Required(CONF_PATH): vol.All(cv.path, validate_yaml_suffix),
-                vol.Required(CONF_INPUT): {str: cv.match_all},
+                vol.Required(CONF_INPUT, default=dict): {str: cv.match_all},
             }
         )
     },

--- a/homeassistant/components/blueprint/schemas.py
+++ b/homeassistant/components/blueprint/schemas.py
@@ -10,10 +10,32 @@ from homeassistant.helpers import config_validation as cv, selector
 from .const import (
     CONF_BLUEPRINT,
     CONF_DESCRIPTION,
+    CONF_HOMEASSISTANT,
     CONF_INPUT,
+    CONF_MIN_VERSION,
     CONF_SOURCE_URL,
     CONF_USE_BLUEPRINT,
 )
+
+
+def version_validator(value):
+    """Validate a Home Assistant version."""
+    if not isinstance(value, str):
+        raise vol.Invalid("Version needs to be a string")
+
+    parts = value.split(".")
+
+    if len(parts) != 3:
+        raise vol.Invalid("Version needs to be formatted as {major}.{minor}.{patch}")
+
+    try:
+        parts = [int(p) for p in parts]
+    except ValueError:
+        raise vol.Invalid(
+            "Major, minor and patch version needs to be an integer"
+        ) from None
+
+    return value
 
 
 @callback
@@ -43,6 +65,9 @@ BLUEPRINT_SCHEMA = vol.Schema(
                 vol.Required(CONF_NAME): str,
                 vol.Required(CONF_DOMAIN): str,
                 vol.Optional(CONF_SOURCE_URL): cv.url,
+                vol.Optional(CONF_HOMEASSISTANT): {
+                    vol.Optional(CONF_MIN_VERSION): version_validator
+                },
                 vol.Optional(CONF_INPUT, default=dict): {
                     str: vol.Any(
                         None,

--- a/homeassistant/components/blueprint/websocket_api.py
+++ b/homeassistant/components/blueprint/websocket_api.py
@@ -85,6 +85,7 @@ async def ws_import_blueprint(hass, connection, msg):
             "blueprint": {
                 "metadata": imported_blueprint.blueprint.metadata,
             },
+            "validation_errors": imported_blueprint.blueprint.validate(),
         },
     )
 

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -38,7 +38,9 @@ class EntitySelector(Selector):
 
     CONFIG_SCHEMA = vol.Schema(
         {
+            # Integration that provided the entity
             vol.Optional("integration"): str,
+            # Domain the entity belongs to
             vol.Optional("domain"): str,
         }
     )
@@ -50,8 +52,11 @@ class DeviceSelector(Selector):
 
     CONFIG_SCHEMA = vol.Schema(
         {
+            # Integration linked to it with a config entry
             vol.Optional("integration"): str,
+            # Manufacturer of device
             vol.Optional("manufacturer"): str,
+            # Model of device
             vol.Optional("model"): str,
         }
     )

--- a/tests/components/blueprint/test_models.py
+++ b/tests/components/blueprint/test_models.py
@@ -71,7 +71,7 @@ def test_blueprint_properties(blueprint_1):
 
 
 def test_blueprint_update_metadata():
-    """Test properties."""
+    """Test update metadata."""
     bp = models.Blueprint(
         {
             "blueprint": {
@@ -83,6 +83,34 @@ def test_blueprint_update_metadata():
 
     bp.update_metadata(source_url="http://bla.com")
     assert bp.metadata["source_url"] == "http://bla.com"
+
+
+def test_blueprint_validate():
+    """Test validate blueprint."""
+    assert (
+        models.Blueprint(
+            {
+                "blueprint": {
+                    "name": "Hello",
+                    "domain": "automation",
+                },
+            }
+        ).validate()
+        is None
+    )
+
+    assert (
+        models.Blueprint(
+            {
+                "blueprint": {
+                    "name": "Hello",
+                    "domain": "automation",
+                    "homeassistant": {"min_version": "100000.0.0"},
+                },
+            }
+        ).validate()
+        == ["Requires at least Home Assistant 100000.0.0"]
+    )
 
 
 def test_blueprint_inputs(blueprint_1):

--- a/tests/components/blueprint/test_schemas.py
+++ b/tests/components/blueprint/test_schemas.py
@@ -31,6 +31,26 @@ _LOGGER = logging.getLogger(__name__)
                 },
             }
         },
+        # With selector
+        {
+            "blueprint": {
+                "name": "Test Name",
+                "domain": "automation",
+                "input": {
+                    "some_placeholder": {"selector": {"entity": {}}},
+                },
+            }
+        },
+        # With min version
+        {
+            "blueprint": {
+                "name": "Test Name",
+                "domain": "automation",
+                "homeassistant": {
+                    "min_version": "1000000.0.0",
+                },
+            }
+        },
     ),
 )
 def test_blueprint_schema(blueprint):
@@ -61,6 +81,16 @@ def test_blueprint_schema(blueprint):
                 "name": "Example name",
                 "domain": "automation",
                 "input": {"some_placeholder": {"non_existing": "bla"}},
+            }
+        },
+        # Invalid version
+        {
+            "blueprint": {
+                "name": "Test Name",
+                "domain": "automation",
+                "homeassistant": {
+                    "min_version": "1000000.invalid.0",
+                },
             }
         },
     ),

--- a/tests/components/blueprint/test_schemas.py
+++ b/tests/components/blueprint/test_schemas.py
@@ -99,3 +99,16 @@ def test_blueprint_schema_invalid(blueprint):
     """Test different schemas."""
     with pytest.raises(vol.Invalid):
         schemas.BLUEPRINT_SCHEMA(blueprint)
+
+
+@pytest.mark.parametrize(
+    "bp_instance",
+    (
+        {"path": "hello.yaml"},
+        {"path": "hello.yaml", "input": {}},
+        {"path": "hello.yaml", "input": {"hello": None}},
+    ),
+)
+def test_blueprint_instance_fields(bp_instance):
+    """Test blueprint instance fields."""
+    schemas.BLUEPRINT_INSTANCE_FIELDS({"use_blueprint": bp_instance})

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -96,6 +96,7 @@ async def test_import_blueprint(hass, aioclient_mock, hass_ws_client):
                 "name": "Call service based on event",
             },
         },
+        "validation_errors": None,
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for checking minimum version. Currently only returned from import data so we can prevent it from being imported. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
