### PR TITLE
Fix RTS cover with set position available

### DIFF
--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -164,12 +164,12 @@ class SomfyEntity(CoordinatorEntity, Entity):
         return self.coordinator.data[self._id]
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return the unique id base on the id returned by Somfy."""
         return self._id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the device."""
         return self.device.name
 
@@ -188,13 +188,18 @@ class SomfyEntity(CoordinatorEntity, Entity):
             "manufacturer": "Somfy",
         }
 
-    def has_capability(self, capability):
+    def has_capability(self, capability: str) -> bool:
         """Test if device has a capability."""
         capabilities = self.device.capabilities
         return bool([c for c in capabilities if c.name == capability])
 
+    def has_state(self, state: str) -> bool:
+        """Test if device has a state."""
+        states = self.device.states
+        return bool([c for c in states if c.name == state])
+
     @property
-    def assumed_state(self):
+    def assumed_state(self) -> bool:
         """Return if the device has an assumed state."""
         return not bool(self.device.states)
 

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -8,15 +8,15 @@ from homeassistant.components.cover import (
     ATTR_TILT_POSITION,
     DEVICE_CLASS_BLIND,
     DEVICE_CLASS_SHUTTER,
-    CoverEntity,
-    SUPPORT_SET_POSITION,
-    SUPPORT_OPEN,
     SUPPORT_CLOSE,
-    SUPPORT_SET_TILT_POSITION,
     SUPPORT_CLOSE_TILT,
+    SUPPORT_OPEN,
     SUPPORT_OPEN_TILT,
+    SUPPORT_SET_POSITION,
+    SUPPORT_SET_TILT_POSITION,
     SUPPORT_STOP,
     SUPPORT_STOP_TILT,
+    CoverEntity,
 )
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.helpers.restore_state import RestoreEntity

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -9,6 +9,14 @@ from homeassistant.components.cover import (
     DEVICE_CLASS_BLIND,
     DEVICE_CLASS_SHUTTER,
     CoverEntity,
+    SUPPORT_SET_POSITION,
+    SUPPORT_OPEN,
+    SUPPORT_CLOSE,
+    SUPPORT_SET_TILT_POSITION,
+    SUPPORT_CLOSE_TILT,
+    SUPPORT_OPEN_TILT,
+    SUPPORT_STOP,
+    SUPPORT_STOP_TILT,
 )
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -57,9 +65,31 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         self.cover = None
         self._create_device()
 
-    def _create_device(self):
+    def _create_device(self) -> Blind:
         """Update the device with the latest data."""
         self.cover = Blind(self.device, self.api)
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        supported_features = 0
+        if self.has_capability("open"):
+            supported_features |= SUPPORT_OPEN
+        if self.has_capability("close"):
+            supported_features |= SUPPORT_CLOSE
+        if self.has_capability("stop"):
+            supported_features |= SUPPORT_STOP
+        if self.has_capability("position"):
+            supported_features |= SUPPORT_SET_POSITION
+        if self.has_capability("rotation"):
+            supported_features |= (
+                SUPPORT_OPEN_TILT
+                | SUPPORT_CLOSE_TILT
+                | SUPPORT_STOP_TILT
+                | SUPPORT_SET_TILT_POSITION
+            )
+
+        return supported_features
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
@@ -105,10 +135,9 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
     @property
     def current_cover_position(self):
         """Return the current position of cover shutter."""
-        position = None
-        if self.has_capability("position"):
-            position = 100 - self.cover.get_position()
-        return position
+        if not self.has_state("position"):
+            return None
+        return 100 - self.cover.get_position()
 
     @property
     def is_opening(self):
@@ -125,25 +154,24 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
         return self._is_closing
 
     @property
-    def is_closed(self):
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
         is_closed = None
-        if self.has_capability("position"):
+        if self.has_state("position"):
             is_closed = self.cover.is_closed()
         elif self.optimistic:
             is_closed = self._closed
         return is_closed
 
     @property
-    def current_cover_tilt_position(self):
+    def current_cover_tilt_position(self) -> int:
         """Return current position of cover tilt.
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        orientation = None
-        if self.has_capability("rotation"):
-            orientation = 100 - self.cover.orientation
-        return orientation
+        if not self.has_state("orientation"):
+            return None
+        return 100 - self.cover.orientation
 
     def set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
By default, HA assumes that if a cover has a state, it can set it. That's not the case for Somfy. Some stateless covers can be set to a specific position (using delay).  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43477
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
