### PR TITLE
Avoid proxied Roku images during internal requests

### DIFF
--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -253,13 +253,17 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         """Implement the websocket media browsing helper."""
         is_internal = is_internal_request(self.hass)
 
-        def _get_thumbnail_url(media_content_type, media_content_id, media_image_id=None):
+        def _get_thumbnail_url(
+            media_content_type, media_content_id, media_image_id=None
+        ):
             if is_internal:
                 if media_content_type == MEDIA_TYPE_APP and media_content_id:
                     return self.coordinator.roku.app_icon_url(media_content_id)
                 return None
 
-            return self.get_browse_image_url(media_content_type, media_content_id, media_image_id)
+            return self.get_browse_image_url(
+                media_content_type, media_content_id, media_image_id
+            )
 
         if media_content_type in [None, "library"]:
             return library_payload(self.coordinator, _get_thumbnail_url)

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     STATE_STANDBY,
 )
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers.network import is_internal_request
 
 from . import RokuDataUpdateCoordinator, RokuEntity, roku_exception_handler
 from .browse_media import build_item_response, library_payload
@@ -250,9 +251,15 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""
+        is_internal = is_internal_request(self.hass)
 
-        def _get_thumbnail_url(*args, **kwargs):
-            return self.get_browse_image_url(*args, **kwargs)
+        def _get_thumbnail_url(media_content_type, media_content_id, media_image_id=None):
+            if is_internal:
+                if media_content_type == MEDIA_TYPE_APP and media_content_id:
+                    return self.coordinator.roku.app_icon_url(media_content_id)
+                return None
+
+            return self.get_browse_image_url(media_content_type, media_content_id, media_image_id)
 
         if media_content_type in [None, "library"]:
             return library_payload(self.coordinator, _get_thumbnail_url)

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -39,6 +39,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.components.roku.const import ATTR_KEYWORD, DOMAIN, SERVICE_SEARCH
 from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_MEDIA_NEXT_TRACK,
@@ -597,6 +598,67 @@ async def test_media_browse(hass, aioclient_mock, hass_ws_client):
     assert msg["id"] == 4
     assert msg["type"] == TYPE_RESULT
     assert not msg["success"]
+
+
+async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
+    """Test browsing media with internal url."""
+    await async_process_ha_core_config(
+        hass,
+        {"internal_url": "http://example.local:8123"},
+    )
+
+    assert hass.config.internal_url == "http://example.local:8123"
+    
+    await setup_integration(
+        hass,
+        aioclient_mock,
+        device="rokutv",
+        app="tvinput-dtv",
+        host=TV_HOST,
+        unique_id=TV_SERIAL,
+    )
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "media_player/browse_media",
+            "entity_id": TV_ENTITY_ID,
+            "media_content_type": MEDIA_TYPE_APPS,
+            "media_content_id": "apps",
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert msg["id"] == 2
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    assert msg["result"]
+    assert msg["result"]["title"] == "Apps"
+    assert msg["result"]["media_class"] == MEDIA_CLASS_DIRECTORY
+    assert msg["result"]["media_content_type"] == MEDIA_TYPE_APPS
+    assert msg["result"]["children_media_class"] == MEDIA_CLASS_APP
+    assert msg["result"]["can_expand"]
+    assert not msg["result"]["can_play"]
+    assert len(msg["result"]["children"]) == 11
+    assert msg["result"]["children_media_class"] == MEDIA_CLASS_APP
+
+    assert msg["result"]["children"][0]["title"] == "Satellite TV"
+    assert msg["result"]["children"][0]["media_content_type"] == MEDIA_TYPE_APP
+    assert msg["result"]["children"][0]["media_content_id"] == "tvinput.hdmi2"
+    assert (
+        "/browse_media/app/tvinput.hdmi2" in msg["result"]["children"][0]["thumbnail"]
+    )
+    assert msg["result"]["children"][0]["can_play"]
+
+    assert msg["result"]["children"][3]["title"] == "Roku Channel Store"
+    assert msg["result"]["children"][3]["media_content_type"] == MEDIA_TYPE_APP
+    assert msg["result"]["children"][3]["media_content_id"] == "11"
+    assert "/browse_media/app/11" in msg["result"]["children"][3]["thumbnail"]
+    assert msg["result"]["children"][3]["can_play"]
 
 
 async def test_integration_services(

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -608,7 +608,7 @@ async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
     )
 
     assert hass.config.internal_url == "http://example.local:8123"
-    
+
     await setup_integration(
         hass,
         aioclient_mock,
@@ -650,14 +650,14 @@ async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
     assert msg["result"]["children"][0]["media_content_type"] == MEDIA_TYPE_APP
     assert msg["result"]["children"][0]["media_content_id"] == "tvinput.hdmi2"
     assert (
-        "/browse_media/app/tvinput.hdmi2" in msg["result"]["children"][0]["thumbnail"]
+        "/query/icon/tvinput.hdmi2" in msg["result"]["children"][0]["thumbnail"]
     )
     assert msg["result"]["children"][0]["can_play"]
 
     assert msg["result"]["children"][3]["title"] == "Roku Channel Store"
     assert msg["result"]["children"][3]["media_content_type"] == MEDIA_TYPE_APP
     assert msg["result"]["children"][3]["media_content_id"] == "11"
-    assert "/browse_media/app/11" in msg["result"]["children"][3]["thumbnail"]
+    assert "/query/icon/11" in msg["result"]["children"][3]["thumbnail"]
     assert msg["result"]["children"][3]["can_play"]
 
 

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -600,7 +600,6 @@ async def test_media_browse(hass, aioclient_mock, hass_ws_client):
     assert not msg["success"]
 
 
-@patch("homeassistant.helpers.network._get_request_host", return_value="example.local")
 async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
     """Test browsing media with internal url."""
     await async_process_ha_core_config(
@@ -621,17 +620,18 @@ async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
 
     client = await hass_ws_client(hass)
 
-    await client.send_json(
-        {
-            "id": 2,
-            "type": "media_player/browse_media",
-            "entity_id": TV_ENTITY_ID,
-            "media_content_type": MEDIA_TYPE_APPS,
-            "media_content_id": "apps",
-        }
-    )
+    with patch("homeassistant.helpers.network._get_request_host", return_value="example.local"):
+        await client.send_json(
+            {
+                "id": 2,
+                "type": "media_player/browse_media",
+                "entity_id": TV_ENTITY_ID,
+                "media_content_type": MEDIA_TYPE_APPS,
+                "media_content_id": "apps",
+            }
+        )
 
-    msg = await client.receive_json()
+        msg = await client.receive_json()
 
     assert msg["id"] == 2
     assert msg["type"] == TYPE_RESULT

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -620,7 +620,9 @@ async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
 
     client = await hass_ws_client(hass)
 
-    with patch("homeassistant.helpers.network._get_request_host", return_value="example.local"):
+    with patch(
+        "homeassistant.helpers.network._get_request_host", return_value="example.local"
+    ):
         await client.send_json(
             {
                 "id": 2,

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -600,6 +600,7 @@ async def test_media_browse(hass, aioclient_mock, hass_ws_client):
     assert not msg["success"]
 
 
+@patch("homeassistant.helpers.network._get_request_host", return_value="example.local")
 async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
     """Test browsing media with internal url."""
     await async_process_ha_core_config(
@@ -649,9 +650,7 @@ async def test_media_browse_internal(hass, aioclient_mock, hass_ws_client):
     assert msg["result"]["children"][0]["title"] == "Satellite TV"
     assert msg["result"]["children"][0]["media_content_type"] == MEDIA_TYPE_APP
     assert msg["result"]["children"][0]["media_content_id"] == "tvinput.hdmi2"
-    assert (
-        "/query/icon/tvinput.hdmi2" in msg["result"]["children"][0]["thumbnail"]
-    )
+    assert "/query/icon/tvinput.hdmi2" in msg["result"]["children"][0]["thumbnail"]
     assert msg["result"]["children"][0]["can_play"]
 
     assert msg["result"]["children"][3]["title"] == "Roku Channel Store"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
