### PR TITLE
Add initial esphome climate presets

### DIFF
--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -174,10 +174,9 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
     @property
     def preset_modes(self):
         """Return preset modes."""
-        presets = []
+        presets = [PRESET_HOME]
         if self._static_info.supports_away:
             presets.append(PRESET_AWAY)
-            presets.append(PRESET_HOME)
         if self._static_info.supports_boost:
             presets.append(PRESET_BOOST)
         if self._static_info.supports_night:
@@ -312,30 +311,51 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
     async def async_set_preset_mode(self, preset_mode):
         """Set preset mode."""
         if preset_mode == "away":
-            await self._client.climate_command(key=self._static_info.key, boost=False)
-            await self._client.climate_command(key=self._static_info.key, night=False)
-            await self._client.climate_command(key=self._static_info.key, eco=False)
-            await self._client.climate_command(key=self._static_info.key, away=True)
+            if self._static_info.supports_away:
+                await self._client.climate_command(key=self._static_info.key, away=True)
+            if self._static_info.supports_boost:
+                await self._client.climate_command(key=self._static_info.key, boost=False)
+            if self._static_info.supports_night:
+                await self._client.climate_command(key=self._static_info.key, night=False)
+            if self._static_info.supports_eco:
+                await self._client.climate_command(key=self._static_info.key, eco=False)
+            
         if preset_mode == "home":
-            await self._client.climate_command(key=self._static_info.key, away=False)
-            await self._client.climate_command(key=self._static_info.key, boost=False)
-            await self._client.climate_command(key=self._static_info.key, eco=False)
-            await self._client.climate_command(key=self._static_info.key, night=False)
+            if self._static_info.supports_away:
+                await self._client.climate_command(key=self._static_info.key, away=False)
+            if self._static_info.supports_boost:
+                await self._client.climate_command(key=self._static_info.key, boost=False)
+            if self._static_info.supports_night:
+                await self._client.climate_command(key=self._static_info.key, night=False)
+            if self._static_info.supports_eco:
+                await self._client.climate_command(key=self._static_info.key, eco=False)
         if preset_mode == "boost":
-            await self._client.climate_command(key=self._static_info.key, away=False)
-            await self._client.climate_command(key=self._static_info.key, night=False)
-            await self._client.climate_command(key=self._static_info.key, eco=False)
-            await self._client.climate_command(key=self._static_info.key, boost=True)
+            if self._static_info.supports_away:
+                await self._client.climate_command(key=self._static_info.key, away=False)
+            if self._static_info.supports_boost:
+                await self._client.climate_command(key=self._static_info.key, boost=True)
+            if self._static_info.supports_night:
+                await self._client.climate_command(key=self._static_info.key, night=False)
+            if self._static_info.supports_eco:
+                await self._client.climate_command(key=self._static_info.key, eco=False)
         if preset_mode == "sleep":
-            await self._client.climate_command(key=self._static_info.key, away=False)
-            await self._client.climate_command(key=self._static_info.key, boost=False)
-            await self._client.climate_command(key=self._static_info.key, eco=False)
-            await self._client.climate_command(key=self._static_info.key, night=True)
+            if self._static_info.supports_away:
+                await self._client.climate_command(key=self._static_info.key, away=False)
+            if self._static_info.supports_boost:
+                await self._client.climate_command(key=self._static_info.key, boost=False)
+            if self._static_info.supports_night:
+                await self._client.climate_command(key=self._static_info.key, night=True)
+            if self._static_info.supports_eco:
+                await self._client.climate_command(key=self._static_info.key, eco=False)
         if preset_mode == "eco":
-            await self._client.climate_command(key=self._static_info.key, away=False)
-            await self._client.climate_command(key=self._static_info.key, boost=False)
-            await self._client.climate_command(key=self._static_info.key, night=False)
-            await self._client.climate_command(key=self._static_info.key, eco=True)
+            if self._static_info.supports_away:
+                await self._client.climate_command(key=self._static_info.key, away=False)
+            if self._static_info.supports_boost:
+                await self._client.climate_command(key=self._static_info.key, boost=False)
+            if self._static_info.supports_night:
+                await self._client.climate_command(key=self._static_info.key, night=False)
+            if self._static_info.supports_eco:
+                await self._client.climate_command(key=self._static_info.key, eco=True)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -255,16 +255,16 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
     @esphome_state_property
     def preset_mode(self):
         """Return current preset mode."""
+        state = ""
         if self._state.away:
             return PRESET_AWAY
-        elif self._state.boost:
+        if self._state.boost:
             return PRESET_BOOST
-        elif self._state.night:
+        if self._state.night:
             return PRESET_SLEEP
-        elif self._state.eco:
+        if self._state.eco:
             return PRESET_ECO
-        else:
-            return PRESET_HOME
+        return PRESET_HOME
 
     @esphome_state_property
     def swing_mode(self):

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -314,45 +314,73 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
             if self._static_info.supports_away:
                 await self._client.climate_command(key=self._static_info.key, away=True)
             if self._static_info.supports_boost:
-                await self._client.climate_command(key=self._static_info.key, boost=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, boost=False
+                )
             if self._static_info.supports_night:
-                await self._client.climate_command(key=self._static_info.key, night=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, night=False
+                )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
         if preset_mode == "home":
             if self._static_info.supports_away:
-                await self._client.climate_command(key=self._static_info.key, away=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, away=False
+                )
             if self._static_info.supports_boost:
-                await self._client.climate_command(key=self._static_info.key, boost=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, boost=False
+                )
             if self._static_info.supports_night:
-                await self._client.climate_command(key=self._static_info.key, night=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, night=False
+                )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
         if preset_mode == "boost":
             if self._static_info.supports_away:
-                await self._client.climate_command(key=self._static_info.key, away=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, away=False
+                )
             if self._static_info.supports_boost:
-                await self._client.climate_command(key=self._static_info.key, boost=True)
+                await self._client.climate_command(
+                    key=self._static_info.key, boost=True
+                )
             if self._static_info.supports_night:
-                await self._client.climate_command(key=self._static_info.key, night=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, night=False
+                )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
         if preset_mode == "sleep":
             if self._static_info.supports_away:
-                await self._client.climate_command(key=self._static_info.key, away=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, away=False
+                )
             if self._static_info.supports_boost:
-                await self._client.climate_command(key=self._static_info.key, boost=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, boost=False
+                )
             if self._static_info.supports_night:
-                await self._client.climate_command(key=self._static_info.key, night=True)
+                await self._client.climate_command(
+                    key=self._static_info.key, night=True
+                )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
         if preset_mode == "eco":
             if self._static_info.supports_away:
-                await self._client.climate_command(key=self._static_info.key, away=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, away=False
+                )
             if self._static_info.supports_boost:
-                await self._client.climate_command(key=self._static_info.key, boost=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, boost=False
+                )
             if self._static_info.supports_night:
-                await self._client.climate_command(key=self._static_info.key, night=False)
+                await self._client.climate_command(
+                    key=self._static_info.key, night=False
+                )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=True)
 

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -255,7 +255,6 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
     @esphome_state_property
     def preset_mode(self):
         """Return current preset mode."""
-        state = ""
         if self._state.away:
             return PRESET_AWAY
         if self._state.boost:

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -319,7 +319,6 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
                 await self._client.climate_command(key=self._static_info.key, night=False)
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
-            
         if preset_mode == "home":
             if self._static_info.supports_away:
                 await self._client.climate_command(key=self._static_info.key, away=False)

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -188,10 +188,6 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
         if self._static_info.supports_night:
            presets.append(PRESET_SLEEP)
            none_flag = True
-        ##Uncomment this to enable None preset - See row 269
-        #if none_flag:
-        #   presets.append(PRESET_NONE)
-
         return presets
 
     @property
@@ -261,11 +257,7 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
         if self._state.away: return PRESET_AWAY 
         elif self._state.boost: return PRESET_BOOST
         elif self._state.night: return PRESET_SLEEP
-        #####Change This to get preset None instead of preset Home when Idle - see row 196
-        #elif not self._static_info.supports_boost and not self._static_info.supports_night: 
-        #    return PRESET_HOME
-        #else: return PRESET_NONE
-        else: return PRESET_HOME #and comment this...
+        else: return PRESET_HOME
 
     @esphome_state_property
     def swing_mode(self):
@@ -329,11 +321,6 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
            await self._client.climate_command(key=self._static_info.key, away=False)
            await self._client.climate_command(key=self._static_info.key, boost=False)
            await self._client.climate_command(key=self._static_info.key, night=True) 
-        #Uncomment to make None available   
-        #if preset_mode == "none":
-        #   await self._client.climate_command(key=self._static_info.key, away=False)
-        #   await self._client.climate_command(key=self._static_info.key, boost=False)
-        #   await self._client.climate_command(key=self._static_info.key, night=False)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -179,7 +179,7 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
             presets.append(PRESET_AWAY)
         if self._static_info.supports_boost:
             presets.append(PRESET_BOOST)
-        if self._static_info.supports_night:
+        if self._static_info.supports_sleep_:
             presets.append(PRESET_SLEEP)
         if self._static_info.supports_eco:
             presets.append(PRESET_ECO)
@@ -219,7 +219,7 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
             features |= SUPPORT_TARGET_TEMPERATURE
         if (
             self._static_info.supports_away
-            or self._static_info.supports_night
+            or self._static_info.supports_sleep_
             or self._static_info.supports_boost
             or self._static_info.supports_eco
         ):
@@ -258,7 +258,7 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
             return PRESET_AWAY
         if self._state.boost:
             return PRESET_BOOST
-        if self._state.night:
+        if self._state.sleep_:
             return PRESET_SLEEP
         if self._state.eco:
             return PRESET_ECO
@@ -317,9 +317,9 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
                 await self._client.climate_command(
                     key=self._static_info.key, boost=False
                 )
-            if self._static_info.supports_night:
+            if self._static_info.supports_sleep_:
                 await self._client.climate_command(
-                    key=self._static_info.key, night=False
+                    key=self._static_info.key, sleep_=False
                 )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
@@ -332,9 +332,9 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
                 await self._client.climate_command(
                     key=self._static_info.key, boost=False
                 )
-            if self._static_info.supports_night:
+            if self._static_info.supports_sleep_:
                 await self._client.climate_command(
-                    key=self._static_info.key, night=False
+                    key=self._static_info.key, sleep_=False
                 )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
@@ -347,9 +347,9 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
                 await self._client.climate_command(
                     key=self._static_info.key, boost=True
                 )
-            if self._static_info.supports_night:
+            if self._static_info.supports_sleep_:
                 await self._client.climate_command(
-                    key=self._static_info.key, night=False
+                    key=self._static_info.key, sleep_=False
                 )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
@@ -362,9 +362,9 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
                 await self._client.climate_command(
                     key=self._static_info.key, boost=False
                 )
-            if self._static_info.supports_night:
+            if self._static_info.supports_sleep_:
                 await self._client.climate_command(
-                    key=self._static_info.key, night=True
+                    key=self._static_info.key, sleep_=True
                 )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=False)
@@ -377,9 +377,9 @@ class EsphomeClimateEntity(EsphomeEntity, ClimateEntity):
                 await self._client.climate_command(
                     key=self._static_info.key, boost=False
                 )
-            if self._static_info.supports_night:
+            if self._static_info.supports_sleep_:
                 await self._client.climate_command(
-                    key=self._static_info.key, night=False
+                    key=self._static_info.key, sleep_=False
                 )
             if self._static_info.supports_eco:
                 await self._client.climate_command(key=self._static_info.key, eco=True)

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==2.6.3"],
+  "requirements": ["aioesphomeapi==2.6.5"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "codeowners": ["@OttoWinter"],
   "after_dependencies": ["zeroconf", "tag"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
By tests seems that there aren't breaking changes. The presets logic was expandend maintaining the previous support

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
That mod allow to use "sleep" and "boost" presets in esphome climate integrations. It needs an updated version of aioesphomeapi to work. Without that it works as before. The "new" aioesphomeapi is already under PR, https://github.com/esphome/aioesphomeapi/pull/21
The version is https://github.com/fraschizzato/aioesphomeapi

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

~~There is some commented code. The fact is that original integration uses "home" preset as "none", to maintain the same user experience and to not create a breaking change I've maintained the same logic. The commented code is to restore/change to the "normal" preset mode, where when there's nothing it reports "none"~~

Tested as custom_components with bang-bang climate
In daily use as custom_components with (actually in PR) mideaAC integration

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
