### PR TITLE
Ensure MariaDB/MySQL can be purged and handle states being deleted out from under the recorder 

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -514,6 +514,14 @@ class Recorder(threading.Thread):
                         self.event_session.expunge(dbstate)
                 self._pending_expunge = []
             self.event_session.commit()
+        except exc.IntegrityError as err:
+            _LOGGER.error(
+                "Integrity error executing query (database likely deleted out from under us): %s",
+                err,
+            )
+            self.event_session.rollback()
+            self._old_states = {}
+            raise
         except Exception as err:
             _LOGGER.error("Error executing query: %s", err)
             self.event_session.rollback()

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1,12 +1,13 @@
 """Schema migration helpers."""
 import logging
 
-from sqlalchemy import Table, text
+from sqlalchemy import ForeignKeyConstraint, MetaData, Table, text
 from sqlalchemy.engine import reflection
 from sqlalchemy.exc import InternalError, OperationalError, SQLAlchemyError
+from sqlalchemy.schema import AddConstraint, DropConstraint
 
 from .const import DOMAIN
-from .models import SCHEMA_VERSION, Base, SchemaChanges
+from .models import SCHEMA_VERSION, TABLE_STATES, Base, SchemaChanges
 from .util import session_scope
 
 _LOGGER = logging.getLogger(__name__)
@@ -205,6 +206,39 @@ def _add_columns(engine, table_name, columns_def):
             )
 
 
+def _update_states_table_with_foreign_key_options(engine):
+    """Add the options to foreign key constraints."""
+    inspector = reflection.Inspector.from_engine(engine)
+    alters = []
+    for fk in inspector.get_foreign_keys(TABLE_STATES):
+        if fk["name"] and not fk["options"]:
+            alters.append(
+                {
+                    "old_fk": ForeignKeyConstraint((), (), name=fk["name"]),
+                    "columns": fk["constrained_columns"],
+                }
+            )
+
+    if not alters:
+        return
+
+    states_key_constraints = Base.metadata.tables[TABLE_STATES].foreign_key_constraints
+    old_states_table = Table(  # noqa: F841
+        TABLE_STATES, MetaData(), *[alter["old_fk"] for alter in alters]
+    )
+
+    for alter in alters:
+        try:
+            engine.execute(DropConstraint(alter["old_fk"]))
+            for fkc in states_key_constraints:
+                if fkc.column_keys == alter["columns"]:
+                    engine.execute(AddConstraint(fkc))
+        except (InternalError, OperationalError):
+            _LOGGER.exception(
+                "Could not update foreign options in % table", TABLE_STATES
+            )
+
+
 def _apply_update(engine, new_version, old_version):
     """Perform operations to bring schema up to date."""
     if new_version == 1:
@@ -277,6 +311,8 @@ def _apply_update(engine, new_version, old_version):
         _drop_index(engine, "states", "ix_states_entity_id")
         _create_index(engine, "events", "ix_events_event_type_time_fired")
         _drop_index(engine, "events", "ix_events_event_type")
+    elif new_version == 10:
+        _update_states_table_with_foreign_key_options(engine)
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -210,12 +210,12 @@ def _update_states_table_with_foreign_key_options(engine):
     """Add the options to foreign key constraints."""
     inspector = reflection.Inspector.from_engine(engine)
     alters = []
-    for fk in inspector.get_foreign_keys(TABLE_STATES):
-        if fk["name"] and not fk["options"]:
+    for foreign_key in inspector.get_foreign_keys(TABLE_STATES):
+        if foreign_key["name"] and not foreign_key["options"]:
             alters.append(
                 {
-                    "old_fk": ForeignKeyConstraint((), (), name=fk["name"]),
-                    "columns": fk["constrained_columns"],
+                    "old_fk": ForeignKeyConstraint((), (), name=foreign_key["name"]),
+                    "columns": foreign_key["constrained_columns"],
                 }
             )
 
@@ -223,7 +223,7 @@ def _update_states_table_with_foreign_key_options(engine):
         return
 
     states_key_constraints = Base.metadata.tables[TABLE_STATES].foreign_key_constraints
-    old_states_table = Table(  # noqa: F841
+    old_states_table = Table(  # noqa: F841 pylint: disable=unused-variable
         TABLE_STATES, MetaData(), *[alter["old_fk"] for alter in alters]
     )
 
@@ -235,7 +235,7 @@ def _update_states_table_with_foreign_key_options(engine):
                     engine.execute(AddConstraint(fkc))
         except (InternalError, OperationalError):
             _LOGGER.exception(
-                "Could not update foreign options in % table", TABLE_STATES
+                "Could not update foreign options in %s table", TABLE_STATES
             )
 
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -102,11 +102,11 @@ class States(Base):  # type: ignore
     entity_id = Column(String(255))
     state = Column(String(255))
     attributes = Column(Text)
-    event_id = Column(Integer, ForeignKey("events.event_id"), index=True)
+    event_id = Column(Integer, ForeignKey("events.event_id", ondelete="SET NULL"), index=True)
     last_changed = Column(DateTime(timezone=True), default=dt_util.utcnow)
     last_updated = Column(DateTime(timezone=True), default=dt_util.utcnow, index=True)
     created = Column(DateTime(timezone=True), default=dt_util.utcnow)
-    old_state_id = Column(Integer, ForeignKey("states.state_id"))
+    old_state_id = Column(Integer, ForeignKey("states.state_id", ondelete="SET NULL"), index=True)
     event = relationship("Events", uselist=False)
     old_state = relationship("States", remote_side=[state_id])
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -102,11 +102,15 @@ class States(Base):  # type: ignore
     entity_id = Column(String(255))
     state = Column(String(255))
     attributes = Column(Text)
-    event_id = Column(Integer, ForeignKey("events.event_id", ondelete="SET NULL"), index=True)
+    event_id = Column(
+        Integer, ForeignKey("events.event_id", ondelete="SET NULL"), index=True
+    )
     last_changed = Column(DateTime(timezone=True), default=dt_util.utcnow)
     last_updated = Column(DateTime(timezone=True), default=dt_util.utcnow, index=True)
     created = Column(DateTime(timezone=True), default=dt_util.utcnow)
-    old_state_id = Column(Integer, ForeignKey("states.state_id", ondelete="SET NULL"), index=True)
+    old_state_id = Column(
+        Integer, ForeignKey("states.state_id", ondelete="SET NULL"), index=True
+    )
     event = relationship("Events", uselist=False)
     old_state = relationship("States", remote_side=[state_id])
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -103,7 +103,7 @@ class States(Base):  # type: ignore
     state = Column(String(255))
     attributes = Column(Text)
     event_id = Column(
-        Integer, ForeignKey("events.event_id", ondelete="SET NULL"), index=True
+        Integer, ForeignKey("events.event_id", ondelete="CASCADE"), index=True
     )
     last_changed = Column(DateTime(timezone=True), default=dt_util.utcnow)
     last_updated = Column(DateTime(timezone=True), default=dt_util.utcnow, index=True)

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ TABLE_STATES = "states"
 TABLE_RECORDER_RUNS = "recorder_runs"
 TABLE_SCHEMA_CHANGES = "schema_changes"
 
-ALL_TABLES = [TABLE_EVENTS, TABLE_STATES, TABLE_RECORDER_RUNS, TABLE_SCHEMA_CHANGES]
+ALL_TABLES = [TABLE_STATES, TABLE_EVENTS, TABLE_RECORDER_RUNS, TABLE_SCHEMA_CHANGES]
 
 
 class Events(Base):  # type: ignore


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Relationships within table "states" and between tables `states` and `events` prevent the purge from working correctly on some databases.

This proposal sets related indices to NULL or CASCADE to permit deleting of old rows.

Further explanations can be found here home-assistant#42402

This proposal also allows to purge the tables "events" and "states" in any order.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42402
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
