### PR TITLE
0.118.1

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -146,6 +146,14 @@ RESET_ACCESSORY_SERVICE_SCHEMA = vol.Schema(
 )
 
 
+def _async_get_entries_by_name(current_entries):
+    """Return a dict of the entries by name."""
+
+    # For backwards compat, its possible the first bridge is using the default
+    # name.
+    return {entry.data.get(CONF_NAME, BRIDGE_NAME): entry for entry in current_entries}
+
+
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the HomeKit from yaml."""
     hass.data.setdefault(DOMAIN, {})
@@ -156,8 +164,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         return True
 
     current_entries = hass.config_entries.async_entries(DOMAIN)
-
-    entries_by_name = {entry.data[CONF_NAME]: entry for entry in current_entries}
+    entries_by_name = _async_get_entries_by_name(current_entries)
 
     for index, conf in enumerate(config[DOMAIN]):
         if _async_update_config_entry_if_from_yaml(hass, entries_by_name, conf):
@@ -384,7 +391,7 @@ def _async_register_events_and_services(hass: HomeAssistant):
             return
 
         current_entries = hass.config_entries.async_entries(DOMAIN)
-        entries_by_name = {entry.data[CONF_NAME]: entry for entry in current_entries}
+        entries_by_name = _async_get_entries_by_name(current_entries)
 
         for conf in config[DOMAIN]:
             _async_update_config_entry_if_from_yaml(hass, entries_by_name, conf)

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -37,6 +37,7 @@ from .const import (
     STORAGE_DASHBOARD_UPDATE_FIELDS,
     url_slug,
 )
+from .system_health import system_health_info  # NOQA
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.0.31"],
+  "requirements": ["hatasmota==0.0.32"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vizio",
   "name": "VIZIO SmartCast",
   "documentation": "https://www.home-assistant.io/integrations/vizio",
-  "requirements": ["pyvizio==0.1.56"],
+  "requirements": ["pyvizio==0.1.57"],
   "codeowners": ["@raman325"],
   "config_flow": true,
   "zeroconf": ["_viziocast._tcp.local."],

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from httpcore import ConnectError, ConnectTimeout
 from wolf_smartset.token_auth import InvalidAuth
-from wolf_smartset.wolf_client import WolfClient
+from wolf_smartset.wolf_client import FetchFailed, WolfClient
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -55,6 +55,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         except ConnectError as exception:
             raise UpdateFailed(
                 f"Error communicating with API: {exception}"
+            ) from exception
+        except FetchFailed as exception:
+            raise UpdateFailed(
+                f"Could not fetch values from server due to: {exception}"
             ) from exception
         except InvalidAuth as exception:
             raise UpdateFailed("Invalid authentication during update.") from exception

--- a/homeassistant/components/wolflink/manifest.json
+++ b/homeassistant/components/wolflink/manifest.json
@@ -3,6 +3,6 @@
   "name": "Wolf SmartSet Service",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wolflink",
-  "requirements": ["wolf_smartset==0.1.6"],
+  "requirements": ["wolf_smartset==0.1.8"],
   "codeowners": ["@adamkrol93"]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 118
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -741,7 +741,7 @@ hass-nabucasa==0.37.2
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.0.31
+hatasmota==0.0.32
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1876,7 +1876,7 @@ pyversasense==0.0.6
 pyvesync==1.2.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.56
+pyvizio==0.1.57
 
 # homeassistant.components.velux
 pyvlx==0.2.18

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2286,7 +2286,7 @@ withings-api==2.1.6
 wled==0.4.4
 
 # homeassistant.components.wolflink
-wolf_smartset==0.1.6
+wolf_smartset==0.1.8
 
 # homeassistant.components.xbee
 xbee-helper==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1097,7 +1097,7 @@ withings-api==2.1.6
 wled==0.4.4
 
 # homeassistant.components.wolflink
-wolf_smartset==0.1.6
+wolf_smartset==0.1.8
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -376,7 +376,7 @@ hangups==0.4.11
 hass-nabucasa==0.37.2
 
 # homeassistant.components.tasmota
-hatasmota==0.0.31
+hatasmota==0.0.32
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -908,7 +908,7 @@ pyvera==0.3.11
 pyvesync==1.2.0
 
 # homeassistant.components.vizio
-pyvizio==0.1.56
+pyvizio==0.1.57
 
 # homeassistant.components.volumio
 pyvolumio==0.1.3

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -22,6 +22,25 @@ async def test_subscribing_config_topic(hass, mqtt_mock, setup_tasmota):
     assert call_args[2] == 0
 
 
+async def test_future_discovery_message(hass, mqtt_mock, caplog):
+    """Test we handle backwards compatible discovery messages."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["future_option"] = "BEST_SINCE_SLICED_BREAD"
+    config["so"]["another_future_option"] = "EVEN_BETTER"
+
+    with patch(
+        "homeassistant.components.tasmota.discovery.tasmota_get_device_config",
+        return_value={},
+    ) as mock_tasmota_get_device_config:
+        await setup_tasmota_helper(hass)
+
+        async_fire_mqtt_message(
+            hass, f"{DEFAULT_PREFIX}/00000049A3BC/config", json.dumps(config)
+        )
+        await hass.async_block_till_done()
+        assert mock_tasmota_get_device_config.called
+
+
 async def test_valid_discovery_message(hass, mqtt_mock, caplog):
     """Test discovery callback called."""
     config = copy.deepcopy(DEFAULT_CONFIG)


### PR DESCRIPTION
- Bump wolf_smartset to 0.1.8 and handle server fetch error ([@adamkrol93] - [#43351]) ([wolflink docs])
- Bump hatasmota to 0.0.32 ([@emontnemery] - [#43360]) ([tasmota docs])
- Fix homekit bridges when no name was provided ([@bdraco] - [#43364]) ([homekit docs])
- Bump pyvizio to 0.1.57 ([@raman325] - [#43374]) ([vizio docs])
- Add back system_health_info to the base of lovelace ([@ludeeus] - [#43382]) ([lovelace docs])

[#43351]: https://github.com/home-assistant/core/pull/43351
[#43360]: https://github.com/home-assistant/core/pull/43360
[#43364]: https://github.com/home-assistant/core/pull/43364
[#43374]: https://github.com/home-assistant/core/pull/43374
[#43382]: https://github.com/home-assistant/core/pull/43382
[@adamkrol93]: https://github.com/adamkrol93
[@bdraco]: https://github.com/bdraco
[@emontnemery]: https://github.com/emontnemery
[@ludeeus]: https://github.com/ludeeus
[@raman325]: https://github.com/raman325
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[lovelace docs]: https://www.home-assistant.io/integrations/lovelace/
[tasmota docs]: https://www.home-assistant.io/integrations/tasmota/
[vizio docs]: https://www.home-assistant.io/integrations/vizio/
[wolflink docs]: https://www.home-assistant.io/integrations/wolflink/