### PR TITLE
Track deCONZ lib changes to light based devices

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -84,7 +84,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     @property
     def is_on(self):
         """Return true if sensor is on."""
-        return self._device.is_tripped
+        return self._device.state
 
     @property
     def device_class(self):

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -66,12 +66,12 @@ class DeconzCover(DeconzDevice, CoverEntity):
     @property
     def current_cover_position(self):
         """Return the current position of the cover."""
-        return 100 - int(self._device.brightness / 254 * 100)
+        return 100 - self._device.position
 
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self._device.state
+        return self._device.is_open is False
 
     @property
     def device_class(self):
@@ -88,26 +88,16 @@ class DeconzCover(DeconzDevice, CoverEntity):
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
-        data = {"on": False}
-
-        if position < 100:
-            data["on"] = True
-            data["bri"] = 254 - int(position / 100 * 254)
-
-        await self._device.async_set_state(data)
+        await self._device.set_position(kwargs[ATTR_POSITION])
 
     async def async_open_cover(self, **kwargs):
         """Open cover."""
-        data = {ATTR_POSITION: 100}
-        await self.async_set_cover_position(**data)
+        await self._device.open()
 
     async def async_close_cover(self, **kwargs):
         """Close cover."""
-        data = {ATTR_POSITION: 0}
-        await self.async_set_cover_position(**data)
+        await self._device.close()
 
     async def async_stop_cover(self, **kwargs):
         """Stop cover."""
-        data = {"bri_inc": 0}
-        await self._device.async_set_state(data)
+        await self._device.stop()

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -18,10 +18,7 @@ from .gateway import get_gateway_from_config_entry
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up covers for deCONZ component.
-
-    Covers are based on the same device class as lights in deCONZ.
-    """
+    """Set up covers for deCONZ component."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -68,7 +68,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self._device.is_open is False
+        return not self._device.is_open
 
     @property
     def device_class(self):

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -108,9 +108,7 @@ class DeconzFan(DeconzDevice, FanEntity):
         if speed not in SPEEDS:
             raise ValueError(f"Unsupported speed {speed}")
 
-        data = {"speed": SPEEDS[speed]}
-
-        await self._device.async_set_state(data)
+        await self._device.set_speed(SPEEDS[speed])
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on fan."""

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -32,10 +32,7 @@ def convert_speed(speed: int) -> str:
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
-    """Set up fans for deCONZ component.
-
-    Fans are based on the same device class as lights in deCONZ.
-    """
+    """Set up fans for deCONZ component."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -171,7 +171,7 @@ class DeconzGateway:
             raise ConfigEntryNotReady from err
 
         except Exception as err:  # pylint: disable=broad-except
-            LOGGER.error("Error connecting with deCONZ gateway: %s", err)
+            LOGGER.error("Error connecting with deCONZ gateway: %s", err, exc_info=True)
             return False
 
         for component in SUPPORTED_PLATFORMS:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -42,6 +42,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 
+    other_light_resource_types = CONTROLLER + COVER_TYPES + LOCK_TYPES + SWITCH_TYPES
+
     @callback
     def async_add_light(lights):
         """Add light from deCONZ."""
@@ -49,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for light in lights:
             if (
-                light.type not in CONTROLLER + COVER_TYPES + LOCK_TYPES + SWITCH_TYPES
+                light.type not in other_light_resource_types
                 and light.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLight(light, gateway))

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -34,6 +34,8 @@ from .const import (
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
+CONTROLLER = ["Configuration tool"]
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ lights and groups from a config entry."""
@@ -47,7 +49,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for light in lights:
             if (
-                light.type not in COVER_TYPES + LOCK_TYPES + SWITCH_TYPES
+                light.type not in CONTROLLER + COVER_TYPES + LOCK_TYPES + SWITCH_TYPES
                 and light.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLight(light, gateway))

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -9,10 +9,7 @@ from .gateway import get_gateway_from_config_entry
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up locks for deCONZ component.
-
-    Locks are based on the same device class as lights in deCONZ.
-    """
+    """Set up locks for deCONZ component."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -46,14 +46,12 @@ class DeconzLock(DeconzDevice, LockEntity):
     @property
     def is_locked(self):
         """Return true if lock is on."""
-        return self._device.state
+        return self._device.is_locked
 
     async def async_lock(self, **kwargs):
         """Lock the lock."""
-        data = {"on": True}
-        await self._device.async_set_state(data)
+        await self._device.lock()
 
     async def async_unlock(self, **kwargs):
         """Unlock the lock."""
-        data = {"on": False}
-        await self._device.async_set_state(data)
+        await self._device.unlock()

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==73"],
+  "requirements": ["pydeconz==74"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -75,14 +75,12 @@ class DeconzSiren(DeconzDevice, SwitchEntity):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self._device.alert == "lselect"
+        return self._device.is_on
 
     async def async_turn_on(self, **kwargs):
         """Turn on switch."""
-        data = {"alert": "lselect"}
-        await self._device.async_set_state(data)
+        await self._device.turn_on()
 
     async def async_turn_off(self, **kwargs):
         """Turn off switch."""
-        data = {"alert": "none"}
-        await self._device.async_set_state(data)
+        await self._device.turn_off()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1334,7 +1334,7 @@ pydaikin==2.3.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==73
+pydeconz==74
 
 # homeassistant.components.delijn
 pydelijn==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -667,7 +667,7 @@ pycountry==19.8.18
 pydaikin==2.3.1
 
 # homeassistant.components.deconz
-pydeconz==73
+pydeconz==74
 
 # homeassistant.components.dexcom
 pydexcom==0.2.0

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -40,7 +40,7 @@ SENSORS = {
         "id": "CLIP presence sensor id",
         "name": "CLIP presence sensor",
         "type": "CLIPPresence",
-        "state": {},
+        "state": {"presence": False},
         "config": {},
         "uniqueid": "00:00:00:00:00:00:00:02-00",
     },

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -330,3 +330,26 @@ async def test_disable_light_groups(hass):
 
     assert len(hass.states.async_all()) == 5
     assert hass.states.get("light.light_group") is None
+
+
+async def test_configuration_tool(hass):
+    """Test that lights or groups entities are created."""
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["lights"] = {
+        "0": {
+            "etag": "26839cb118f5bf7ba1f2108256644010",
+            "hascolor": False,
+            "lastannounced": None,
+            "lastseen": "2020-11-22T11:27Z",
+            "manufacturername": "dresden elektronik",
+            "modelid": "ConBee II",
+            "name": "Configuration tool 1",
+            "state": {"reachable": True},
+            "swversion": "0x264a0700",
+            "type": "Configuration tool",
+            "uniqueid": "00:21:2e:ff:ff:05:a7:a3-01",
+        }
+    }
+    await setup_deconz_integration(hass, get_state_response=data)
+
+    assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -242,3 +242,81 @@ async def test_add_battery_later(hass):
     assert len(remote._callbacks) == 2  # Event and battery entity
 
     assert hass.states.get("sensor.switch_1_battery_level")
+
+
+async def test_air_quality_sensor(hass):
+    """Test successful creation of air quality sensor entities."""
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["sensors"] = {
+        "0": {
+            "config": {"on": True, "reachable": True},
+            "ep": 2,
+            "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
+            "lastseen": "2020-11-20T22:48Z",
+            "manufacturername": "BOSCH",
+            "modelid": "AIR",
+            "name": "Air quality",
+            "state": {
+                "airquality": "poor",
+                "airqualityppb": 809,
+                "lastupdated": "2020-11-20T22:48:00.209",
+            },
+            "swversion": "20200402",
+            "type": "ZHAAirQuality",
+            "uniqueid": "00:12:4b:00:14:4d:00:07-02-fdef",
+        }
+    }
+    await setup_deconz_integration(hass, get_state_response=data)
+
+    assert len(hass.states.async_all()) == 1
+
+    air_quality = hass.states.get("sensor.air_quality")
+    assert air_quality.state == "poor"
+
+
+async def test_time_sensor(hass):
+    """Test successful creation of time sensor entities."""
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["sensors"] = {
+        "0": {
+            "config": {"battery": 40, "on": True, "reachable": True},
+            "ep": 1,
+            "etag": "28e796678d9a24712feef59294343bb6",
+            "lastseen": "2020-11-22T11:26Z",
+            "manufacturername": "Danfoss",
+            "modelid": "eTRV0100",
+            "name": "Time",
+            "state": {
+                "lastset": "2020-11-19T08:07:08Z",
+                "lastupdated": "2020-11-22T10:51:03.444",
+                "localtime": "2020-11-22T10:51:01",
+                "utc": "2020-11-22T10:51:01Z",
+            },
+            "swversion": "20200429",
+            "type": "ZHATime",
+            "uniqueid": "cc:cc:cc:ff:fe:38:4d:b3-01-000a",
+        }
+    }
+    await setup_deconz_integration(hass, get_state_response=data)
+
+    assert len(hass.states.async_all()) == 2
+
+    time = hass.states.get("sensor.time")
+    assert time.state == "2020-11-19T08:07:08Z"
+
+    time_battery = hass.states.get("sensor.time_battery_level")
+    assert time_battery.state == "40"
+
+
+async def test_unsupported_sensor(hass):
+    """Test that unsupported sensors doesn't break anything."""
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["sensors"] = {
+        "0": {"type": "not supported", "name": "name", "state": {}, "config": {}}
+    }
+    await setup_deconz_integration(hass, get_state_response=data)
+
+    assert len(hass.states.async_all()) == 1
+
+    unsupported_sensor = hass.states.get("sensor.name")
+    assert unsupported_sensor.state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Main reason for change:
deCONZ are changing the API to certain devices so it is time to move the knowledge about them into pydeCONZ.

Main changes to library:
Add specific classes for ConfigurationTool, Cover, Fan, Lock and Siren based in light resources.
Add new classes AirQuality and Time to sensors.
Cleaned up sensors a bit, minimising the difference between binary and non binary sensors.
Increased testing of library up to near 100% coverage.

https://github.com/Kane610/deconz/compare/v73...v74

Breaking change(?):
Don't create entity for Configuration tool which is only a representation of the deCONZ hardware. Previously exposed as a confusing and unusable light.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40627 #43223 #43409
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
