### PR TITLE
Implement RTSP transport and FFMPeg Snapshot

### DIFF
--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.core import callback
 # pylint: disable=unused-import
 from .const import (
     CONF_DEVICE_ID,
+    CONF_FFMPEG_SNAPSHOT,
     CONF_RTSP_TRANSPORT,
     DEFAULT_ARGUMENTS,
     DEFAULT_PORT,
@@ -158,6 +159,7 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_NAME): str,
                     vol.Required(CONF_HOST): str,
                     vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                    vol.Required(CONF_FFMPEG_SNAPSHOT, default=False): bool,
                 }
             ),
         )

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -14,6 +14,7 @@ DEFAULT_ARGUMENTS = "-pred 1"
 CONF_DEVICE_ID = "deviceid"
 CONF_RTSP_TRANSPORT = "rtsp_transport"
 CONF_SNAPSHOT_AUTH = "snapshot_auth"
+CONF_FFMPEG_SNAPSHOT = "ffmpeg_snapshot"
 
 RTSP_TRANS_PROTOCOLS = ["tcp", "udp", "udp_multicast", "http"]
 

--- a/homeassistant/components/onvif/strings.json
+++ b/homeassistant/components/onvif/strings.json
@@ -26,7 +26,7 @@
           "name": "[%key:common::config_flow::data::name%]",
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
-          "ffmpeg_snapshot": "[%key:common::config_flow::data::ffmpeg_snapshot%]"
+          "ffmpeg_snapshot": "Only use FFMpeg for snapshots"
         },
         "title": "Configure ONVIF device"
       },

--- a/homeassistant/components/onvif/strings.json
+++ b/homeassistant/components/onvif/strings.json
@@ -25,7 +25,8 @@
         "data": {
           "name": "[%key:common::config_flow::data::name%]",
           "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "port": "[%key:common::config_flow::data::port%]",
+          "ffmpeg_snapshot": "[%key:common::config_flow::data::ffmpeg_snapshot%]"
         },
         "title": "Configure ONVIF device"
       },

--- a/homeassistant/components/onvif/translations/en.json
+++ b/homeassistant/components/onvif/translations/en.json
@@ -35,7 +35,8 @@
                 "data": {
                     "host": "Host",
                     "name": "Name",
-                    "port": "Port"
+                    "port": "Port",
+                    "ffmpeg_snapshot": "Only use FFMpeg for snapshots"
                 },
                 "title": "Configure ONVIF device"
             },

--- a/homeassistant/components/onvif/translations/it.json
+++ b/homeassistant/components/onvif/translations/it.json
@@ -35,7 +35,8 @@
                 "data": {
                     "host": "Host",
                     "name": "Nome",
-                    "port": "Porta"
+                    "port": "Porta",
+                    "ffmpeg_snapshot": "Usa FFMpeg per foto"
                 },
                 "title": "Configurare il dispositivo ONVIF"
             },

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -11,6 +11,7 @@ from tests.common import MockConfigEntry
 URN = "urn:uuid:123456789"
 NAME = "TestCamera"
 HOST = "1.2.3.4"
+FFMPEG_SNAPSHOT = True
 PORT = 80
 USERNAME = "admin"
 PASSWORD = "12345"
@@ -379,6 +380,7 @@ async def test_flow_manual_entry(hass):
                 config_flow.CONF_NAME: NAME,
                 config_flow.CONF_HOST: HOST,
                 config_flow.CONF_PORT: PORT,
+                config_flow.CONF_FFMPEG_SNAPSHOT: FFMPEG_SNAPSHOT,
             },
         )
 
@@ -408,6 +410,7 @@ async def test_flow_manual_entry(hass):
             config_flow.CONF_NAME: NAME,
             config_flow.CONF_HOST: HOST,
             config_flow.CONF_PORT: PORT,
+            config_flow.CONF_FFMPEG_SNAPSHOT: FFMPEG_SNAPSHOT,
             config_flow.CONF_USERNAME: USERNAME,
             config_flow.CONF_PASSWORD: PASSWORD,
         }


### PR DESCRIPTION
## Proposed change

Two fixes here here:

* When not using the `stream` component home assistant falls back to the camera provided stream. Currently that stream - a `mjpeg` stream - is ignoring the preferred RTSP transport. This PR passes the preference also to the MJPEG stream;

* My device - Reolink E1 Pro - doesn't support the snapshot URL, despite advertising it. This is quite annoying since it will log an error every time ONVIF trries to make a snapshot and has to fall back to FFMpeg. This PR adds an option for these devices to simply ignore the snapshot URL and use directly FFMPeg to create the snapshot, freeing the logs form an ugly looking error.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
