### PR TITLE
Add support for multi-light Blinkstick devices 

### DIFF
--- a/homeassistant/components/blinksticklight/light.py
+++ b/homeassistant/components/blinksticklight/light.py
@@ -1,4 +1,4 @@
-"""Support for Blinkstick lights."""
+"""Support for Blinkstick Square lights."""
 from blinkstick import blinkstick
 import voluptuous as vol
 
@@ -18,7 +18,7 @@ CONF_SERIAL = "serial"
 
 CONF_INDEX = "index"
 
-DEFAULT_NAME = "Blinkstick"
+DEFAULT_NAME = "Blinkstick Square"
 
 DEFAULT_INDEX = 0
 
@@ -101,7 +101,9 @@ class BlinkStickLight(LightEntity):
         rgb_color = color_util.color_hsv_to_RGB(
             self._hs_color[0], self._hs_color[1], self._brightness / 255 * 100
         )
-        self._stick.set_color(red=rgb_color[0], green=rgb_color[1], blue=rgb_color[2], index=self._index)
+        self._stick.set_color(
+            red=rgb_color[0], green=rgb_color[1], blue=rgb_color[2], index=self._index
+        )
 
     def turn_off(self, **kwargs):
         """Turn the device off."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds support for Blinkstick devices with more than one LED, by exposing the Blinkstick Python library's `index` value as a configuration option.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml entry for a single-LED Blinkstick
light:
  - serial: BS030781-3.0
    platform: blinksticklight
```
```yaml
# Example configuration.yaml entry for an 8-LED Blinkstick Square
light:
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 0
    name: Blinkstick 0
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 1
    name: Blinkstick 1
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 2
    name: Blinkstick 2
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 3
    name: Blinkstick 3
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 4
    name: Blinkstick 4
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 5
    name: Blinkstick 5
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 6
    name: Blinkstick 6
  - serial: BS030781-3.0
    platform: blinksticklight
    index: 7
    name: Blinkstick 7
```


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15747

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
