### PR TITLE
Add additional API calls to OpenSky for richer event data

### DIFF
--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -127,19 +127,17 @@ class OpenSkySensor(Entity):
 
     def _get_route(self, callsign):
         request = self._session.get(OPENSKY_ROUTE_API_URL + str(callsign))
-        _LOGGER.debug("Route API status: " + str(request.status_code))
+        _LOGGER.debug("Route API status: %d", request.status_code)
         if request.status_code == 200:
             return request.json()
-        else:
-            return None
+        return None
 
     def _get_plane_meta(self, icao24):
         request = self._session.get(OPENSKY_AIRPLANE_META_API_URL + str(icao24))
-        _LOGGER.debug("Plane Meta API status: " + str(request.status_code))
+        _LOGGER.debug("Plane Meta API status: %d", request.status_code)
         if request.status_code == 200:
             return request.json()
-        else:
-            return None
+        return None
 
     def _handle_boundary(self, flights, event, metadata):
         """Handle flights crossing region boundary."""
@@ -154,8 +152,8 @@ class OpenSkySensor(Entity):
 
             if flight in metadata and metadata[flight].get(ATTR_CALLSIGN) != "":
                 _LOGGER.debug(
-                    "Fetching route for callsign "
-                    + str(metadata[flight].get(ATTR_CALLSIGN))
+                    "Fetching route for callsign %s",
+                    str(metadata[flight].get(ATTR_CALLSIGN)),
                 )
                 route = self._get_route(metadata[flight].get(ATTR_CALLSIGN))
                 if route is not None:
@@ -167,7 +165,7 @@ class OpenSkySensor(Entity):
             else:
                 route = None
                 flightnumber = ""
-            _LOGGER.debug("Flight: " + flightnumber)
+            _LOGGER.debug("Flight: %s", flightnumber)
 
             if flight in metadata and metadata[flight].get(ATTR_ICAO24) != "":
                 planemeta = self._get_plane_meta(metadata[flight].get(ATTR_ICAO24))
@@ -186,7 +184,7 @@ class OpenSkySensor(Entity):
                 data = {**data, **route}
             if planemeta is not None:
                 data = {**data, **planemeta}
-            _LOGGER.debug("Fire event for: " + str(data))
+            _LOGGER.debug("Fire event for: %s", str(data))
             self._hass.bus.fire(event, data)
 
     def update(self):
@@ -194,7 +192,7 @@ class OpenSkySensor(Entity):
         currently_tracked = set()
         flight_metadata = {}
         states = self._session.get(OPENSKY_API_URL).json().get(ATTR_STATES)
-        _LOGGER.debug(str(len(states)) + " flights parsed")
+        _LOGGER.debug("%d flights parsed", len(states))
         for state in states:
             flight = dict(zip(OPENSKY_API_FIELDS, state))
             callsign = flight[ATTR_CALLSIGN].strip()

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -216,6 +216,8 @@ class OpenSkySensor(Entity):
             if distance is None or distance > self._radius:
                 continue
             altitude = flight.get(ATTR_ALTITUDE)
+            if altitude is None:
+                continue
             if altitude > self._altitude and self._altitude != 0:
                 continue
             currently_tracked.add(callsign)


### PR DESCRIPTION
This commit adds additional API calls to OpenSky to enrich the flight
data with route information (e.g. flight number) and meta data on the
airplane (e.g. type and registration) if this data is available. It also
provides some DEBUG log output now.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The OpenSky integration fires events when airplanes enter or exit the defined areas. This information was not very rich and did for example not include the commonly used flight numbers or airplane registration numbers even though this data is (now) available for many flights from OpenSky. This commit adds additional API calls when events are fired to enrich the data. This will allow for example more informative notifications from automations that react to the events or automations based on airplane type.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
The configuration is retained as before:
```yaml
# Example configuration.yaml
sensor:
  - platform: opensky
    radius: 10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: None open as far as I could see
- This PR is related to issue: None
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15775

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
