### PR TITLE
Fix config validation tests for upcoming beta

### DIFF
--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -710,13 +710,13 @@ def test_deprecated_with_invalidation_version(caplog, schema, version):
             is detected
     """
     deprecated_schema = vol.All(
-        cv.deprecated("mars", invalidation_version="1.0.0"), schema
+        cv.deprecated("mars", invalidation_version="9999.99.9"), schema
     )
 
     message = (
         "The 'mars' option is deprecated, "
         "please remove it from your configuration. "
-        "This option will become invalid in version 1.0.0"
+        "This option will become invalid in version 9999.99.9"
     )
 
     test_data = {"mars": True}
@@ -763,14 +763,16 @@ def test_deprecated_with_replacement_key_and_invalidation_version(
         is detected
     """
     deprecated_schema = vol.All(
-        cv.deprecated("mars", replacement_key="jupiter", invalidation_version="1.0.0"),
+        cv.deprecated(
+            "mars", replacement_key="jupiter", invalidation_version="9999.99.9"
+        ),
         schema,
     )
 
     warning = (
         "The 'mars' option is deprecated, "
         "please replace it with 'jupiter'. This option will become "
-        "invalid in version 1.0.0"
+        "invalid in version 9999.99.9"
     )
 
     test_data = {"mars": True}
@@ -912,7 +914,7 @@ def test_deprecated_with_replacement_key_invalidation_version_default(
         cv.deprecated(
             "mars",
             replacement_key="jupiter",
-            invalidation_version="1.0.0",
+            invalidation_version="9999.99.9",
             default=False,
         ),
         schema,
@@ -924,7 +926,7 @@ def test_deprecated_with_replacement_key_invalidation_version_default(
     assert (
         "The 'mars' option is deprecated, "
         "please replace it with 'jupiter'. This option will become "
-        "invalid in version 1.0.0"
+        "invalid in version 9999.99.9"
     ) in caplog.text
     assert {"jupiter": True} == output
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adjust the tests to handle the upcoming beta changes with the config validation tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
