### PR TITLE
Add Homematic option for jsonport for hosts

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -236,7 +236,7 @@ def setup(hass, config):
         remotes[sname] = {
             "ip": sconfig.get(CONF_HOST),
             "port": sconfig[CONF_PORT],
-            "jsonport": rconfig.get(CONF_JSONPORT),
+            "jsonport": sconfig.get(CONF_JSONPORT),
             "username": sconfig.get(CONF_USERNAME),
             "password": sconfig.get(CONF_PASSWORD),
             "connect": False,

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -139,6 +139,7 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.match_all: {
                         vol.Required(CONF_HOST): cv.string,
                         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                        vol.Optional(CONF_JSONPORT, default=DEFAULT_JSONPORT): cv.port,
                         vol.Optional(
                             CONF_USERNAME, default=DEFAULT_USERNAME
                         ): cv.string,
@@ -235,6 +236,7 @@ def setup(hass, config):
         remotes[sname] = {
             "ip": sconfig.get(CONF_HOST),
             "port": sconfig[CONF_PORT],
+            "jsonport": rconfig.get(CONF_JSONPORT),
             "username": sconfig.get(CONF_USERNAME),
             "password": sconfig.get(CONF_PASSWORD),
             "connect": False,


### PR DESCRIPTION
## Proposed change
This PR is related to the homematic component. It adds "jsonport" option for homematic configuration in HA. "jsonport" option already exist for "interfaces:" section, but not for "hosts:" section. The pyhomematic library already uses this jsonport option for both, interafces and hosts. This option is optioinal, therefore it is not a breaking change. The default value is specified in pyhomematic library as "80".
The "jsonport" option for hosts fix the issue/bug that occurs if the Web Interface of Homematic CCU is not on port 80, but on different port. In this case jsonrpc request from HA to CCU can not reach the CCU for hosts and as a result, for example, system variables of CCU can not be accessed from HA.
This PR can be considered as completion of these old PRs:
[https://github.com/home-assistant/core/pull/15029](https://github.com/home-assistant/core/pull/15029)
[https://github.com/danielperna84/pyhomematic/pull/137](https://github.com/danielperna84/pyhomematic/pull/137)

The respective change in documentation: [https://github.com/home-assistant/home-assistant.io/pull/15761](https://github.com/home-assistant/home-assistant.io/pull/15761)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
homematic:
  interfaces:
    rf:
      host: 127.0.0.1
      jsonport: 8888
      username: Admin
      password: xx_secret
    ip:
      host: 127.0.0.1
      port: 2010
      jsonport: 8888
      username: Admin
      password: xx_secret
    groups:
      host: 127.0.0.1
      port: 9292
      jsonport: 8888
      username: Admin
      password: xx_secret
      path: /groups
  hosts:
    ccu3:
      host: 127.0.0.1
      port: 2010
      jsonport: 8888
      username: Admin
      password: xx_secret

```

## Additional information

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
