### PR TITLE
Tweak invalidation_version for Hyperion Light

### DIFF
--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -80,6 +80,7 @@ SUPPORT_HYPERION = SUPPORT_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT
 
 # Usage of YAML for configuration of the Hyperion component is deprecated.
 PLATFORM_SCHEMA = vol.All(
+    cv.deprecated(CONF_HDMI_PRIORITY, invalidation_version="0.118"),
     cv.deprecated(CONF_HOST, invalidation_version="0.120"),
     cv.deprecated(CONF_PORT, invalidation_version="0.120"),
     cv.deprecated(CONF_DEFAULT_COLOR, invalidation_version="0.118"),

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -80,11 +80,11 @@ SUPPORT_HYPERION = SUPPORT_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT
 
 # Usage of YAML for configuration of the Hyperion component is deprecated.
 PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_HOST, invalidation_version="0.118"),
-    cv.deprecated(CONF_PORT, invalidation_version="0.118"),
+    cv.deprecated(CONF_HOST, invalidation_version="0.120"),
+    cv.deprecated(CONF_PORT, invalidation_version="0.120"),
     cv.deprecated(CONF_DEFAULT_COLOR, invalidation_version="0.118"),
-    cv.deprecated(CONF_NAME, invalidation_version="0.118"),
-    cv.deprecated(CONF_PRIORITY, invalidation_version="0.118"),
+    cv.deprecated(CONF_NAME, invalidation_version="0.120"),
+    cv.deprecated(CONF_PRIORITY, invalidation_version="0.120"),
     cv.deprecated(CONF_EFFECT_LIST, invalidation_version="0.118"),
     PLATFORM_SCHEMA.extend(
         {

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -81,11 +81,11 @@ SUPPORT_HYPERION = SUPPORT_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_EFFECT
 # Usage of YAML for configuration of the Hyperion component is deprecated.
 PLATFORM_SCHEMA = vol.All(
     cv.deprecated(CONF_HDMI_PRIORITY, invalidation_version="0.118"),
-    cv.deprecated(CONF_HOST, invalidation_version="0.120"),
-    cv.deprecated(CONF_PORT, invalidation_version="0.120"),
+    cv.deprecated(CONF_HOST),
+    cv.deprecated(CONF_PORT),
     cv.deprecated(CONF_DEFAULT_COLOR, invalidation_version="0.118"),
-    cv.deprecated(CONF_NAME, invalidation_version="0.120"),
-    cv.deprecated(CONF_PRIORITY, invalidation_version="0.120"),
+    cv.deprecated(CONF_NAME),
+    cv.deprecated(CONF_PRIORITY),
     cv.deprecated(CONF_EFFECT_LIST, invalidation_version="0.118"),
     PLATFORM_SCHEMA.extend(
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Before we merge the `add-hyperion-config-options-flow` branch into `dev`, we need to update the invalidation_version on the options that aren't required anymore -- as time has passed since this special branch was created. If we don't do this, it would immediately complain to users after merge.

There are 7 options for Hyperion on the `dev` branch. These 3 options are already invalidated, in `dev` at 0.118:
 - CONF_HDMI_PRIORITY
 - CONF_DEFAULT_COLOR
 - CONF_EFFECT_LIST

These 4 should be deprecated, but are used in unittests. Mark them as deprecated, but without an invalidation_version to ensure tests continue to pass until these codepaths are removed:
 - CONF_HOST
 - CONF_PORT
 - CONF_NAME
 - CONF_PRIORITY

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 43673
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
