### PR TITLE
Cleanup unique_id on onewire integration

### DIFF
--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -108,6 +108,7 @@ def get_entities(onewirehub: OneWireHub):
             device_file = os.path.join(
                 os.path.split(device["path"])[0], device_sensor["path"]
             )
+            unique_id = f"/{sensor_id}/{device_sensor['path']}"
             entities.append(
                 OneWireProxyBinarySensor(
                     sensor_id,
@@ -117,6 +118,7 @@ def get_entities(onewirehub: OneWireHub):
                     device_info,
                     device_sensor.get("default_disabled", False),
                     onewirehub.owproxy,
+                    unique_id,
                 )
             )
 

--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -94,31 +94,28 @@ def get_entities(onewirehub: OneWireHub):
     for device in onewirehub.devices:
         family = device["family"]
         device_type = device["type"]
-        sensor_id = os.path.split(os.path.split(device["path"])[0])[1]
+        device_id = os.path.split(os.path.split(device["path"])[0])[1]
 
         if family not in DEVICE_BINARY_SENSORS:
             continue
         device_info = {
-            "identifiers": {(DOMAIN, sensor_id)},
+            "identifiers": {(DOMAIN, device_id)},
             "manufacturer": "Maxim Integrated",
             "model": device_type,
-            "name": sensor_id,
+            "name": device_id,
         }
-        for device_sensor in DEVICE_BINARY_SENSORS[family]:
-            device_file = os.path.join(
-                os.path.split(device["path"])[0], device_sensor["path"]
+        for entity_specs in DEVICE_BINARY_SENSORS[family]:
+            entity_path = os.path.join(
+                os.path.split(device["path"])[0], entity_specs["path"]
             )
-            unique_id = f"/{sensor_id}/{device_sensor['path']}"
             entities.append(
                 OneWireProxyBinarySensor(
-                    sensor_id,
-                    device_file,
-                    device_sensor["type"],
-                    device_sensor["name"],
-                    device_info,
-                    device_sensor.get("default_disabled", False),
-                    onewirehub.owproxy,
-                    unique_id,
+                    device_id=device_id,
+                    device_name=device_id,
+                    device_info=device_info,
+                    entity_path=entity_path,
+                    entity_specs=entity_specs,
+                    owproxy=onewirehub.owproxy,
                 )
             )
 

--- a/homeassistant/components/onewire/onewire_entities.py
+++ b/homeassistant/components/onewire/onewire_entities.py
@@ -83,24 +83,22 @@ class OneWireProxyEntity(OneWireBaseEntity):
 
     def __init__(
         self,
-        name: str,
-        device_file: str,
-        entity_type: str,
-        entity_name: str,
+        device_id: str,
+        device_name: str,
         device_info: Dict[str, Any],
-        default_disabled: bool,
+        entity_path: str,
+        entity_specs: Dict[str, Any],
         owproxy: protocol._Proxy,
-        unique_id: str,
     ):
         """Initialize the sensor."""
         super().__init__(
-            name,
-            device_file,
-            entity_type,
-            entity_name,
-            device_info,
-            default_disabled,
-            unique_id,
+            name=device_name,
+            device_file=entity_path,
+            entity_type=entity_specs["type"],
+            entity_name=entity_specs["name"],
+            device_info=device_info,
+            default_disabled=entity_specs.get("default_disabled", False),
+            unique_id=f"/{device_id}/{entity_specs['path']}",
         )
         self._owproxy = owproxy
 

--- a/homeassistant/components/onewire/onewire_entities.py
+++ b/homeassistant/components/onewire/onewire_entities.py
@@ -28,6 +28,7 @@ class OneWireBaseEntity(Entity):
         entity_name: str = None,
         device_info=None,
         default_disabled: bool = False,
+        unique_id: str = None,
     ):
         """Initialize the entity."""
         self._name = f"{name} {entity_name or entity_type.capitalize()}"
@@ -39,6 +40,7 @@ class OneWireBaseEntity(Entity):
         self._state = None
         self._value_raw = None
         self._default_disabled = default_disabled
+        self._unique_id = unique_id or device_file
 
     @property
     def name(self) -> Optional[str]:
@@ -63,7 +65,7 @@ class OneWireBaseEntity(Entity):
     @property
     def unique_id(self) -> Optional[str]:
         """Return a unique ID."""
-        return self._device_file
+        return self._unique_id
 
     @property
     def device_info(self) -> Optional[Dict[str, Any]]:
@@ -88,10 +90,17 @@ class OneWireProxyEntity(OneWireBaseEntity):
         device_info: Dict[str, Any],
         default_disabled: bool,
         owproxy: protocol._Proxy,
+        unique_id: str,
     ):
         """Initialize the sensor."""
         super().__init__(
-            name, device_file, entity_type, entity_name, device_info, default_disabled
+            name,
+            device_file,
+            entity_type,
+            entity_name,
+            device_info,
+            default_disabled,
+            unique_id,
         )
         self._owproxy = owproxy
 

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -277,6 +277,7 @@ def get_entities(onewirehub: OneWireHub, config):
                 device_file = os.path.join(
                     os.path.split(device["path"])[0], device_sensor["path"]
                 )
+                unique_id = f"/{sensor_id}/{device_sensor['path']}"
                 entities.append(
                     OneWireProxySensor(
                         device_names.get(sensor_id, sensor_id),
@@ -286,6 +287,7 @@ def get_entities(onewirehub: OneWireHub, config):
                         device_info,
                         device_sensor.get("default_disabled", False),
                         onewirehub.owproxy,
+                        unique_id,
                     )
                 )
 

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -244,7 +244,7 @@ def get_entities(onewirehub: OneWireHub, config):
         for device in onewirehub.devices:
             family = device["family"]
             device_type = device["type"]
-            sensor_id = os.path.split(os.path.split(device["path"])[0])[1]
+            device_id = os.path.split(os.path.split(device["path"])[0])[1]
             dev_type = "std"
             if "EF" in family:
                 dev_type = "HobbyBoard"
@@ -254,40 +254,37 @@ def get_entities(onewirehub: OneWireHub, config):
                 _LOGGER.warning(
                     "Ignoring unknown family (%s) of sensor found for device: %s",
                     family,
-                    sensor_id,
+                    device_id,
                 )
                 continue
             device_info = {
-                "identifiers": {(DOMAIN, sensor_id)},
+                "identifiers": {(DOMAIN, device_id)},
                 "manufacturer": "Maxim Integrated",
                 "model": device_type,
-                "name": sensor_id,
+                "name": device_id,
             }
-            for device_sensor in hb_info_from_type(dev_type)[family]:
-                if device_sensor["type"] == SENSOR_TYPE_MOISTURE:
-                    s_id = device_sensor["path"].split(".")[1]
+            for entity_specs in hb_info_from_type(dev_type)[family]:
+                if entity_specs["type"] == SENSOR_TYPE_MOISTURE:
+                    s_id = entity_specs["path"].split(".")[1]
                     is_leaf = int(
                         onewirehub.owproxy.read(
                             f"{device['path']}moisture/is_leaf.{s_id}"
                         ).decode()
                     )
                     if is_leaf:
-                        device_sensor["type"] = SENSOR_TYPE_WETNESS
-                        device_sensor["name"] = f"Wetness {s_id}"
-                device_file = os.path.join(
-                    os.path.split(device["path"])[0], device_sensor["path"]
+                        entity_specs["type"] = SENSOR_TYPE_WETNESS
+                        entity_specs["name"] = f"Wetness {s_id}"
+                entity_path = os.path.join(
+                    os.path.split(device["path"])[0], entity_specs["path"]
                 )
-                unique_id = f"/{sensor_id}/{device_sensor['path']}"
                 entities.append(
                     OneWireProxySensor(
-                        device_names.get(sensor_id, sensor_id),
-                        device_file,
-                        device_sensor["type"],
-                        device_sensor["name"],
-                        device_info,
-                        device_sensor.get("default_disabled", False),
-                        onewirehub.owproxy,
-                        unique_id,
+                        device_id=device_id,
+                        device_name=device_names.get(device_id, device_id),
+                        device_info=device_info,
+                        entity_path=entity_path,
+                        entity_specs=entity_specs,
+                        owproxy=onewirehub.owproxy,
                     )
                 )
 

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -172,6 +172,7 @@ def get_entities(onewirehub: OneWireHub):
             device_file = os.path.join(
                 os.path.split(device["path"])[0], device_switch["path"]
             )
+            unique_id = f"/{sensor_id}/{device_switch['path']}"
             entities.append(
                 OneWireProxySwitch(
                     sensor_id,
@@ -181,6 +182,7 @@ def get_entities(onewirehub: OneWireHub):
                     device_info,
                     device_switch.get("default_disabled", False),
                     onewirehub.owproxy,
+                    unique_id,
                 )
             )
 

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -157,32 +157,29 @@ def get_entities(onewirehub: OneWireHub):
     for device in onewirehub.devices:
         family = device["family"]
         device_type = device["type"]
-        sensor_id = os.path.split(os.path.split(device["path"])[0])[1]
+        device_id = os.path.split(os.path.split(device["path"])[0])[1]
 
         if family not in DEVICE_SWITCHES:
             continue
 
         device_info = {
-            "identifiers": {(DOMAIN, sensor_id)},
+            "identifiers": {(DOMAIN, device_id)},
             "manufacturer": "Maxim Integrated",
             "model": device_type,
-            "name": sensor_id,
+            "name": device_id,
         }
-        for device_switch in DEVICE_SWITCHES[family]:
-            device_file = os.path.join(
-                os.path.split(device["path"])[0], device_switch["path"]
+        for entity_specs in DEVICE_SWITCHES[family]:
+            entity_path = os.path.join(
+                os.path.split(device["path"])[0], entity_specs["path"]
             )
-            unique_id = f"/{sensor_id}/{device_switch['path']}"
             entities.append(
                 OneWireProxySwitch(
-                    sensor_id,
-                    device_file,
-                    device_switch["type"],
-                    device_switch["name"],
-                    device_info,
-                    device_switch.get("default_disabled", False),
-                    onewirehub.owproxy,
-                    unique_id,
+                    device_id=device_id,
+                    device_name=device_id,
+                    device_info=device_info,
+                    entity_path=entity_path,
+                    entity_specs=entity_specs,
+                    owproxy=onewirehub.owproxy,
                 )
             )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This is NOT a breaking change, as couplers have never been implemented on OWServer implementation.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the unique_id is based on the device path:
```
path = /{sensor_id}/temperature
unique_id = path = /{sensor_id}/temperature (== path)
```

This is fine if the device is at root, but would cause issues if the device was connected via a coupler:
```
path = /{coupler_id}/{branch}/{sensor_id}/temperature
unique_id = /{coupler_id}/{branch}/{sensor_id}/temperature (== path)
```

This PR ensure the unique_id would stay the same, regardless of the presence of a coupler, as a pre-requisite for #43599
```
- path = /{coupler_id}/{branch}/{sensor_id}/temperature
- unique_id = /{sensor_id}/temperature (!= path)
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #43599
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
