### PR TITLE
Support for Shelly Input Events

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -35,6 +35,7 @@ from .const import (
     SLEEP_PERIOD_MULTIPLIER,
     UPDATE_PERIOD_MULTIPLIER,
 )
+from .utils import get_device_name
 
 PLATFORMS = ["binary_sensor", "cover", "light", "sensor", "switch"]
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -110,6 +110,7 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
 
     def __init__(self, hass, entry, device: aioshelly.Device):
         """Initialize the Shelly device wrapper."""
+        self.device_id = None
         sleep_mode = device.settings.get("sleep_mode")
 
         if sleep_mode:

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -22,3 +22,13 @@ UPDATE_PERIOD_MULTIPLIER = 2.2
 
 # Shelly Air - Maximum work hours before lamp replacement
 SHAIR_MAX_WORK_HOURS = 9000
+
+# Map Shelly input events
+INPUTS_EVENTS_DICT = {
+    "S": "single",
+    "SS": "double",
+    "SSS": "triple",
+    "L": "long",
+    "SL": "single_long",
+    "LS": "long_single",
+}

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -116,7 +116,7 @@ class ShellyBlockEntity(entity.Entity):
         """Initialize Shelly entity."""
         self.wrapper = wrapper
         self.block = block
-        self._name = get_entity_name(wrapper, block)
+        self._name = get_entity_name(wrapper.device, block)
 
     @property
     def name(self):
@@ -182,7 +182,7 @@ class ShellyBlockAttributeEntity(ShellyBlockEntity, entity.Entity):
 
         self._unit = unit
         self._unique_id = f"{super().unique_id}-{self.attribute}"
-        self._name = get_entity_name(wrapper, block, self.description.name)
+        self._name = get_entity_name(wrapper.device, block, self.description.name)
 
     @property
     def unique_id(self):
@@ -255,7 +255,7 @@ class ShellyRestAttributeEntity(update_coordinator.CoordinatorEntity):
         self.description = description
 
         self._unit = self.description.unit
-        self._name = get_entity_name(wrapper, None, self.description.name)
+        self._name = get_entity_name(wrapper.device, None, self.description.name)
         self.path = self.description.path
         self._attributes = self.description.attributes
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -9,7 +9,6 @@ import aioshelly
 from homeassistant.components.sensor import DEVICE_CLASS_TIMESTAMP
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 
-from . import ShellyDeviceWrapper
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,22 +30,27 @@ def temperature_unit(block_info: dict) -> str:
     return TEMP_CELSIUS
 
 
+def get_device_name(device: aioshelly.Device) -> str:
+    """Naming for device."""
+    return device.settings["name"] or device.settings["device"]["hostname"]
+
+
 def get_entity_name(
-    wrapper: ShellyDeviceWrapper,
+    device: aioshelly.Device,
     block: aioshelly.Block,
     description: Optional[str] = None,
-):
+) -> str:
     """Naming for switch and sensors."""
-    entity_name = wrapper.name
+    entity_name = get_device_name(device)
 
     if block:
         channels = None
         if block.type == "input":
-            channels = wrapper.device.shelly.get("num_inputs")
+            channels = device.shelly.get("num_inputs")
         elif block.type == "emeter":
-            channels = wrapper.device.shelly.get("num_emeters")
+            channels = device.shelly.get("num_emeters")
         elif block.type in ["relay", "light"]:
-            channels = wrapper.device.shelly.get("num_outputs")
+            channels = device.shelly.get("num_outputs")
         elif block.type in ["roller", "device"]:
             channels = 1
 
@@ -55,20 +59,23 @@ def get_entity_name(
         if channels > 1 and block.type != "device":
             entity_name = None
             mode = block.type + "s"
-            if mode in wrapper.device.settings:
-                entity_name = wrapper.device.settings[mode][int(block.channel)].get(
-                    "name"
-                )
+            if mode in device.settings:
+                entity_name = device.settings[mode][int(block.channel)].get("name")
 
             if not entity_name:
-                if wrapper.model == "SHEM-3":
+                if device.settings["device"]["type"] == "SHEM-3":
                     base = ord("A")
                 else:
                     base = ord("1")
-                entity_name = f"{wrapper.name} channel {chr(int(block.channel)+base)}"
+                entity_name = (
+                    f"{get_device_name(device)} channel {chr(int(block.channel)+base)}"
+                )
 
         # Shelly Dimmer has two input channels and missing "num_inputs"
-        if wrapper.model in ["SHDM-1", "SHDM-2"] and block.type == "input":
+        if (
+            device.settings["device"]["type"] in ["SHDM-1", "SHDM-2"]
+            and block.type == "input"
+        ):
             entity_name = f"{entity_name} channel {int(block.channel)+1}"
 
     if description:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -46,7 +46,11 @@ def get_entity_name(
     if block:
         channels = None
         if block.type == "input":
-            channels = device.shelly.get("num_inputs")
+            # Shelly Dimmer/1L has two input channels and missing "num_inputs"
+            if device.settings["device"]["type"] in ["SHDM-1", "SHDM-2", "SHSW-L"]:
+                channels = 2
+            else:
+                channels = device.shelly.get("num_inputs")
         elif block.type == "emeter":
             channels = device.shelly.get("num_emeters")
         elif block.type in ["relay", "light"]:
@@ -70,13 +74,6 @@ def get_entity_name(
                 entity_name = (
                     f"{get_device_name(device)} channel {chr(int(block.channel)+base)}"
                 )
-
-        # Shelly Dimmer has two input channels and missing "num_inputs"
-        if (
-            device.settings["device"]["type"] in ["SHDM-1", "SHDM-2"]
-            and block.type == "input"
-        ):
-            entity_name = f"{entity_name} channel {int(block.channel)+1}"
 
     if description:
         entity_name = f"{entity_name} {description}"


### PR DESCRIPTION
Support for shelly momentary buttons input events:
single, double triple, long, single_long, long_single.
Move `get_device_name` to `utils`

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for firing events for input events from momentary buttons

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
