### PR TITLE
Implement heartbeat in the Broadlink integration

### DIFF
--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -1,8 +1,11 @@
 """The Broadlink integration."""
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 from .const import DOMAIN
 from .device import BroadlinkDevice
+from .heartbeat import BroadlinkHeartbeat
 
 
 @dataclass
@@ -11,6 +14,7 @@ class BroadlinkData:
 
     devices: dict = field(default_factory=dict)
     platforms: dict = field(default_factory=dict)
+    heartbeat: BroadlinkHeartbeat | None = None
 
 
 async def async_setup(hass, config):
@@ -21,11 +25,25 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up a Broadlink device from a config entry."""
+    data = hass.data[DOMAIN]
+
+    if data.heartbeat is None:
+        data.heartbeat = BroadlinkHeartbeat(hass)
+        hass.async_create_task(data.heartbeat.async_setup())
+
     device = BroadlinkDevice(hass, entry)
     return await device.async_setup()
 
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
-    device = hass.data[DOMAIN].devices.pop(entry.entry_id)
-    return await device.async_unload()
+    data = hass.data[DOMAIN]
+
+    device = data.devices.pop(entry.entry_id)
+    result = await device.async_unload()
+
+    if not data.devices:
+        await data.heartbeat.async_unload()
+        data.heartbeat = None
+
+    return result

--- a/homeassistant/components/broadlink/heartbeat.py
+++ b/homeassistant/components/broadlink/heartbeat.py
@@ -1,0 +1,55 @@
+"""Heartbeats for Broadlink devices."""
+import datetime as dt
+import logging
+
+import broadlink as blk
+
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers import event
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BroadlinkHeartbeat:
+    """Manages heartbeats in the Broadlink integration.
+
+    Some devices reboot when they cannot reach the cloud. This mechanism
+    feeds their watchdog timers so they can be used offline.
+    """
+
+    INTERVAL = dt.timedelta(minutes=2)
+
+    def __init__(self, hass):
+        """Initialize the heartbeat."""
+        self._hass = hass
+        self._unsubscribe = None
+
+    async def async_setup(self):
+        """Set up the heartbeat."""
+        if self._unsubscribe is None:
+            await self.async_heartbeat(dt.datetime.now())
+            self._unsubscribe = event.async_track_time_interval(
+                self._hass, self.async_heartbeat, self.INTERVAL
+            )
+
+    async def async_unload(self):
+        """Unload the heartbeat."""
+        if self._unsubscribe is not None:
+            self._unsubscribe()
+            self._unsubscribe = None
+
+    async def async_heartbeat(self, now):
+        """Send packets to feed watchdog timers."""
+        hass = self._hass
+        config_entries = hass.config_entries.async_entries(DOMAIN)
+
+        for entry in config_entries:
+            host = entry.data[CONF_HOST]
+            try:
+                await hass.async_add_executor_job(blk.ping, host)
+            except OSError as err:
+                _LOGGER.debug("Failed to send heartbeat to %s: %s", host, err)
+            else:
+                _LOGGER.debug("Heartbeat sent to %s", host)

--- a/homeassistant/components/broadlink/heartbeat.py
+++ b/homeassistant/components/broadlink/heartbeat.py
@@ -19,7 +19,7 @@ class BroadlinkHeartbeat:
     feeds their watchdog timers so they can be used offline.
     """
 
-    INTERVAL = dt.timedelta(minutes=2)
+    HEARTBEAT_INTERVAL = dt.timedelta(minutes=2)
 
     def __init__(self, hass):
         """Initialize the heartbeat."""
@@ -31,7 +31,7 @@ class BroadlinkHeartbeat:
         if self._unsubscribe is None:
             await self.async_heartbeat(dt.datetime.now())
             self._unsubscribe = event.async_track_time_interval(
-                self._hass, self.async_heartbeat, self.INTERVAL
+                self._hass, self.async_heartbeat, self.HEARTBEAT_INTERVAL
             )
 
     async def async_unload(self):

--- a/tests/components/broadlink/test_heartbeat.py
+++ b/tests/components/broadlink/test_heartbeat.py
@@ -1,0 +1,100 @@
+"""Tests for Broadlink heartbeats."""
+from unittest.mock import call, patch
+
+from homeassistant.components.broadlink.heartbeat import BroadlinkHeartbeat
+from homeassistant.util import dt
+
+from . import get_device
+
+from tests.common import async_fire_time_changed
+
+DEVICE_PING = "homeassistant.components.broadlink.heartbeat.blk.ping"
+
+
+async def test_heartbeat_trigger_startup(hass):
+    """Test that the heartbeat is initialized with the first config entry."""
+    device = get_device("Office")
+
+    with patch(DEVICE_PING) as mock_ping:
+        await device.setup_entry(hass)
+        await hass.async_block_till_done()
+
+    assert mock_ping.call_count == 1
+    assert mock_ping.call_args == call(device.host)
+
+
+async def test_heartbeat_ignore_oserror(hass):
+    """Test that an OSError is ignored."""
+    device = get_device("Office")
+
+    with patch(DEVICE_PING, side_effect=OSError()):
+        await device.setup_entry(hass)
+        await hass.async_block_till_done()
+
+
+async def test_heartbeat_trigger_right_time(hass):
+    """Test that the heartbeat is triggered at the right time."""
+    device = get_device("Office")
+
+    await device.setup_entry(hass)
+    await hass.async_block_till_done()
+
+    with patch(DEVICE_PING) as mock_ping:
+        async_fire_time_changed(hass, dt.utcnow() + BroadlinkHeartbeat.INTERVAL)
+        await hass.async_block_till_done()
+
+    assert mock_ping.call_count == 1
+    assert mock_ping.call_args == call(device.host)
+
+
+async def test_heartbeat_do_not_trigger_before_time(hass):
+    """Test that the heartbeat is not triggered before the time."""
+    device = get_device("Office")
+
+    await device.setup_entry(hass)
+    await hass.async_block_till_done()
+
+    with patch(DEVICE_PING) as mock_ping:
+        async_fire_time_changed(
+            hass,
+            dt.utcnow() + BroadlinkHeartbeat.INTERVAL // 2,
+        )
+        await hass.async_block_till_done()
+
+    assert mock_ping.call_count == 0
+
+
+async def test_heartbeat_unload(hass):
+    """Test that the heartbeat is deactivated when the last config entry is removed."""
+    device = get_device("Office")
+
+    _, mock_entry = await device.setup_entry(hass)
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_remove(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(DEVICE_PING) as mock_ping:
+        async_fire_time_changed(hass, dt.utcnow() + BroadlinkHeartbeat.INTERVAL)
+
+    assert mock_ping.call_count == 0
+
+
+async def test_heartbeat_do_not_unload(hass):
+    """Test that the heartbeat is not deactivated until the last config entry is removed."""
+    device_a = get_device("Office")
+    device_b = get_device("Bedroom")
+
+    _, mock_entry_a = await device_a.setup_entry(hass)
+    await device_b.setup_entry(hass)
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_remove(mock_entry_a.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(DEVICE_PING) as mock_ping:
+        async_fire_time_changed(hass, dt.utcnow() + BroadlinkHeartbeat.INTERVAL)
+        await hass.async_block_till_done()
+
+    assert mock_ping.call_count == 1
+    assert mock_ping.call_args == call(device_b.host)

--- a/tests/components/broadlink/test_heartbeat.py
+++ b/tests/components/broadlink/test_heartbeat.py
@@ -40,7 +40,9 @@ async def test_heartbeat_trigger_right_time(hass):
     await hass.async_block_till_done()
 
     with patch(DEVICE_PING) as mock_ping:
-        async_fire_time_changed(hass, dt.utcnow() + BroadlinkHeartbeat.INTERVAL)
+        async_fire_time_changed(
+            hass, dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
+        )
         await hass.async_block_till_done()
 
     assert mock_ping.call_count == 1
@@ -57,7 +59,7 @@ async def test_heartbeat_do_not_trigger_before_time(hass):
     with patch(DEVICE_PING) as mock_ping:
         async_fire_time_changed(
             hass,
-            dt.utcnow() + BroadlinkHeartbeat.INTERVAL // 2,
+            dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL // 2,
         )
         await hass.async_block_till_done()
 
@@ -75,7 +77,9 @@ async def test_heartbeat_unload(hass):
     await hass.async_block_till_done()
 
     with patch(DEVICE_PING) as mock_ping:
-        async_fire_time_changed(hass, dt.utcnow() + BroadlinkHeartbeat.INTERVAL)
+        async_fire_time_changed(
+            hass, dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
+        )
 
     assert mock_ping.call_count == 0
 
@@ -93,7 +97,9 @@ async def test_heartbeat_do_not_unload(hass):
     await hass.async_block_till_done()
 
     with patch(DEVICE_PING) as mock_ping:
-        async_fire_time_changed(hass, dt.utcnow() + BroadlinkHeartbeat.INTERVAL)
+        async_fire_time_changed(
+            hass, dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
+        )
         await hass.async_block_till_done()
 
     assert mock_ping.call_count == 1

--- a/tests/components/broadlink/test_heartbeat.py
+++ b/tests/components/broadlink/test_heartbeat.py
@@ -23,13 +23,15 @@ async def test_heartbeat_trigger_startup(hass):
     assert mock_ping.call_args == call(device.host)
 
 
-async def test_heartbeat_ignore_oserror(hass):
+async def test_heartbeat_ignore_oserror(hass, caplog):
     """Test that an OSError is ignored."""
     device = get_device("Office")
 
     with patch(DEVICE_PING, side_effect=OSError()):
         await device.setup_entry(hass)
         await hass.async_block_till_done()
+
+    assert "Failed to send heartbeat to" in caplog.text
 
 
 async def test_heartbeat_trigger_right_time(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## The problem
Some devices have a watchdog timer to ensure that the device remains connected to the cloud. They reboot when they don't receive heartbeats from the cloud for more than 3 minutes.

Lots of users want to block access to the internet for privacy reasons and this is causing their devices to reboot periodically. This PR comes to implement a local heartbeat to keep their devices awake even without access to the cloud.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Send watchdog packets every two minutes to feed the watchdog timers of Broadlink devices. This will prevent them from rebooting when they cannot reach the cloud, so users can keep things local if they wish.

Credits to @marcan, who found the watchdog packet.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes https://github.com/home-assistant/core/issues/37361 closes https://github.com/home-assistant/core/issues/40457 closes https://github.com/home-assistant/core/issues/44771
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
