### PR TITLE
Move Ambient PWS logger to a package logger

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -1,6 +1,5 @@
 """Support for Ambient Weather Station Service."""
 import asyncio
-import logging
 
 from aioambient import Client
 from aioambient.errors import WebsocketError
@@ -39,11 +38,10 @@ from .const import (
     CONF_APP_KEY,
     DATA_CLIENT,
     DOMAIN,
+    LOGGER,
     TYPE_BINARY_SENSOR,
     TYPE_SENSOR,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 DATA_CONFIG = "config"
 
@@ -307,7 +305,7 @@ async def async_setup_entry(hass, config_entry):
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketError as err:
-        _LOGGER.error("Config entry failed: %s", err)
+        LOGGER.error("Config entry failed: %s", err)
         raise ConfigEntryNotReady from err
 
     async def _async_disconnect_websocket(*_):
@@ -337,7 +335,7 @@ async def async_migrate_entry(hass, config_entry):
     """Migrate old entry."""
     version = config_entry.version
 
-    _LOGGER.debug("Migrating from version %s", version)
+    LOGGER.debug("Migrating from version %s", version)
 
     # 1 -> 2: Unique ID format changed, so delete and re-import:
     if version == 1:
@@ -350,7 +348,7 @@ async def async_migrate_entry(hass, config_entry):
         version = config_entry.version = 2
         hass.config_entries.async_update_entry(config_entry)
 
-    _LOGGER.info("Migration to version %s successful", version)
+    LOGGER.info("Migration to version %s successful", version)
 
     return True
 
@@ -377,7 +375,7 @@ class AmbientStation:
         try:
             await connect()
         except WebsocketError as err:
-            _LOGGER.error("Error with the websocket connection: %s", err)
+            LOGGER.error("Error with the websocket connection: %s", err)
             self._ws_reconnect_delay = min(2 * self._ws_reconnect_delay, 480)
             async_call_later(self._hass, self._ws_reconnect_delay, connect)
 
@@ -386,13 +384,13 @@ class AmbientStation:
 
         def on_connect():
             """Define a handler to fire when the websocket is connected."""
-            _LOGGER.info("Connected to websocket")
+            LOGGER.info("Connected to websocket")
 
         def on_data(data):
             """Define a handler to fire when the data is received."""
             mac_address = data["macAddress"]
             if data != self.stations[mac_address][ATTR_LAST_DATA]:
-                _LOGGER.debug("New data received: %s", data)
+                LOGGER.debug("New data received: %s", data)
                 self.stations[mac_address][ATTR_LAST_DATA] = data
                 async_dispatcher_send(
                     self._hass, f"ambient_station_data_update_{mac_address}"
@@ -400,7 +398,7 @@ class AmbientStation:
 
         def on_disconnect():
             """Define a handler to fire when the websocket is disconnected."""
-            _LOGGER.info("Disconnected from websocket")
+            LOGGER.info("Disconnected from websocket")
 
         def on_subscribed(data):
             """Define a handler to fire when the subscription is set."""
@@ -408,7 +406,7 @@ class AmbientStation:
                 if station["macAddress"] in self.stations:
                     continue
 
-                _LOGGER.debug("New station subscription: %s", data)
+                LOGGER.debug("New station subscription: %s", data)
 
                 # Only create entities based on the data coming through the socket.
                 # If the user is monitoring brightness (in W/m^2), make sure we also

--- a/homeassistant/components/ambient_station/const.py
+++ b/homeassistant/components/ambient_station/const.py
@@ -1,5 +1,8 @@
 """Define constants for the Ambient PWS component."""
+import logging
+
 DOMAIN = "ambient_station"
+LOGGER = logging.getLogger(__package__)
 
 ATTR_LAST_DATA = "last_data"
 ATTR_MONITORED_CONDITIONS = "monitored_conditions"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR moves the Ambient PWS logger to a package-level logger.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
