### PR TITLE
Add WS API for extended Tasmota device info

### DIFF
--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -2,16 +2,7 @@
 import asyncio
 import logging
 
-from hatasmota.const import (
-    CONF_MAC,
-    CONF_MANUFACTURER,
-    CONF_MODEL,
-    CONF_NAME,
-    CONF_SW_VERSION,
-)
-from hatasmota.discovery import clear_discovery_topic
 from hatasmota.mqtt import TasmotaMQTTClient
-import voluptuous as vol
 
 from homeassistant.components import mqtt, websocket_api
 from homeassistant.components.mqtt.subscription import (
@@ -19,20 +10,16 @@ from homeassistant.components.mqtt.subscription import (
     async_unsubscribe_topics,
 )
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import (
-    CONNECTION_NETWORK_MAC,
-    EVENT_DEVICE_REGISTRY_UPDATED,
-    async_entries_for_config_entry,
-)
+from homeassistant.helpers.device_registry import async_entries_for_config_entry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import device_automation, discovery
-from .const import (
-    CONF_DISCOVERY_PREFIX,
-    DATA_REMOVE_DISCOVER_COMPONENT,
-    DATA_UNSUB,
-    DOMAIN,
-    PLATFORMS,
+from . import device_automation
+from .const import DATA_REMOVE_DISCOVER_COMPONENT, DATA_UNSUB, PLATFORMS
+from .device import (
+    async_start_device_discovery,
+    async_stop_device_discovery,
+    websocket_get_device,
+    websocket_remove_device,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,6 +33,7 @@ async def async_setup(hass: HomeAssistantType, config: dict):
 async def async_setup_entry(hass, entry):
     """Set up Tasmota from a config entry."""
     websocket_api.async_register_command(hass, websocket_remove_device)
+    websocket_api.async_register_command(hass, websocket_get_device)
     hass.data[DATA_UNSUB] = []
 
     def _publish(*args, **kwds):
@@ -63,31 +51,6 @@ async def async_setup_entry(hass, entry):
 
     tasmota_mqtt = TasmotaMQTTClient(_publish, _subscribe_topics, _unsubscribe_topics)
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-
-    def async_discover_device(config, mac):
-        """Discover and add a Tasmota device."""
-        async_setup_device(hass, mac, config, entry, tasmota_mqtt, device_registry)
-
-    async def async_device_removed(event):
-        """Handle the removal of a device."""
-        device_registry = await hass.helpers.device_registry.async_get_registry()
-        if event.data["action"] != "remove":
-            return
-
-        device = device_registry.deleted_devices[event.data["device_id"]]
-
-        if entry.entry_id not in device.config_entries:
-            return
-
-        macs = [c[1] for c in device.connections if c[0] == CONNECTION_NETWORK_MAC]
-        for mac in macs:
-            clear_discovery_topic(mac, entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt)
-
-    hass.data[DATA_UNSUB].append(
-        hass.bus.async_listen(EVENT_DEVICE_REGISTRY_UPDATED, async_device_removed)
-    )
-
     async def start_platforms():
         await device_automation.async_setup_entry(hass, entry)
         await asyncio.gather(
@@ -97,10 +60,7 @@ async def async_setup_entry(hass, entry):
             ]
         )
 
-        discovery_prefix = entry.data[CONF_DISCOVERY_PREFIX]
-        await discovery.async_start(
-            hass, discovery_prefix, entry, tasmota_mqtt, async_discover_device
-        )
+        await async_start_device_discovery(hass, entry, tasmota_mqtt)
 
     hass.async_create_task(start_platforms())
     return True
@@ -121,8 +81,8 @@ async def async_unload_entry(hass, entry):
     if not unload_ok:
         return False
 
-    # disable discovery
-    await discovery.async_stop(hass)
+    # disable device discovery
+    await async_stop_device_discovery(hass)
 
     # cleanup subscriptions
     for unsub in hass.data[DATA_UNSUB]:
@@ -138,67 +98,3 @@ async def async_unload_entry(hass, entry):
         await device_automation.async_remove_automations(hass, device.id)
 
     return True
-
-
-def _remove_device(hass, config_entry, mac, tasmota_mqtt, device_registry):
-    """Remove device from device registry."""
-    device = device_registry.async_get_device(set(), {(CONNECTION_NETWORK_MAC, mac)})
-
-    if device is None:
-        return
-
-    _LOGGER.debug("Removing tasmota device %s", mac)
-    device_registry.async_remove_device(device.id)
-    clear_discovery_topic(mac, config_entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt)
-
-
-def _update_device(hass, config_entry, config, device_registry):
-    """Add or update device registry."""
-    config_entry_id = config_entry.entry_id
-    device_info = {
-        "connections": {(CONNECTION_NETWORK_MAC, config[CONF_MAC])},
-        "manufacturer": config[CONF_MANUFACTURER],
-        "model": config[CONF_MODEL],
-        "name": config[CONF_NAME],
-        "sw_version": config[CONF_SW_VERSION],
-        "config_entry_id": config_entry_id,
-    }
-    _LOGGER.debug("Adding or updating tasmota device %s", config[CONF_MAC])
-    device_registry.async_get_or_create(**device_info)
-
-
-def async_setup_device(hass, mac, config, config_entry, tasmota_mqtt, device_registry):
-    """Set up the Tasmota device."""
-    if not config:
-        _remove_device(hass, config_entry, mac, tasmota_mqtt, device_registry)
-    else:
-        _update_device(hass, config_entry, config, device_registry)
-
-
-@websocket_api.websocket_command(
-    {vol.Required("type"): "tasmota/device/remove", vol.Required("device_id"): str}
-)
-@websocket_api.async_response
-async def websocket_remove_device(hass, connection, msg):
-    """Delete device."""
-    device_id = msg["device_id"]
-    dev_registry = await hass.helpers.device_registry.async_get_registry()
-
-    device = dev_registry.async_get(device_id)
-    if not device:
-        connection.send_error(
-            msg["id"], websocket_api.const.ERR_NOT_FOUND, "Device not found"
-        )
-        return
-
-    for config_entry in device.config_entries:
-        config_entry = hass.config_entries.async_get_entry(config_entry)
-        # Only delete the device if it belongs to a Tasmota device entry
-        if config_entry.domain == DOMAIN:
-            dev_registry.async_remove_device(device_id)
-            connection.send_message(websocket_api.result_message(msg["id"]))
-            return
-
-    connection.send_error(
-        msg["id"], websocket_api.const.ERR_NOT_FOUND, "Non Tasmota device"
-    )

--- a/homeassistant/components/tasmota/const.py
+++ b/homeassistant/components/tasmota/const.py
@@ -1,6 +1,7 @@
 """Constants used by multiple Tasmota modules."""
 CONF_DISCOVERY_PREFIX = "discovery_prefix"
 
+DATA_DEVICES = "tasmota_devices"
 DATA_REMOVE_DISCOVER_COMPONENT = "tasmota_discover_{}"
 DATA_UNSUB = "tasmota_subscriptions"
 

--- a/homeassistant/components/tasmota/device.py
+++ b/homeassistant/components/tasmota/device.py
@@ -1,0 +1,202 @@
+"""Device support for the Tasmota integration."""
+import logging
+
+from hatasmota import const as hc
+from hatasmota.const import (
+    CONF_IP,
+    CONF_MAC,
+    CONF_MANUFACTURER,
+    CONF_MODEL,
+    CONF_NAME,
+    CONF_SW_VERSION,
+)
+from hatasmota.device_status import TasmotaDeviceStatus, TasmotaDeviceStatusConfig
+from hatasmota.discovery import clear_discovery_topic
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    EVENT_DEVICE_REGISTRY_UPDATED,
+)
+
+from . import discovery
+from .const import CONF_DISCOVERY_PREFIX, DATA_DEVICES, DATA_UNSUB, DOMAIN
+
+DEVICE_ATTRIBUTES = [hc.SENSOR_STATUS_RSSI]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_start_device_discovery(hass, entry, tasmota_mqtt):
+    """Start Tasmota device discovery."""
+    hass.data[DATA_DEVICES] = {}
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+
+    async def async_discover_device(device_config, mac, full_config):
+        """Discover and add a Tasmota device."""
+        await async_setup_device(
+            hass, mac, device_config, full_config, entry, tasmota_mqtt, device_registry
+        )
+
+    async def async_device_removed(event):
+        """Handle the removal of a device."""
+        device_registry = await hass.helpers.device_registry.async_get_registry()
+        if event.data["action"] != "remove":
+            return
+
+        device = device_registry.deleted_devices[event.data["device_id"]]
+
+        if entry.entry_id not in device.config_entries:
+            return
+
+        macs = [c[1] for c in device.connections if c[0] == CONNECTION_NETWORK_MAC]
+        for mac in macs:
+            clear_discovery_topic(mac, entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt)
+        hass.data[DATA_DEVICES].pop(event.data["device_id"], None)
+
+    hass.data[DATA_UNSUB].append(
+        hass.bus.async_listen(EVENT_DEVICE_REGISTRY_UPDATED, async_device_removed)
+    )
+
+    discovery_prefix = entry.data[CONF_DISCOVERY_PREFIX]
+    await discovery.async_start(
+        hass, discovery_prefix, entry, tasmota_mqtt, async_discover_device
+    )
+
+
+async def async_stop_device_discovery(hass):
+    """Stop Tasmota device discovery."""
+    await discovery.async_stop(hass)
+    hass.data.pop(DATA_DEVICES)
+
+
+async def _remove_device(hass, config_entry, mac, tasmota_mqtt, device_registry):
+    """Remove device from device registry."""
+    device = device_registry.async_get_device(set(), {(CONNECTION_NETWORK_MAC, mac)})
+
+    if device is None:
+        return
+
+    _LOGGER.debug("Removing tasmota device %s", mac)
+    device_registry.async_remove_device(device.id)
+    clear_discovery_topic(mac, config_entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt)
+    if "device_status" not in hass.data[DATA_DEVICES][device.id]:
+        return
+    device_status = hass.data[DATA_DEVICES][device.id].pop("device_status")
+    await device_status.unsubscribe_topics()
+
+
+async def _update_device(
+    hass, config_entry, device_config, full_config, tasmota_mqtt, device_registry
+):
+    """Add or update device registry."""
+    config_entry_id = config_entry.entry_id
+    registry_device_info = {
+        "connections": {(CONNECTION_NETWORK_MAC, device_config[CONF_MAC])},
+        "manufacturer": device_config[CONF_MANUFACTURER],
+        "model": device_config[CONF_MODEL],
+        "name": device_config[CONF_NAME],
+        "sw_version": device_config[CONF_SW_VERSION],
+        "config_entry_id": config_entry_id,
+    }
+    _LOGGER.debug("Adding or updating tasmota device %s", device_config[CONF_MAC])
+    device_entry = device_registry.async_get_or_create(**registry_device_info)
+    hass.data[DATA_DEVICES].setdefault(
+        device_entry.id, {"mac": device_config[CONF_MAC]}
+    )
+    device_info = hass.data[DATA_DEVICES][device_entry.id].setdefault("device_info", {})
+    device_info.update(
+        {
+            "ip": device_config[CONF_IP],
+            "mac": ":".join(
+                device_config[CONF_MAC].lower()[i : i + 2] for i in range(0, 12, 2)
+            ),
+            "manufacturer": device_config[CONF_MANUFACTURER],
+            "model": device_config[CONF_MODEL],
+            "name": device_config[CONF_NAME],
+            "sw_version": device_config[CONF_SW_VERSION],
+        }
+    )
+
+    def _device_status_updated(attributes):
+        device_info = hass.data[DATA_DEVICES][device_entry.id]["device_info"]
+        if hc.SENSOR_STATUS_RSSI in attributes:
+            device_info["rssi"] = attributes[hc.SENSOR_STATUS_RSSI]
+
+    device_status_config = TasmotaDeviceStatusConfig.from_discovery_message(full_config)
+    if "device_status" not in hass.data[DATA_DEVICES][device_entry.id]:
+        device_status = TasmotaDeviceStatus(
+            config=device_status_config, mqtt_client=tasmota_mqtt
+        )
+        device_status.set_on_state_callback(_device_status_updated)
+        hass.data[DATA_DEVICES][device_entry.id]["device_status"] = device_status
+    else:
+        device_status = hass.data[DATA_DEVICES][device_entry.id]["device_status"]
+        if device_status.config_same(device_status_config):
+            return
+        device_status.config_update(device_status_config)
+    await device_status.subscribe_topics()
+
+
+async def async_setup_device(
+    hass, mac, device_config, full_config, config_entry, tasmota_mqtt, device_registry
+):
+    """Set up the Tasmota device."""
+    if not device_config:
+        await _remove_device(hass, config_entry, mac, tasmota_mqtt, device_registry)
+    else:
+        await _update_device(
+            hass,
+            config_entry,
+            device_config,
+            full_config,
+            tasmota_mqtt,
+            device_registry,
+        )
+
+
+@websocket_api.websocket_command(
+    {vol.Required("type"): "tasmota/device/remove", vol.Required("device_id"): str}
+)
+@websocket_api.async_response
+async def websocket_remove_device(hass, connection, msg):
+    """Delete device."""
+    device_id = msg["device_id"]
+    dev_registry = await hass.helpers.device_registry.async_get_registry()
+
+    device = dev_registry.async_get(device_id)
+    if not device:
+        connection.send_error(
+            msg["id"], websocket_api.const.ERR_NOT_FOUND, "Device not found"
+        )
+        return
+
+    for config_entry in device.config_entries:
+        config_entry = hass.config_entries.async_get_entry(config_entry)
+        # Only delete the device if it belongs to a Tasmota device entry
+        if config_entry.domain == DOMAIN:
+            dev_registry.async_remove_device(device_id)
+            connection.send_message(websocket_api.result_message(msg["id"]))
+            return
+
+    connection.send_error(
+        msg["id"], websocket_api.const.ERR_NOT_FOUND, "Non Tasmota device"
+    )
+
+
+@websocket_api.websocket_command(
+    {vol.Required("type"): "tasmota/device", vol.Required("device_id"): str}
+)
+@websocket_api.async_response
+async def websocket_get_device(hass, connection, msg):
+    """Get extended device information."""
+    device_id = msg["device_id"]
+    if device_id not in hass.data[DATA_DEVICES]:
+        connection.send_error(
+            msg["id"], websocket_api.const.ERR_NOT_FOUND, "Unknown device"
+        )
+        return
+    device_info = hass.data[DATA_DEVICES][device_id]["device_info"]
+    connection.send_message(websocket_api.result_message(msg["id"], device_info))

--- a/homeassistant/components/tasmota/discovery.py
+++ b/homeassistant/components/tasmota/discovery.py
@@ -94,7 +94,7 @@ async def async_start(
 
         _LOGGER.debug("Received discovery data for tasmota device: %s", mac)
         tasmota_device_config = tasmota_get_device_config(payload)
-        setup_device(tasmota_device_config, mac)
+        await setup_device(tasmota_device_config, mac, payload)
 
         if not payload:
             return

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.1.2"],
+  "requirements": ["hatasmota==0.2.0"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/tasmota/mixins.py
+++ b/homeassistant/components/tasmota/mixins.py
@@ -95,7 +95,6 @@ class TasmotaAvailability(TasmotaEntity):
     @callback
     def availability_updated(self, available: bool) -> None:
         """Handle updated availability."""
-        self._tasmota_entity.poll_status()
         self._available = available
         self.async_write_ha_state()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ hass-nabucasa==0.38.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.1.2
+hatasmota==0.2.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -376,7 +376,7 @@ hangups==0.4.11
 hass-nabucasa==0.38.0
 
 # homeassistant.components.tasmota
-hatasmota==0.1.2
+hatasmota==0.2.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/tests/components/tasmota/test_common.py
+++ b/tests/components/tasmota/test_common.py
@@ -319,7 +319,8 @@ async def help_test_availability_poll_state(
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    mqtt_mock.async_publish.assert_called_once_with(poll_topic, poll_payload, 0, False)
+    assert mqtt_mock.async_publish.call_count == 2  # device status and tested component
+    mqtt_mock.async_publish.assert_called_with(poll_topic, poll_payload, 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     # Disconnected from MQTT server
@@ -347,7 +348,8 @@ async def help_test_availability_poll_state(
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    mqtt_mock.async_publish.assert_called_once_with(poll_topic, poll_payload, 0, False)
+    assert mqtt_mock.async_publish.call_count == 2  # device status and tested component
+    mqtt_mock.async_publish.assert_called_with(poll_topic, poll_payload, 0, False)
 
 
 async def help_test_discovery_removal(
@@ -525,7 +527,8 @@ async def help_test_entity_id_update_subscriptions(
 
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state is not None
-    assert mqtt_mock.async_subscribe.call_count == len(topics)
+    number_of_device_topics = 3
+    assert mqtt_mock.async_subscribe.call_count == len(topics) + number_of_device_topics
     for topic in topics:
         mqtt_mock.async_subscribe.assert_any_call(topic, ANY, ANY, ANY)
     mqtt_mock.async_subscribe.reset_mock()

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -503,7 +503,8 @@ async def test_no_resubscribe_same_topic(hass, device_reg, mqtt_mock, setup_tasm
     )
 
     call_count = mqtt_mock.async_subscribe.call_count
-    assert call_count == 1
+    number_of_device_topics = 3
+    assert call_count == 1 + number_of_device_topics
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
     assert mqtt_mock.async_subscribe.call_count == call_count


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WS API for extended Tasmota device info.
Frontend PR: https://github.com/home-assistant/frontend/pull/7863
Bump hatasmota from 0.1.2 to 0.2.0

Changes:
 - 0.2.0 (https://github.com/emontnemery/hatasmota/releases/tag/0.2.0)
   - Add device status [#53](https://github.com/emontnemery/hatasmota/pull/53) @emontnemery
 
https://github.com/emontnemery/hatasmota/compare/0.1.2...0.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
