### PR TITLE
Prevent ping integration from delaying startup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -742,6 +742,7 @@ omit =
     homeassistant/components/picotts/tts.py
     homeassistant/components/piglow/light.py
     homeassistant/components/pilight/*
+    homeassistant/components/ping/__init__.py
     homeassistant/components/ping/const.py
     homeassistant/components/ping/binary_sensor.py
     homeassistant/components/ping/device_tracker.py

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -1,5 +1,9 @@
 """The ping component."""
 
+from functools import cache
+
+from icmplib import SocketPermissionError, ping as icmp_ping
+
 from homeassistant.core import callback
 
 DOMAIN = "ping"
@@ -26,3 +30,13 @@ def async_get_next_ping_id(hass):
     hass.data[DOMAIN][PING_ID] = next_id
 
     return next_id
+
+
+@cache
+def can_create_raw_socket():
+    """Verify we can create a raw socket."""
+    try:
+        icmp_ping("127.0.0.1", count=0, timeout=0)
+        return True
+    except SocketPermissionError:
+        return False

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -1,6 +1,6 @@
 """The ping component."""
 
-from functools import cache
+from functools import lru_cache
 
 from icmplib import SocketPermissionError, ping as icmp_ping
 
@@ -32,7 +32,8 @@ def async_get_next_ping_id(hass):
     return next_id
 
 
-@cache
+# In python 3.9 and later, this can be converted to just be `cache`
+@lru_cache(maxsize=None)
 def can_create_raw_socket():
     """Verify we can create a raw socket."""
     try:

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -1,4 +1,5 @@
 """The ping component."""
+from __future__ import annotations
 
 from functools import lru_cache
 
@@ -34,10 +35,16 @@ def async_get_next_ping_id(hass):
 
 # In python 3.9 and later, this can be converted to just be `cache`
 @lru_cache(maxsize=None)
-def can_create_raw_socket():
+def can_use_icmp_lib_with_privilege() -> None | bool:
     """Verify we can create a raw socket."""
     try:
         icmp_ping("127.0.0.1", count=0, timeout=0)
-        return True
     except SocketPermissionError:
-        return False
+        try:
+            icmp_ping("127.0.0.1", count=0, timeout=0, privileged=False)
+        except SocketPermissionError:
+            return None
+        else:
+            return False
+    else:
+        return True

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -7,6 +7,7 @@ import logging
 from icmplib import SocketPermissionError, ping as icmp_ping
 
 from homeassistant.core import callback
+from homeassistant.helpers.reload import async_setup_reload_service
 
 DOMAIN = "ping"
 PLATFORMS = ["binary_sensor"]
@@ -16,6 +17,13 @@ DEFAULT_START_ID = 129
 MAX_PING_ID = 65534
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass, config):
+    """Set up the template integration."""
+    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
+
+    return True
 
 
 @callback
@@ -34,6 +42,13 @@ def async_get_next_ping_id(hass):
     hass.data[DOMAIN][PING_ID] = next_id
 
     return next_id
+
+
+# In python 3.9 and later, this can be converted to just be `cache`
+@lru_cache(maxsize=None)
+async def async_can_use_icmp_lib_with_privilege(hass) -> None | bool:
+    """Verify we can create a raw socket."""
+    return await hass.async_add_executor_job(can_use_icmp_lib_with_privilege)
 
 
 # In python 3.9 and later, this can be converted to just be `cache`

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -48,12 +48,10 @@ def async_get_next_ping_id(hass):
 @lru_cache(maxsize=None)
 async def async_can_use_icmp_lib_with_privilege(hass) -> None | bool:
     """Verify we can create a raw socket."""
-    return await hass.async_add_executor_job(can_use_icmp_lib_with_privilege)
+    return await hass.async_add_executor_job(_can_use_icmp_lib_with_privilege)
 
 
-# In python 3.9 and later, this can be converted to just be `cache`
-@lru_cache(maxsize=None)
-def can_use_icmp_lib_with_privilege() -> None | bool:
+def _can_use_icmp_lib_with_privilege() -> None | bool:
     """Verify we can create a raw socket."""
     try:
         icmp_ping("127.0.0.1", count=0, timeout=0, privileged=True)

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -43,8 +43,11 @@ def can_use_icmp_lib_with_privilege() -> None | bool:
         try:
             icmp_ping("127.0.0.1", count=0, timeout=0, privileged=False)
         except SocketPermissionError:
+            # Cannot use icmplib even with privileged=False
             return None
         else:
+            # Can use icmplib with privileged=False
             return False
     else:
+        # Can use icmplib privileged=True
         return True

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import logging
 
 from icmplib import SocketPermissionError, ping as icmp_ping
 
@@ -13,6 +14,8 @@ PLATFORMS = ["binary_sensor"]
 PING_ID = "ping_id"
 DEFAULT_START_ID = 129
 MAX_PING_ID = 65534
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback
@@ -43,11 +46,13 @@ def can_use_icmp_lib_with_privilege() -> None | bool:
         try:
             icmp_ping("127.0.0.1", count=0, timeout=0, privileged=False)
         except SocketPermissionError:
-            # Cannot use icmplib even with privileged=False
+            _LOGGER.debug(
+                "Cannot use icmplib because privileges are insufficient to create the socket"
+            )
             return None
         else:
-            # Can use icmplib with privileged=False
+            _LOGGER.debug("Using icmplib in privileged=False mode")
             return False
     else:
-        # Can use icmplib privileged=True
+        _LOGGER.debug("Using icmplib in privileged=True mode")
         return True

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -41,7 +41,7 @@ def async_get_next_ping_id(hass):
 def can_use_icmp_lib_with_privilege() -> None | bool:
     """Verify we can create a raw socket."""
     try:
-        icmp_ping("127.0.0.1", count=0, timeout=0)
+        icmp_ping("127.0.0.1", count=0, timeout=0, privileged=True)
     except SocketPermissionError:
         try:
             icmp_ping("127.0.0.1", count=0, timeout=0, privileged=False)

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -8,9 +8,9 @@ from functools import partial
 import logging
 import re
 import sys
-from typing import Any
+from typing import Any, Dict
 
-from icmplib import SocketPermissionError, ping as icmp_ping
+from icmplib import ping as icmp_ping
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -23,7 +23,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import setup_reload_service
 
 from . import DOMAIN, PLATFORMS, async_get_next_ping_id
-from .const import PING_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,15 +70,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
     count = config[CONF_PING_COUNT]
     name = config.get(CONF_NAME, f"{DEFAULT_NAME} {host}")
 
-    try:
-        # Verify we can create a raw socket, or
-        # fallback to using a subprocess
-        icmp_ping("127.0.0.1", count=0, timeout=0)
-        ping_cls = PingDataICMPLib
-    except SocketPermissionError:
-        ping_cls = PingDataSubProcess
-
-    ping_data = ping_cls(hass, host, count)
+    ping_data = PingDataICMPLib(hass, host, count)
 
     add_entities([PingBinarySensor(name, ping_data)], True)
 

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -8,7 +8,7 @@ from functools import partial
 import logging
 import re
 import sys
-from typing import Any, Dict
+from typing import Any
 
 from icmplib import NameLookupError, ping as icmp_ping
 import voluptuous as vol
@@ -18,12 +18,13 @@ from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA,
     BinarySensorEntity,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_ON
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import setup_reload_service
+from homeassistant.helpers.restore_state import RestoreEntity
 
-from . import DOMAIN, PLATFORMS, async_get_next_ping_id, can_create_raw_socket
-from .const import ICMP_TIMEOUT
+from . import DOMAIN, PLATFORMS, async_get_next_ping_id, can_use_icmp_lib_with_privilege
+from .const import ICMP_TIMEOUT, PING_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,14 +72,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
     count = config[CONF_PING_COUNT]
     name = config.get(CONF_NAME, f"{DEFAULT_NAME} {host}")
 
-    privileged = can_create_raw_socket()
+    privileged = can_use_icmp_lib_with_privilege()
+    if privileged is None:
+        ping_cls = PingDataSubProcess
+    else:
+        ping_cls = PingDataICMPLib
 
-    ping_data = PingDataICMPLib(hass, host, count, privileged)
+    ping_data = ping_cls(hass, host, count, privileged)
 
-    add_entities([PingBinarySensor(name, ping_data)], True)
+    add_entities([PingBinarySensor(name, ping_data)])
 
 
-class PingBinarySensor(BinarySensorEntity):
+class PingBinarySensor(RestoreEntity, BinarySensorEntity):
     """Representation of a Ping Binary sensor."""
 
     def __init__(self, name: str, ping) -> None:
@@ -116,8 +121,26 @@ class PingBinarySensor(BinarySensorEntity):
         """Get the latest data."""
         await self._ping.async_update()
 
+    async def async_added_to_hass(self):
+        """Restore ATTR_CHANGED_BY on startup since it is likely no longer in the activity log."""
+        await super().async_added_to_hass()
 
-class PingDataICMPLib:
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state != STATE_ON:
+            self._ping.data = False
+            return
+
+        attributes = last_state.attributes
+        self._ping.available = True
+        self._ping.data = {
+            "min": attributes[ATTR_ROUND_TRIP_TIME_AVG],
+            "max": attributes[ATTR_ROUND_TRIP_TIME_MAX],
+            "avg": attributes[ATTR_ROUND_TRIP_TIME_MDEV],
+            "mdev": attributes[ATTR_ROUND_TRIP_TIME_MIN],
+        }
+
+
+class PingData:
     """The Class for handling the data retrieval using icmplib."""
 
     def __init__(self, hass, host, count, privileged) -> None:
@@ -128,6 +151,10 @@ class PingDataICMPLib:
         self.data = {}
         self.available = False
         self._privileged = privileged
+
+
+class PingDataICMPLib(PingData):
+    """The Class for handling the data retrieval using icmplib."""
 
     async def async_update(self) -> None:
         """Retrieve the latest details from the host."""
@@ -163,7 +190,7 @@ class PingDataICMPLib:
 class PingDataSubProcess(PingData):
     """The Class for handling the data retrieval using the ping binary."""
 
-    def __init__(self, hass, host, count) -> None:
+    def __init__(self, hass, host, count, privileged) -> None:
         """Initialize the data object."""
         super().__init__(hass, host, count)
         if sys.platform == "win32":

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -22,8 +22,8 @@ from homeassistant.const import CONF_HOST, CONF_NAME, STATE_ON
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from . import async_can_use_icmp_lib_with_privilege, async_get_next_ping_id
-from .const import ICMP_TIMEOUT, PING_TIMEOUT
+from . import async_get_next_ping_id
+from .const import DOMAIN, ICMP_TIMEOUT, PING_PRIVS, PING_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,8 +70,7 @@ async def async_setup_platform(
     host = config[CONF_HOST]
     count = config[CONF_PING_COUNT]
     name = config.get(CONF_NAME, f"{DEFAULT_NAME} {host}")
-
-    privileged = await async_can_use_icmp_lib_with_privilege(hass)
+    privileged = hass.data[DOMAIN][PING_PRIVS]
     if privileged is None:
         ping_cls = PingDataSubProcess
     else:

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -10,7 +10,7 @@ import re
 import sys
 from typing import Any, Dict
 
-from icmplib import ping as icmp_ping
+from icmplib import NameLookupError, ping as icmp_ping
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -22,7 +22,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import setup_reload_service
 
-from . import DOMAIN, PLATFORMS, async_get_next_ping_id
+from . import DOMAIN, PLATFORMS, async_get_next_ping_id, can_create_raw_socket
 from .const import ICMP_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,7 +71,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
     count = config[CONF_PING_COUNT]
     name = config.get(CONF_NAME, f"{DEFAULT_NAME} {host}")
 
-    ping_data = PingDataICMPLib(hass, host, count)
+    privileged = can_create_raw_socket()
+
+    ping_data = PingDataICMPLib(hass, host, count, privileged)
 
     add_entities([PingBinarySensor(name, ping_data)], True)
 
@@ -115,33 +117,36 @@ class PingBinarySensor(BinarySensorEntity):
         await self._ping.async_update()
 
 
-class PingData:
-    """The base class for handling the data retrieval."""
+class PingDataICMPLib:
+    """The Class for handling the data retrieval using icmplib."""
 
-    def __init__(self, hass, host, count) -> None:
+    def __init__(self, hass, host, count, privileged) -> None:
         """Initialize the data object."""
         self.hass = hass
         self._ip_address = host
         self._count = count
         self.data = {}
         self.available = False
-
-
-class PingDataICMPLib(PingData):
-    """The Class for handling the data retrieval using icmplib."""
+        self._privileged = privileged
 
     async def async_update(self) -> None:
         """Retrieve the latest details from the host."""
         _LOGGER.debug("ping address: %s", self._ip_address)
-        data = await self.hass.async_add_executor_job(
-            partial(
-                icmp_ping,
-                self._ip_address,
-                count=self._count,
-                timeout=ICMP_TIMEOUT,
-                id=async_get_next_ping_id(self.hass),
+        try:
+            data = await self.hass.async_add_executor_job(
+                partial(
+                    icmp_ping,
+                    self._ip_address,
+                    count=self._count,
+                    timeout=ICMP_TIMEOUT,
+                    id=async_get_next_ping_id(self.hass),
+                    privileged=self._privileged,
+                )
             )
-        )
+        except NameLookupError:
+            self.available = False
+            return
+
         self.available = data.is_alive
         if not self.available:
             self.data = False

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -151,18 +151,22 @@ class PingBinarySensor(RestoreEntity, BinarySensorEntity):
 class PingData:
     """The base class for handling the data retrieval."""
 
-    def __init__(self, hass, host, count, privileged) -> None:
+    def __init__(self, hass, host, count) -> None:
         """Initialize the data object."""
         self.hass = hass
         self._ip_address = host
         self._count = count
         self.data = {}
         self.is_alive = False
-        self._privileged = privileged
 
 
 class PingDataICMPLib(PingData):
     """The Class for handling the data retrieval using icmplib."""
+
+    def __init__(self, hass, host, count, privileged) -> None:
+        """Initialize the data object."""
+        super().__init__(hass, host, count)
+        self._privileged = privileged
 
     async def async_update(self) -> None:
         """Retrieve the latest details from the host."""

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -122,7 +122,7 @@ class PingBinarySensor(RestoreEntity, BinarySensorEntity):
         await self._ping.async_update()
 
     async def async_added_to_hass(self):
-        """Restore ATTR_CHANGED_BY on startup since it is likely no longer in the activity log."""
+        """Restore previous state on restart to avoid blocking startup."""
         await super().async_added_to_hass()
 
         last_state = await self.async_get_last_state()
@@ -141,7 +141,7 @@ class PingBinarySensor(RestoreEntity, BinarySensorEntity):
 
 
 class PingData:
-    """The Class for handling the data retrieval using icmplib."""
+    """The base class for handling the data retrieval."""
 
     def __init__(self, hass, host, count, privileged) -> None:
         """Initialize the data object."""

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -23,6 +23,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import setup_reload_service
 
 from . import DOMAIN, PLATFORMS, async_get_next_ping_id
+from .const import ICMP_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -137,7 +138,7 @@ class PingDataICMPLib(PingData):
                 icmp_ping,
                 self._ip_address,
                 count=self._count,
-                timeout=1,
+                timeout=ICMP_TIMEOUT,
                 id=async_get_next_ping_id(self.hass),
             )
         )

--- a/homeassistant/components/ping/const.py
+++ b/homeassistant/components/ping/const.py
@@ -1,4 +1,4 @@
 """Tracks devices by sending a ICMP echo request (ping)."""
 
-PING_TIMEOUT = 3
+ICMP_TIMEOUT = 1
 PING_ATTEMPTS_COUNT = 3

--- a/homeassistant/components/ping/const.py
+++ b/homeassistant/components/ping/const.py
@@ -11,3 +11,11 @@ PING_TIMEOUT = 3
 ICMP_TIMEOUT = 1
 
 PING_ATTEMPTS_COUNT = 3
+
+DOMAIN = "ping"
+PLATFORMS = ["binary_sensor"]
+
+PING_ID = "ping_id"
+PING_PRIVS = "ping_privs"
+DEFAULT_START_ID = 129
+MAX_PING_ID = 65534

--- a/homeassistant/components/ping/const.py
+++ b/homeassistant/components/ping/const.py
@@ -1,4 +1,13 @@
 """Tracks devices by sending a ICMP echo request (ping)."""
 
+# The ping binary and icmplib timeouts are not the same
+# timeout. ping is an overall timeout, icmplib is the
+# time since the data was sent.
+
+# ping binary
+PING_TIMEOUT = 3
+
+# icmplib timeout
 ICMP_TIMEOUT = 1
+
 PING_ATTEMPTS_COUNT = 3

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async_ import run_callback_threadsafe
 
 from . import async_get_next_ping_id
-from .const import PING_ATTEMPTS_COUNT
+from .const import ICMP_TIMEOUT, PING_ATTEMPTS_COUNT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class HostICMPLib:
         ).result()
 
         return icmp_ping(
-            self.ip_address, count=PING_ATTEMPTS_COUNT, timeout=1, id=next_id
+            self.ip_address, count=PING_ATTEMPTS_COUNT, timeout=ICMP_TIMEOUT, id=next_id
         ).is_alive
 
     def update(self, see):

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -1,10 +1,8 @@
 """Tracks devices by sending a ICMP echo request (ping)."""
 from datetime import timedelta
 import logging
-import subprocess
-import sys
 
-from icmplib import SocketPermissionError, ping as icmp_ping
+from icmplib import ping as icmp_ping
 import voluptuous as vol
 
 from homeassistant import const, util
@@ -16,10 +14,9 @@ from homeassistant.components.device_tracker.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async_ import run_callback_threadsafe
-from homeassistant.util.process import kill_subprocess
 
 from . import async_get_next_ping_id
-from .const import PING_ATTEMPTS_COUNT, PING_TIMEOUT
+from .const import PING_ATTEMPTS_COUNT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,47 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_PING_COUNT, default=1): cv.positive_int,
     }
 )
-
-
-class HostSubProcess:
-    """Host object with ping detection."""
-
-    def __init__(self, ip_address, dev_id, hass, config):
-        """Initialize the Host pinger."""
-        self.hass = hass
-        self.ip_address = ip_address
-        self.dev_id = dev_id
-        self._count = config[CONF_PING_COUNT]
-        if sys.platform == "win32":
-            self._ping_cmd = ["ping", "-n", "1", "-w", "1000", self.ip_address]
-        else:
-            self._ping_cmd = ["ping", "-n", "-q", "-c1", "-W1", self.ip_address]
-
-    def ping(self):
-        """Send an ICMP echo request and return True if success."""
-        pinger = subprocess.Popen(
-            self._ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
-        )
-        try:
-            pinger.communicate(timeout=1 + PING_TIMEOUT)
-            return pinger.returncode == 0
-        except subprocess.TimeoutExpired:
-            kill_subprocess(pinger)
-            return False
-
-        except subprocess.CalledProcessError:
-            return False
-
-    def update(self, see):
-        """Update device state by sending one or more ping messages."""
-        failed = 0
-        while failed < self._count:  # check more times if host is unreachable
-            if self.ping():
-                see(dev_id=self.dev_id, source_type=SOURCE_TYPE_ROUTER)
-                return True
-            failed += 1
-
-        _LOGGER.debug("No response from %s failed=%d", self.ip_address, failed)
 
 
 class HostICMPLib:
@@ -112,16 +68,8 @@ class HostICMPLib:
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Host objects and return the update function."""
 
-    try:
-        # Verify we can create a raw socket, or
-        # fallback to using a subprocess
-        icmp_ping("127.0.0.1", count=0, timeout=0)
-        host_cls = HostICMPLib
-    except SocketPermissionError:
-        host_cls = HostSubProcess
-
     hosts = [
-        host_cls(ip, dev_id, hass, config)
+        HostICMPLib(ip, dev_id, hass, config)
         for (dev_id, ip) in config[const.CONF_HOSTS].items()
     ]
     interval = config.get(

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -16,6 +16,7 @@ from homeassistant.components.device_tracker.const import (
     SOURCE_TYPE_ROUTER,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.process import kill_subprocess
 
@@ -135,8 +136,8 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
         try:
             await async_update(now)
         finally:
-            hass.helpers.event.track_point_in_utc_time(
-                _async_update_interval, util.dt.utcnow() + interval
+            async_track_point_in_utc_time(
+                hass, _async_update_interval, util.dt.utcnow() + interval
             )
 
     await _async_update_interval(None)

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -107,7 +107,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
             )
             for idx, host in enumerate(hosts):
                 if results[idx]:
-                    async_see(dev_id=host.dev_id, source_type=SOURCE_TYPE_ROUTER)
+                    await async_see(dev_id=host.dev_id, source_type=SOURCE_TYPE_ROUTER)
 
     else:
 
@@ -127,7 +127,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
             _LOGGER.debug("Multiping responses: %s", responses)
             for idx, dev_id in enumerate(ip_to_dev_id.values()):
                 if responses[idx].is_alive:
-                    async_see(
+                    await async_see(
                         dev_id=dev_id,
                         source_type=SOURCE_TYPE_ROUTER,
                     )

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -19,8 +19,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.process import kill_subprocess
 
-from . import async_can_use_icmp_lib_with_privilege, async_get_next_ping_id
-from .const import ICMP_TIMEOUT, PING_ATTEMPTS_COUNT, PING_TIMEOUT
+from . import async_get_next_ping_id
+from .const import DOMAIN, ICMP_TIMEOUT, PING_ATTEMPTS_COUNT, PING_PRIVS, PING_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class HostSubProcess:
 async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     """Set up the Host objects and return the update function."""
 
-    privileged = async_can_use_icmp_lib_with_privilege()
+    privileged = hass.data[DOMAIN][PING_PRIVS]
     ip_to_dev_id = {ip: dev_id for (dev_id, ip) in config[const.CONF_HOSTS].items()}
     interval = config.get(
         CONF_SCAN_INTERVAL,

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -115,12 +115,14 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 privileged=privileged,
                 id=next_id,
             )
-            for host in responses:
-                if host.is_alive:
+            idx = 0
+            for dev_id in ip_to_dev_id.values():
+                if responses[idx].is_alive:
                     see(
-                        dev_id=ip_to_dev_id[host.address],
+                        dev_id=dev_id,
                         source_type=SOURCE_TYPE_ROUTER,
                     )
+                idx += 1
 
     def _update_interval(now):
         try:

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -123,6 +123,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
                     id=next_id,
                 )
             )
+            _LOGGER.debug("Multiping responses: %s", responses)
             for idx, dev_id in enumerate(ip_to_dev_id.values()):
                 if responses[idx].is_alive:
                     async_see(

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 class Host:
     """A single host to track."""
 
-    def __init__(self, ip_address, dev_id, hass, config, privileged):
+    def __init__(self, ip_address, dev_id, hass, config):
         """Initialize the Host pinger."""
         self.hass = hass
         self.ip_address = ip_address

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -113,7 +113,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
 
         async def async_update(now):
             """Update all the hosts on every interval time."""
-            next_id = async_get_next_ping_id()
+            next_id = async_get_next_ping_id(hass)
             responses = await hass.async_add_executor_job(
                 partial(
                     multiping,

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.process import kill_subprocess
 
-from . import async_get_next_ping_id, can_create_raw_socket
+from . import async_get_next_ping_id, can_use_icmp_lib_with_privilege
 from .const import ICMP_TIMEOUT, PING_ATTEMPTS_COUNT, PING_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,19 +34,27 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-class HostSubProcess:
-    """Host object with ping detection."""
+class Host:
+    """A single host to track."""
 
-    def __init__(self, ip_address, dev_id, hass, config):
+    def __init__(self, ip_address, dev_id, hass, config, privileged):
         """Initialize the Host pinger."""
         self.hass = hass
         self.ip_address = ip_address
         self.dev_id = dev_id
         self._count = config[CONF_PING_COUNT]
+
+
+class HostSubProcess(Host):
+    """Host object with ping detection."""
+
+    def __init__(self, ip_address, dev_id, hass, config, privileged):
+        """Initialize the Host pinger."""
+        super().__init__(ip_address, dev_id, hass, config)
         if sys.platform == "win32":
-            self._ping_cmd = ["ping", "-n", "1", "-w", "1000", self.ip_address]
+            self._ping_cmd = ["ping", "-n", "1", "-w", "1000", ip_address]
         else:
-            self._ping_cmd = ["ping", "-n", "-q", "-c1", "-W1", self.ip_address]
+            self._ping_cmd = ["ping", "-n", "-q", "-c1", "-W1", ip_address]
 
     def ping(self):
         """Send an ICMP echo request and return True if success."""
@@ -75,15 +83,12 @@ class HostSubProcess:
         _LOGGER.debug("No response from %s failed=%d", self.ip_address, failed)
 
 
-class HostICMPLib:
+class HostICMPLib(Host):
     """Host object with ping detection."""
 
     def __init__(self, ip_address, dev_id, hass, config, privileged):
         """Initialize the Host pinger."""
-        self.hass = hass
-        self.ip_address = ip_address
-        self.dev_id = dev_id
-        self._count = config[CONF_PING_COUNT]
+        super().__init__(ip_address, dev_id, hass, config)
         self._privileged = privileged
 
     def ping(self):
@@ -122,10 +127,14 @@ class HostICMPLib:
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Host objects and return the update function."""
 
-    privileged = can_create_raw_socket()
+    privileged = can_use_icmp_lib_with_privilege()
+    if privileged is None:
+        host_cls = HostSubProcess
+    else:
+        host_cls = HostICMPLib
 
     hosts = [
-        HostICMPLib(ip, dev_id, hass, config, privileged)
+        host_cls(ip, dev_id, hass, config, privileged)
         for (dev_id, ip) in config[const.CONF_HOSTS].items()
     ]
     interval = config.get(

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -4,7 +4,7 @@ import logging
 import subprocess
 import sys
 
-from icmplib import NameLookupError, ping as icmp_ping
+from icmplib import multiping
 import voluptuous as vol
 
 from homeassistant import const, util
@@ -34,23 +34,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-class Host:
-    """A single host to track."""
+class HostSubProcess:
+    """Host object with ping detection."""
 
-    def __init__(self, ip_address, dev_id, hass, config):
+    def __init__(self, ip_address, dev_id, hass, config, privileged):
         """Initialize the Host pinger."""
         self.hass = hass
         self.ip_address = ip_address
         self.dev_id = dev_id
         self._count = config[CONF_PING_COUNT]
-
-
-class HostSubProcess(Host):
-    """Host object with ping detection."""
-
-    def __init__(self, ip_address, dev_id, hass, config, privileged):
-        """Initialize the Host pinger."""
-        super().__init__(ip_address, dev_id, hass, config)
         if sys.platform == "win32":
             self._ping_cmd = ["ping", "-n", "1", "-w", "1000", ip_address]
         else:
@@ -83,79 +75,60 @@ class HostSubProcess(Host):
         _LOGGER.debug("No response from %s failed=%d", self.ip_address, failed)
 
 
-class HostICMPLib(Host):
-    """Host object with ping detection."""
-
-    def __init__(self, ip_address, dev_id, hass, config, privileged):
-        """Initialize the Host pinger."""
-        super().__init__(ip_address, dev_id, hass, config)
-        self._privileged = privileged
-
-    def ping(self):
-        """Send an ICMP echo request and return True if success."""
-        next_id = run_callback_threadsafe(
-            self.hass.loop, async_get_next_ping_id, self.hass
-        ).result()
-
-        try:
-            data = icmp_ping(
-                self.ip_address,
-                count=PING_ATTEMPTS_COUNT,
-                timeout=ICMP_TIMEOUT,
-                privileged=self._privileged,
-                id=next_id,
-            )
-        except NameLookupError:
-            return False
-
-        return data.is_alive
-
-    def update(self, see):
-        """Update device state by sending one or more ping messages."""
-        if self.ping():
-            see(dev_id=self.dev_id, source_type=SOURCE_TYPE_ROUTER)
-            return True
-
-        _LOGGER.debug(
-            "No response from %s (%s) failed=%d",
-            self.ip_address,
-            self.dev_id,
-            PING_ATTEMPTS_COUNT,
-        )
-
-
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Host objects and return the update function."""
 
     privileged = can_use_icmp_lib_with_privilege()
-    if privileged is None:
-        host_cls = HostSubProcess
-    else:
-        host_cls = HostICMPLib
-
-    hosts = [
-        host_cls(ip, dev_id, hass, config, privileged)
-        for (dev_id, ip) in config[const.CONF_HOSTS].items()
-    ]
+    ip_to_dev_id = {ip: dev_id for (dev_id, ip) in config[const.CONF_HOSTS].items()}
     interval = config.get(
         CONF_SCAN_INTERVAL,
-        timedelta(seconds=len(hosts) * config[CONF_PING_COUNT]) + SCAN_INTERVAL,
+        timedelta(seconds=len(ip_to_dev_id) * config[CONF_PING_COUNT]) + SCAN_INTERVAL,
     )
     _LOGGER.debug(
         "Started ping tracker with interval=%s on hosts: %s",
         interval,
-        ",".join([host.ip_address for host in hosts]),
+        ",".join(ip_to_dev_id.keys()),
     )
 
-    def update_interval(now):
-        """Update all the hosts on every interval time."""
-        try:
+    if privileged is None:
+        hosts = [
+            HostSubProcess(ip, dev_id, hass, config, privileged)
+            for (dev_id, ip) in config[const.CONF_HOSTS].items()
+        ]
+
+        def update(now):
+            """Update all the hosts on every interval time."""
             for host in hosts:
                 host.update(see)
+
+    else:
+
+        def update(now):
+            """Update all the hosts on every interval time."""
+            next_id = run_callback_threadsafe(
+                hass.loop, async_get_next_ping_id, hass
+            ).result()
+            responses = multiping(
+                ip_to_dev_id.keys(),
+                count=PING_ATTEMPTS_COUNT,
+                timeout=ICMP_TIMEOUT,
+                privileged=privileged,
+                id=next_id,
+            )
+            for host in responses:
+                if host.is_alive:
+                    see(
+                        dev_id=ip_to_dev_id[host.address],
+                        source_type=SOURCE_TYPE_ROUTER,
+                    )
+
+    def _update_interval(now):
+        try:
+            update(now)
         finally:
             hass.helpers.event.track_point_in_utc_time(
-                update_interval, util.dt.utcnow() + interval
+                _update_interval, util.dt.utcnow() + interval
             )
 
-    update_interval(None)
+    _update_interval(None)
     return True

--- a/homeassistant/components/ping/manifest.json
+++ b/homeassistant/components/ping/manifest.json
@@ -3,6 +3,6 @@
   "name": "Ping (ICMP)",
   "documentation": "https://www.home-assistant.io/integrations/ping",
   "codeowners": [],
-  "requirements": ["icmplib==2.0.2"],
+  "requirements": ["icmplib==2.1.1"],
   "quality_scale": "internal"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -811,7 +811,7 @@ ibm-watson==4.0.1
 ibmiotf==0.3.4
 
 # homeassistant.components.ping
-icmplib==2.0.2
+icmplib==2.1.1
 
 # homeassistant.components.iglo
 iglo==1.2.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -440,7 +440,7 @@ hyperion-py==0.7.0
 iaqualink==0.3.4
 
 # homeassistant.components.ping
-icmplib==2.0.2
+icmplib==2.1.1
 
 # homeassistant.components.influxdb
 influxdb-client==1.14.0


### PR DESCRIPTION
## Breaking change

When restarting Home Assistant, the previous ping sensor state is now
restored and then updated in the background to allow startup to proceed
without the risk of timing out.

When the user has many ping sensors, the ping integration could
timeout starting up because each ping has to happen in the
executor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Now that icmplib does not require root for newer kernels, we
can use it if the `can_use_icmp_lib_with_privilege` test passes
with `privileged=False`

The startup time problem with ping has been solved by 
restoring the previous state instead of waiting for the ping to run
before starting.

`NameLookupError` is now handled to avoid the log filling up
when a host is offline.

`device_tracker` now uses multiping when possible to avoid
tying up the executor when there are many hosts.

<https://github.com/ValentinBELYN/icmplib/compare/v2.0.2...v2.1.1>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43785 and fixes #43188
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
