### PR TITLE
Refactor ZHA tests to allow attribute reads during device initialization

### DIFF
--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -1,5 +1,4 @@
 """Common test objects."""
-import logging
 import time
 
 from zigpy.device import Device as zigpy_dev
@@ -15,8 +14,6 @@ import homeassistant.components.zha.core.const as zha_const
 from homeassistant.util import slugify
 
 from tests.async_mock import AsyncMock, Mock
-
-LOGGER = logging.getLogger(__name__)
 
 
 class FakeEndpoint:
@@ -76,13 +73,6 @@ def patch_cluster(cluster):
     cluster.PLUGGED_ATTR_READS = {}
 
     async def _read_attribute_raw(attributes, *args, **kwargs):
-        LOGGER.debug(
-            "'%s' trying to read %s attrs. args: %s; kwargs: %s",
-            cluster.ep_attribute,
-            attributes,
-            args,
-            kwargs,
-        )
         result = []
         for attr_id in attributes:
             value = cluster.PLUGGED_ATTR_READS.get(attr_id)

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -86,6 +86,10 @@ def patch_cluster(cluster):
         result = []
         for attr_id in attributes:
             value = cluster.PLUGGED_ATTR_READS.get(attr_id)
+            if value is None:
+                # try converting attr_id to attr_name and lookup the plugs again
+                attr_name = cluster.attributes.get(attr_id)
+                value = attr_name and cluster.PLUGGED_ATTR_READS.get(attr_name[0])
             if value is not None:
                 result.append(
                     zcl_f.ReadAttributeRecord(

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -32,7 +32,7 @@ from .common import (
     send_attributes_report,
 )
 
-from tests.async_mock import AsyncMock, MagicMock, patch
+from tests.async_mock import AsyncMock, patch
 from tests.common import async_capture_events, mock_coro, mock_restore_cache
 
 
@@ -104,19 +104,13 @@ def zigpy_keen_vent(zigpy_device_mock):
 async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
     """Test zha cover platform."""
 
-    async def get_chan_attr(*args, **kwargs):
-        return 100
-
-    with patch(
-        "homeassistant.components.zha.core.channels.base.ZigbeeChannel.get_attribute_value",
-        new=MagicMock(side_effect=get_chan_attr),
-    ) as get_attr_mock:
-        # load up cover domain
-        zha_device = await zha_device_joined_restored(zigpy_cover_device)
-        assert get_attr_mock.call_count == 2
-        assert get_attr_mock.call_args[0][0] == "current_position_lift_percentage"
-
+    # load up cover domain
     cluster = zigpy_cover_device.endpoints.get(1).window_covering
+    cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 100}
+    zha_device = await zha_device_joined_restored(zigpy_cover_device)
+    assert cluster.read_attributes.call_count == 2
+    assert "current_position_lift_percentage" in cluster.read_attributes.call_args[0][0]
+
     entity_id = await find_entity_id(DOMAIN, zha_device, hass)
     assert entity_id is not None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor ZHA tests and allow mock attribute reads for predefined attributes. Update ZHA climate tests to use the new feature.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
