### PR TITLE
Migrate from pytz to python-dateutil

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1493,7 +1493,7 @@ class Config:
         self.longitude: float = 0
         self.elevation: int = 0
         self.location_name: str = "Home"
-        self.time_zone: datetime.tzinfo = dt_util.UTC
+        self.time_zone: str = "UTC"
         self.units: UnitSystem = METRIC_SYSTEM
         self.internal_url: Optional[str] = None
         self.external_url: Optional[str] = None
@@ -1583,17 +1583,13 @@ class Config:
 
         Async friendly.
         """
-        time_zone = dt_util.UTC.zone
-        if self.time_zone and getattr(self.time_zone, "zone"):
-            time_zone = getattr(self.time_zone, "zone")
-
         return {
             "latitude": self.latitude,
             "longitude": self.longitude,
             "elevation": self.elevation,
             "unit_system": self.units.as_dict(),
             "location_name": self.location_name,
-            "time_zone": time_zone,
+            "time_zone": self.time_zone,
             "components": self.components,
             "config_dir": self.config_dir,
             # legacy, backwards compat
@@ -1613,7 +1609,7 @@ class Config:
         time_zone = dt_util.get_time_zone(time_zone_str)
 
         if time_zone:
-            self.time_zone = time_zone
+            self.time_zone = time_zone_str
             dt_util.set_default_time_zone(time_zone)
         else:
             raise ValueError(f"Received invalid time zone {time_zone_str}")
@@ -1715,17 +1711,13 @@ class Config:
 
     async def async_store(self) -> None:
         """Store [homeassistant] core config."""
-        time_zone = dt_util.UTC.zone
-        if self.time_zone and getattr(self.time_zone, "zone"):
-            time_zone = getattr(self.time_zone, "zone")
-
         data = {
             "latitude": self.latitude,
             "longitude": self.longitude,
             "elevation": self.elevation,
             "unit_system": self.units.name,
             "location_name": self.location_name,
-            "time_zone": time_zone,
+            "time_zone": self.time_zone,
             "external_url": self.external_url,
             "internal_url": self.internal_url,
         }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -21,8 +21,8 @@ netdisco==2.8.2
 paho-mqtt==1.5.1
 pillow==7.2.0
 pip>=8.0.3
+python-dateutil==2.8.1
 python-slugify==4.0.1
-pytz>=2020.1
 pyyaml==5.3.1
 requests==2.25.0
 ruamel.yaml==0.15.100

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ jinja2>=2.11.2
 PyJWT==1.7.1
 cryptography==3.2
 pip>=8.0.3
+python-dateutil==2.8.1
 python-slugify==4.0.1
-pytz>=2020.1
 pyyaml==5.3.1
 requests==2.25.0
 ruamel.yaml==0.15.100

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ REQUIRES = [
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==3.2",
     "pip>=8.0.3",
+    "python-dateutil==2.8.1",
     "python-slugify==4.0.1",
-    "pytz>=2020.1",
     "pyyaml==5.3.1",
     "requests==2.25.0",
     "ruamel.yaml==0.15.100",

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -16,17 +16,12 @@ def teardown():
 
 def test_get_time_zone_retrieves_valid_time_zone():
     """Test getting a time zone."""
-    time_zone = dt_util.get_time_zone(TEST_TIME_ZONE)
-
-    assert time_zone is not None
-    assert TEST_TIME_ZONE == time_zone.zone
+    assert dt_util.get_time_zone(TEST_TIME_ZONE) is not None
 
 
 def test_get_time_zone_returns_none_for_garbage_time_zone():
     """Test getting a non existing time zone."""
-    time_zone = dt_util.get_time_zone("Non existing time zone")
-
-    assert time_zone is None
+    assert dt_util.get_time_zone("Non existing time zone") is None
 
 
 def test_set_default_time_zone():
@@ -35,8 +30,7 @@ def test_set_default_time_zone():
 
     dt_util.set_default_time_zone(time_zone)
 
-    # We cannot compare the timezones directly because of DST
-    assert time_zone.zone == dt_util.now().tzinfo.zone
+    assert dt_util.now().tzinfo is time_zone
 
 
 def test_utcnow():
@@ -239,35 +233,35 @@ def test_find_next_time_expression_time_dst():
         return dt_util.find_next_time_expression_time(dt, seconds, minutes, hours)
 
     # Entering DST, clocks are rolled forward
-    assert tz.localize(datetime(2018, 3, 26, 2, 30, 0)) == find(
-        tz.localize(datetime(2018, 3, 25, 1, 50, 0)), 2, 30, 0
+    assert datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz) == find(
+        datetime(2018, 3, 25, 1, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert tz.localize(datetime(2018, 3, 26, 2, 30, 0)) == find(
-        tz.localize(datetime(2018, 3, 25, 3, 50, 0)), 2, 30, 0
+    assert datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz) == find(
+        datetime(2018, 3, 25, 3, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert tz.localize(datetime(2018, 3, 26, 2, 30, 0)) == find(
-        tz.localize(datetime(2018, 3, 26, 1, 50, 0)), 2, 30, 0
+    assert datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz) == find(
+        datetime(2018, 3, 26, 1, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
     # Leaving DST, clocks are rolled back
-    assert tz.localize(datetime(2018, 10, 28, 2, 30, 0), is_dst=False) == find(
-        tz.localize(datetime(2018, 10, 28, 2, 5, 0), is_dst=False), 2, 30, 0
+    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, is_dst=False) == find(
+        datetime(2018, 10, 28, 2, 5, 0, tzinfo=tz, is_dst=False), 2, 30, 0
     )
 
-    assert tz.localize(datetime(2018, 10, 28, 2, 30, 0), is_dst=False) == find(
-        tz.localize(datetime(2018, 10, 28, 2, 55, 0), is_dst=True), 2, 30, 0
+    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, is_dst=False) == find(
+        datetime(2018, 10, 28, 2, 55, 0, tzinfo=tz, is_dst=True), 2, 30, 0
     )
 
-    assert tz.localize(datetime(2018, 10, 28, 4, 30, 0), is_dst=False) == find(
-        tz.localize(datetime(2018, 10, 28, 2, 55, 0), is_dst=True), 4, 30, 0
+    assert datetime(2018, 10, 28, 4, 30, 0, tzinfo=tz, is_dst=False) == find(
+        datetime(2018, 10, 28, 2, 55, 0, tzinfo=tz, is_dst=True), 4, 30, 0
     )
 
-    assert tz.localize(datetime(2018, 10, 28, 2, 30, 0), is_dst=True) == find(
-        tz.localize(datetime(2018, 10, 28, 2, 5, 0), is_dst=True), 2, 30, 0
+    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, is_dst=True) == find(
+        datetime(2018, 10, 28, 2, 5, 0, tzinfo=tz, is_dst=True), 2, 30, 0
     )
 
-    assert tz.localize(datetime(2018, 10, 29, 2, 30, 0)) == find(
-        tz.localize(datetime(2018, 10, 28, 2, 55, 0), is_dst=False), 2, 30, 0
+    assert datetime(2018, 10, 29, 2, 30, 0, tzinfo=tz) == find(
+        datetime(2018, 10, 28, 2, 55, 0, tzinfo=tz, is_dst=False), 2, 30, 0
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After reading https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html I wanted to give a stab at using python-dateutil. 

This is the result. It's not done because of the complex edge case handling in `find_next_time_expression_time`. Putting it up as draft. Might not finish it though as I don't want to dig so deep into time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
