### PR TITLE
Add cors_allowed for history component

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -454,6 +454,7 @@ class HistoryPeriodView(HomeAssistantView):
     url = "/api/history/period"
     name = "api:history:view-period"
     extra_urls = ["/api/history/period/{datetime}"]
+    cors_allowed = True
 
     def __init__(self, filters, use_include_order):
         """Initialize the history period view."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows making a cross-origin requests to /api/history/* REST API,
same as is already possible for other REST APIs listed at
https://developers.home-assistant.io/docs/api/rest/#actions

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
CORS has worked for other APIs but not this one because other API
endpoints are registered using register_view() in the "api" component [1]
and all of those are automatically CORS-enabled when app is ready [2].

The history component, on the other hand, also registers the
"HistoryPeriodView" using register_view() but does it later, after the
app is ready and that means it doesn't get the same treatment.

Fix by explicitly marking "HistoryPeriodView" [3] as having enabled CORS
so that it doesn't have to rely on the order of initialization.

[1] https://github.com/home-assistant/core/blob/edf70e9f06639123ff4221f1ab56b775e3303cd8/homeassistant/components/api/__init__.py#L59-L59
[2] https://github.com/home-assistant/core/blob/edf70e9f06639123ff4221f1ab56b775e3303cd8/homeassistant/components/http/cors.py#L73-L78
[3] https://github.com/home-assistant/core/blob/edf70e9f06639123ff4221f1ab56b775e3303cd8/homeassistant/components/history/__init__.py#L451-L451

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

So setting `cors_allowed_origins` is actually not necessary to make this fix work. I really wonder if that is broken also but it's not really relevant for this issue as it behaves the same way for other API endpoints also.

```yaml
# Example configuration.yaml
http:
  use_x_forwarded_for: true
  cors_allowed_origins:
    - http://localhost:8080
```

## Additional information

- This PR fixes or closes issue: fixes #39727
- This PR is related to issue: -
- Link to documentation pull request: -

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
