### PR TITLE
Move uptime from relative time to absolute time

### DIFF
--- a/homeassistant/components/uptime/sensor.py
+++ b/homeassistant/components/uptime/sensor.py
@@ -1,5 +1,4 @@
 """Platform to retrieve uptime for Home Assistant."""
-import logging
 
 import voluptuous as vol
 
@@ -9,12 +8,10 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
-_LOGGER = logging.getLogger(__name__)
-
 DEFAULT_NAME = "Uptime"
 
 PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_UNIT_OF_MEASUREMENT, invalidation_version="0.119"),
+    cv.deprecated(CONF_UNIT_OF_MEASUREMENT),
     PLATFORM_SCHEMA.extend(
         {
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -56,6 +53,7 @@ class UptimeSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
-    async def async_update(self):
-        """Update the state of the sensor."""
-        return self._state
+    @property
+    def should_poll(self) -> bool:
+        """Disable polling for this entity."""
+        return False

--- a/homeassistant/components/uptime/sensor.py
+++ b/homeassistant/components/uptime/sensor.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import DEVICE_CLASS_TIMESTAMP, PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
@@ -13,10 +13,16 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Uptime"
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
+PLATFORM_SCHEMA = vol.All(
+    cv.deprecated(CONF_UNIT_OF_MEASUREMENT, invalidation_version="0.119"),
+    PLATFORM_SCHEMA.extend(
+        {
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT, default="days"): vol.All(
+                cv.string, vol.In(["minutes", "hours", "days", "seconds"])
+            ),
+        }
+    ),
 )
 
 
@@ -33,8 +39,7 @@ class UptimeSensor(Entity):
     def __init__(self, name):
         """Initialize the uptime sensor."""
         self._name = name
-        self.initial = dt_util.now().isoformat()
-        self._state = None
+        self._state = dt_util.now().isoformat()
 
     @property
     def name(self):
@@ -53,4 +58,4 @@ class UptimeSensor(Entity):
 
     async def async_update(self):
         """Update the state of the sensor."""
-        self._state = self.initial
+        return self._state

--- a/homeassistant/components/uptime/sensor.py
+++ b/homeassistant/components/uptime/sensor.py
@@ -3,8 +3,8 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.components.sensor import DEVICE_CLASS_TIMESTAMP, PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
@@ -13,14 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Uptime"
 
-ICON = "mdi:clock"
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT, default="days"): vol.All(
-            cv.string, vol.In(["minutes", "hours", "days", "seconds"])
-        ),
     }
 )
 
@@ -28,19 +23,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the uptime sensor platform."""
     name = config.get(CONF_NAME)
-    units = config.get(CONF_UNIT_OF_MEASUREMENT)
 
-    async_add_entities([UptimeSensor(name, units)], True)
+    async_add_entities([UptimeSensor(name)], True)
 
 
 class UptimeSensor(Entity):
     """Representation of an uptime sensor."""
 
-    def __init__(self, name, unit):
+    def __init__(self, name):
         """Initialize the uptime sensor."""
         self._name = name
-        self._unit = unit
-        self.initial = dt_util.now()
+        self.initial = dt_util.now().isoformat()
         self._state = None
 
     @property
@@ -49,14 +42,9 @@ class UptimeSensor(Entity):
         return self._name
 
     @property
-    def icon(self):
-        """Icon to display in the front end."""
-        return ICON
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement the value is expressed in."""
-        return self._unit
+    def device_class(self):
+        """Return device class."""
+        return DEVICE_CLASS_TIMESTAMP
 
     @property
     def state(self):
@@ -65,16 +53,4 @@ class UptimeSensor(Entity):
 
     async def async_update(self):
         """Update the state of the sensor."""
-        delta = dt_util.now() - self.initial
-        div_factor = 3600
-
-        if self.unit_of_measurement == "days":
-            div_factor *= 24
-        elif self.unit_of_measurement == "minutes":
-            div_factor /= 60
-        elif self.unit_of_measurement == "seconds":
-            div_factor /= 3600
-
-        delta = delta.total_seconds() / div_factor
-        self._state = round(delta, 2)
-        _LOGGER.debug("New value: %s", delta)
+        self._state = self.initial

--- a/tests/components/uptime/test_sensor.py
+++ b/tests/components/uptime/test_sensor.py
@@ -1,19 +1,6 @@
 """The tests for the uptime sensor platform."""
-from datetime import timedelta
 
-from homeassistant.components.uptime.sensor import UptimeSensor
 from homeassistant.setup import async_setup_component
-
-from tests.async_mock import patch
-
-
-async def test_uptime_min_config(hass):
-    """Test minimum uptime configuration."""
-    config = {"sensor": {"platform": "uptime"}}
-    assert await async_setup_component(hass, "sensor", config)
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.uptime")
-    assert state.attributes.get("unit_of_measurement") == "days"
 
 
 async def test_uptime_sensor_name_change(hass):
@@ -21,65 +8,4 @@ async def test_uptime_sensor_name_change(hass):
     config = {"sensor": {"platform": "uptime", "name": "foobar"}}
     assert await async_setup_component(hass, "sensor", config)
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.foobar")
-    assert state.attributes.get("unit_of_measurement") == "days"
-
-
-async def test_uptime_sensor_config_hours(hass):
-    """Test uptime sensor with hours defined in config."""
-    config = {"sensor": {"platform": "uptime", "unit_of_measurement": "hours"}}
-    assert await async_setup_component(hass, "sensor", config)
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.uptime")
-    assert state.attributes.get("unit_of_measurement") == "hours"
-
-
-async def test_uptime_sensor_config_minutes(hass):
-    """Test uptime sensor with minutes defined in config."""
-    config = {"sensor": {"platform": "uptime", "unit_of_measurement": "minutes"}}
-    assert await async_setup_component(hass, "sensor", config)
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.uptime")
-    assert state.attributes.get("unit_of_measurement") == "minutes"
-
-
-async def test_uptime_sensor_days_output(hass):
-    """Test uptime sensor output data."""
-    sensor = UptimeSensor("test", "days")
-    assert sensor.unit_of_measurement == "days"
-    new_time = sensor.initial + timedelta(days=1)
-    with patch("homeassistant.util.dt.now", return_value=new_time):
-        await sensor.async_update()
-        assert sensor.state == 1.00
-    new_time = sensor.initial + timedelta(days=111.499)
-    with patch("homeassistant.util.dt.now", return_value=new_time):
-        await sensor.async_update()
-        assert sensor.state == 111.50
-
-
-async def test_uptime_sensor_hours_output(hass):
-    """Test uptime sensor output data."""
-    sensor = UptimeSensor("test", "hours")
-    assert sensor.unit_of_measurement == "hours"
-    new_time = sensor.initial + timedelta(hours=16)
-    with patch("homeassistant.util.dt.now", return_value=new_time):
-        await sensor.async_update()
-        assert sensor.state == 16.00
-    new_time = sensor.initial + timedelta(hours=72.499)
-    with patch("homeassistant.util.dt.now", return_value=new_time):
-        await sensor.async_update()
-        assert sensor.state == 72.50
-
-
-async def test_uptime_sensor_minutes_output(hass):
-    """Test uptime sensor output data."""
-    sensor = UptimeSensor("test", "minutes")
-    assert sensor.unit_of_measurement == "minutes"
-    new_time = sensor.initial + timedelta(minutes=16)
-    with patch("homeassistant.util.dt.now", return_value=new_time):
-        await sensor.async_update()
-        assert sensor.state == 16.00
-    new_time = sensor.initial + timedelta(minutes=12.499)
-    with patch("homeassistant.util.dt.now", return_value=new_time):
-        await sensor.async_update()
-        assert sensor.state == 12.50
+    assert hass.states.get("sensor.foobar")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
In order to optimize stability and performance of HomeAssistant, sensors should use only absolute time values (store the date of the event) and not relative time values (seconds from event) so the db value doesn't change each seconds.
"uptime" integration is one leftover, so to adhere to HomeAssistant development rules, the sensor is now changed to a timestamp.
Please review your lovelace config to reflect the change.

Moved uptime sensor from relative time to absolute time

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moved uptime sensor from relative time to absolute time

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40004
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15750

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
