### PR TITLE
Support asking covers to stop using google assistant

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -104,6 +104,7 @@ ERR_UNSUPPORTED_INPUT = "unsupportedInput"
 
 ERR_ALREADY_DISARMED = "alreadyDisarmed"
 ERR_ALREADY_ARMED = "alreadyArmed"
+ERR_ALREADY_STOPPED = "alreadyStopped"
 
 ERR_CHALLENGE_NEEDED = "challengeNeeded"
 ERR_CHALLENGE_NOT_SETUP = "challengeFailedNotSetup"

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -67,6 +67,7 @@ from .const import (
     CHALLENGE_PIN_NEEDED,
     ERR_ALREADY_ARMED,
     ERR_ALREADY_DISARMED,
+    ERR_ALREADY_STOPPED,
     ERR_CHALLENGE_NOT_SETUP,
     ERR_FUNCTION_NOT_SUPPORTED,
     ERR_NOT_SUPPORTED,
@@ -564,24 +565,52 @@ class StartStopTrait(_Trait):
     @staticmethod
     def supported(domain, features, device_class):
         """Test if state is supported."""
-        return domain == vacuum.DOMAIN
+        if domain == vacuum.DOMAIN:
+            return True
+
+        if domain == cover.DOMAIN and features & cover.SUPPORT_STOP:
+            return True
+
+        return False
 
     def sync_attributes(self):
         """Return StartStop attributes for a sync request."""
-        return {
-            "pausable": self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-            & vacuum.SUPPORT_PAUSE
-            != 0
-        }
+        domain = self.state.domain
+        if domain == vacuum.DOMAIN:
+            return {
+                "pausable": self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+                & vacuum.SUPPORT_PAUSE
+                != 0
+            }
+        if domain == cover.DOMAIN:
+            return {}
 
     def query_attributes(self):
         """Return StartStop query attributes."""
-        return {
-            "isRunning": self.state.state == vacuum.STATE_CLEANING,
-            "isPaused": self.state.state == vacuum.STATE_PAUSED,
-        }
+        domain = self.state.domain
+        state = self.state.state
+
+        if domain == vacuum.DOMAIN:
+            return {
+                "isRunning": state == vacuum.STATE_CLEANING,
+                "isPaused": state == vacuum.STATE_PAUSED,
+            }
+
+        if domain == cover.DOMAIN:
+            return {
+                "isRunning": state == cover.STATE_CLOSING
+                or state == cover.STATE_OPENING
+            }
 
     async def execute(self, command, data, params, challenge):
+        """Execute a StartStop command."""
+        domain = self.state.domain
+        if domain == vacuum.DOMAIN:
+            return await self._execute_vacuum(command, data, params, challenge)
+        elif domain == cover.DOMAIN:
+            return await self._execute_cover(command, data, params, challenge)
+
+    async def _execute_vacuum(self, command, data, params, challenge):
         """Execute a StartStop command."""
         if command == COMMAND_STARTSTOP:
             if params["start"]:
@@ -617,6 +646,31 @@ class StartStopTrait(_Trait):
                     blocking=True,
                     context=data.context,
                 )
+
+    async def _execute_cover(self, command, data, params, challenge):
+        """Execute a StartStop command."""
+        if command == COMMAND_STARTSTOP:
+            if params["start"] is False:
+                if self.state.state in (cover.STATE_CLOSING, cover.STATE_OPENING):
+                    await self.hass.services.async_call(
+                        self.state.domain,
+                        cover.SERVICE_STOP_COVER,
+                        {ATTR_ENTITY_ID: self.state.entity_id},
+                        blocking=True,
+                        context=data.context,
+                    )
+                else:
+                    raise SmartHomeError(
+                        ERR_ALREADY_STOPPED, "Cover is already stopped"
+                    )
+            else:
+                raise SmartHomeError(
+                    ERR_NOT_SUPPORTED, "Starting a cover is not supported"
+                )
+        else:
+            raise SmartHomeError(
+                ERR_NOT_SUPPORTED, f"Command {command} is not supported"
+            )
 
 
 @register_trait

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -597,17 +597,14 @@ class StartStopTrait(_Trait):
             }
 
         if domain == cover.DOMAIN:
-            return {
-                "isRunning": state == cover.STATE_CLOSING
-                or state == cover.STATE_OPENING
-            }
+            return {"isRunning": state in (cover.STATE_CLOSING, cover.STATE_OPENING)}
 
     async def execute(self, command, data, params, challenge):
         """Execute a StartStop command."""
         domain = self.state.domain
         if domain == vacuum.DOMAIN:
             return await self._execute_vacuum(command, data, params, challenge)
-        elif domain == cover.DOMAIN:
+        if domain == cover.DOMAIN:
             return await self._execute_cover(command, data, params, challenge)
 
     async def _execute_vacuum(self, command, data, params, challenge):

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -136,14 +136,20 @@ DEMO_DEVICES = [
     {
         "id": "cover.living_room_window",
         "name": {"name": "Living Room Window"},
-        "traits": ["action.devices.traits.OpenClose"],
+        "traits": [
+            "action.devices.traits.StartStop",
+            "action.devices.traits.OpenClose",
+        ],
         "type": "action.devices.types.BLINDS",
         "willReportState": False,
     },
     {
         "id": "cover.hall_window",
         "name": {"name": "Hall Window"},
-        "traits": ["action.devices.traits.OpenClose"],
+        "traits": [
+            "action.devices.traits.StartStop",
+            "action.devices.traits.OpenClose",
+        ],
         "type": "action.devices.types.BLINDS",
         "willReportState": False,
     },
@@ -157,7 +163,10 @@ DEMO_DEVICES = [
     {
         "id": "cover.kitchen_window",
         "name": {"name": "Kitchen Window"},
-        "traits": ["action.devices.traits.OpenClose"],
+        "traits": [
+            "action.devices.traits.StartStop",
+            "action.devices.traits.OpenClose",
+        ],
         "type": "action.devices.types.BLINDS",
         "willReportState": False,
     },

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -842,7 +842,10 @@ async def test_device_class_cover(hass, device_class, google_type):
                     "attributes": {},
                     "id": "cover.demo_sensor",
                     "name": {"name": "Demo Sensor"},
-                    "traits": ["action.devices.traits.OpenClose"],
+                    "traits": [
+                        "action.devices.traits.StartStop",
+                        "action.devices.traits.OpenClose",
+                    ],
                     "type": google_type,
                     "willReportState": False,
                 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allow stopping an opening/closing cover using google assistant

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
