### PR TITLE
Add ozw add-on discovery and mqtt client

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 import os
+from typing import Optional
 
 import voluptuous as vol
 
@@ -23,6 +24,7 @@ from homeassistant.util.dt import utcnow
 
 from .addon_panel import async_setup_addon_panel
 from .auth import async_setup_auth_view
+from .const import ATTR_DISCOVERY
 from .discovery import async_setup_discovery_view
 from .handler import HassIO, HassioAPIError, api_data
 from .http import HassIOView
@@ -198,6 +200,17 @@ async def async_set_addon_options(
     hassio = hass.data[DOMAIN]
     command = f"/addons/{slug}/options"
     return await hassio.send_command(command, payload=options)
+
+
+@bind_hass
+async def async_get_addon_discovery_info(
+    hass: HomeAssistantType, slug: str
+) -> Optional[dict]:
+    """Return discovery data for an add-on."""
+    hassio = hass.data[DOMAIN]
+    data = await hassio.retrieve_discovery_messages()
+    discovered_addons = data[ATTR_DISCOVERY]
+    return next((addon for addon in discovered_addons if addon["addon"] == slug), None)
 
 
 @callback

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -63,9 +63,6 @@ DATA_MQTT_CLIENT = "ozw_mqtt_client"
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Initialize basic config of ozw component."""
-    if "mqtt" not in hass.config.components:
-        _LOGGER.error("MQTT integration is not set up")
-        return False
     hass.data[DOMAIN] = {}
     return True
 
@@ -110,6 +107,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         ozw_data[DATA_MQTT_CLIENT] = mqtt_client
 
     else:
+        if "mqtt" not in hass.config.components:
+            _LOGGER.error("MQTT integration is not set up")
+            return False
 
         @callback
         def send_message(topic, payload):

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -83,7 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         if not discovery_info:
             _LOGGER.error("Failed to get add-on discovery info")
-            return False
+            raise ConfigEntryNotReady
 
         discovery_info_config = discovery_info["config"]
 

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -277,8 +277,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             ]
         )
         if entry.data.get(CONF_USE_ADDON):
-            mqtt_client.add_manager(manager)
-            mqtt_client_task = asyncio.create_task(mqtt_client.start_client())
+            mqtt_client_task = asyncio.create_task(mqtt_client.start_client(manager))
 
             async def async_stop_mqtt_client(event=None):
                 """Stop the mqtt client.
@@ -326,7 +325,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     if entry.data.get(CONF_USE_ADDON):
         mqtt_client = hass.data[DOMAIN][entry.entry_id][DATA_MQTT_CLIENT]
         manager = hass.data[DOMAIN][MANAGER]
-        await mqtt_client.remove_manager(manager)
+        await mqtt_client.unsubscribe_manager(manager)
 
     hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -77,6 +77,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     removed_nodes = []
     manager_options = {"topic_prefix": f"{TOPIC_OPENZWAVE}/"}
 
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(entry, unique_id=DOMAIN)
+
     if entry.data.get(CONF_USE_ADDON):
         # Do not use MQTT integration. Use own MQTT client.
         host = entry.data.get(CONF_HOST)
@@ -88,17 +91,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     "core_zwave"
                 )
             )
+            discovery_info_config = discovery_info["config"]
             addon_discovery_info = {
-                CONF_HOST: discovery_info["host"],
-                CONF_PORT: discovery_info["port"],
-                CONF_USERNAME: discovery_info["username"],
-                CONF_PASSWORD: discovery_info["password"],
+                CONF_HOST: discovery_info_config["host"],
+                CONF_PORT: discovery_info_config["port"],
+                CONF_USERNAME: discovery_info_config["username"],
+                CONF_PASSWORD: discovery_info_config["password"],
             }
             hass.config_entries.async_update_entry(
                 entry,
                 data={**entry.data, **addon_discovery_info},
             )
 
+        host = entry.data[CONF_HOST]
         port = entry.data[CONF_PORT]
         username = entry.data[CONF_USERNAME]
         password = entry.data[CONF_PASSWORD]

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -91,6 +91,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     "core_zwave"
                 )
             )
+
+            if not discovery_info:
+                _LOGGER.error("Failed to get add-on discovery info")
+                return False
+
             discovery_info_config = discovery_info["config"]
             addon_discovery_info = {
                 CONF_HOST: discovery_info_config["host"],

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 
-from .const import CONF_INTEGRATION_CREATED_ADDON
+from .const import CONF_INTEGRATION_CREATED_ADDON, CONF_USE_ADDON
 from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
@@ -16,7 +16,6 @@ CONF_ADDON_DEVICE = "device"
 CONF_ADDON_NETWORK_KEY = "network_key"
 CONF_NETWORK_KEY = "network_key"
 CONF_USB_PATH = "usb_path"
-CONF_USE_ADDON = "use_addon"
 TITLE = "OpenZWave"
 
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=False): bool})

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -77,12 +77,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Confirm the add-on discovery."""
         if user_input is not None:
             self.use_addon = True
-            return await self._async_create_entry_from_vars()
+            return self._async_create_entry_from_vars()
 
-        return self.async_show_form(
-            step_id="hassio_confirm",
-            description_placeholders={"addon": self.addon_discovery_info["addon"]},
-        )
+        return self.async_show_form(step_id="hassio_confirm")
 
     def _async_create_entry_from_vars(self):
         """Return a config entry for the flow."""

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -1,6 +1,5 @@
 """Config flow for ozw integration."""
 import logging
-from pprint import pformat
 
 import voluptuous as vol
 
@@ -64,7 +63,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         This flow is triggered by the OpenZWave add-on.
         """
-        _LOGGER.debug("Add-on discovery info %s", pformat(discovery_info))
         self.addon_discovery_info = {
             CONF_HOST: discovery_info["host"],
             CONF_PORT: discovery_info["port"],

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -44,12 +44,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
-        # Currently all flow results need the MQTT integration.
-        # This will change when we have the direct MQTT client connection.
-        # When that is implemented, move this check to _async_use_mqtt_integration.
-        if "mqtt" not in self.hass.config.components:
-            return self.async_abort(reason="mqtt_required")
-
         # Set a unique_id to make sure discovery flow is aborted on progress.
         await self.async_set_unique_id(DOMAIN)
 
@@ -110,6 +104,8 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         This is the entry point for the logic that is needed
         when this integration will depend on the MQTT integration.
         """
+        if "mqtt" not in self.hass.config.components:
+            return self.async_abort(reason="mqtt_required")
         return self._async_create_entry_from_vars()
 
     async def async_step_on_supervisor(self, user_input=None):

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -45,7 +45,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         # Set a unique_id to make sure discovery flow is aborted on progress.
-        await self.async_set_unique_id(DOMAIN)
+        await self.async_set_unique_id(DOMAIN, raise_on_progress=False)
 
         if not self.hass.components.hassio.is_hassio():
             return self._async_use_mqtt_integration()

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -4,7 +4,6 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 
@@ -31,7 +30,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Set up flow instance."""
         self.addon_config = None
-        self.addon_discovery_info = {}
         self.network_key = None
         self.usb_path = None
         self.use_addon = False
@@ -57,15 +55,8 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         This flow is triggered by the OpenZWave add-on.
         """
-        self.addon_discovery_info = {
-            CONF_HOST: discovery_info["host"],
-            CONF_PORT: discovery_info["port"],
-            CONF_USERNAME: discovery_info["username"],
-            CONF_PASSWORD: discovery_info["password"],
-        }
-
         await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured(updates=self.addon_discovery_info)
+        self._abort_if_unique_id_configured()
 
         addon_config = await self._async_get_addon_config()
         self.usb_path = addon_config[CONF_ADDON_DEVICE]
@@ -90,7 +81,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_NETWORK_KEY: self.network_key,
                 CONF_USE_ADDON: self.use_addon,
                 CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
-                **self.addon_discovery_info,
             },
         )
 

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -51,6 +51,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if "mqtt" not in self.hass.config.components:
             return self.async_abort(reason="mqtt_required")
 
+        # Set a unique_id to make sure discovery flow is aborted on progress.
+        await self.async_set_unique_id(DOMAIN)
+
         if not self.hass.components.hassio.is_hassio():
             return self._async_use_mqtt_integration()
 

--- a/homeassistant/components/ozw/const.py
+++ b/homeassistant/components/ozw/const.py
@@ -25,7 +25,6 @@ PLATFORMS = [
     SWITCH_DOMAIN,
 ]
 MANAGER = "manager"
-OPTIONS = "options"
 
 # MQTT Topics
 TOPIC_OPENZWAVE = "OpenZWave"

--- a/homeassistant/components/ozw/const.py
+++ b/homeassistant/components/ozw/const.py
@@ -12,6 +12,7 @@ DOMAIN = "ozw"
 DATA_UNSUBSCRIBE = "unsubscribe"
 
 CONF_INTEGRATION_CREATED_ADDON = "integration_created_addon"
+CONF_USE_ADDON = "use_addon"
 
 PLATFORMS = [
     BINARY_SENSOR_DOMAIN,

--- a/homeassistant/components/ozw/manifest.json
+++ b/homeassistant/components/ozw/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ozw",
   "requirements": [
-    "python-openzwave-mqtt==1.3.2"
+    "python-openzwave-mqtt[mqtt-client]==1.4.0"
   ],
   "after_dependencies": [
     "mqtt"

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -12,6 +12,10 @@
       "start_addon": {
         "title": "Enter the OpenZWave add-on configuration",
         "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}
+      },
+      "hassio_confirm": {
+        "title": "Set up OpenZWave integration with the OpenZWave add-on",
+        "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on {addon}?"
       }
     },
     "abort": {

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -17,8 +17,7 @@
         }
       },
       "hassio_confirm": {
-        "title": "Set up OpenZWave integration with the OpenZWave add-on",
-        "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on?"
+        "title": "Set up OpenZWave integration with the OpenZWave add-on"
       }
     },
     "abort": {

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -4,18 +4,21 @@
       "on_supervisor": {
         "title": "Select connection method",
         "description": "Do you want to use the OpenZWave Supervisor add-on?",
-        "data": {"use_addon": "Use the OpenZWave Supervisor add-on"}
+        "data": { "use_addon": "Use the OpenZWave Supervisor add-on" }
       },
       "install_addon": {
         "title": "The OpenZWave add-on installation has started"
       },
       "start_addon": {
         "title": "Enter the OpenZWave add-on configuration",
-        "data": {"usb_path": "[%key:common::config_flow::data::usb_path%]", "network_key": "Network Key"}
+        "data": {
+          "usb_path": "[%key:common::config_flow::data::usb_path%]",
+          "network_key": "Network Key"
+        }
       },
       "hassio_confirm": {
         "title": "Set up OpenZWave integration with the OpenZWave add-on",
-        "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on {addon}?"
+        "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on?"
       }
     },
     "abort": {

--- a/homeassistant/components/ozw/strings.json
+++ b/homeassistant/components/ozw/strings.json
@@ -22,6 +22,8 @@
       }
     },
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "addon_info_failed": "Failed to get OpenZWave add-on info.",
       "addon_install_failed": "Failed to install the OpenZWave add-on.",
       "addon_set_config_failed": "Failed to set OpenZWave configuration.",

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -14,6 +14,9 @@
             "install_addon": "Please wait while the OpenZWave add-on installation finishes. This can take several minutes."
         },
         "step": {
+            "hassio_confirm": {
+                "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on {addon}?",
+                "title": "Set up OpenZWave integration with the OpenZWave add-on",
             "install_addon": {
                 "title": "The OpenZWave add-on installation has started"
             },

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -16,7 +16,8 @@
         "step": {
             "hassio_confirm": {
                 "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on {addon}?",
-                "title": "Set up OpenZWave integration with the OpenZWave add-on",
+                "title": "Set up OpenZWave integration with the OpenZWave add-on"
+            },
             "install_addon": {
                 "title": "The OpenZWave add-on installation has started"
             },

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -17,7 +17,6 @@
         },
         "step": {
             "hassio_confirm": {
-                "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on?",
                 "title": "Set up OpenZWave integration with the OpenZWave add-on"
             },
             "install_addon": {

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -15,7 +15,7 @@
         },
         "step": {
             "hassio_confirm": {
-                "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on {addon}?",
+                "description": "Do you want to configure Home Assistant to connect to the OpenZWave daemon provided by the Supervisor add-on?",
                 "title": "Set up OpenZWave integration with the OpenZWave add-on"
             },
             "install_addon": {

--- a/homeassistant/components/ozw/translations/en.json
+++ b/homeassistant/components/ozw/translations/en.json
@@ -4,6 +4,8 @@
             "addon_info_failed": "Failed to get OpenZWave add-on info.",
             "addon_install_failed": "Failed to install the OpenZWave add-on.",
             "addon_set_config_failed": "Failed to set OpenZWave configuration.",
+            "already_configured": "Device is already configured",
+            "already_in_progress": "Configuration flow is already in progress",
             "mqtt_required": "The MQTT integration is not set up",
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         },

--- a/homeassistant/components/ozw/websocket_api.py
+++ b/homeassistant/components/ozw/websocket_api.py
@@ -21,7 +21,7 @@ from homeassistant.components import websocket_api
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
-from .const import ATTR_CONFIG_PARAMETER, ATTR_CONFIG_VALUE, DOMAIN, MANAGER, OPTIONS
+from .const import ATTR_CONFIG_PARAMETER, ATTR_CONFIG_VALUE, DOMAIN, MANAGER
 from .lock import ATTR_USERCODE
 
 TYPE = "type"
@@ -461,7 +461,7 @@ def websocket_refresh_node_info(hass, connection, msg):
     """Tell OpenZWave to re-interview a node."""
 
     manager = hass.data[DOMAIN][MANAGER]
-    options = hass.data[DOMAIN][OPTIONS]
+    options = manager.options
 
     @callback
     def forward_node(node):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1794,7 +1794,7 @@ python-nest==4.1.0
 python-nmap==0.6.1
 
 # homeassistant.components.ozw
-python-openzwave-mqtt==1.3.2
+python-openzwave-mqtt[mqtt-client]==1.4.0
 
 # homeassistant.components.qbittorrent
 python-qbittorrent==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -881,7 +881,7 @@ python-miio==0.5.4
 python-nest==4.1.0
 
 # homeassistant.components.ozw
-python-openzwave-mqtt==1.3.2
+python-openzwave-mqtt[mqtt-client]==1.4.0
 
 # homeassistant.components.songpal
 python-songpal==0.12

--- a/tests/components/ozw/conftest.py
+++ b/tests/components/ozw/conftest.py
@@ -253,3 +253,12 @@ def mock_uninstall_addon():
         "homeassistant.components.hassio.async_uninstall_addon"
     ) as uninstall_addon:
         yield uninstall_addon
+
+
+@pytest.fixture(name="get_addon_discovery_info")
+def mock_get_addon_discovery_info():
+    """Mock get add-on discovery info."""
+    with patch(
+        "homeassistant.components.hassio.async_get_addon_discovery_info"
+    ) as get_addon_discovery_info:
+        yield get_addon_discovery_info

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -473,3 +473,28 @@ async def test_abort_discovery_with_user_flow(
     assert result["type"] == "abort"
     assert result["reason"] == "already_in_progress"
     assert len(hass.config_entries.flow.async_progress()) == 1
+
+
+async def test_abort_discovery_with_existing_entry(
+    hass, supervisor, addon_running, addon_options
+):
+    """Test discovery flow is aborted if an entry already exists."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title=TITLE, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=ADDON_DISCOVERY_INFO,
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert entry.data == {
+        "host": ADDON_DISCOVERY_INFO["host"],
+        "port": ADDON_DISCOVERY_INFO["port"],
+        "username": ADDON_DISCOVERY_INFO["username"],
+        "password": ADDON_DISCOVERY_INFO["password"],
+    }

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -400,10 +400,6 @@ async def test_supervisor_discovery(hass, supervisor, addon_running, addon_optio
         "network_key": "abc123",
         "use_addon": True,
         "integration_created_addon": False,
-        "host": ADDON_DISCOVERY_INFO["host"],
-        "port": ADDON_DISCOVERY_INFO["port"],
-        "username": ADDON_DISCOVERY_INFO["username"],
-        "password": ADDON_DISCOVERY_INFO["password"],
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -492,9 +488,3 @@ async def test_abort_discovery_with_existing_entry(
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data == {
-        "host": ADDON_DISCOVERY_INFO["host"],
-        "port": ADDON_DISCOVERY_INFO["port"],
-        "username": ADDON_DISCOVERY_INFO["username"],
-        "password": ADDON_DISCOVERY_INFO["password"],
-    }

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -9,6 +9,14 @@ from homeassistant.components.ozw.const import DOMAIN
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
 
+ADDON_DISCOVERY_INFO = {
+    "addon": "OpenZWave",
+    "host": "host1",
+    "port": 1234,
+    "username": "name1",
+    "password": "pass1",
+}
+
 
 @pytest.fixture(name="supervisor")
 def mock_supervisor_fixture():
@@ -44,7 +52,7 @@ def mock_addon_installed(addon_info):
 def mock_addon_options(addon_info):
     """Mock add-on options."""
     addon_info.return_value["options"] = {}
-    return addon_info
+    return addon_info.return_value["options"]
 
 
 @pytest.fixture(name="set_addon_options")
@@ -361,3 +369,41 @@ async def test_install_addon_failure(hass, supervisor, addon_installed, install_
 
     assert result["type"] == "abort"
     assert result["reason"] == "addon_install_failed"
+
+
+async def test_supervisor_discovery(hass, supervisor, addon_running, addon_options):
+    """Test flow started from Supervisor discovery."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    addon_options["device"] = "/test"
+    addon_options["network_key"] = "abc123"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=ADDON_DISCOVERY_INFO,
+    )
+
+    with patch(
+        "homeassistant.components.ozw.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.ozw.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == TITLE
+    assert result["data"] == {
+        "usb_path": "/test",
+        "network_key": "abc123",
+        "use_addon": True,
+        "integration_created_addon": False,
+        "host": ADDON_DISCOVERY_INFO["host"],
+        "port": ADDON_DISCOVERY_INFO["port"],
+        "username": ADDON_DISCOVERY_INFO["username"],
+        "password": ADDON_DISCOVERY_INFO["password"],
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/ozw/test_init.py
+++ b/tests/components/ozw/test_init.py
@@ -186,6 +186,7 @@ async def test_setup_entry_without_addon_info(hass, get_addon_discovery_info):
         assert not await hass.config_entries.async_setup(entry.entry_id)
 
     assert mock_client.return_value.start_client.call_count == 0
+    assert entry.state == config_entries.ENTRY_STATE_SETUP_RETRY
 
 
 async def test_unload_entry_with_addon(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Bump python-openzwave-mqtt to 1.4.0. This version includes an MQTT client.
  - https://github.com/cgarwood/python-openzwave-mqtt/releases/tag/v1.4.0
- We use the MQTT client when the user uses the OpenZWave add-on to run the ozwdaemon. In this case the MQTT integration isn't required anymore.
- Add support for Supervisor discovery source in the config flow.
- Add a Supervisor (hassio) integration helper to get the discovery info for an add-on. We need this to get the MQTT client options from the add-on discovery info when the config entry hasn't been created or updated by the discovery flow.

## TODO

- [x] Add some more tests.
- [x] Docs PR. Update this: https://www.home-assistant.io/integrations/ozw/#requirements

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15803

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
