### PR TITLE
Fix flapping derivative tests where time would move between state changes

### DIFF
--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -23,11 +23,13 @@ async def test_state(hass):
     assert await async_setup_component(hass, "sensor", config)
 
     entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 1, {})
-    await hass.async_block_till_done()
+    base = dt_util.utcnow()
+    with patch("homeassistant.util.dt.utcnow") as now:
+        now.return_value = base
+        hass.states.async_set(entity_id, 1, {})
+        await hass.async_block_till_done()
 
-    now = dt_util.utcnow() + timedelta(seconds=3600)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        now.return_value += timedelta(seconds=3600)
         hass.states.async_set(entity_id, 1, {}, force_update=True)
         await hass.async_block_till_done()
 
@@ -63,9 +65,10 @@ async def setup_tests(hass, config, times, values, expected_state):
     config, entity_id = await _setup_sensor(hass, config)
 
     # Testing a energy sensor with non-monotonic intervals and values
-    for time, value in zip(times, values):
-        now = dt_util.utcnow() + timedelta(seconds=time)
-        with patch("homeassistant.util.dt.utcnow", return_value=now):
+    base = dt_util.utcnow()
+    with patch("homeassistant.util.dt.utcnow") as now:
+        for time, value in zip(times, values):
+            now.return_value = base + timedelta(seconds=time)
             hass.states.async_set(entity_id, value, {}, force_update=True)
             await hass.async_block_till_done()
 
@@ -163,8 +166,9 @@ async def test_data_moving_average_for_discrete_sensor(hass):
         },
     )  # two minute window
 
+    base = dt_util.utcnow()
     for time, value in zip(times, temperature_values):
-        now = dt_util.utcnow() + timedelta(seconds=time)
+        now = base + timedelta(seconds=time)
         with patch("homeassistant.util.dt.utcnow", return_value=now):
             hass.states.async_set(entity_id, value, {}, force_update=True)
             await hass.async_block_till_done()
@@ -192,13 +196,15 @@ async def test_prefix(hass):
     assert await async_setup_component(hass, "sensor", config)
 
     entity_id = config["sensor"]["source"]
-    hass.states.async_set(
-        entity_id, 1000, {"unit_of_measurement": POWER_WATT}, force_update=True
-    )
-    await hass.async_block_till_done()
+    base = dt_util.utcnow()
+    with patch("homeassistant.util.dt.utcnow") as now:
+        now.return_value = base
+        hass.states.async_set(
+            entity_id, 1000, {"unit_of_measurement": POWER_WATT}, force_update=True
+        )
+        await hass.async_block_till_done()
 
-    now = dt_util.utcnow() + timedelta(seconds=3600)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        now.return_value += timedelta(seconds=3600)
         hass.states.async_set(
             entity_id, 1000, {"unit_of_measurement": POWER_WATT}, force_update=True
         )
@@ -228,11 +234,13 @@ async def test_suffix(hass):
     assert await async_setup_component(hass, "sensor", config)
 
     entity_id = config["sensor"]["source"]
-    hass.states.async_set(entity_id, 1000, {})
-    await hass.async_block_till_done()
+    base = dt_util.utcnow()
+    with patch("homeassistant.util.dt.utcnow") as now:
+        now.return_value = base
+        hass.states.async_set(entity_id, 1000, {})
+        await hass.async_block_till_done()
 
-    now = dt_util.utcnow() + timedelta(seconds=10)
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        now.return_value += timedelta(seconds=10)
         hass.states.async_set(entity_id, 1000, {}, force_update=True)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix flapping tests for derivate component where utcnow would change between state changes causing derivate to take unexpected values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

```
tests/components/derivative/test_sensor.py#L75
test_dataSet5[pyloop]

AssertionError: assert -1.99 == -2
 +  where -1.99 = round(-1.99, 2)
 +    where -1.99 = float('-1.99')
 +      where '-1.99' = <state sensor.power=-1.99; source=sensor.energy, unit_of_measurement=/s, friendly_name=power, icon=mdi:chart-line @ 2020-11-23T20:35:54.519758+00:00>.state
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
