### PR TITLE
Prefer shorter keys for intent matching

### DIFF
--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -169,10 +169,13 @@ def _fuzzymatch(name: str, items: Iterable[T], key: Callable[[T], str]) -> Optio
     for idx, item in enumerate(items):
         match = regex.search(key(item))
         if match:
-            # Add index so we pick first match in case same group and start
-            matches.append((len(match.group()), match.start(), idx, item))
+            # Add key length so we prefer shorter keys with the same group and start.
+            # Add index so we pick first match in case same group, start, and key length.
+            matches.append(
+                (len(match.group()), match.start(), len(key(item)), idx, item)
+            )
 
-    return sorted(matches)[0][3] if matches else None
+    return sorted(matches)[0][4] if matches else None
 
 
 class ServiceIntentHandler(IntentHandler):

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -38,3 +38,21 @@ def test_async_validate_slots():
     handler1.async_validate_slots(
         {"name": {"value": "kitchen"}, "probability": {"value": "0.5"}}
     )
+
+
+def test_fuzzy_match():
+    """Test _fuzzymatch."""
+    state1 = State("light.living_room_northwest", "off")
+    state2 = State("light.living_room_north", "off")
+    state3 = State("light.living_room_northeast", "off")
+    state4 = State("light.living_room_west", "off")
+    state5 = State("light.living_room", "off")
+    states = [state1, state2, state3, state4, state5]
+
+    state = intent._fuzzymatch("Living Room", states, lambda state: state.name)
+    assert state == state5
+
+    state = intent._fuzzymatch(
+        "Living Room Northwest", states, lambda state: state.name
+    )
+    assert state == state1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The method for matching entities in intents has changed slightly to prefer shorter matches before ordering. This means some intents and/or entity names may need to be adjusted to maintain consistency in some edge cases. For most uses, this should only improve the quality of matches.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When using fuzzy matching to match entity names for intents, whichever
entity is first is preferred in the case of equal matches. This leads
to situations where entities with similar names (such as entities named
for their area and then specific area location) may be used when the
whole area is wanted.

I ran into this with the my Phillips Hue lights. I have each individual
light named such that its room is the first part of the name, and its
location within the room after. So my living room has:
Living Room West
Living Room Northwest
Living Room North
Living Room Northeast

I then have a group for the whole room:
Living Room

Because the group is the last of the entities, trying to adjust the
whole room only activates one light, because all of the lights match
equally well.

By preferring the shortest of equal matches, we prefer keys that have
the least amount of extra information, causing "Living Room" to match
the group instead of an individual light.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
