### PR TITLE
Add tilt support to deCONZ covers

### DIFF
--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -11,6 +11,7 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION,
     SUPPORT_SET_TILT_POSITION,
     SUPPORT_STOP,
+    SUPPORT_STOP_TILT,
     CoverEntity,
 )
 from homeassistant.core import callback
@@ -67,6 +68,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
         if self._device.tilt is not None:
             self._features |= SUPPORT_OPEN_TILT
             self._features |= SUPPORT_CLOSE_TILT
+            self._features |= SUPPORT_STOP_TILT
             self._features |= SUPPORT_SET_TILT_POSITION
 
     @property
@@ -127,3 +129,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
     async def async_close_cover_tilt(self, **kwargs):
         """Close cover tilt."""
         await self._device.set_position(tilt=100)
+
+    async def async_stop_cover_tilt(self, **kwargs):
+        """Stop cover tilt."""
+        await self._device.stop()

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -1,11 +1,15 @@
 """Support for deCONZ covers."""
 from homeassistant.components.cover import (
     ATTR_POSITION,
+    ATTR_TILT_POSITION,
     DEVICE_CLASS_WINDOW,
     DOMAIN,
     SUPPORT_CLOSE,
+    SUPPORT_CLOSE_TILT,
     SUPPORT_OPEN,
+    SUPPORT_OPEN_TILT,
     SUPPORT_SET_POSITION,
+    SUPPORT_SET_TILT_POSITION,
     SUPPORT_STOP,
     CoverEntity,
 )
@@ -60,15 +64,15 @@ class DeconzCover(DeconzDevice, CoverEntity):
         self._features |= SUPPORT_STOP
         self._features |= SUPPORT_SET_POSITION
 
-    @property
-    def current_cover_position(self):
-        """Return the current position of the cover."""
-        return 100 - self._device.position
+        if self._device.tilt is not None:
+            self._features |= SUPPORT_OPEN_TILT
+            self._features |= SUPPORT_CLOSE_TILT
+            self._features |= SUPPORT_SET_TILT_POSITION
 
     @property
-    def is_closed(self):
-        """Return if the cover is closed."""
-        return not self._device.is_open
+    def supported_features(self):
+        """Flag supported features."""
+        return self._features
 
     @property
     def device_class(self):
@@ -79,14 +83,19 @@ class DeconzCover(DeconzDevice, CoverEntity):
             return DEVICE_CLASS_WINDOW
 
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        return self._features
+    def current_cover_position(self):
+        """Return the current position of the cover."""
+        return 100 - self._device.lift
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return not self._device.is_open
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         position = 100 - kwargs[ATTR_POSITION]
-        await self._device.set_position(position)
+        await self._device.set_position(lift=position)
 
     async def async_open_cover(self, **kwargs):
         """Open cover."""
@@ -99,3 +108,22 @@ class DeconzCover(DeconzDevice, CoverEntity):
     async def async_stop_cover(self, **kwargs):
         """Stop cover."""
         await self._device.stop()
+
+    @property
+    def current_cover_tilt_position(self):
+        """Return the current tilt position of the cover."""
+        if self._device.tilt is not None:
+            return 100 - self._device.tilt
+
+    async def async_set_cover_tilt_position(self, **kwargs):
+        """Tilt the cover to a specific position."""
+        position = 100 - kwargs[ATTR_TILT_POSITION]
+        await self._device.set_position(tilt=position)
+
+    async def async_open_cover_tilt(self, **kwargs):
+        """Open cover tilt."""
+        await self._device.set_position(tilt=0)
+
+    async def async_close_cover_tilt(self, **kwargs):
+        """Close cover tilt."""
+        await self._device.set_position(tilt=100)

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==74"],
+  "requirements": ["pydeconz==75"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1337,7 +1337,7 @@ pydaikin==2.3.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==74
+pydeconz==75
 
 # homeassistant.components.delijn
 pydelijn==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -670,7 +670,7 @@ pycountry==19.8.18
 pydaikin==2.3.1
 
 # homeassistant.components.deconz
-pydeconz==74
+pydeconz==75
 
 # homeassistant.components.dexcom
 pydexcom==0.2.0

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -14,6 +14,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
 )
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
@@ -317,3 +318,15 @@ async def test_tilt_cover(hass):
         )
         await hass.async_block_till_done()
         set_callback.assert_called_with("put", "/lights/0/state", json={"tilt": 100})
+
+    # Service stop cover movement
+
+    with patch.object(covering_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER_TILT,
+            {ATTR_ENTITY_ID: "cover.covering_device"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        set_callback.assert_called_with("put", "/lights/0/state", json={"stop": True})

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -3,11 +3,16 @@
 from copy import deepcopy
 
 from homeassistant.components.cover import (
+    ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
+    ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
 )
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
@@ -47,7 +52,7 @@ COVERS = {
         "id": "deconz old brightness cover id",
         "name": "deconz old brightness cover",
         "type": "Level controllable output",
-        "state": {"bri": 254, "on": False, "reachable": True},
+        "state": {"bri": 255, "on": False, "reachable": True},
         "modelid": "Not zigbee spec",
         "uniqueid": "00:00:00:00:00:00:00:03-00",
     },
@@ -165,7 +170,7 @@ async def test_cover(hass):
             blocking=True,
         )
         await hass.async_block_till_done()
-        set_callback.assert_called_with("put", "/lights/2/state", json={"bri_inc": 0})
+        set_callback.assert_called_with("put", "/lights/2/state", json={"stop": True})
 
     # Verify service calls for legacy cover
 
@@ -247,3 +252,68 @@ async def test_cover(hass):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     assert len(hass.states.async_all()) == 0
+
+
+async def test_tilt_cover(hass):
+    """Test that tilting a cover works."""
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["lights"] = {
+        "0": {
+            "etag": "87269755b9b3a046485fdae8d96b252c",
+            "lastannounced": None,
+            "lastseen": "2020-08-01T16:22:05Z",
+            "manufacturername": "AXIS",
+            "modelid": "Gear",
+            "name": "Covering device",
+            "state": {
+                "bri": 0,
+                "lift": 0,
+                "on": False,
+                "open": True,
+                "reachable": True,
+                "tilt": 0,
+            },
+            "swversion": "100-5.3.5.1122",
+            "type": "Window covering device",
+            "uniqueid": "00:24:46:00:00:12:34:56-01",
+        }
+    }
+    config_entry = await setup_deconz_integration(hass, get_state_response=data)
+    gateway = get_gateway_from_config_entry(hass, config_entry)
+
+    assert len(hass.states.async_all()) == 1
+    entity = hass.states.get("cover.covering_device")
+    assert entity.state == STATE_OPEN
+    assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 100
+
+    covering_device = gateway.api.lights["0"]
+
+    with patch.object(covering_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_TILT_POSITION,
+            {ATTR_ENTITY_ID: "cover.covering_device", ATTR_TILT_POSITION: 40},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        set_callback.assert_called_with("put", "/lights/0/state", json={"tilt": 60})
+
+    with patch.object(covering_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER_TILT,
+            {ATTR_ENTITY_ID: "cover.covering_device"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        set_callback.assert_called_with("put", "/lights/0/state", json={"tilt": 0})
+
+    with patch.object(covering_device, "_request", return_value=True) as set_callback:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER_TILT,
+            {ATTR_ENTITY_ID: "cover.covering_device"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        set_callback.assert_called_with("put", "/lights/0/state", json={"tilt": 100})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tilt support to deCONZ covers.
https://github.com/Kane610/deconz/compare/v74...v75

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
