### PR TITLE
Add all installed apps in the androidtv sources list

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
     "adb-shell[async]==0.2.1",
-    "androidtv[async]==0.0.54",
+    "androidtv[async]==0.0.56",
     "pure-python-adb[async]==0.3.0.dev0"
   ],
   "codeowners": ["@JeffLIrion"]

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -793,7 +793,7 @@ class FireTVDevice(ADBDevice):
         if self._state is None:
             self._available = False
 
-        if running_apps:
+        if running_apps and self._source_provider == SOURCE_PROVIDER_RUNNING_APPS:
             sources = [
                 self._app_id_to_name.get(
                     app_id, app_id if not self._exclude_unnamed_apps else None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -245,7 +245,7 @@ ambiclimate==0.2.1
 amcrest==1.7.0
 
 # homeassistant.components.androidtv
-androidtv[async]==0.0.54
+androidtv[async]==0.0.56
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ airly==1.0.0
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv[async]==0.0.54
+androidtv[async]==0.0.56
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -181,6 +181,14 @@ def patch_androidtv_update(
     )
 
 
+def patch_installed_apps(apps):
+    """Patch the AndrdoiTV.get_installed_apps method."""
+    return patch(
+        "androidtv.basetv.basetv_async.BaseTVAsync.get_installed_apps",
+        return_value=apps,
+    )
+
+
 PATCH_LAUNCH_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.launch_app")
 PATCH_STOP_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.stop_app")
 


### PR DESCRIPTION
In python-androidtv =< 0.0.54 apps were exposed but they were only the running apps. For me and I'd assume others, this isn't really ideal as I'm not going to have all my wanted apps running all of the time.

I modified python-androidtv to include querying installed apps, this has been released in python-androidtv 0.0.55

This PR updates the python-androidtv module to 0.0.55 and adds a configuration option of `source_provider` defaulting to `running_apps` to maintain the previous behaviour but also supporting a value of `installed_apps` to switch over to using the installed apps list to populate the sources on home assistant.

## Breaking change

Breaking change has been avoided by defaulting `source_provider` to the original behaviour

## Proposed change

Introduce a `source_provider` configuration option that allows a user to use a list of installed android apps rather than running android apps

## Type of change

- [x] Dependency upgrade
- [x] New feature (which adds functionality to an existing integration)

## Example entry for `configuration.yaml`:

```yaml
media_player:
  - platform: androidtv
    name: Test ABCD
    host: 192.168.20.132
    device_class: androidtv
    get_sources: false
    source_provider: installed_apps
    exclude_unnamed_apps: true
```

## Additional information

This is related to https://github.com/JeffLIrion/python-androidtv/pull/218 thanks to @JeffLIrion for reviewing, merging and releasing.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]