### PR TITLE
Make Brother uptime sensor disabled by default

### DIFF
--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -18,6 +18,7 @@ ATTR_DRUM_COUNTER = "drum_counter"
 ATTR_DRUM_REMAINING_LIFE = "drum_remaining_life"
 ATTR_DRUM_REMAINING_PAGES = "drum_remaining_pages"
 ATTR_DUPLEX_COUNTER = "duplex_unit_pages_counter"
+ATTR_ENABLED = "enabled"
 ATTR_FUSER_REMAINING_LIFE = "fuser_remaining_life"
 ATTR_ICON = "icon"
 ATTR_LABEL = "label"
@@ -51,71 +52,85 @@ SENSOR_TYPES = {
         ATTR_ICON: "mdi:printer",
         ATTR_LABEL: ATTR_STATUS.title(),
         ATTR_UNIT: None,
+        ATTR_ENABLED: True,
     },
     ATTR_PAGE_COUNTER: {
         ATTR_ICON: "mdi:file-document-outline",
         ATTR_LABEL: ATTR_PAGE_COUNTER.replace("_", " ").title(),
         ATTR_UNIT: UNIT_PAGES,
+        ATTR_ENABLED: True,
     },
     ATTR_BW_COUNTER: {
         ATTR_ICON: "mdi:file-document-outline",
         ATTR_LABEL: ATTR_BW_COUNTER.replace("_", " ").title(),
         ATTR_UNIT: UNIT_PAGES,
+        ATTR_ENABLED: True,
     },
     ATTR_COLOR_COUNTER: {
         ATTR_ICON: "mdi:file-document-outline",
         ATTR_LABEL: ATTR_COLOR_COUNTER.replace("_", " ").title(),
         ATTR_UNIT: UNIT_PAGES,
+        ATTR_ENABLED: True,
     },
     ATTR_DUPLEX_COUNTER: {
         ATTR_ICON: "mdi:file-document-outline",
         ATTR_LABEL: ATTR_DUPLEX_COUNTER.replace("_", " ").title(),
         ATTR_UNIT: UNIT_PAGES,
+        ATTR_ENABLED: True,
     },
     ATTR_DRUM_REMAINING_LIFE: {
         ATTR_ICON: "mdi:chart-donut",
         ATTR_LABEL: ATTR_DRUM_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_BLACK_DRUM_REMAINING_LIFE: {
         ATTR_ICON: "mdi:chart-donut",
         ATTR_LABEL: ATTR_BLACK_DRUM_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_CYAN_DRUM_REMAINING_LIFE: {
         ATTR_ICON: "mdi:chart-donut",
         ATTR_LABEL: ATTR_CYAN_DRUM_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_MAGENTA_DRUM_REMAINING_LIFE: {
         ATTR_ICON: "mdi:chart-donut",
         ATTR_LABEL: ATTR_MAGENTA_DRUM_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_YELLOW_DRUM_REMAINING_LIFE: {
         ATTR_ICON: "mdi:chart-donut",
         ATTR_LABEL: ATTR_YELLOW_DRUM_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_BELT_UNIT_REMAINING_LIFE: {
         ATTR_ICON: "mdi:current-ac",
         ATTR_LABEL: ATTR_BELT_UNIT_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_FUSER_REMAINING_LIFE: {
         ATTR_ICON: "mdi:water-outline",
         ATTR_LABEL: ATTR_FUSER_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_LASER_REMAINING_LIFE: {
         ATTR_ICON: "mdi:spotlight-beam",
         ATTR_LABEL: ATTR_LASER_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_PF_KIT_1_REMAINING_LIFE: {
         ATTR_ICON: "mdi:printer-3d",
         ATTR_LABEL: ATTR_PF_KIT_1_REMAINING_LIFE.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_PF_KIT_MP_REMAINING_LIFE: {
         ATTR_ICON: "mdi:printer-3d",
@@ -126,41 +141,54 @@ SENSOR_TYPES = {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_BLACK_TONER_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_CYAN_TONER_REMAINING: {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_CYAN_TONER_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_MAGENTA_TONER_REMAINING: {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_MAGENTA_TONER_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_YELLOW_TONER_REMAINING: {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_YELLOW_TONER_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_BLACK_INK_REMAINING: {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_BLACK_INK_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_CYAN_INK_REMAINING: {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_CYAN_INK_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_MAGENTA_INK_REMAINING: {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_MAGENTA_INK_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
     ATTR_YELLOW_INK_REMAINING: {
         ATTR_ICON: "mdi:printer-3d-nozzle",
         ATTR_LABEL: ATTR_YELLOW_INK_REMAINING.replace("_", " ").title(),
         ATTR_UNIT: PERCENTAGE,
+        ATTR_ENABLED: True,
     },
-    ATTR_UPTIME: {ATTR_ICON: None, ATTR_LABEL: ATTR_UPTIME.title(), ATTR_UNIT: None},
+    ATTR_UPTIME: {
+        ATTR_ICON: None,
+        ATTR_LABEL: ATTR_UPTIME.title(),
+        ATTR_UNIT: None,
+        ATTR_ENABLED: False,
+    },
 }

--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -15,6 +15,7 @@ from .const import (
     ATTR_DRUM_COUNTER,
     ATTR_DRUM_REMAINING_LIFE,
     ATTR_DRUM_REMAINING_PAGES,
+    ATTR_ENABLED,
     ATTR_ICON,
     ATTR_LABEL,
     ATTR_MAGENTA_DRUM_COUNTER,
@@ -139,4 +140,4 @@ class BrotherPrinterSensor(CoordinatorEntity):
     @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry."""
-        return True
+        return SENSOR_TYPES[self.kind][ATTR_ENABLED]

--- a/tests/components/brother/__init__.py
+++ b/tests/components/brother/__init__.py
@@ -8,7 +8,7 @@ from tests.async_mock import patch
 from tests.common import MockConfigEntry, load_fixture
 
 
-async def init_integration(hass) -> MockConfigEntry:
+async def init_integration(hass, skip_setup=False) -> MockConfigEntry:
     """Set up the Brother integration in Home Assistant."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -16,12 +16,15 @@ async def init_integration(hass) -> MockConfigEntry:
         unique_id="0123456789",
         data={CONF_HOST: "localhost", CONF_TYPE: "laser"},
     )
-    with patch(
-        "brother.Brother._get_data",
-        return_value=json.loads(load_fixture("brother_printer_data.json")),
-    ):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+
+    entry.add_to_hass(hass)
+
+    if not skip_setup:
+        with patch(
+            "brother.Brother._get_data",
+            return_value=json.loads(load_fixture("brother_printer_data.json")),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
 
     return entry

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -26,11 +26,7 @@ ATTR_COUNTER = "counter"
 
 async def test_sensors(hass):
     """Test states of the sensors."""
-    test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=UTC)
-    with patch(
-        "homeassistant.components.brother.sensor.utcnow", return_value=test_time
-    ):
-        entry = await init_integration(hass, skip_setup=True)
+    entry = await init_integration(hass, skip_setup=True)
 
     registry = await hass.helpers.entity_registry.async_get_registry()
 
@@ -42,8 +38,10 @@ async def test_sensors(hass):
         suggested_object_id="hl_l2340dw_uptime",
         disabled_by=None,
     )
-
+    test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=UTC)
     with patch(
+        "homeassistant.components.brother.sensor.utcnow", return_value=test_time
+    ), patch(
         "brother.Brother._get_data",
         return_value=json.loads(load_fixture("brother_printer_data.json")),
     ):

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -2,7 +2,8 @@
 from datetime import datetime, timedelta
 import json
 
-from homeassistant.components.brother.const import UNIT_PAGES
+from homeassistant.components.brother.const import DOMAIN, UNIT_PAGES
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -29,9 +30,25 @@ async def test_sensors(hass):
     with patch(
         "homeassistant.components.brother.sensor.utcnow", return_value=test_time
     ):
-        await init_integration(hass)
+        entry = await init_integration(hass, skip_setup=True)
 
     registry = await hass.helpers.entity_registry.async_get_registry()
+
+    # Pre-create registry entries for disabled by default sensors
+    registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "0123456789_uptime",
+        suggested_object_id="hl_l2340dw_uptime",
+        disabled_by=None,
+    )
+
+    with patch(
+        "brother.Brother._get_data",
+        return_value=json.loads(load_fixture("brother_printer_data.json")),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     state = hass.states.get("sensor.hl_l2340dw_status")
     assert state
@@ -222,6 +239,21 @@ async def test_sensors(hass):
     entry = registry.async_get("sensor.hl_l2340dw_uptime")
     assert entry
     assert entry.unique_id == "0123456789_uptime"
+
+
+async def test_disabled_by_default_sensors(hass):
+    """Test the disabled by default Brother sensors."""
+    await init_integration(hass)
+
+    registry = await hass.helpers.entity_registry.async_get_registry()
+    state = hass.states.get("sensor.hl_l2340dw_uptime")
+    assert state is None
+
+    entry = registry.async_get("sensor.hl_l2340dw_uptime")
+    assert entry
+    assert entry.unique_id == "0123456789_uptime"
+    assert entry.disabled
+    assert entry.disabled_by == "integration"
 
 
 async def test_availability(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Most integrations add the `uptime` sensor as disabled by default, for advanced users only.
This PR changes the sensor `uptime` to disabled by default and adds a test to check it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
