### PR TITLE
Bump pypck to v0.7.6

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -233,7 +233,6 @@ async def async_setup(hass, config):
         }
 
         connection = pypck.connection.PchkConnectionManager(
-            hass.loop,
             conf_connection[CONF_HOST],
             conf_connection[CONF_PORT],
             conf_connection[CONF_USERNAME],

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -119,10 +119,14 @@ class LcnClimate(LcnDevice, ClimateEntity):
         """Set new target hvac mode."""
         if hvac_mode == const.HVAC_MODE_HEAT:
             self._is_on = True
-            self.address_connection.lock_regulator(self.regulator_id, False)
+            self.hass.async_create_task(
+                self.address_connection.lock_regulator(self.regulator_id, False)
+            )
         elif hvac_mode == const.HVAC_MODE_OFF:
             self._is_on = False
-            self.address_connection.lock_regulator(self.regulator_id, True)
+            self.hass.async_create_task(
+                self.address_connection.lock_regulator(self.regulator_id, True)
+            )
             self._target_temperature = None
 
         self.async_write_ha_state()
@@ -134,8 +138,10 @@ class LcnClimate(LcnDevice, ClimateEntity):
             return
 
         self._target_temperature = temperature
-        self.address_connection.var_abs(
-            self.setpoint, self._target_temperature, self.unit
+        self.hass.async_create_task(
+            self.address_connection.var_abs(
+                self.setpoint, self._target_temperature, self.unit
+            )
         )
         self.async_write_ha_state()
 

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -17,6 +17,8 @@ from .const import (
 )
 from .helpers import get_connection
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_platform(
     hass, hass_config, async_add_entities, discovery_info=None
@@ -118,18 +120,20 @@ class LcnClimate(LcnDevice, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
         if hvac_mode == const.HVAC_MODE_HEAT:
+            if not await self.address_connection.lock_regulator(
+                self.regulator_id, False
+            ):
+                return
             self._is_on = True
-            self.hass.async_create_task(
-                self.address_connection.lock_regulator(self.regulator_id, False)
-            )
+            self.async_write_ha_state()
         elif hvac_mode == const.HVAC_MODE_OFF:
+            if not await self.address_connection.lock_regulator(
+                self.regulator_id, True
+            ):
+                return
             self._is_on = False
-            self.hass.async_create_task(
-                self.address_connection.lock_regulator(self.regulator_id, True)
-            )
             self._target_temperature = None
-
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -137,12 +141,11 @@ class LcnClimate(LcnDevice, ClimateEntity):
         if temperature is None:
             return
 
+        if not await self.address_connection.var_abs(
+            self.setpoint, self._target_temperature, self.unit
+        ):
+            return
         self._target_temperature = temperature
-        self.hass.async_create_task(
-            self.address_connection.var_abs(
-                self.setpoint, self._target_temperature, self.unit
-            )
-        )
         self.async_write_ha_state()
 
     def input_received(self, input_obj):

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -8,6 +8,8 @@ from . import LcnDevice
 from .const import CONF_CONNECTIONS, CONF_MOTOR, CONF_REVERSE_TIME, DATA_LCN
 from .helpers import get_connection
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_platform(
     hass, hass_config, async_add_entities, discovery_info=None
@@ -86,33 +88,34 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
+        state = pypck.lcn_defs.MotorStateModifier.DOWN
+        if not await self.address_connection.control_motors_outputs(
+            state, self.reverse_time
+        ):
+            return
         self._is_opening = False
         self._is_closing = True
-        state = pypck.lcn_defs.MotorStateModifier.DOWN
-        self.hass.async_create_task(
-            self.address_connection.control_motors_outputs(state, self.reverse_time)
-        )
         self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
+        state = pypck.lcn_defs.MotorStateModifier.UP
+        if not await self.address_connection.control_motors_outputs(
+            state, self.reverse_time
+        ):
+            return
         self._is_closed = False
         self._is_opening = True
         self._is_closing = False
-        state = pypck.lcn_defs.MotorStateModifier.UP
-        self.hass.async_create_task(
-            self.address_connection.control_motors_outputs(state, self.reverse_time)
-        )
         self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
+        state = pypck.lcn_defs.MotorStateModifier.STOP
+        if not await self.address_connection.control_motors_outputs(state):
+            return
         self._is_closing = False
         self._is_opening = False
-        state = pypck.lcn_defs.MotorStateModifier.STOP
-        self.hass.async_create_task(
-            self.address_connection.control_motors_outputs(state)
-        )
         self.async_write_ha_state()
 
     def input_received(self, input_obj):
@@ -182,36 +185,33 @@ class LcnRelayCover(LcnDevice, CoverEntity):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        self._is_opening = False
-        self._is_closing = True
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.DOWN
-        self.hass.async_create_task(
-            self.address_connection.control_motors_relays(states)
-        )
+        if not await self.address_connection.control_motors_relays(states):
+            return
+        self._is_opening = False
+        self._is_closing = True
         self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
+        states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
+        states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.UP
+        if not await self.address_connection.control_motors_relays(states):
+            return
         self._is_closed = False
         self._is_opening = True
         self._is_closing = False
-        states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
-        states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.UP
-        self.hass.async_create_task(
-            self.address_connection.control_motors_relays(states)
-        )
         self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        self._is_closing = False
-        self._is_opening = False
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.STOP
-        self.hass.async_create_task(
-            self.address_connection.control_motors_relays(states)
-        )
+        if not await self.address_connection.control_motors_relays(states):
+            return
+        self._is_closing = False
+        self._is_opening = False
         self.async_write_ha_state()
 
     def input_received(self, input_obj):

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -89,7 +89,9 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
         self._is_opening = False
         self._is_closing = True
         state = pypck.lcn_defs.MotorStateModifier.DOWN
-        self.address_connection.control_motors_outputs(state, self.reverse_time)
+        self.hass.async_create_task(
+            self.address_connection.control_motors_outputs(state, self.reverse_time)
+        )
         self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs):
@@ -98,7 +100,9 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
         self._is_opening = True
         self._is_closing = False
         state = pypck.lcn_defs.MotorStateModifier.UP
-        self.address_connection.control_motors_outputs(state, self.reverse_time)
+        self.hass.async_create_task(
+            self.address_connection.control_motors_outputs(state, self.reverse_time)
+        )
         self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs):
@@ -106,7 +110,9 @@ class LcnOutputsCover(LcnDevice, CoverEntity):
         self._is_closing = False
         self._is_opening = False
         state = pypck.lcn_defs.MotorStateModifier.STOP
-        self.address_connection.control_motors_outputs(state)
+        self.hass.async_create_task(
+            self.address_connection.control_motors_outputs(state)
+        )
         self.async_write_ha_state()
 
     def input_received(self, input_obj):
@@ -180,7 +186,9 @@ class LcnRelayCover(LcnDevice, CoverEntity):
         self._is_closing = True
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.DOWN
-        self.address_connection.control_motors_relays(states)
+        self.hass.async_create_task(
+            self.address_connection.control_motors_relays(states)
+        )
         self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs):
@@ -190,7 +198,9 @@ class LcnRelayCover(LcnDevice, CoverEntity):
         self._is_closing = False
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.UP
-        self.address_connection.control_motors_relays(states)
+        self.hass.async_create_task(
+            self.address_connection.control_motors_relays(states)
+        )
         self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs):
@@ -199,7 +209,9 @@ class LcnRelayCover(LcnDevice, CoverEntity):
         self._is_opening = False
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.STOP
-        self.address_connection.control_motors_relays(states)
+        self.hass.async_create_task(
+            self.address_connection.control_motors_relays(states)
+        )
         self.async_write_ha_state()
 
     def input_received(self, input_obj):

--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -21,6 +21,8 @@ from .const import (
 )
 from .helpers import get_connection
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_platform(
     hass, hass_config, async_add_entities, discovery_info=None
@@ -87,8 +89,6 @@ class LcnOutputLight(LcnDevice, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        self._is_on = True
-        self._is_dimming_to_zero = False
         if ATTR_BRIGHTNESS in kwargs:
             percent = int(kwargs[ATTR_BRIGHTNESS] / 255.0 * 100)
         else:
@@ -100,14 +100,16 @@ class LcnOutputLight(LcnDevice, LightEntity):
         else:
             transition = self._transition
 
-        self.hass.async_create_task(
-            self.address_connection.dim_output(self.output.value, percent, transition)
-        )
+        if not await self.address_connection.dim_output(
+            self.output.value, percent, transition
+        ):
+            return
+        self._is_on = True
+        self._is_dimming_to_zero = False
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        self._is_on = False
         if ATTR_TRANSITION in kwargs:
             transition = pypck.lcn_defs.time_to_ramp_value(
                 kwargs[ATTR_TRANSITION] * 1000
@@ -115,11 +117,12 @@ class LcnOutputLight(LcnDevice, LightEntity):
         else:
             transition = self._transition
 
+        if not await self.address_connection.dim_output(
+            self.output.value, 0, transition
+        ):
+            return
         self._is_dimming_to_zero = bool(transition)
-
-        self.hass.async_create_task(
-            self.address_connection.dim_output(self.output.value, 0, transition)
-        )
+        self._is_on = False
         self.async_write_ha_state()
 
     def input_received(self, input_obj):
@@ -161,22 +164,22 @@ class LcnRelayLight(LcnDevice, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        self._is_on = True
 
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.ON
-        self.hass.async_create_task(self.address_connection.control_relays(states))
-
+        if not await self.address_connection.control_relays(states):
+            return
+        self._is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        self._is_on = False
 
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.OFF
-        self.hass.async_create_task(self.address_connection.control_relays(states))
-
+        if not await self.address_connection.control_relays(states):
+            return
+        self._is_on = False
         self.async_write_ha_state()
 
     def input_received(self, input_obj):

--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -100,7 +100,9 @@ class LcnOutputLight(LcnDevice, LightEntity):
         else:
             transition = self._transition
 
-        self.address_connection.dim_output(self.output.value, percent, transition)
+        self.hass.async_create_task(
+            self.address_connection.dim_output(self.output.value, percent, transition)
+        )
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
@@ -115,7 +117,9 @@ class LcnOutputLight(LcnDevice, LightEntity):
 
         self._is_dimming_to_zero = bool(transition)
 
-        self.address_connection.dim_output(self.output.value, 0, transition)
+        self.hass.async_create_task(
+            self.address_connection.dim_output(self.output.value, 0, transition)
+        )
         self.async_write_ha_state()
 
     def input_received(self, input_obj):
@@ -161,7 +165,7 @@ class LcnRelayLight(LcnDevice, LightEntity):
 
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.ON
-        self.address_connection.control_relays(states)
+        self.hass.async_create_task(self.address_connection.control_relays(states))
 
         self.async_write_ha_state()
 
@@ -171,7 +175,7 @@ class LcnRelayLight(LcnDevice, LightEntity):
 
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.OFF
-        self.address_connection.control_relays(states)
+        self.hass.async_create_task(self.address_connection.control_relays(states))
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -2,6 +2,6 @@
   "domain": "lcn",
   "name": "LCN",
   "documentation": "https://www.home-assistant.io/integrations/lcn",
-  "requirements": ["pypck==0.7.4"],
+  "requirements": ["pypck==0.7.6"],
   "codeowners": ["@alengwenus"]
 }

--- a/homeassistant/components/lcn/scene.py
+++ b/homeassistant/components/lcn/scene.py
@@ -67,10 +67,12 @@ class LcnScene(LcnDevice, Scene):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene."""
-        self.address_connection.activate_scene(
-            self.register_id,
-            self.scene_id,
-            self.output_ports,
-            self.relay_ports,
-            self.transition,
+        self.hass.async_create_task(
+            self.address_connection.activate_scene(
+                self.register_id,
+                self.scene_id,
+                self.output_ports,
+                self.relay_ports,
+                self.transition,
+            )
         )

--- a/homeassistant/components/lcn/scene.py
+++ b/homeassistant/components/lcn/scene.py
@@ -18,6 +18,8 @@ from .const import (
 )
 from .helpers import get_connection
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_platform(
     hass, hass_config, async_add_entities, discovery_info=None
@@ -67,12 +69,10 @@ class LcnScene(LcnDevice, Scene):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene."""
-        self.hass.async_create_task(
-            self.address_connection.activate_scene(
-                self.register_id,
-                self.scene_id,
-                self.output_ports,
-                self.relay_ports,
-                self.transition,
-            )
+        await self.address_connection.activate_scene(
+            self.register_id,
+            self.scene_id,
+            self.output_ports,
+            self.relay_ports,
+            self.transition,
         )

--- a/homeassistant/components/lcn/switch.py
+++ b/homeassistant/components/lcn/switch.py
@@ -8,6 +8,8 @@ from . import LcnDevice
 from .const import CONF_CONNECTIONS, CONF_OUTPUT, DATA_LCN, OUTPUT_PORTS
 from .helpers import get_connection
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_platform(
     hass, hass_config, async_add_entities, discovery_info=None
@@ -57,18 +59,16 @@ class LcnOutputSwitch(LcnDevice, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
+        if not await self.address_connection.dim_output(self.output.value, 100, 0):
+            return
         self._is_on = True
-        self.hass.async_create_task(
-            self.address_connection.dim_output(self.output.value, 100, 0)
-        )
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
+        if not await self.address_connection.dim_output(self.output.value, 0, 0):
+            return
         self._is_on = False
-        self.hass.async_create_task(
-            self.address_connection.dim_output(self.output.value, 0, 0)
-        )
         self.async_write_ha_state()
 
     def input_received(self, input_obj):
@@ -106,20 +106,21 @@ class LcnRelaySwitch(LcnDevice, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        self._is_on = True
-
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.ON
-        self.hass.async_create_task(self.address_connection.control_relays(states))
+        if not await self.address_connection.control_relays(states):
+            return
+        self._is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        self._is_on = False
 
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.OFF
-        self.hass.async_create_task(self.address_connection.control_relays(states))
+        if not await self.address_connection.control_relays(states):
+            return
+        self._is_on = False
         self.async_write_ha_state()
 
     def input_received(self, input_obj):

--- a/homeassistant/components/lcn/switch.py
+++ b/homeassistant/components/lcn/switch.py
@@ -58,13 +58,17 @@ class LcnOutputSwitch(LcnDevice, SwitchEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
         self._is_on = True
-        self.address_connection.dim_output(self.output.value, 100, 0)
+        self.hass.async_create_task(
+            self.address_connection.dim_output(self.output.value, 100, 0)
+        )
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
         self._is_on = False
-        self.address_connection.dim_output(self.output.value, 0, 0)
+        self.hass.async_create_task(
+            self.address_connection.dim_output(self.output.value, 0, 0)
+        )
         self.async_write_ha_state()
 
     def input_received(self, input_obj):
@@ -106,7 +110,7 @@ class LcnRelaySwitch(LcnDevice, SwitchEntity):
 
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.ON
-        self.address_connection.control_relays(states)
+        self.hass.async_create_task(self.address_connection.control_relays(states))
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
@@ -115,7 +119,7 @@ class LcnRelaySwitch(LcnDevice, SwitchEntity):
 
         states = [pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
         states[self.output.value] = pypck.lcn_defs.RelayStateModifier.OFF
-        self.address_connection.control_relays(states)
+        self.hass.async_create_task(self.address_connection.control_relays(states))
         self.async_write_ha_state()
 
     def input_received(self, input_obj):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1607,7 +1607,7 @@ pyownet==0.10.0.post1
 pypca==0.0.7
 
 # homeassistant.components.lcn
-pypck==0.7.4
+pypck==0.7.6
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The logic operation sensor states are renamed from (`not`, `or`, `and`) to (`none`, `some`, `all`). The renaming is more consistent with the LCN naming convention.
When using the states in an automation ensure they are correctly renamed.


## Proposed change
The major changes:
- Methods invoking LCN actions have been changed to coroutines.
- Removed the loop parameter from all calls, as it's deprecated since Python 3.8
- Wrong formatters  caused an error message when logging the pypck module in debug level.

Release notes: https://github.com/alengwenus/pypck/releases
Code changes: https://github.com/alengwenus/pypck/compare/release-0.7.4...release-0.7.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [home-assistant/home-assistant.io#15767](https://github.com/home-assistant/home-assistant.io/pull/15767)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
