### PR TITLE
Add reauth step to Hyperion config flow

### DIFF
--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -90,7 +90,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def _create_reauth_flow(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    hyperion_const: client.HyperionClient,
 ) -> None:
     hass.async_create_task(
         hass.config_entries.flow.async_init(
@@ -141,12 +140,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
         and token is None
     ):
-        await _create_reauth_flow(hass, config_entry, hyperion_client)
+        await _create_reauth_flow(hass, config_entry)
         return False
 
     # Client login doesn't work? => Reauth.
     if not await hyperion_client.async_client_login():
-        await _create_reauth_flow(hass, config_entry, hyperion_client)
+        await _create_reauth_flow(hass, config_entry)
         return False
 
     # Cannot switch instance or cannot load state? => Not ready.

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -9,19 +9,21 @@ from pkg_resources import parse_version
 
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SOURCE, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import (
+    CONF_ENTRY_ID,
     CONF_ON_UNLOAD,
     CONF_ROOT_CLIENT,
     DOMAIN,
     HYPERION_RELEASES_URL,
     HYPERION_VERSION_WARN_CUTOFF,
     SIGNAL_INSTANCES_UPDATED,
+    SOURCE_REAUTH,
 )
 
 PLATFORMS = [LIGHT_DOMAIN]
@@ -85,6 +87,23 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+async def _create_reauth_flow(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    hyperion_const: client.HyperionClient,
+) -> None:
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={CONF_SOURCE: SOURCE_REAUTH},
+            data={
+                **config_entry.data,
+                CONF_ENTRY_ID: config_entry.entry_id,
+            },
+        )
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Hyperion from a config entry."""
     host = config_entry.data[CONF_HOST]
@@ -92,8 +111,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     token = config_entry.data.get(CONF_TOKEN)
 
     hyperion_client = await async_create_connect_hyperion_client(
-        host, port, token=token
+        host, port, token=token, raw_connection=True
     )
+
+    # Client won't connect? => Not ready.
     if not hyperion_client:
         raise ConfigEntryNotReady
     version = await hyperion_client.async_sysinfo_version()
@@ -109,6 +130,31 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 )
         except ValueError:
             pass
+
+    # Client needs authentication, but no token provided? => Reauth.
+    auth_resp = await hyperion_client.async_is_auth_required()
+    if (
+        auth_resp is not None
+        and client.ResponseOK(auth_resp)
+        and auth_resp.get(hyperion_const.KEY_INFO, {}).get(
+            hyperion_const.KEY_REQUIRED, False
+        )
+        and token is None
+    ):
+        await _create_reauth_flow(hass, config_entry, hyperion_client)
+        return False
+
+    # Client login doesn't work? => Reauth.
+    if not await hyperion_client.async_client_login():
+        await _create_reauth_flow(hass, config_entry, hyperion_client)
+        return False
+
+    # Cannot switch instance or cannot load state? => Not ready.
+    if (
+        not await hyperion_client.async_client_switch_instance()
+        or not client.ServerInfoResponseOK(await hyperion_client.async_get_serverinfo())
+    ):
+        raise ConfigEntryNotReady
 
     hyperion_client.set_callbacks(
         {
@@ -139,17 +185,17 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             ]
         )
         hass.data[DOMAIN][config_entry.entry_id][CONF_ON_UNLOAD].append(
-            config_entry.add_update_listener(_async_options_updated)
+            config_entry.add_update_listener(_async_entry_updated)
         )
 
     hass.async_create_task(setup_then_listen())
     return True
 
 
-async def _async_options_updated(
+async def _async_entry_updated(
     hass: HomeAssistantType, config_entry: ConfigEntry
 ) -> None:
-    """Handle options update."""
+    """Handle entry updates."""
     await hass.config_entries.async_reload(config_entry.entry_id)
 
 

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import (
-    CONF_ENTRY_ID,
     CONF_ON_UNLOAD,
     CONF_ROOT_CLIENT,
     DOMAIN,
@@ -93,12 +92,7 @@ async def _create_reauth_flow(
 ) -> None:
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={CONF_SOURCE: SOURCE_REAUTH},
-            data={
-                **config_entry.data,
-                CONF_ENTRY_ID: config_entry.entry_id,
-            },
+            DOMAIN, context={CONF_SOURCE: SOURCE_REAUTH}, data=config_entry.data
         )
     )
 

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -8,7 +8,7 @@ from hyperion import client, const as hyperion_const
 from pkg_resources import parse_version
 
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SOURCE, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -22,7 +22,6 @@ from .const import (
     HYPERION_RELEASES_URL,
     HYPERION_VERSION_WARN_CUTOFF,
     SIGNAL_INSTANCES_UPDATED,
-    SOURCE_REAUTH,
 )
 
 PLATFORMS = [LIGHT_DOMAIN]

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -425,7 +425,8 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
             assert entry is not None
             self.hass.config_entries.async_update_entry(entry, data=self._data)
             # Need to manually reload, as the listener won't have been installed because
-            # the initial load did not succeed.
+            # the initial load did not succeed (the reauth flow will not be initiated if
+            # the load succeeds)
             await self.hass.config_entries.async_reload(entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -26,6 +26,7 @@ from . import create_hyperion_client
 from .const import (
     CONF_AUTH_ID,
     CONF_CREATE_TOKEN,
+    CONF_ENTRY_ID,
     CONF_PRIORITY,
     DEFAULT_ORIGIN,
     DEFAULT_PRIORITY,
@@ -35,13 +36,13 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.DEBUG)
 
-#  +------------------+    +------------------+    +--------------------+
-#  |Step: SSDP        |    |Step: user        |    |Step: import        |
-#  |                  |    |                  |    |                    |
-#  |Input: <discovery>|    |Input: <host/port>|    |Input: <import data>|
-#  +------------------+    +------------------+    +--------------------+
-#           v                      v                       v
-#           +----------------------+-----------------------+
+#  +------------------+ +------------------+ +--------------------+ +--------------------+
+#  |Step: SSDP        | |Step: user        | |Step: import        | |Step: reauth        |
+#  |                  | |                  | |                    | |                    |
+#  |Input: <discovery>| |Input: <host/port>| |Input: <import data>| |Input: <entry_data> |
+#  +------------------+ +------------------+ +--------------------+ +--------------------+
+#           v                   v                       v                    v
+#           +-------------------+-----------------------+--------------------+
 # Auth not  |         Auth      |
 # required? |         required? |
 #           |                   v
@@ -82,7 +83,7 @@ _LOGGER.setLevel(logging.DEBUG)
 #                                           |
 #                                           v
 #                                 +----------------+
-#                                 |    Create!     |
+#                                 | Create/Update! |
 #                                 +----------------+
 
 # A note on choice of discovery mechanisms: Hyperion supports both Zeroconf and SSDP out
@@ -108,6 +109,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
         self._auth_id: Optional[str] = None
         self._require_confirm: bool = False
         self._port_ui: int = const.DEFAULT_PORT_UI
+        self._entry_id: Optional[str] = None
 
     def _create_client(self, raw_connection: bool = False) -> client.HyperionClient:
         """Create and connect a client instance."""
@@ -135,6 +137,20 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_data: ConfigType) -> Dict[str, Any]:
         """Handle a flow initiated by a YAML config import."""
         self._data.update(import_data)
+        async with self._create_client(raw_connection=True) as hyperion_client:
+            if not hyperion_client:
+                return self.async_abort(reason="cannot_connect")
+            return await self._advance_to_auth_step_if_necessary(hyperion_client)
+
+    async def async_step_reauth(
+        self,
+        config_data: ConfigType,
+    ) -> Dict[str, Any]:
+        """Handle a reauthentication flow."""
+        entry_data = dict(config_data)
+        assert CONF_ENTRY_ID in entry_data
+        self._entry_id = entry_data.pop(CONF_ENTRY_ID)
+        self._data = entry_data
         async with self._create_client(raw_connection=True) as hyperion_client:
             if not hyperion_client:
                 return self.async_abort(reason="cannot_connect")
@@ -402,6 +418,17 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_id")
 
         await self.async_set_unique_id(hyperion_id, raise_on_progress=False)
+
+        if self._entry_id:
+            assert self.hass
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            assert entry is not None
+            self.hass.config_entries.async_update_entry(entry, data=self._data)
+            # Need to manually reload, as the listener won't have been installed because
+            # the initial load did not succeed.
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
         self._abort_if_unique_id_configured()
 
         # pylint: disable=no-member  # https://github.com/PyCQA/pylint/issues/3167

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -16,7 +16,14 @@ from homeassistant.config_entries import (
     ConfigFlow,
     OptionsFlow,
 )
-from homeassistant.const import CONF_BASE, CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
+from homeassistant.const import (
+    CONF_BASE,
+    CONF_HOST,
+    CONF_ID,
+    CONF_PORT,
+    CONF_SOURCE,
+    CONF_TOKEN,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.typing import ConfigType
 
@@ -30,6 +37,7 @@ from .const import (
     DEFAULT_ORIGIN,
     DEFAULT_PRIORITY,
     DOMAIN,
+    SOURCE_REAUTH,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -414,7 +422,8 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
         entry = await self.async_set_unique_id(hyperion_id, raise_on_progress=False)
 
-        if entry is not None:
+        # pylint: disable=no-member
+        if self.context.get(CONF_SOURCE) == SOURCE_REAUTH and entry is not None:
             assert self.hass
             self.hass.config_entries.async_update_entry(entry, data=self._data)
             # Need to manually reload, as the listener won't have been installed because

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
 from homeassistant.config_entries import (
     CONN_CLASS_LOCAL_PUSH,
+    SOURCE_REAUTH,
     ConfigEntry,
     ConfigFlow,
     OptionsFlow,
@@ -37,7 +38,6 @@ from .const import (
     DEFAULT_ORIGIN,
     DEFAULT_PRIORITY,
     DOMAIN,
-    SOURCE_REAUTH,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -9,6 +9,7 @@ CONF_AUTH_ID = "auth_id"
 CONF_CREATE_TOKEN = "create_token"
 CONF_INSTANCE = "instance"
 CONF_PRIORITY = "priority"
+CONF_ENTRY_ID = "entry_id"
 
 CONF_ROOT_CLIENT = "ROOT_CLIENT"
 CONF_ON_UNLOAD = "ON_UNLOAD"
@@ -17,6 +18,7 @@ SIGNAL_INSTANCES_UPDATED = f"{DOMAIN}_instances_updated_signal." "{}"
 SIGNAL_INSTANCE_REMOVED = f"{DOMAIN}_instance_removed_signal." "{}"
 
 SOURCE_IMPORT = "import"
+SOURCE_REAUTH = "reauth"
 
 HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.9"
 HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/releases"

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -17,9 +17,6 @@ CONF_ON_UNLOAD = "ON_UNLOAD"
 SIGNAL_INSTANCES_UPDATED = f"{DOMAIN}_instances_updated_signal." "{}"
 SIGNAL_INSTANCE_REMOVED = f"{DOMAIN}_instance_removed_signal." "{}"
 
-SOURCE_IMPORT = "import"
-SOURCE_REAUTH = "reauth"
-
 HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.9"
 HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/releases"
 

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -9,7 +9,6 @@ CONF_AUTH_ID = "auth_id"
 CONF_CREATE_TOKEN = "create_token"
 CONF_INSTANCE = "instance"
 CONF_PRIORITY = "priority"
-CONF_ENTRY_ID = "entry_id"
 
 CONF_ROOT_CLIENT = "ROOT_CLIENT"
 CONF_ON_UNLOAD = "ON_UNLOAD"

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -21,7 +21,7 @@ from homeassistant.components.light import (
     SUPPORT_EFFECT,
     LightEntity,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TOKEN
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
@@ -47,7 +47,6 @@ from .const import (
     DOMAIN,
     SIGNAL_INSTANCE_REMOVED,
     SIGNAL_INSTANCES_UPDATED,
-    SOURCE_IMPORT,
     TYPE_HYPERION_LIGHT,
 )
 

--- a/homeassistant/components/hyperion/strings.json
+++ b/homeassistant/components/hyperion/strings.json
@@ -37,7 +37,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "auth_new_token_not_granted_error": "Newly created token was not approved on Hyperion UI",
       "auth_new_token_not_work_error": "Failed to authenticate using newly created token",
-      "no_id": "The Hyperion Ambilight instance did not report its id"
+      "no_id": "The Hyperion Ambilight instance did not report its id",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -50,7 +50,7 @@ TEST_INSTANCE_3: Dict[str, Any] = {
     "running": True,
 }
 
-TEST_AUTH_REQUIRED_RESP = {
+TEST_AUTH_REQUIRED_RESP: Dict[str, Any] = {
     "command": "authorize-tokenRequired",
     "info": {
         "required": True,

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -50,6 +50,20 @@ TEST_INSTANCE_3: Dict[str, Any] = {
     "running": True,
 }
 
+TEST_AUTH_REQUIRED_RESP = {
+    "command": "authorize-tokenRequired",
+    "info": {
+        "required": True,
+    },
+    "success": True,
+    "tan": 1,
+}
+
+TEST_AUTH_NOT_REQUIRED_RESP = {
+    **TEST_AUTH_REQUIRED_RESP,
+    "info": {"required": False},
+}
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -78,12 +92,7 @@ def create_mock_client() -> Mock:
     mock_client.async_client_connect = AsyncMock(return_value=True)
     mock_client.async_client_disconnect = AsyncMock(return_value=True)
     mock_client.async_is_auth_required = AsyncMock(
-        return_value={
-            "command": "authorize-tokenRequired",
-            "info": {"required": False},
-            "success": True,
-            "tan": 1,
-        }
+        return_value=TEST_AUTH_NOT_REQUIRED_RESP
     )
     mock_client.async_login = AsyncMock(
         return_value={"command": "authorize-login", "success": True, "tan": 0}
@@ -91,6 +100,17 @@ def create_mock_client() -> Mock:
 
     mock_client.async_sysinfo_id = AsyncMock(return_value=TEST_SYSINFO_ID)
     mock_client.async_sysinfo_version = AsyncMock(return_value=TEST_SYSINFO_ID)
+    mock_client.async_client_switch_instance = AsyncMock(return_value=True)
+    mock_client.async_client_login = AsyncMock(return_value=True)
+    mock_client.async_get_serverinfo = AsyncMock(
+        return_value={
+            "command": "serverinfo",
+            "success": True,
+            "tan": 0,
+            "info": {"fake": "data"},
+        }
+    )
+
     mock_client.adjustment = None
     mock_client.effects = None
     mock_client.instances = [
@@ -100,12 +120,15 @@ def create_mock_client() -> Mock:
     return mock_client
 
 
-def add_test_config_entry(hass: HomeAssistantType) -> ConfigEntry:
+def add_test_config_entry(
+    hass: HomeAssistantType, data: Optional[Dict[str, Any]] = None
+) -> ConfigEntry:
     """Add a test config entry."""
     config_entry: MockConfigEntry = MockConfigEntry(  # type: ignore[no-untyped-call]
         entry_id=TEST_CONFIG_ENTRY_ID,
         domain=DOMAIN,
-        data={
+        data=data
+        or {
             CONF_HOST: TEST_HOST,
             CONF_PORT: TEST_PORT,
         },
@@ -118,10 +141,12 @@ def add_test_config_entry(hass: HomeAssistantType) -> ConfigEntry:
 
 
 async def setup_test_config_entry(
-    hass: HomeAssistantType, hyperion_client: Optional[Mock] = None
+    hass: HomeAssistantType,
+    config_entry: Optional[ConfigEntry] = None,
+    hyperion_client: Optional[Mock] = None,
 ) -> ConfigEntry:
     """Add a test Hyperion entity to hass."""
-    config_entry = add_test_config_entry(hass)
+    config_entry = config_entry or add_test_config_entry(hass)
 
     hyperion_client = hyperion_client or create_mock_client()
     # pylint: disable=attribute-defined-outside-init

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -9,9 +9,11 @@ from homeassistant import data_entry_flow
 from homeassistant.components.hyperion.const import (
     CONF_AUTH_ID,
     CONF_CREATE_TOKEN,
+    CONF_ENTRY_ID,
     CONF_PRIORITY,
     DOMAIN,
     SOURCE_IMPORT,
+    SOURCE_REAUTH,
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
@@ -25,6 +27,7 @@ from homeassistant.const import (
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
+    TEST_AUTH_REQUIRED_RESP,
     TEST_CONFIG_ENTRY_ID,
     TEST_ENTITY_ID_1,
     TEST_HOST,
@@ -47,15 +50,6 @@ TEST_IP_ADDRESS = "192.168.0.1"
 TEST_HOST_PORT: Dict[str, Any] = {
     CONF_HOST: TEST_HOST,
     CONF_PORT: TEST_PORT,
-}
-
-TEST_AUTH_REQUIRED_RESP = {
-    "command": "authorize-tokenRequired",
-    "info": {
-        "required": True,
-    },
-    "success": True,
-    "tan": 1,
 }
 
 TEST_AUTH_ID = "ABCDE"
@@ -694,3 +688,37 @@ async def test_options(hass: HomeAssistantType) -> None:
             blocking=True,
         )
         assert client.async_send_set_color.call_args[1][CONF_PRIORITY] == new_priority
+
+
+async def test_reauth_success(hass):
+    """Check an import flow that cannot connect."""
+
+    config_data = {
+        CONF_HOST: TEST_HOST,
+        CONF_PORT: TEST_PORT,
+    }
+
+    config_entry = add_test_config_entry(hass, data=config_data)
+    client = create_mock_client()
+    client.async_is_auth_required = AsyncMock(return_value=TEST_AUTH_REQUIRED_RESP)
+
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
+    ), patch("homeassistant.components.hyperion.async_setup", return_value=True), patch(
+        "homeassistant.components.hyperion.async_setup_entry", return_value=True
+    ):
+        result = await _init_flow(
+            hass,
+            source=SOURCE_REAUTH,
+            data={**config_data, CONF_ENTRY_ID: config_entry.entry_id},
+        )
+        await hass.async_block_till_done()
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+        result = await _configure_flow(
+            hass, result, user_input={CONF_CREATE_TOKEN: False, CONF_TOKEN: TEST_TOKEN}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "reauth_successful"
+        assert CONF_TOKEN in config_entry.data

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -690,7 +690,7 @@ async def test_options(hass: HomeAssistantType) -> None:
         assert client.async_send_set_color.call_args[1][CONF_PRIORITY] == new_priority
 
 
-async def test_reauth_success(hass):
+async def test_reauth_success(hass: HomeAssistantType) -> None:
     """Check a reauth flow that succeeds."""
 
     config_data = {
@@ -724,7 +724,7 @@ async def test_reauth_success(hass):
         assert CONF_TOKEN in config_entry.data
 
 
-async def test_reauth_cannot_connect(hass):
+async def test_reauth_cannot_connect(hass: HomeAssistantType) -> None:
     """Check a reauth flow that fails to connect."""
 
     config_data = {

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -167,7 +167,7 @@ async def test_user_if_no_configuration(hass: HomeAssistantType) -> None:
     assert result["handler"] == DOMAIN
 
 
-async def test_user_existing_id_reauth(hass: HomeAssistantType) -> None:
+async def test_user_existing_id_abort(hass: HomeAssistantType) -> None:
     """Verify a duplicate ID results in a reauth."""
     result = await _init_flow(hass)
 
@@ -178,7 +178,7 @@ async def test_user_existing_id_reauth(hass: HomeAssistantType) -> None:
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "reauth_successful"
+        assert result["reason"] == "already_configured"
 
 
 async def test_user_client_errors(hass: HomeAssistantType) -> None:

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -9,7 +9,6 @@ from homeassistant import data_entry_flow
 from homeassistant.components.hyperion.const import (
     CONF_AUTH_ID,
     CONF_CREATE_TOKEN,
-    CONF_ENTRY_ID,
     CONF_PRIORITY,
     DOMAIN,
 )
@@ -713,7 +712,7 @@ async def test_reauth_success(hass: HomeAssistantType) -> None:
         result = await _init_flow(
             hass,
             source=SOURCE_REAUTH,
-            data={**config_data, CONF_ENTRY_ID: config_entry.entry_id},
+            data=config_data,
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -745,7 +744,7 @@ async def test_reauth_cannot_connect(hass: HomeAssistantType) -> None:
         result = await _init_flow(
             hass,
             source=SOURCE_REAUTH,
-            data={**config_data, CONF_ENTRY_ID: config_entry.entry_id},
+            data=config_data,
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -167,8 +167,8 @@ async def test_user_if_no_configuration(hass: HomeAssistantType) -> None:
     assert result["handler"] == DOMAIN
 
 
-async def test_user_existing_id_abort(hass: HomeAssistantType) -> None:
-    """Verify a duplicate ID results in an abort."""
+async def test_user_existing_id_reauth(hass: HomeAssistantType) -> None:
+    """Verify a duplicate ID results in a reauth."""
     result = await _init_flow(hass)
 
     await _create_mock_entry(hass)
@@ -178,7 +178,7 @@ async def test_user_existing_id_abort(hass: HomeAssistantType) -> None:
     ):
         result = await _configure_flow(hass, result, user_input=TEST_HOST_PORT)
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
+        assert result["reason"] == "reauth_successful"
 
 
 async def test_user_client_errors(hass: HomeAssistantType) -> None:

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -12,11 +12,14 @@ from homeassistant.components.hyperion.const import (
     CONF_ENTRY_ID,
     CONF_PRIORITY,
     DOMAIN,
-    SOURCE_IMPORT,
-    SOURCE_REAUTH,
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
+from homeassistant.config_entries import (
+    SOURCE_IMPORT,
+    SOURCE_REAUTH,
+    SOURCE_SSDP,
+    SOURCE_USER,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,
@@ -168,7 +171,7 @@ async def test_user_if_no_configuration(hass: HomeAssistantType) -> None:
 
 
 async def test_user_existing_id_abort(hass: HomeAssistantType) -> None:
-    """Verify a duplicate ID results in a reauth."""
+    """Verify a duplicate ID results in an abort."""
     result = await _init_flow(hass)
 
     await _create_mock_entry(hass)

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -734,7 +734,7 @@ async def test_reauth_cannot_connect(hass: HomeAssistantType) -> None:
         CONF_PORT: TEST_PORT,
     }
 
-    config_entry = add_test_config_entry(hass, data=config_data)
+    add_test_config_entry(hass, data=config_data)
     client = create_mock_client()
     client.async_client_connect = AsyncMock(return_value=False)
 

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -733,7 +733,7 @@ async def test_unload_entry(hass: HomeAssistantType) -> None:
     assert client.async_client_disconnect.call_count == 2
 
 
-async def test_version_log_warning(caplog, hass: HomeAssistantType) -> None:
+async def test_version_log_warning(caplog, hass: HomeAssistantType) -> None:  # type: ignore[no-untyped-def]
     """Test warning on old version."""
     client = create_mock_client()
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.7")
@@ -742,7 +742,7 @@ async def test_version_log_warning(caplog, hass: HomeAssistantType) -> None:
     assert "Please consider upgrading" in caplog.text
 
 
-async def test_version_no_log_warning(caplog, hass: HomeAssistantType) -> None:
+async def test_version_no_log_warning(caplog, hass: HomeAssistantType) -> None:  # type: ignore[no-untyped-def]
     """Test no warning on acceptable version."""
     client = create_mock_client()
     client.async_sysinfo_version = AsyncMock(return_value="2.0.0-alpha.9")

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -220,10 +220,38 @@ async def test_setup_config_entry(hass: HomeAssistantType) -> None:
     assert hass.states.get(TEST_ENTITY_ID_1) is not None
 
 
-async def test_setup_config_entry_not_ready(hass: HomeAssistantType) -> None:
+async def test_setup_config_entry_not_ready_connect_fail(
+    hass: HomeAssistantType,
+) -> None:
     """Test the component not being ready."""
     client = create_mock_client()
     client.async_client_connect = AsyncMock(return_value=False)
+    await setup_test_config_entry(hass, hyperion_client=client)
+    assert hass.states.get(TEST_ENTITY_ID_1) is None
+
+
+async def test_setup_config_entry_not_ready_switch_instance_fail(
+    hass: HomeAssistantType,
+) -> None:
+    """Test the component not being ready."""
+    client = create_mock_client()
+    client.async_client_switch_instance = AsyncMock(return_value=False)
+    await setup_test_config_entry(hass, hyperion_client=client)
+    assert hass.states.get(TEST_ENTITY_ID_1) is None
+
+
+async def test_setup_config_entry_not_ready_load_state_fail(
+    hass: HomeAssistantType,
+) -> None:
+    """Test the component not being ready."""
+    client = create_mock_client()
+    client.async_get_serverinfo = AsyncMock(
+        return_value={
+            "command": "serverinfo",
+            "success": False,
+        }
+    )
+
     await setup_test_config_entry(hass, hyperion_client=client)
     assert hass.states.get(TEST_ENTITY_ID_1) is None
 

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -10,18 +10,18 @@ from homeassistant.components.hyperion import (
     get_hyperion_unique_id,
     light as hyperion_light,
 )
-from homeassistant.components.hyperion.const import (
-    DOMAIN,
-    SOURCE_REAUTH,
-    TYPE_HYPERION_LIGHT,
-)
+from homeassistant.components.hyperion.const import DOMAIN, TYPE_HYPERION_LIGHT
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     DOMAIN as LIGHT_DOMAIN,
 )
-from homeassistant.config_entries import ENTRY_STATE_SETUP_ERROR, ConfigEntry
+from homeassistant.config_entries import (
+    ENTRY_STATE_SETUP_ERROR,
+    SOURCE_REAUTH,
+    ConfigEntry,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -764,7 +764,7 @@ async def test_setup_entry_no_token_reauth(hass: HomeAssistantType) -> None:
         mock_flow_init.assert_called_once_with(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_REAUTH},
-            data={"entry_id": config_entry.entry_id, **config_entry.data},
+            data=config_entry.data,
         )
         assert config_entry.state == ENTRY_STATE_SETUP_ERROR
 
@@ -787,6 +787,6 @@ async def test_setup_entry_bad_token_reauth(hass: HomeAssistantType) -> None:
         mock_flow_init.assert_called_once_with(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_REAUTH},
-            data={"entry_id": config_entry.entry_id, **config_entry.data},
+            data=config_entry.data,
         )
         assert config_entry.state == ENTRY_STATE_SETUP_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a re-authentication config flow step should authentication to Hyperion fail.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
