### PR TITLE
Make plex media players update position on state change

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -195,6 +195,8 @@ class PlexMediaPlayer(MediaPlayerEntity):
 
         self._available = self.device or self.session
 
+        old_player_state = self._player_state
+
         if self.device:
             try:
                 device_url = self.device.url("/")
@@ -239,7 +241,12 @@ class PlexMediaPlayer(MediaPlayerEntity):
             if self._media_position is not None:
                 pos_diff = position - self._media_position
                 time_diff = now - self._media_position_updated_at
-                if pos_diff != 0 and abs(time_diff.total_seconds() - pos_diff) > 5:
+                if (
+                    pos_diff != 0
+                    and abs(time_diff.total_seconds() - pos_diff) > 5
+                    # Make sure time correct time is displayed on paused players
+                    or (self._player_state != old_player_state)
+                ):
                     self._media_position_updated_at = now
                     self._media_position = position
             else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, media players for plex do throttled updates for the `media_position` attribute.
This means that when a player is paused, it displays the incorrect position and there's no way to work out what the actual position is.

This change changes the throttle logic slightly so that if the player state changed (e.g `paused` to `playing`, or vice-versa), it updates the position anyway.

This way, frontend components can always work out the current exact media position with the following logic:
- if player state is `paused`, then the current value is correct
- if player state is `playing`, then current position is `media_position` + time delta between `now` and `media_position_updated_at`.

This will reduce the throttling slightly, and I hope that's okay. If not, please let me know and we can discuss alternate ways of allowing frontend components to determine the exact position of a plex media player. 
Also happy to make any improvements to the proposed code change; just let me know :smile: 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
