### PR TITLE
Bump hatasmota to 0.0.32

### DIFF
--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.0.31"],
+  "requirements": ["hatasmota==0.0.32"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -741,7 +741,7 @@ hass-nabucasa==0.38.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.0.31
+hatasmota==0.0.32
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -379,7 +379,7 @@ hangups==0.4.11
 hass-nabucasa==0.38.0
 
 # homeassistant.components.tasmota
-hatasmota==0.0.31
+hatasmota==0.0.32
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -22,6 +22,25 @@ async def test_subscribing_config_topic(hass, mqtt_mock, setup_tasmota):
     assert call_args[2] == 0
 
 
+async def test_future_discovery_message(hass, mqtt_mock, caplog):
+    """Test we handle backwards compatible discovery messages."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["future_option"] = "BEST_SINCE_SLICED_BREAD"
+    config["so"]["another_future_option"] = "EVEN_BETTER"
+
+    with patch(
+        "homeassistant.components.tasmota.discovery.tasmota_get_device_config",
+        return_value={},
+    ) as mock_tasmota_get_device_config:
+        await setup_tasmota_helper(hass)
+
+        async_fire_mqtt_message(
+            hass, f"{DEFAULT_PREFIX}/00000049A3BC/config", json.dumps(config)
+        )
+        await hass.async_block_till_done()
+        assert mock_tasmota_get_device_config.called
+
+
 async def test_valid_discovery_message(hass, mqtt_mock, caplog):
     """Test discovery callback called."""
     config = copy.deepcopy(DEFAULT_CONFIG)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump hatasmota from 0.0.31 to 0.0.32

Changes:
 - 0.0.32 (https://github.com/emontnemery/hatasmota/releases/tag/0.0.32)
   - Accept backwards compatible discovery messages [#47](https://github.com/emontnemery/hatasmota/pull/47) @emontnemery
 
https://github.com/emontnemery/hatasmota/compare/0.0.31...0.0.32

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
