### PR TITLE
Use image proxy in volumio media browser

### DIFF
--- a/homeassistant/components/volumio/browse_media.py
+++ b/homeassistant/components/volumio/browse_media.py
@@ -1,5 +1,4 @@
 """Support for media browsing."""
-import hashlib
 import json
 
 from homeassistant.components.media_player import BrowseError, BrowseMedia
@@ -105,7 +104,7 @@ def _raw_item_payload(entity, item, parent_item=None, title=None, info=None):
     if "type" in item:
         thumbnail = item.get("albumart")
         if thumbnail:
-            item_hash = hashlib.md5(thumbnail.encode("utf-8")).hexdigest()
+            item_hash = str(hash(thumbnail))
             entity.thumbnail_cache.setdefault(item_hash, thumbnail)
             thumbnail = entity.get_browse_image_url(MEDIA_TYPE_MUSIC, item_hash)
     else:

--- a/homeassistant/components/volumio/browse_media.py
+++ b/homeassistant/components/volumio/browse_media.py
@@ -1,6 +1,6 @@
 """Support for media browsing."""
+import hashlib
 import json
-from urllib.parse import quote_plus
 
 from homeassistant.components.media_player import BrowseError, BrowseMedia
 from homeassistant.components.media_player.const import (
@@ -105,9 +105,9 @@ def _raw_item_payload(entity, item, parent_item=None, title=None, info=None):
     if "type" in item:
         thumbnail = item.get("albumart")
         if thumbnail:
-            # we double encode because yarl is over-zealous with decoding
-            encoded_url = quote_plus(quote_plus(thumbnail))
-            thumbnail = entity.get_browse_image_url(MEDIA_TYPE_MUSIC, encoded_url)
+            item_hash = hashlib.md5(thumbnail.encode("utf-8")).hexdigest()
+            entity.thumbnail_cache.setdefault(item_hash, thumbnail)
+            thumbnail = entity.get_browse_image_url(MEDIA_TYPE_MUSIC, item_hash)
     else:
         # don't use the built-in volumio white-on-white icons
         thumbnail = None

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -258,6 +258,7 @@ class Volumio(MediaPlayerEntity):
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""
+        self.thumbnail_cache = {}
         if media_content_type in [None, "library"]:
             return await browse_top_level(self._volumio)
 

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -5,6 +5,7 @@ Volumio rest API: https://volumio.github.io/docs/API/REST_API.html
 """
 from datetime import timedelta
 import json
+from urllib.parse import unquote_plus
 
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
@@ -260,4 +261,13 @@ class Volumio(MediaPlayerEntity):
         if media_content_type in [None, "library"]:
             return await browse_top_level(self._volumio)
 
-        return await browse_node(self._volumio, media_content_type, media_content_id)
+        return await browse_node(
+            self, self._volumio, media_content_type, media_content_id
+        )
+
+    async def async_get_browse_image(
+        self, media_content_type, media_content_id, media_image_id=None
+    ):
+        """Get album art from Volumio."""
+        image_url = self._volumio.canonic_url(unquote_plus(media_content_id))
+        return await self._async_fetch_image(image_url)

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -5,7 +5,6 @@ Volumio rest API: https://volumio.github.io/docs/API/REST_API.html
 """
 from datetime import timedelta
 import json
-from urllib.parse import unquote_plus
 
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
@@ -84,6 +83,7 @@ class Volumio(MediaPlayerEntity):
         self._state = {}
         self._playlists = []
         self._currentplaylist = None
+        self.thumbnail_cache = {}
 
     async def async_update(self):
         """Update state."""
@@ -269,5 +269,6 @@ class Volumio(MediaPlayerEntity):
         self, media_content_type, media_content_id, media_image_id=None
     ):
         """Get album art from Volumio."""
-        image_url = self._volumio.canonic_url(unquote_plus(media_content_id))
+        cached_url = self.thumbnail_cache.get(media_content_id)
+        image_url = self._volumio.canonic_url(cached_url)
         return await self._async_fetch_image(image_url)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some browser enforce a strict mixed content policy by requesting all resources over HTTPS when the top level resource is HTTPS. Volumio by default does not provide HTTPS access, which causes the media browser thumbnails to not be displayed.
This change uses the HA image proxy to fix this.
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/43742
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
