### PR TITLE
Propagate RFLink 'send_command' event

### DIFF
--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -66,6 +66,7 @@ SERVICE_SEND_COMMAND = "send_command"
 
 SIGNAL_AVAILABILITY = "rflink_device_available"
 SIGNAL_HANDLE_EVENT = "rflink_handle_event_{}"
+SIGNAL_EVENT = "rflink_event"
 
 TMP_ENTITY = "tmp.{}"
 
@@ -136,6 +137,15 @@ async def async_setup(hass, config):
             )
         ):
             _LOGGER.error("Failed Rflink command for %s", str(call.data))
+        else:
+            async_dispatcher_send(
+                hass,
+                SIGNAL_EVENT,
+                {
+                    EVENT_KEY_ID: call.data.get(CONF_DEVICE_ID),
+                    EVENT_KEY_COMMAND: call.data.get(CONF_COMMAND),
+                },
+            )
 
     hass.services.async_register(
         DOMAIN, SERVICE_SEND_COMMAND, async_send_command, schema=SEND_COMMAND_SCHEMA
@@ -265,6 +275,7 @@ async def async_setup(hass, config):
         _LOGGER.info("Connected to Rflink")
 
     hass.async_create_task(connect())
+    async_dispatcher_connect(hass, SIGNAL_EVENT, event_callback)
     return True
 
 

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -196,6 +196,50 @@ async def test_send_command_invalid_arguments(hass, monkeypatch):
     assert not success, "send command should not succeed for unknown command"
 
 
+async def test_send_command_event_propagation(hass, monkeypatch):
+    """Test event propagation for send_command service."""
+    domain = "light"
+    config = {
+        "rflink": {"port": "/dev/ttyABC0"},
+        domain: {
+            "platform": "rflink",
+            "devices": {
+                "protocol_0_1": {"name": "test1"},
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    _, _, protocol, _ = await mock_rflink(hass, config, domain, monkeypatch)
+
+    # default value = 'off'
+    assert hass.states.get(f"{domain}.test1").state == "off"
+
+    hass.async_create_task(
+        hass.services.async_call(
+            "rflink",
+            SERVICE_SEND_COMMAND,
+            {"device_id": "protocol_0_1", "command": "on"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert protocol.send_command_ack.call_args_list[0][0][0] == "protocol_0_1"
+    assert protocol.send_command_ack.call_args_list[0][0][1] == "on"
+    assert hass.states.get(f"{domain}.test1").state == "on"
+
+    hass.async_create_task(
+        hass.services.async_call(
+            "rflink",
+            SERVICE_SEND_COMMAND,
+            {"device_id": "protocol_0_1", "command": "alloff"},
+        )
+    )
+    await hass.async_block_till_done()
+    assert protocol.send_command_ack.call_args_list[1][0][0] == "protocol_0_1"
+    assert protocol.send_command_ack.call_args_list[1][0][1] == "alloff"
+    assert hass.states.get(f"{domain}.test1").state == "off"
+
+
 async def test_reconnecting_after_disconnect(hass, monkeypatch):
     """An unexpected disconnect should cause a reconnect."""
     domain = "sensor"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The RFLink integration has a `send_command` service to send signals through the gateway. This service can be used in scripts and automations to operate HA entities (and not HA devices as well).
With this PR, the event generated by the signal sent by the `send_command` service is propagated internally so that HA updates correctly, just like other services do.

The 'problem' detected is that the signal sent does not propagate within HA and therefore does not update the states of the controlled entities. Some users have opted for 'imaginative' solutions to be able to update the status of their devices when using this service (see related link).
I see this PR more as a 'bugfix' than a 'breaking change', but it is true that it can cause problems with some workaround or implementation that sought to solve this gap.

It seems that the method is not documented, so I have not been able to update the documentation.
It is my intention to review the documentation of the method, but I will do it in a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
  - https://community.home-assistant.io/t/rflink-nexa-newkaku-and-group-commands/245161/11
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- **N/A** The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- **N/A** New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- **N/A** Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
