### PR TITLE
Update nest library: switch events to full async and improved error handling

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import logging
 import threading
 
-from google_nest_sdm.event import EventCallback, EventMessage
+from google_nest_sdm.event import AsyncEventCallback, EventMessage
 from google_nest_sdm.exceptions import GoogleNestException
 from google_nest_sdm.google_nest_subscriber import GoogleNestSubscriber
 from nest import Nest
@@ -160,14 +160,14 @@ async def async_setup(hass: HomeAssistant, config: dict):
     return True
 
 
-class SignalUpdateCallback(EventCallback):
+class SignalUpdateCallback(AsyncEventCallback):
     """An EventCallback invoked when new events arrive from subscriber."""
 
     def __init__(self, hass: HomeAssistant):
         """Initialize EventCallback."""
         self._hass = hass
 
-    def handle_event(self, event_message: EventMessage):
+    async def async_handle_event(self, event_message: EventMessage):
         """Process an incoming EventMessage."""
         _LOGGER.debug("Update %s @ %s", event_message.event_id, event_message.timestamp)
         traits = event_message.resource_update_traits

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/nest",
   "requirements": [
       "python-nest==4.1.0",
-      "google-nest-sdm==0.1.15"
+      "google-nest-sdm==0.2.0"
   ],
   "codeowners": [
       "@awarecan",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.1.15
+google-nest-sdm==0.2.0
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -355,7 +355,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.1.15
+google-nest-sdm==0.2.0
 
 # homeassistant.components.gree
 greeclimate==0.10.3

--- a/tests/components/nest/climate_sdm_test.py
+++ b/tests/components/nest/climate_sdm_test.py
@@ -417,7 +417,7 @@ async def test_thermostat_set_hvac_mode(hass, auth):
         },
         auth=None,
     )
-    subscriber.receive_event(event)
+    await subscriber.async_receive_event(event)
     await hass.async_block_till_done()  # Process dispatch/update signal
 
     thermostat = hass.states.get("climate.my_thermostat")
@@ -441,7 +441,7 @@ async def test_thermostat_set_hvac_mode(hass, auth):
         },
         auth=None,
     )
-    subscriber.receive_event(event)
+    await subscriber.async_receive_event(event)
     await hass.async_block_till_done()  # Process dispatch/update signal
 
     thermostat = hass.states.get("climate.my_thermostat")
@@ -514,7 +514,7 @@ async def test_thermostat_set_eco_preset(hass, auth):
         },
         auth=auth,
     )
-    subscriber.receive_event(event)
+    await subscriber.async_receive_event(event)
     await hass.async_block_till_done()  # Process dispatch/update signal
 
     thermostat = hass.states.get("climate.my_thermostat")
@@ -834,7 +834,7 @@ async def test_thermostat_target_temp(hass, auth):
         },
         auth=None,
     )
-    subscriber.receive_event(event)
+    await subscriber.async_receive_event(event)
     await hass.async_block_till_done()  # Process dispatch/update signal
 
     thermostat = hass.states.get("climate.my_thermostat")

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -3,7 +3,7 @@
 import time
 
 from google_nest_sdm.device_manager import DeviceManager
-from google_nest_sdm.event import EventCallback, EventMessage
+from google_nest_sdm.event import AsyncEventCallback, EventMessage
 from google_nest_sdm.google_nest_subscriber import GoogleNestSubscriber
 
 from homeassistant.components.nest import DOMAIN
@@ -61,7 +61,7 @@ class FakeSubscriber(GoogleNestSubscriber):
         self._device_manager = device_manager
         self._callback = None
 
-    def set_update_callback(self, callback: EventCallback):
+    def set_update_callback(self, callback: AsyncEventCallback):
         """Capture the callback set by Home Assistant."""
         self._callback = callback
 
@@ -77,11 +77,11 @@ class FakeSubscriber(GoogleNestSubscriber):
         """No-op to stop the subscriber."""
         return None
 
-    def receive_event(self, event_message: EventMessage):
+    async def async_receive_event(self, event_message: EventMessage):
         """Simulate a received pubsub message, invoked by tests."""
         # Update device state, then invoke HomeAssistant to refresh
-        self._device_manager.handle_event(event_message)
-        self._callback.handle_event(event_message)
+        await self._device_manager.async_handle_event(event_message)
+        await self._callback.async_handle_event(event_message)
 
 
 async def async_setup_sdm_platform(hass, platform, devices={}, structures={}):

--- a/tests/components/nest/sensor_sdm_test.py
+++ b/tests/components/nest/sensor_sdm_test.py
@@ -164,7 +164,7 @@ async def test_event_updates_sensor(hass):
         },
         auth=None,
     )
-    subscriber.receive_event(event)
+    await subscriber.async_receive_event(event)
     await hass.async_block_till_done()  # Process dispatch/update signal
 
     temperature = hass.states.get("sensor.my_sensor_temperature")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update nest python library and switch subscriber events to use the new fully async interface.  The google subscriber runs blocking callbacks from a background thread, and the python nest library now has a wrapper to run invoke home assistant callbacks in the event loop.   This is in preparation for doing async work when events fire in order to translate an API device to a device registry device id [nest device triggers](https://github.com/home-assistant/core/pull/43548), but pulled out into a separate PR to make it easier to review.

The updated library also has some other usability improvements:
- Fail with an error message if the subscriber_id is in the wrong format, with a hint for the correct format.  This is a common misconfiguration.
- Gracefully handy empty device responses instead of printing a stack trace.  

See change log for v0.1.15 to v0.2.0: https://github.com/allenporter/python-google-nest-sdm/compare/v0.1.15...v0.2.0 for all changes in the python library.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
