### PR TITLE
Blueprint: descriptions + descriptive errors

### DIFF
--- a/homeassistant/components/automation/blueprints/motion_light.yaml
+++ b/homeassistant/components/automation/blueprints/motion_light.yaml
@@ -1,5 +1,6 @@
 blueprint:
   name: Motion-activated Light
+  description: Turn on a light when motion is detected.
   domain: automation
   source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/motion_light.yaml
   input:
@@ -17,7 +18,7 @@ blueprint:
             domain: light
     no_motion_wait:
       name: Wait time
-      description: Time to wait until the light should be turned off.
+      description: Time to leave the light on after last motion is detected.
       default: 120
       selector:
         number:

--- a/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
+++ b/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
@@ -1,5 +1,6 @@
 blueprint:
-  name: Send notification when a person leaves a zone
+  name: Zone Notification
+  description: Send a notification to a device when a person leaves a specific zone.
   domain: automation
   source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
   input:
@@ -26,6 +27,7 @@ trigger:
 
 variables:
   zone_entity: !input zone_entity
+  # This is the state of the person when it's in this zone.
   zone_state: "{{ states[zone_entity].name }}"
   person_entity: !input person_entity
   person_name: "{{ states[person_entity].name }}"

--- a/homeassistant/components/blueprint/importer.py
+++ b/homeassistant/components/blueprint/importer.py
@@ -124,7 +124,9 @@ def _extract_blueprint_from_community_topic(
         break
 
     if blueprint is None:
-        raise HomeAssistantError("No valid blueprint found in the topic")
+        raise HomeAssistantError(
+            "No valid blueprint found in the topic. Blueprint Syntax blocks need to be marked as YAML or no syntax."
+        )
 
     return ImportedBlueprint(
         f'{post["username"]}/{topic["slug"]}', block_content, blueprint
@@ -204,7 +206,9 @@ async def fetch_blueprint_from_github_gist_url(
         break
 
     if blueprint is None:
-        raise HomeAssistantError("No valid blueprint found in the gist")
+        raise HomeAssistantError(
+            "No valid blueprint found in the gist. The blueprint file needs to end with '.yaml'"
+        )
 
     return ImportedBlueprint(
         f"{gist['owner']['login']}/{filename[:-5]}", content, blueprint

--- a/homeassistant/components/blueprint/importer.py
+++ b/homeassistant/components/blueprint/importer.py
@@ -125,7 +125,7 @@ def _extract_blueprint_from_community_topic(
 
     if blueprint is None:
         raise HomeAssistantError(
-            "No valid blueprint found in the topic. Blueprint Syntax blocks need to be marked as YAML or no syntax."
+            "No valid blueprint found in the topic. Blueprint syntax blocks need to be marked as YAML or no syntax."
         )
 
     return ImportedBlueprint(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
