### PR TITLE
Add support for effects, transition/brightness parameters to template light, min_mireds and max_mireds templates

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -705,14 +705,7 @@ class LightTemplate(TemplateEntity, LightEntity):
     @callback
     def _update_supports_transition(self, render):
         """Update the supports transition from the template."""
-        try:
-            if render in ("None", ""):
-                self._supports_transition = False
-                return
-            self._supports_transition = bool(render)
-        except ValueError:
-            _LOGGER.error(
-                "Template must supply an boolean value",
-                exc_info=True,
-            )
+        if render in ("None", ""):
             self._supports_transition = False
+            return
+        self._supports_transition = bool(render)

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -516,7 +516,7 @@ class LightTemplate(TemplateEntity, LightEntity):
         if effect_list in ("None", "") or not isinstance(effect_list, list):
             _LOGGER.error(
                 "Received invalid effect list: %s. Expected list of strings",
-                effect_list
+                effect_list,
             )
             self._effect_list = None
             return

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -8,8 +8,6 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
-    ATTR_MAX_MIREDS,
-    ATTR_MIN_MIREDS,
     ATTR_TRANSITION,
     ATTR_WHITE_VALUE,
     ENTITY_ID_FORMAT,

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -513,7 +513,11 @@ class LightTemplate(TemplateEntity, LightEntity):
     @callback
     def _update_effect_list(self, effect_list):
         """Update the effect list from the template."""
-        if effect_list in ("None", "") or not isinstance(effect_list, list):
+        if effect_list in ("None", "") :
+            self._effect_list = None
+            return
+
+        if not isinstance(effect_list, list):
             _LOGGER.error(
                 "Received invalid effect list: %s. Expected list of strings",
                 effect_list,

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -513,7 +513,7 @@ class LightTemplate(TemplateEntity, LightEntity):
     @callback
     def _update_effect_list(self, effect_list):
         """Update the effect list from the template."""
-        if effect_list in ("None", "") :
+        if effect_list in ("None", ""):
             self._effect_list = None
             return
 

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -319,8 +319,6 @@ class LightTemplate(TemplateEntity, LightEntity):
             supported_features |= SUPPORT_WHITE_VALUE
         if self._effect_script is not None:
             supported_features |= SUPPORT_EFFECT
-        if self._effect_script is not None:
-            supported_features |= SUPPORT_EFFECT
         if self._supports_transition == True:
             supported_features |= SUPPORT_TRANSITION
         return supported_features

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -437,7 +437,7 @@ class LightTemplate(TemplateEntity, LightEntity):
         if ATTR_BRIGHTNESS in kwargs:
             common_params["brightness"] = kwargs[ATTR_BRIGHTNESS]
 
-        if ATTR_TRANSITION in kwargs:
+        if ATTR_TRANSITION in kwargs and self._supports_transition == True:
             common_params["transition"] = kwargs[ATTR_TRANSITION]
 
         if ATTR_COLOR_TEMP in kwargs and self._temperature_script:

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -513,18 +513,14 @@ class LightTemplate(TemplateEntity, LightEntity):
     @callback
     def _update_effect_list(self, effect_list):
         """Update the effect list from the template."""
-        try:
-            if effect_list in ("None", ""):
-                self._effect_list = None
-                return
-
-            self._effect_list = effect_list
-        except ValueError:
+        if effect_list in ("None", "") or not isinstance(effect_list, list):
             _LOGGER.error(
-                "Template must supply a list of effects, or 'None'",
-                exc_info=True,
+                "Received invalid effect list: %s. Expected list of strings", effect_list
             )
             self._effect_list = None
+            return
+
+        self._effect_list = effect_list
 
     @callback
     def _update_state(self, result):

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -319,7 +319,7 @@ class LightTemplate(TemplateEntity, LightEntity):
             supported_features |= SUPPORT_WHITE_VALUE
         if self._effect_script is not None:
             supported_features |= SUPPORT_EFFECT
-        if self._supports_transition == True:
+        if self._supports_transition is True:
             supported_features |= SUPPORT_TRANSITION
         return supported_features
 
@@ -435,7 +435,7 @@ class LightTemplate(TemplateEntity, LightEntity):
         if ATTR_BRIGHTNESS in kwargs:
             common_params["brightness"] = kwargs[ATTR_BRIGHTNESS]
 
-        if ATTR_TRANSITION in kwargs and self._supports_transition == True:
+        if ATTR_TRANSITION in kwargs and self._supports_transition is True:
             common_params["transition"] = kwargs[ATTR_TRANSITION]
 
         if ATTR_COLOR_TEMP in kwargs and self._temperature_script:
@@ -475,6 +475,8 @@ class LightTemplate(TemplateEntity, LightEntity):
             )
         elif ATTR_BRIGHTNESS in kwargs and self._level_script:
             await self._level_script.async_run(common_params, context=self._context)
+        elif ATTR_TRANSITION in kwargs and self._supports_transition is True:
+            await self._on_script.async_run(common_params, context=self._context)
         else:
             await self._on_script.async_run(context=self._context)
 
@@ -483,7 +485,10 @@ class LightTemplate(TemplateEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
-        await self._off_script.async_run(context=self._context)
+        if ATTR_TRANSITION in kwargs and self._supports_transition is True:
+            await self._off_script.async_run({"transition": kwargs[ATTR_TRANSITION]}, context=self._context)
+        else:
+            await self._off_script.async_run(context=self._context)
         if self._template is None:
             self._state = False
             self.async_write_ha_state()

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -254,12 +254,18 @@ class LightTemplate(TemplateEntity, LightEntity):
     @property
     def max_mireds(self):
         """Return the max mireds value in mireds."""
-        return self._max_mireds
+        if self._max_mireds is not None:
+            return self._max_mireds
+
+        return super().max_mireds
 
     @property
     def min_mireds(self):
         """Return the min mireds value in mireds."""
-        return self._min_mireds
+        if self._min_mireds is not None:
+            return self._min_mireds
+
+        return super().min_mireds
 
     @property
     def white_value(self):

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -515,7 +515,8 @@ class LightTemplate(TemplateEntity, LightEntity):
         """Update the effect list from the template."""
         if effect_list in ("None", "") or not isinstance(effect_list, list):
             _LOGGER.error(
-                "Received invalid effect list: %s. Expected list of strings", effect_list
+                "Received invalid effect list: %s. Expected list of strings",
+                effect_list
             )
             self._effect_list = None
             return

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1230,10 +1230,10 @@ async def test_color_template(hass, expected_hs, template):
         "expected_min_mireds,template",
         [
             (118, "{{118}}"),
-            (None, "{{x - 12}}"),
-            (None, "None"),
-            (None, "{{ none }}"),
-            (None, ""),
+            (153, "{{x - 12}}"),
+            (153, "None"),
+            (153, "{{ none }}"),
+            (153, ""),
         ],
     )
     def test_min_mireds_template(self, expected_min_mireds, template):
@@ -1256,13 +1256,14 @@ async def test_color_template(hass, expected_hs, template):
                                     "service": "light.turn_off",
                                     "entity_id": "light.test_state",
                                 },
-                                "set_effect": {
+                                "set_temperature": {
                                     "service": "light.turn_on",
                                     "data_template": {
                                         "entity_id": "light.test_state",
-                                        "effect": "{{effect}}",
+                                        "color_temp": "{{color_temp}}",
                                     },
                                 },
+                                "temperature_template": template,
                                 "min_mireds_template": template,
                             }
                         },
@@ -1281,11 +1282,11 @@ async def test_color_template(hass, expected_hs, template):
     @pytest.mark.parametrize(
         "expected_max_mireds,template",
         [
-            (118, "{{118}}"),
-            (None, "{{x - 12}}"),
-            (None, "None"),
-            (None, "{{ none }}"),
-            (None, ""),
+            (488, "{{488}}"),
+            (500, "{{x - 12}}"),
+            (500, "None"),
+            (500, "{{ none }}"),
+            (500, ""),
         ],
     )
     def test_max_mireds_template(self, expected_max_mireds, template):
@@ -1308,13 +1309,14 @@ async def test_color_template(hass, expected_hs, template):
                                     "service": "light.turn_off",
                                     "entity_id": "light.test_state",
                                 },
-                                "set_effect": {
+                                "set_temperature": {
                                     "service": "light.turn_on",
                                     "data_template": {
                                         "entity_id": "light.test_state",
-                                        "effect": "{{effect}}",
+                                        "color_temp": "{{color_temp}}",
                                     },
                                 },
+                                "temperature_template": template,
                                 "max_mireds_template": template,
                             }
                         },

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1328,7 +1328,8 @@ async def test_color_template(hass, expected_hs, template):
 
         state = self.hass.states.get("light.test_template_light")
         assert state is not None
-        assert state.attributes.get("min_mireds") == expected_min_mireds
+        assert state.attributes.get("max_mireds") == expected_max_mireds
+
 
 async def test_available_template_with_entities(hass):
     """Test availability templates with values from other entities."""

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1180,6 +1180,8 @@ async def test_color_template(hass, expected_hs, template):
             ),
             ([], "{{ [] }}"),
             ([], "{{ '[]' }}"),
+            (None, "{{ 124 }}"),
+            (None, "{{ '124' }}"),
             (None, "{{ none }}"),
             (None, ""),
         ],
@@ -1234,6 +1236,7 @@ async def test_color_template(hass, expected_hs, template):
             (153, "None"),
             (153, "{{ none }}"),
             (153, ""),
+            (153, "{{ 'a' }}"),
         ],
     )
     def test_min_mireds_template(self, expected_min_mireds, template):
@@ -1287,6 +1290,7 @@ async def test_color_template(hass, expected_hs, template):
             (500, "None"),
             (500, "{{ none }}"),
             (500, ""),
+            (500, "{{ 'a' }}"),
         ],
     )
     def test_max_mireds_template(self, expected_max_mireds, template):

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -8,6 +8,7 @@ import homeassistant.components.light as light
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
+    ATTR_EFFECT,
     ATTR_HS_COLOR,
     ATTR_WHITE_VALUE,
 )
@@ -1118,6 +1119,216 @@ async def test_color_template(hass, expected_hs, template):
     assert state is not None
     assert state.attributes.get("hs_color") == expected_hs
 
+    def test_effect_action_no_template(self):
+        """Test setting effect with optimistic template."""
+        assert setup.setup_component(
+            self.hass,
+            "light",
+            {
+                "light": {
+                    "platform": "template",
+                    "lights": {
+                        "test_template_light": {
+                            "value_template": "{{1 == 1}}",
+                            "turn_on": {
+                                "service": "light.turn_on",
+                                "entity_id": "light.test_state",
+                            },
+                            "turn_off": {
+                                "service": "light.turn_off",
+                                "entity_id": "light.test_state",
+                            },
+                            "set_effect": {
+                                "service": "test.automation",
+                                "data_template": {
+                                    "entity_id": "test.test_state",
+                                    "effect": "{{effect}}",
+                                },
+                            },
+                        }
+                    },
+                }
+            },
+        )
+        self.hass.block_till_done()
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("light.test_template_light")
+        assert state.attributes.get("effect") is None
+
+        common.turn_on(self.hass, "light.test_template_light", **{ATTR_EFFECT: "Disco"})
+        self.hass.block_till_done()
+        assert len(self.calls) == 1
+        assert self.calls[0].data["effect"] == "Disco"
+
+        state = self.hass.states.get("light.test_template_light")
+        _LOGGER.info(str(state.attributes))
+        assert state is not None
+        assert state.attributes.get("effect") == "Disco"
+
+    @pytest.mark.parametrize(
+        "expected_effect_list,template",
+        [
+            (
+                ["Strobe color", "Police", "Christmas", "RGB", "Random Loop"],
+                '{{ \'["Strobe color", "Police", "Christmas", "RGB", "Random Loop"]\' }}',
+            ),
+            (
+                ["Police", "RGB", "Random Loop"],
+                '{{ \'["Police", "RGB", "Random Loop"]\' }}',
+            ),
+            ([], "{{ [] }}"),
+            ([], "{{ '[]' }}"),
+            (None, "{{ none }}"),
+            (None, ""),
+        ],
+    )
+    def test_effect_list_template(self, expected_effect_list, template):
+        """Test the template for the effect."""
+        with assert_setup_component(1, "light"):
+            assert setup.setup_component(
+                self.hass,
+                "light",
+                {
+                    "light": {
+                        "platform": "template",
+                        "lights": {
+                            "test_template_light": {
+                                "value_template": "{{ 1 == 1 }}",
+                                "turn_on": {
+                                    "service": "light.turn_on",
+                                    "entity_id": "light.test_state",
+                                },
+                                "turn_off": {
+                                    "service": "light.turn_off",
+                                    "entity_id": "light.test_state",
+                                },
+                                "set_effect": {
+                                    "service": "light.turn_on",
+                                    "data_template": {
+                                        "entity_id": "light.test_state",
+                                        "effect": "{{effect}}",
+                                    },
+                                },
+                                "effect_list_template": template,
+                            }
+                        },
+                    }
+                },
+            )
+
+        self.hass.block_till_done()
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("light.test_template_light")
+        assert state is not None
+        assert state.attributes.get("effect_list") == expected_effect_list
+
+    @pytest.mark.parametrize(
+        "expected_min_mireds,template",
+        [
+            (118, "{{118}}"),
+            (None, "{{x - 12}}"),
+            (None, "None"),
+            (None, "{{ none }}"),
+            (None, ""),
+        ],
+    )
+    def test_min_mireds_template(self, expected_min_mireds, template):
+        """Test the template for the min mireds."""
+        with assert_setup_component(1, "light"):
+            assert setup.setup_component(
+                self.hass,
+                "light",
+                {
+                    "light": {
+                        "platform": "template",
+                        "lights": {
+                            "test_template_light": {
+                                "value_template": "{{ 1 == 1 }}",
+                                "turn_on": {
+                                    "service": "light.turn_on",
+                                    "entity_id": "light.test_state",
+                                },
+                                "turn_off": {
+                                    "service": "light.turn_off",
+                                    "entity_id": "light.test_state",
+                                },
+                                "set_effect": {
+                                    "service": "light.turn_on",
+                                    "data_template": {
+                                        "entity_id": "light.test_state",
+                                        "effect": "{{effect}}",
+                                    },
+                                },
+                                "min_mireds_template": template,
+                            }
+                        },
+                    }
+                },
+            )
+
+        self.hass.block_till_done()
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("light.test_template_light")
+        assert state is not None
+        assert state.attributes.get("min_mireds") == expected_min_mireds
+
+    @pytest.mark.parametrize(
+        "expected_max_mireds,template",
+        [
+            (118, "{{118}}"),
+            (None, "{{x - 12}}"),
+            (None, "None"),
+            (None, "{{ none }}"),
+            (None, ""),
+        ],
+    )
+    def test_max_mireds_template(self, expected_max_mireds, template):
+        """Test the template for the max mireds."""
+        with assert_setup_component(1, "light"):
+            assert setup.setup_component(
+                self.hass,
+                "light",
+                {
+                    "light": {
+                        "platform": "template",
+                        "lights": {
+                            "test_template_light": {
+                                "value_template": "{{ 1 == 1 }}",
+                                "turn_on": {
+                                    "service": "light.turn_on",
+                                    "entity_id": "light.test_state",
+                                },
+                                "turn_off": {
+                                    "service": "light.turn_off",
+                                    "entity_id": "light.test_state",
+                                },
+                                "set_effect": {
+                                    "service": "light.turn_on",
+                                    "data_template": {
+                                        "entity_id": "light.test_state",
+                                        "effect": "{{effect}}",
+                                    },
+                                },
+                                "max_mireds_template": template,
+                            }
+                        },
+                    }
+                },
+            )
+
+        self.hass.block_till_done()
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get("light.test_template_light")
+        assert state is not None
+        assert state.attributes.get("min_mireds") == expected_min_mireds
 
 async def test_available_template_with_entities(hass):
     """Test availability templates with values from other entities."""

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -379,6 +379,7 @@ async def test_on_action(hass, calls):
 
     assert len(calls) == 1
 
+
 async def test_on_action_with_transition(hass, calls):
     """Test on action with transition."""
     assert await setup.async_setup_component(
@@ -528,6 +529,7 @@ async def test_off_action(hass, calls):
 
     assert len(calls) == 1
 
+
 async def test_off_action_with_transition(hass, calls):
     """Test off action with transition."""
     assert await setup.async_setup_component(
@@ -577,6 +579,7 @@ async def test_off_action_with_transition(hass, calls):
 
     assert len(calls) == 1
     assert calls[0].data["transition"] == 2
+
 
 async def test_off_action_optimistic(hass, calls):
     """Test off action with optimistic state."""
@@ -1220,62 +1223,6 @@ async def test_color_template(hass, expected_hs, template):
     assert state.attributes.get("hs_color") == expected_hs
 
 
-@pytest.mark.parametrize(
-    "expected_hs,template",
-    [
-        ((360, 100), "{{(360, 100)}}"),
-        ((359.9, 99.9), "{{(359.9, 99.9)}}"),
-        (None, "{{(361, 100)}}"),
-        (None, "{{(360, 101)}}"),
-        (None, "{{x - 12}}"),
-        (None, ""),
-        (None, "{{ none }}"),
-    ],
-)
-async def test_color_template(hass, expected_hs, template):
-    """Test the template for the color."""
-    with assert_setup_component(1, light.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            light.DOMAIN,
-            {
-                "light": {
-                    "platform": "template",
-                    "lights": {
-                        "test_template_light": {
-                            "value_template": "{{ 1 == 1 }}",
-                            "turn_on": {
-                                "service": "light.turn_on",
-                                "entity_id": "light.test_state",
-                            },
-                            "turn_off": {
-                                "service": "light.turn_off",
-                                "entity_id": "light.test_state",
-                            },
-                            "set_color": [
-                                {
-                                    "service": "input_number.set_value",
-                                    "data_template": {
-                                        "entity_id": "input_number.h",
-                                        "value": "{{h}}",
-                                    },
-                                }
-                            ],
-                            "color_template": template,
-                            "supports_transition_template": "{{ true }}",
-                        }
-                    },
-                }
-            },
-        )
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-    state = hass.states.get("light.test_template_light")
-    assert state is not None
-    assert state.attributes.get("hs_color") == expected_hs
-
-
 async def test_effect_action(hass, calls):
     """Test setting effect with template."""
     assert setup.setup_component(
@@ -1308,11 +1255,11 @@ async def test_effect_action(hass, calls):
             }
         },
     )
-    self.hass.block_till_done()
-    self.hass.start()
-    self.hass.block_till_done()
+    await hass.block_till_done()
+    await hass.start()
+    await hass.block_till_done()
 
-    state = self.hass.states.get("light.test_template_light")
+    state = hass.states.get("light.test_template_light")
     assert state.attributes.get("effect") is None
 
     await hass.services.async_call(
@@ -1322,10 +1269,10 @@ async def test_effect_action(hass, calls):
         blocking=True,
     )
 
-    assert len(self.calls) == 1
-    assert self.calls[0].data["effect"] == "Disco"
+    assert len(calls) == 1
+    assert calls[0].data["effect"] == "Disco"
 
-    state = self.hass.states.get("light.test_template_light")
+    state = hass.states.get("light.test_template_light")
     _LOGGER.info(str(state.attributes))
     assert state is not None
     assert state.attributes.get("effect") == "Disco"


### PR DESCRIPTION
## Breaking change
`brightness` in a `turn_on` call to a template light will now be passed as a parameter to either of color_temp, effect, hs_color or white_value scripts if the corresponding parameter is also in the `turn_on` call instead of calling the `set_level` script.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update template light with support for:
- Effects, including effect_list
- Transition, which will be passed as a parameter to the brightness, color_temp, effect, hs_color or white_value scripts
- min_mired + max_mireds templates

Also, `brightness` in a `turn_on` call will now be passed as a parameter to either of color_temp, effect, hs_color or white_value scripts if the corresponding parameter is also in the `turn_on` call instead of calling the `brightness` script.

This is my first PR :)
I use it to group two or more led strips and then control group of lights at the same time

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
    salon_leds:
      value_template: "{{ is_state('binary_sensor.salon_leds', 'on') }}"
      turn_on:
        service: switch.turn_on
        data:
          entity_id: switch.smart_salon_all_led
      turn_off:
        service: switch.turn_off
        data:
          entity_id: switch.smart_salon_all_led
      level_template: "{{ state_attr('light.yeelight_strip2_7c49ebb119e5', 'brightness') | int }}"
      set_level:
        - service: light.turn_on
          data_template:
            entity_id:
              - light.yeelight_strip2_7c49ebb115f8
              - light.yeelight_strip2_7c49ebb119e5
            transition: >-
              {% if not transition is defined or transition == None or transition == 'undefined' %}{{ 1 | float }}
              {% else %}{{ transition | float }}
              {% endif %}
            brightness: "{{ brightness }}"
      color_template: >-
        {% set color = state_attr('light.yeelight_strip2_7c49ebb119e5', 'hs_color') %}
        {% if color == None or color == 'undefined' %}None
        {% else %}({{color[0] | float}}, {{color[1] | float}})
        {% endif %}
      set_color:
        - service: light.turn_on
          data_template:
            entity_id:
              - light.yeelight_strip2_7c49ebb115f8
              - light.yeelight_strip2_7c49ebb119e5
            transition: >-
              {% if not transition is defined or transition == None or transition == 'undefined' %}{{ 1 | float }}
              {% else %}{{ transition | float }}
              {% endif %}
            hs_color:
              - "{{ hs[0] }}"
              - "{{ hs[1] }}"
      effect_list_template: >-
        {{ state_attr('light.yeelight_strip2_7c49ebb119e5', 'effect_list') }}
      set_effect:
        - service: light.turn_on
          data_template:
            entity_id:
              - light.yeelight_strip2_7c49ebb115f8
              - light.yeelight_strip2_7c49ebb119e5
              - light.yeelight_c2_7c49ebae794c
            transition: >-
              {% if not transition is defined or transition == None or transition == 'undefined' %}{{ 1 | float }}
              {% else %}{{ transition | float }}
              {% endif %}
            effect: "{{ effect }}"
      min_mireds_template: >-
        {% set min = state_attr('light.yeelight_strip2_7c49ebb119e5', 'min_mireds') %}
        {% if min == None %}
          {{ 153 | float}}
        {% else %}
          {{ min | float }}
        {% endif %}
      max_mireds_template: >-
        {% set max = state_attr('light.yeelight_strip2_7c49ebb119e5', 'max_mireds') %}
        {% if max == None %}
          {{ 588 | float}}
        {% else %}
          {{ max | float }}
        {% endif %}
      supports_transition_template: "{{ true }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: home-assistant/home-assistant.io#15801

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-asc+-review%3Aapproved

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
