### PR TITLE
Update stream source to support refreshing nest streaming urls

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -279,10 +279,10 @@ async def async_setup(hass, config):
 
             # Double callback to bind loop variable camera
             def stream_source_cb(camera) -> Callable[[], Awaitable[StreamSource]]:
-                async def callback() -> StreamSource:
+                async def source_callback() -> StreamSource:
                     return await _async_get_request_stream_source(camera)
 
-                return callback
+                return source_callback
 
             await request_stream(hass, stream_source_cb(camera))
 

--- a/tests/components/stream/common.py
+++ b/tests/components/stream/common.py
@@ -5,7 +5,7 @@ import io
 import av
 import numpy as np
 
-from homeassistant.components.stream import Stream
+from homeassistant.components.stream import Stream, StreamSource
 from homeassistant.components.stream.const import ATTR_STREAMS, DOMAIN
 
 AUDIO_SAMPLE_RATE = 8000
@@ -92,11 +92,11 @@ def generate_h264_video(container_format="mp4", audio_codec=None):
     container.close()
     output.seek(0)
 
-    return output
+    return StreamSource(output)
 
 
 def preload_stream(hass, stream_source):
     """Preload a stream for use in tests."""
-    stream = Stream(hass, stream_source)
-    hass.data[DOMAIN][ATTR_STREAMS][stream_source] = stream
+    stream = Stream(hass, stream_source.source)
+    hass.data[DOMAIN][ATTR_STREAMS][stream_source.cache_key] = stream
     return stream


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add ability to update a stream to use a different stream source. The motivation is for `nest` camera streams that require an auth parameter which is updated to extend the lifetime of the stream.

Background: The Nest SDM API has an [RPC that generates a streaming URL](https://developers.google.com/nest/device-access/api/camera#access_a_live_stream) (contains an ?auth= param), and another [RPC that extends the lifetime](https://developers.google.com/nest/device-access/api/camera#extend_a_live_stream) of the stream giving a new ?auth= param to use instead.   That is, the stream is valid for 5 minutes and it needs to use a new URL.

For context, see the logic in `nest` for [refreshing the stream source](https://github.com/home-assistant/core/blob/dev/homeassistant/components/nest/camera_sdm.py#L115)

Problem: The existing camera + stream API expects a stable URL.  When the nest cam URLchanges, it ends up creating one stream every 5 minutes(!)

This change does not fully address the problem, but adds the glue to allow `stream` URL updates to be passed in from `camera`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #42793
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
