### PR TITLE
Add option to deactivate a user

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -284,6 +284,7 @@ class AuthManager:
         self,
         user: models.User,
         name: Optional[str] = None,
+        is_active: Optional[bool] = None,
         group_ids: Optional[List[str]] = None,
     ) -> None:
         """Update a user."""
@@ -293,6 +294,12 @@ class AuthManager:
         if group_ids is not None:
             kwargs["group_ids"] = group_ids
         await self._store.async_update_user(user, **kwargs)
+
+        if is_active is not None:
+            if is_active is True:
+                await self.async_activate_user(user)
+            else:
+                await self.async_deactivate_user(user)
 
     async def async_activate_user(self, user: models.User) -> None:
         """Activate a user."""

--- a/homeassistant/components/config/auth.py
+++ b/homeassistant/components/config/auth.py
@@ -112,6 +112,16 @@ async def websocket_update(hass, connection, msg):
         )
         return
 
+    if user.is_owner and msg["is_active"] is False:
+        connection.send_message(
+            websocket_api.error_message(
+                msg["id"],
+                "cannot_deactivate_owner",
+                "Unable to deactivate owners.",
+            )
+        )
+        return
+
     msg.pop("type")
     msg_id = msg.pop("id")
 

--- a/homeassistant/components/config/auth.py
+++ b/homeassistant/components/config/auth.py
@@ -86,6 +86,7 @@ async def websocket_create(hass, connection, msg):
         vol.Required("type"): "config/auth/update",
         vol.Required("user_id"): str,
         vol.Optional("name"): str,
+        vol.Optional("is_active"): bool,
         vol.Optional("group_ids"): [str],
     }
 )

--- a/homeassistant/components/config/auth.py
+++ b/homeassistant/components/config/auth.py
@@ -117,7 +117,7 @@ async def websocket_update(hass, connection, msg):
             websocket_api.error_message(
                 msg["id"],
                 "cannot_deactivate_owner",
-                "Unable to deactivate owners.",
+                "Unable to deactivate owner.",
             )
         )
         return


### PR DESCRIPTION
**Note**: Linked to this frontend PR https://github.com/home-assistant/frontend/pull/7757.

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Adds option to pass an `is_active` information via the WS.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
