### PR TITLE
0.118.3

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,11 +1,11 @@
 {
   "image": "homeassistant/{arch}-homeassistant",
   "build_from": {
-    "aarch64": "homeassistant/aarch64-homeassistant-base:2020.10.1",
-    "armhf": "homeassistant/armhf-homeassistant-base:2020.10.1",
-    "armv7": "homeassistant/armv7-homeassistant-base:2020.10.1",
-    "amd64": "homeassistant/amd64-homeassistant-base:2020.10.1",
-    "i386": "homeassistant/i386-homeassistant-base:2020.10.1"
+    "aarch64": "homeassistant/aarch64-homeassistant-base:2020.11.1",
+    "armhf": "homeassistant/armhf-homeassistant-base:2020.11.1",
+    "armv7": "homeassistant/armv7-homeassistant-base:2020.11.1",
+    "amd64": "homeassistant/amd64-homeassistant-base:2020.11.1",
+    "i386": "homeassistant/i386-homeassistant-base:2020.11.1"
   },
   "labels": {
     "io.hass.type": "core"

--- a/build.json
+++ b/build.json
@@ -1,11 +1,11 @@
 {
   "image": "homeassistant/{arch}-homeassistant",
   "build_from": {
-    "aarch64": "homeassistant/aarch64-homeassistant-base:2020.11.1",
-    "armhf": "homeassistant/armhf-homeassistant-base:2020.11.1",
-    "armv7": "homeassistant/armv7-homeassistant-base:2020.11.1",
-    "amd64": "homeassistant/amd64-homeassistant-base:2020.11.1",
-    "i386": "homeassistant/i386-homeassistant-base:2020.11.1"
+    "aarch64": "homeassistant/aarch64-homeassistant-base:2020.11.2",
+    "armhf": "homeassistant/armhf-homeassistant-base:2020.11.2",
+    "armv7": "homeassistant/armv7-homeassistant-base:2020.11.2",
+    "amd64": "homeassistant/amd64-homeassistant-base:2020.11.2",
+    "i386": "homeassistant/i386-homeassistant-base:2020.11.2"
   },
   "labels": {
     "io.hass.type": "core"

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -155,6 +155,9 @@ class IQVIAEntity(CoordinatorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self.coordinator.last_update_success:
+            return
+
         self.update_from_latest_data()
         self.async_write_ha_state()
 

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -105,6 +105,7 @@ class ForecastSensor(IQVIAEntity):
     def update_from_latest_data(self):
         """Update the sensor."""
         data = self.coordinator.data.get("Location")
+
         if not data or not data.get("periods"):
             return
 
@@ -142,6 +143,9 @@ class IndexSensor(IQVIAEntity):
     @callback
     def update_from_latest_data(self):
         """Update the sensor."""
+        if not self.coordinator.last_update_success:
+            return
+
         try:
             if self._type in (TYPE_ALLERGY_TODAY, TYPE_ALLERGY_TOMORROW):
                 data = self.coordinator.data.get("Location")

--- a/homeassistant/components/kodi/config_flow.py
+++ b/homeassistant/components/kodi/config_flow.py
@@ -104,7 +104,10 @@ class KodiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._host = discovery_info["host"]
         self._port = int(discovery_info["port"])
         self._name = discovery_info["hostname"][: -len(".local.")]
-        uuid = discovery_info["properties"]["uuid"]
+        uuid = discovery_info["properties"].get("uuid")
+        if not uuid:
+            return self.async_abort(reason="no_uuid")
+
         self._discovery_name = discovery_info["name"]
 
         await self.async_set_unique_id(uuid)

--- a/homeassistant/components/kodi/strings.json
+++ b/homeassistant/components/kodi/strings.json
@@ -37,7 +37,8 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "no_uuid": "Kodi instance does not have a unique id. This is most likely due to an old Kodi version (17.x or below). You can configure the integration manually or upgrade to a more recent Kodi version."
     }
   },
   "device_automation": {

--- a/homeassistant/components/notion/binary_sensor.py
+++ b/homeassistant/components/notion/binary_sensor.py
@@ -77,7 +77,7 @@ class NotionBinarySensor(NotionEntity, BinarySensorEntity):
     @callback
     def _async_update_from_latest_data(self) -> None:
         """Fetch new state data for the sensor."""
-        task = self.coordinator.data["tasks"][self._task_id]
+        task = self.coordinator.data["tasks"][self.task_id]
 
         if "value" in task["status"]:
             self._state = task["status"]["value"]
@@ -87,7 +87,7 @@ class NotionBinarySensor(NotionEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return whether the sensor is on or off."""
-        task = self.coordinator.data["tasks"][self._task_id]
+        task = self.coordinator.data["tasks"][self.task_id]
 
         if task["task_type"] == SENSOR_BATTERY:
             return self._state == "critical"

--- a/homeassistant/components/notion/sensor.py
+++ b/homeassistant/components/notion/sensor.py
@@ -79,7 +79,7 @@ class NotionSensor(NotionEntity):
     @callback
     def _async_update_from_latest_data(self) -> None:
         """Fetch new state data for the sensor."""
-        task = self.coordinator.data["tasks"][self._task_id]
+        task = self.coordinator.data["tasks"][self.task_id]
 
         if task["task_type"] == SENSOR_TEMPERATURE:
             self._state = round(float(task["status"]["value"]), 1)

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -227,7 +227,7 @@ async def async_setup_entry(hass, entry):
     play_on_sonos_schema = vol.Schema(
         {
             vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-            vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+            vol.Required(ATTR_MEDIA_CONTENT_ID): cv.string,
             vol.Optional(ATTR_MEDIA_CONTENT_TYPE): vol.In("music"),
         }
     )

--- a/homeassistant/components/sleepiq/manifest.json
+++ b/homeassistant/components/sleepiq/manifest.json
@@ -2,6 +2,6 @@
   "domain": "sleepiq",
   "name": "SleepIQ",
   "documentation": "https://www.home-assistant.io/integrations/sleepiq",
-  "requirements": ["sleepyq==0.7"],
+  "requirements": ["sleepyq==0.8.1"],
   "codeowners": []
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 118
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2033,7 +2033,7 @@ skybellpy==0.6.1
 slackclient==2.5.0
 
 # homeassistant.components.sleepiq
-sleepyq==0.7
+sleepyq==0.8.1
 
 # homeassistant.components.xmpp
 slixmpp==1.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -978,7 +978,7 @@ simplisafe-python==9.6.0
 slackclient==2.5.0
 
 # homeassistant.components.sleepiq
-sleepyq==0.7
+sleepyq==0.8.1
 
 # homeassistant.components.smart_meter_texas
 smart-meter-texas==0.4.0

--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.kodi.const import DEFAULT_TIMEOUT, DOMAIN
 from .util import (
     TEST_CREDENTIALS,
     TEST_DISCOVERY,
+    TEST_DISCOVERY_WO_UUID,
     TEST_HOST,
     TEST_IMPORT,
     TEST_WS_PORT,
@@ -571,6 +572,16 @@ async def test_discovery_updates_unique_id(hass):
     assert entry.data["host"] == "1.1.1.1"
     assert entry.data["port"] == 8080
     assert entry.data["name"] == "hostname"
+
+
+async def test_discovery_without_unique_id(hass):
+    """Test a discovery flow with no unique id aborts."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "zeroconf"}, data=TEST_DISCOVERY_WO_UUID
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "no_uuid"
 
 
 async def test_form_import(hass):

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -24,6 +24,16 @@ TEST_DISCOVERY = {
 }
 
 
+TEST_DISCOVERY_WO_UUID = {
+    "host": "1.1.1.1",
+    "port": 8080,
+    "hostname": "hostname.local.",
+    "type": "_xbmc-jsonrpc-h._tcp.local.",
+    "name": "hostname._xbmc-jsonrpc-h._tcp.local.",
+    "properties": {},
+}
+
+
 TEST_IMPORT = {
     "name": "name",
     "host": "1.1.1.1",


### PR DESCRIPTION
- Fix bug related to possibly missing task ID in Notion API data ([@bachya] - [#43330]) ([notion docs])
- Fix unhandled exception when IQVIA API fails to return data ([@bachya] - [#43359]) ([iqvia docs])
- Ensure Plex content_id in play_on_sonos service is a string ([@frenck] - [#43483]) ([plex docs])
- Gracefully handle no uuid in kodi discovery ([@OnFreund] - [#43494]) ([kodi docs])
- Bump sleepyq to 0.8.1 ([@ahertz] - [#43505]) ([sleepiq docs])
- Upgrade Docker base image to 2020.11.1 ([@frenck] - [#43538])
- Upgrade Docker base image to 2020.11.2 ([@frenck] - [#43560])

[#43330]: https://github.com/home-assistant/core/pull/43330
[#43359]: https://github.com/home-assistant/core/pull/43359
[#43483]: https://github.com/home-assistant/core/pull/43483
[#43494]: https://github.com/home-assistant/core/pull/43494
[#43505]: https://github.com/home-assistant/core/pull/43505
[#43538]: https://github.com/home-assistant/core/pull/43538
[#43560]: https://github.com/home-assistant/core/pull/43560
[@OnFreund]: https://github.com/OnFreund
[@ahertz]: https://github.com/ahertz
[@bachya]: https://github.com/bachya
[@frenck]: https://github.com/frenck
[iqvia docs]: https://www.home-assistant.io/integrations/iqvia/
[kodi docs]: https://www.home-assistant.io/integrations/kodi/
[notion docs]: https://www.home-assistant.io/integrations/notion/
[plex docs]: https://www.home-assistant.io/integrations/plex/
[sleepiq docs]: https://www.home-assistant.io/integrations/sleepiq/