### PR TITLE
Add Roomba support for automatic emptying of bin

### DIFF
--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 import async_timeout
-from roomba import Roomba, RoombaConnectionError
+from roombapy import Roomba, RoombaConnectionError
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -1,5 +1,5 @@
 """Config flow to configure roomba component."""
-from roomba import Roomba
+from roombapy import Roomba
 import voluptuous as vol
 
 from homeassistant import config_entries, core

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -51,7 +51,7 @@ SUPPORT_IROBOT = (
 STATE_MAP = {
     "": STATE_IDLE,
     "charge": STATE_DOCKED,
-    "evac": STATE_RETURNING, # Emptying at cleanbase
+    "evac": STATE_RETURNING,  # Emptying at cleanbase
     "hmMidMsn": STATE_CLEANING,  # Recharging at the middle of a cycle
     "hmPostMsn": STATE_RETURNING,  # Cycle finished
     "hmUsrDock": STATE_RETURNING,

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -51,6 +51,7 @@ SUPPORT_IROBOT = (
 STATE_MAP = {
     "": STATE_IDLE,
     "charge": STATE_DOCKED,
+    "evac": STATE_RETURNING, # Emptying at cleanbase
     "hmMidMsn": STATE_CLEANING,  # Recharging at the middle of a cycle
     "hmPostMsn": STATE_RETURNING,  # Cycle finished
     "hmUsrDock": STATE_RETURNING,

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -3,6 +3,6 @@
   "name": "iRobot Roomba",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roomba",
-  "requirements": ["roombapy==1.6.1"],
+  "requirements": ["roombapy==1.6.2"],
   "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1954,7 +1954,7 @@ rocketchat-API==0.6.1
 rokuecp==0.6.0
 
 # homeassistant.components.roomba
-roombapy==1.6.1
+roombapy==1.6.2
 
 # homeassistant.components.roon
 roonapi==0.0.25

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -947,7 +947,7 @@ ring_doorbell==0.6.0
 rokuecp==0.6.0
 
 # homeassistant.components.roomba
-roombapy==1.6.1
+roombapy==1.6.2
 
 # homeassistant.components.roon
 roonapi==0.0.25

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the iRobot Roomba config flow."""
-from roomba import RoombaConnectionError
+from roombapy import RoombaConnectionError
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.roomba.const import (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Roomba i7+ and s9+ are capable of auto emptying, and will set their `phase` to `evac` when doing so. This adds a state mapping from `evac` to `STATE_RETURNING` so that the correct data ends up in home assistant. Previously this state would map to `STATE_ERROR`. #roomba
`STATE_CLEANING` was considered but `STATE_RETURNING` seems better as `STATE_CLEANING` refers to actively vacuuming the floor and not cleaning the bin. This `evac` state typically lasts 10 seconds. 
Roombapy support for evac status will be delivered in 1.6.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #43446 
- Link to documentation pull request: 
See also PR #39913 (already closed due to inactivity).

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
