### PR TITLE
Bump libpurecool to 0.6.4

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -117,7 +117,6 @@ homeassistant/components/dunehd/* @bieniu
 homeassistant/components/dwd_weather_warnings/* @runningman84 @stephan192 @Hummel95
 homeassistant/components/dweet/* @fabaff
 homeassistant/components/dynalite/* @ziv1234
-homeassistant/components/dyson/* @etheralm
 homeassistant/components/eafm/* @Jc2k
 homeassistant/components/ecobee/* @marthoc
 homeassistant/components/ecovacs/* @OverloadUT

--- a/homeassistant/components/dyson/manifest.json
+++ b/homeassistant/components/dyson/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dyson",
   "name": "Dyson",
   "documentation": "https://www.home-assistant.io/integrations/dyson",
-  "requirements": ["libpurecool==0.6.3"],
+  "requirements": ["libpurecool==0.6.4"],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@etheralm"]
 }

--- a/homeassistant/components/dyson/manifest.json
+++ b/homeassistant/components/dyson/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/integrations/dyson",
   "requirements": ["libpurecool==0.6.4"],
   "after_dependencies": ["zeroconf"],
-  "codeowners": ["@etheralm"]
+  "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -856,7 +856,7 @@ konnected==1.2.0
 lakeside==0.12
 
 # homeassistant.components.dyson
-libpurecool==0.6.3
+libpurecool==0.6.4
 
 # homeassistant.components.foscam
 libpyfoscam==1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -441,7 +441,7 @@ keyrings.alt==3.4.0
 konnected==1.2.0
 
 # homeassistant.components.dyson
-libpurecool==0.6.3
+libpurecool==0.6.4
 
 # homeassistant.components.mikrotik
 librouteros==3.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `libpurecool` to 0.6.4.

Changelog: <https://github.com/etheralm/libpurecool/blob/master/RELEASES.rst#version-064>
Git compare diff: <https://github.com/etheralm/libpurecool/compare/03c79bdfbadb2aede56f9e54e7ecce28dd30ee88...bac70fc7788dc263df918dadc0d46bf14867c985>

Additionally removes the code ownership for the Dyson integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41027 fixes #43643
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
