### PR TITLE
Improve look up speed by inverting dictionaries

### DIFF
--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -204,7 +204,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     @property
     def preset_modes(self) -> list:
         """Return the list of available preset modes."""
-        return list(PRESET_MODES)
+        return list(PRESET_MODES.values())
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -32,23 +32,23 @@ from .gateway import get_gateway_from_config_entry
 
 DECONZ_FAN_SMART = "smart"
 
-DECONZ_TO_FAN_MODE = {
-    "smart": DECONZ_FAN_SMART,
-    "auto": FAN_AUTO,
-    "high": FAN_HIGH,
-    "medium": FAN_MEDIUM,
-    "low": FAN_LOW,
-    "on": FAN_ON,
-    "off": FAN_OFF,
+FAN_MODE_TO_DECONZ = {
+    DECONZ_FAN_SMART: "smart",
+    FAN_AUTO: "auto",
+    FAN_HIGH: "high",
+    FAN_MEDIUM: "medium",
+    FAN_LOW: "low",
+    FAN_ON: "on",
+    FAN_OFF: "off",
 }
 
-FAN_MODE_TO_DECONZ = {value: key for key, value in DECONZ_TO_FAN_MODE.items()}
+DECONZ_TO_FAN_MODE = {value: key for key, value in FAN_MODE_TO_DECONZ.items()}
 
-DECONZ_TO_HVAC_MODE = {
-    "auto": HVAC_MODE_AUTO,
-    "cool": HVAC_MODE_COOL,
-    "heat": HVAC_MODE_HEAT,
-    "off": HVAC_MODE_OFF,
+HVAC_MODE_TO_DECONZ = {
+    HVAC_MODE_AUTO: "auto",
+    HVAC_MODE_COOL: "cool",
+    HVAC_MODE_HEAT: "heat",
+    HVAC_MODE_OFF: "off",
 }
 
 DECONZ_PRESET_AUTO = "auto"
@@ -56,24 +56,17 @@ DECONZ_PRESET_COMPLEX = "complex"
 DECONZ_PRESET_HOLIDAY = "holiday"
 DECONZ_PRESET_MANUAL = "manual"
 
-DECONZ_TO_PRESET_MODE = {
-    "auto": DECONZ_PRESET_AUTO,
-    "boost": PRESET_BOOST,
-    "comfort": PRESET_COMFORT,
-    "complex": DECONZ_PRESET_COMPLEX,
-    "eco": PRESET_ECO,
-    "holiday": DECONZ_PRESET_HOLIDAY,
-    "manual": DECONZ_PRESET_MANUAL,
+PRESET_MODE_TO_DECONZ = {
+    DECONZ_PRESET_AUTO: "auto",
+    PRESET_BOOST: "boost",
+    PRESET_COMFORT: "comfort",
+    DECONZ_PRESET_COMPLEX: "complex",
+    PRESET_ECO: "eco",
+    DECONZ_PRESET_HOLIDAY: "holiday",
+    DECONZ_PRESET_MANUAL: "manual",
 }
 
-PRESET_MODE_TO_DECONZ = {value: key for key, value in DECONZ_TO_PRESET_MODE.items()}
-
-
-def get_key_from_value(dictionary: dict, input_value: str) -> Optional[str]:
-    """Get key based on input value."""
-    for key, value in dictionary.items():
-        if input_value == value:
-            return key
+DECONZ_TO_PRESET_MODE = {value: key for key, value in PRESET_MODE_TO_DECONZ.items()}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -122,16 +115,16 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         """Set up thermostat device."""
         super().__init__(device, gateway)
 
-        self._deconz_to_hvac_mode = dict(DECONZ_TO_HVAC_MODE)
+        self._hvac_mode_to_deconz = dict(HVAC_MODE_TO_DECONZ)
         if "mode" not in device.raw["config"]:
-            self._deconz_to_hvac_mode = {
-                True: HVAC_MODE_HEAT,
-                False: HVAC_MODE_OFF,
+            self._hvac_mode_to_deconz = {
+                HVAC_MODE_HEAT: True,
+                HVAC_MODE_OFF: False,
             }
         elif "coolsetpoint" not in device.raw["config"]:
-            self._deconz_to_hvac_mode.pop("cool")
-        self._hvac_mode_to_deconz = {
-            value: key for key, value in self._deconz_to_hvac_mode.items()
+            self._hvac_mode_to_deconz.pop(HVAC_MODE_COOL)
+        self._deconz_to_hvac_mode = {
+            value: key for key, value in self._hvac_mode_to_deconz.items()
         }
 
         self._features = SUPPORT_TARGET_TEMPERATURE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Invert dictionaries to improve look up speed, based on Martins comment in #43722

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
