### PR TITLE
Add power entities with unit Watt in DSMR integration

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -119,20 +119,20 @@ async def async_setup_entry(
 
     # Generate device entities
     devices = [
-        DSMREntity(
-            name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config, False
-        )
-        for name, obis in obis_mapping
-    ]
-
-    devices = [
         DSMREntity(name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config, True)
         for name, obis in obis_mapping
     ]
 
     devices += [
-        DSMRPowerEntity(
+        DSMREntity(
             name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config, False
+        )
+        for name, obis in obis_power_mapping
+    ]
+
+    devices += [
+        DSMRPowerEntity(
+            name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config, True
         )
         for name, obis in obis_power_mapping
     ]
@@ -154,7 +154,7 @@ async def async_setup_entry(
                 config[CONF_SERIAL_ID_GAS],
                 gas_obis,
                 config,
-                False,
+                True,
             ),
             DerivativeDSMREntity(
                 "Hourly Gas Consumption",
@@ -162,7 +162,7 @@ async def async_setup_entry(
                 config[CONF_SERIAL_ID_GAS],
                 gas_obis,
                 config,
-                False,
+                True,
             ),
         ]
 
@@ -378,6 +378,16 @@ class DSMREntity(Entity):
 
 class DSMRPowerEntity(DSMREntity):
     """Entity handling power values from DSMR telegram."""
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self._name} (Watt)"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"{self._unique_id}_watt"
 
     @property
     def state(self):

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -414,6 +414,11 @@ class DSMRPowerEntity(DSMREntity):
         """Return the unit of measurement of this entity."""
         return POWER_WATT
 
+    @property
+    def entity_registry_enabled_default(self):
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return False
+
 
 class DerivativeDSMREntity(DSMREntity):
     """Calculated derivative for values where the DSMR doesn't offer one.

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -258,7 +258,7 @@ async def async_setup_entry(
 class DSMREntity(Entity):
     """Entity reading values from DSMR telegram."""
 
-    def __init__(self, name, device_name, device_serial, obis, config, disable_default):
+    def __init__(self, name, device_name, device_serial, obis, config, enable_default):
         """Initialize entity."""
         self._name = name
         self._obis = obis
@@ -269,7 +269,7 @@ class DSMREntity(Entity):
         self._device_serial = device_serial
         self._unique_id = f"{device_serial}_{name}".replace(" ", "_")
 
-        self._disable_default = disable_default
+        self._enable_default = enable_default
 
     @callback
     def update_data(self, telegram):
@@ -373,7 +373,7 @@ class DSMREntity(Entity):
     @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry."""
-        return self._disable_default
+        return self._enable_default
 
 
 class DSMRPowerEntity(DSMREntity):

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -288,19 +288,12 @@ class DSMREntity(Entity):
     def state(self):
         """Return the state of sensor, if available, translate if needed."""
         value = self.get_dsmr_object_attr("value")
-        unit = self.get_dsmr_object_attr("unit")
 
         if self._obis == obis_ref.ELECTRICITY_ACTIVE_TARIFF:
             return self.translate_tariff(value, self._config[CONF_DSMR_VERSION])
 
         try:
-            if unit == POWER_KILO_WATT:
-                value = round(
-                    float(value) * 1000.0,
-                    self._config[CONF_PRECISION],
-                )
-            else:
-                value = round(float(value), self._config[CONF_PRECISION])
+            value = round(float(value), self._config[CONF_PRECISION])
         except TypeError:
             pass
 
@@ -312,12 +305,7 @@ class DSMREntity(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        unit = self.get_dsmr_object_attr("unit")
-
-        if unit == POWER_KILO_WATT:
-            return POWER_WATT
-
-        return unit
+        return self.get_dsmr_object_attr("unit")
 
     @property
     def unique_id(self) -> str:
@@ -360,6 +348,37 @@ class DSMREntity(Entity):
             return "low"
 
         return None
+
+
+class DSMRPowerEntity(DSMREntity):
+    """Entity handling power values from DSMR telegram."""
+
+    @property
+    def state(self):
+        """Return the state of sensor, if available, translate if needed."""
+        value = self.get_dsmr_object_attr("value")
+        unit = self.get_dsmr_object_attr("unit")
+
+        try:
+            if unit == POWER_KILO_WATT:
+                value = round(
+                    float(value) * 1000.0,
+                    self._config[CONF_PRECISION],
+                )
+            else:
+                value = round(float(value), self._config[CONF_PRECISION])
+        except TypeError:
+            pass
+
+        if value is not None:
+            return value
+
+        return None
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
+        return POWER_WATT
 
 
 class DerivativeDSMREntity(DSMREntity):

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -114,10 +114,44 @@ async def async_setup_entry(
         ["Current Phase L3", obis_ref.INSTANTANEOUS_CURRENT_L3],
     ]
 
+    obis_power_mapping = [
+        ["Power Consumption (Watt)", obis_ref.CURRENT_ELECTRICITY_USAGE],
+        ["Power Production (Watt)", obis_ref.CURRENT_ELECTRICITY_DELIVERY],
+        [
+            "Power Consumption Phase L1 (Watt)",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE,
+        ],
+        [
+            "Power Consumption Phase L2 (Watt)",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE,
+        ],
+        [
+            "Power Consumption Phase L3 (Watt)",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE,
+        ],
+        [
+            "Power Production Phase L1 (Watt)",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE,
+        ],
+        [
+            "Power Production Phase L2 (Watt)",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE,
+        ],
+        [
+            "Power Production Phase L3 (Watt)",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE,
+        ],
+    ]
+
     # Generate device entities
     devices = [
         DSMREntity(name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config)
         for name, obis in obis_mapping
+    ]
+
+    devices += [
+        DSMRPowerEntity(name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config)
+        for name, obis in obis_power_mapping
     ]
 
     # Protocol version specific obis

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -114,6 +114,11 @@ async def test_default_setup(hass, dsmr_connection_fixture):
     assert entry
     assert entry.unique_id == "1234_Power_Consumption"
 
+    entry = registry.async_get("sensor.power_consumption_watt")
+    assert entry
+    assert entry.unique_id == "1234_Power_Consumption_(Watt)"
+    entry.disabled = False
+
     entry = registry.async_get("sensor.gas_consumption")
     assert entry
     assert entry.unique_id == "5678_Gas_Consumption"
@@ -133,8 +138,12 @@ async def test_default_setup(hass, dsmr_connection_fixture):
 
     # ensure entities have new state value after incoming telegram
     power_consumption = hass.states.get("sensor.power_consumption")
-    assert power_consumption.state == "243.0"
-    assert power_consumption.attributes.get("unit_of_measurement") == POWER_WATT
+    assert power_consumption.state == "0.243"
+    assert power_consumption.attributes.get("unit_of_measurement") == POWER_KILO_WATT
+
+    power_consumption_watt = hass.states.get("sensor.power_consumption_watt")
+    assert power_consumption_watt.state == "243"
+    assert power_consumption_watt.attributes.get("unit_of_measurement") == POWER_WATT
 
     # tariff should be translated in human readable and have no unit
     power_tariff = hass.states.get("sensor.power_tariff")

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -14,7 +14,8 @@ from homeassistant.components.dsmr.const import DOMAIN
 from homeassistant.components.dsmr.sensor import DerivativeDSMREntity
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
-    ENERGY_KILO_WATT_HOUR,
+    POWER_KILO_WATT,
+    POWER_WATT,
     VOLUME_CUBIC_METERS,
     VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR,
 )
@@ -87,7 +88,7 @@ async def test_default_setup(hass, dsmr_connection_fixture):
 
     telegram = {
         CURRENT_ELECTRICITY_USAGE: CosemObject(
-            [{"value": Decimal("0.0"), "unit": ENERGY_KILO_WATT_HOUR}]
+            [{"value": Decimal("0.243"), "unit": POWER_KILO_WATT}]
         ),
         ELECTRICITY_ACTIVE_TARIFF: CosemObject([{"value": "0001", "unit": ""}]),
         GAS_METER_READING: MBusObject(
@@ -132,10 +133,8 @@ async def test_default_setup(hass, dsmr_connection_fixture):
 
     # ensure entities have new state value after incoming telegram
     power_consumption = hass.states.get("sensor.power_consumption")
-    assert power_consumption.state == "0.0"
-    assert (
-        power_consumption.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
-    )
+    assert power_consumption.state == "243.0"
+    assert power_consumption.attributes.get("unit_of_measurement") == POWER_WATT
 
     # tariff should be translated in human readable and have no unit
     power_tariff = hass.states.get("sensor.power_tariff")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds new entities to DSMR integration for power related sensors with unit in Watt. The entities with unit from the telegram will be added but disabled by default when created.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
