### PR TITLE
Temperatures, fan and battery in Glances sensors

### DIFF
--- a/homeassistant/components/glances/const.py
+++ b/homeassistant/components/glances/const.py
@@ -36,7 +36,9 @@ SENSOR_TYPES = {
     "process_thread": ["processcount", "Thread", "Count", CPU_ICON],
     "process_sleeping": ["processcount", "Sleeping", "Count", CPU_ICON],
     "cpu_use_percent": ["cpu", "CPU used", PERCENTAGE, CPU_ICON],
-    "sensor_temp": ["sensors", "Temp", TEMP_CELSIUS, "mdi:thermometer"],
+    "temperature_core": ["sensors", "temperature", TEMP_CELSIUS, "mdi:thermometer"],
+    "fan_speed": ["sensors", "fan speed", "RPM", "mdi:fan"],
+    "battery": ["sensors", "charge", PERCENTAGE, "mdi:battery"],
     "docker_active": ["docker", "Containers active", "", "mdi:docker"],
     "docker_cpu_use": ["docker", "Containers CPU used", PERCENTAGE, "mdi:docker"],
     "docker_memory_use": [

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -34,16 +34,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             elif sensor_details[0] == "sensors":
                 # sensors will provide temp for different devices
                 for sensor in client.api.data[sensor_details[0]]:
-                    dev.append(
-                        GlancesSensor(
-                            client,
-                            name,
-                            sensor["label"],
-                            SENSOR_TYPES[sensor_type][1],
-                            sensor_type,
-                            SENSOR_TYPES[sensor_type],
+                    if sensor['type'] == sensor_type:
+                        dev.append(
+                            GlancesSensor(
+                                client,
+                                name,
+                                sensor["label"],
+                                SENSOR_TYPES[sensor_type][1],
+                                sensor_type,
+                                SENSOR_TYPES[sensor_type],
+                            )
                         )
-                    )
             elif client.api.data[sensor_details[0]]:
                 dev.append(
                     GlancesSensor(
@@ -156,11 +157,21 @@ class GlancesSensor(Entity):
                             (disk["size"] - disk["used"]) / 1024 ** 3,
                             1,
                         )
-            elif self.type == "sensor_temp":
+            elif self.type == "battery":
                 for sensor in value["sensors"]:
-                    if sensor["label"] == self._sensor_name_prefix:
-                        self._state = sensor["value"]
-                        break
+                    if sensor["type"] == "battery":
+                        if sensor["label"] == self._sensor_name_prefix:
+                            self._state = sensor["value"]
+            elif self.type == "fan_speed":
+                for sensor in value["sensors"]:
+                    if sensor["type"] == "fan_speed":
+                        if sensor["label"] == self._sensor_name_prefix:
+                            self._state = sensor["value"]
+            elif self.type == "temperature_core":
+                for sensor in value["sensors"]:
+                    if sensor["type"] == "temperature_core":
+                        if sensor["label"] == self._sensor_name_prefix:
+                            self._state = sensor["value"]
             elif self.type == "memory_use_percent":
                 self._state = value["mem"]["percent"]
             elif self.type == "memory_use":

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -34,7 +34,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             elif sensor_details[0] == "sensors":
                 # sensors will provide temp for different devices
                 for sensor in client.api.data[sensor_details[0]]:
-                    if sensor['type'] == sensor_type:
+                    if sensor["type"] == sensor_type:
                         dev.append(
                             GlancesSensor(
                                 client,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Previously, the [Glances integration](https://www.home-assistant.io/integrations/glances/) was presuming that all sensors were temperatures. Now, we can distinguish temperatures, fan speeds and battery charges.

In consequence, those entities have new Entity IDs, so you should update your configuration in the UI or in your YAML files.

Previously, they were all suffixed by _temp. Now they are suffixed by _temperature, _fan_speed and _charge.

Examples:
- sensor.glances_core_0_temp => sensor.glances_core_0_temperature
- sensor.glances_battery_temp => sensor.glances_battery_charge
- sensor.glances_thinkpad_1_temp => sensor.glances_thinkpad_1_fan_speed

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The [Glances integration](https://www.home-assistant.io/integrations/glances/) currently presumes that all "sensors" (as in http://hostname:61208/api/3/sensors) are temperatures. However, some of them can also be fan speeds and battery charge.

![image](https://user-images.githubusercontent.com/4377644/99886765-5bd24200-2c3f-11eb-9729-0c4730b00531.png)

With this PR, sensors are now each correctly identified as temperatures, fan speeds or battery charge.

Before:

![image](https://user-images.githubusercontent.com/4377644/99886921-97b9d700-2c40-11eb-8e27-22a62ec12ce0.png)

After:

![image](https://user-images.githubusercontent.com/4377644/99886903-7a850880-2c40-11eb-8147-dc9122a50b5c.png)

(I also replaced "Temp" by "temperature" but I can revert this)

(don't mind the prefix, on the "before" one I manually added a `name` entry to my production config.yaml)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
