### PR TITLE
Add metrics upload by UDP to graphite

### DIFF
--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -21,9 +21,11 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+PROTOCOL_TCP = "tcp"
+PROTOCOL_UDP = "udp"
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 2003
-DEFAULT_PROTOCOL = "tcp"
+DEFAULT_PROTOCOL = PROTOCOL_TCP
 DEFAULT_PREFIX = "ha"
 DOMAIN = "graphite"
 
@@ -34,7 +36,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                 vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL): vol.Any(
-                    "tcp", "udp"
+                    PROTOCOL_TCP, PROTOCOL_UDP
                 ),
                 vol.Optional(CONF_PREFIX, default=DEFAULT_PREFIX): cv.string,
             }
@@ -52,7 +54,7 @@ def setup(hass, config):
     port = conf.get(CONF_PORT)
     protocol = conf.get(CONF_PROTOCOL)
 
-    if protocol == "tcp":
+    if protocol == PROTOCOL_TCP:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((host, port))
@@ -110,7 +112,7 @@ class GraphiteFeeder(threading.Thread):
 
     def _send_to_graphite(self, data):
         """Send data to Graphite."""
-        if self._protocol == "tcp":
+        if self._protocol == PROTOCOL_TCP:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(10)
             sock.connect((self._host, self._port))

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -53,7 +53,9 @@ class TestGraphite(unittest.TestCase):
     @patch("homeassistant.components.graphite.GraphiteFeeder")
     def test_full_udp_config(self, mock_gf, mock_socket):
         """Test setup with full configuration and UDP protocol."""
-        config = {"graphite": {"host": "foo", "port": 123, "protocol": "udp", "prefix": "me"}}
+        config = {
+            "graphite": {"host": "foo", "port": 123, "protocol": "udp", "prefix": "me"}
+        }
 
         assert setup_component(self.hass, graphite.DOMAIN, config)
         assert mock_gf.call_count == 1

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -24,7 +24,7 @@ class TestGraphite(unittest.TestCase):
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.gf = graphite.GraphiteFeeder(self.hass, "foo", 123, "ha")
+        self.gf = graphite.GraphiteFeeder(self.hass, "foo", 123, "tcp", "ha")
 
     def teardown_method(self, method):
         """Stop everything that was started."""
@@ -63,7 +63,7 @@ class TestGraphite(unittest.TestCase):
     def test_subscribe(self):
         """Test the subscription."""
         fake_hass = mock.MagicMock()
-        gf = graphite.GraphiteFeeder(fake_hass, "foo", 123, "ha")
+        gf = graphite.GraphiteFeeder(fake_hass, "foo", 123, "tcp", "ha")
         fake_hass.bus.listen_once.has_calls(
             [
                 mock.call(EVENT_HOMEASSISTANT_START, gf.start_listen),

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -45,9 +45,21 @@ class TestGraphite(unittest.TestCase):
 
         assert setup_component(self.hass, graphite.DOMAIN, config)
         assert mock_gf.call_count == 1
-        assert mock_gf.call_args == mock.call(self.hass, "foo", 123, "me")
+        assert mock_gf.call_args == mock.call(self.hass, "foo", 123, "tcp", "me")
         assert mock_socket.call_count == 1
         assert mock_socket.call_args == mock.call(socket.AF_INET, socket.SOCK_STREAM)
+
+    @patch("socket.socket")
+    @patch("homeassistant.components.graphite.GraphiteFeeder")
+    def test_full_udp_config(self, mock_gf, mock_socket):
+        """Test setup with full configuration and UDP protocol."""
+        config = {"graphite": {"host": "foo", "port": 123, "protocol": "udp", "prefix": "me"}}
+
+        assert setup_component(self.hass, graphite.DOMAIN, config)
+        assert mock_gf.call_count == 1
+        assert mock_gf.call_args == mock.call(self.hass, "foo", 123, "udp", "me")
+        assert mock_socket.call_count == 1
+        assert mock_socket.call_args == mock.call(socket.AF_INET, socket.SOCK_DGRAM)
 
     @patch("socket.socket")
     @patch("homeassistant.components.graphite.GraphiteFeeder")

--- a/tests/components/graphite/test_init.py
+++ b/tests/components/graphite/test_init.py
@@ -60,8 +60,7 @@ class TestGraphite(unittest.TestCase):
         assert setup_component(self.hass, graphite.DOMAIN, config)
         assert mock_gf.call_count == 1
         assert mock_gf.call_args == mock.call(self.hass, "foo", 123, "udp", "me")
-        assert mock_socket.call_count == 1
-        assert mock_socket.call_args == mock.call(socket.AF_INET, socket.SOCK_DGRAM)
+        assert mock_socket.call_count == 0
 
     @patch("socket.socket")
     @patch("homeassistant.components.graphite.GraphiteFeeder")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Graphite supports receiving metrics not only by TCP (implemented in HA-plugin yet) but also by UDP. In many cases this way is preferred because it does not need to establish connection for each send (like it's right now in plugin) and usually you don't care single metric is lost. It's also better to send metrics with UDP over VPN.
I've added UDP support to HA-plugin. It does not break anything - TCP is still used by default.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
graphite:
  protocol: udp
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15780

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
