### PR TITLE
Add number entity value property

### DIFF
--- a/homeassistant/components/demo/number.py
+++ b/homeassistant/components/demo/number.py
@@ -98,7 +98,7 @@ class DemoNumber(NumberEntity):
         return self._assumed
 
     @property
-    def state(self):
+    def value(self):
         """Return the current value."""
         return self._state
 

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -1,4 +1,5 @@
 """Component to allow numeric input for platforms."""
+from abc import abstractmethod
 from datetime import timedelta
 import logging
 from typing import Any, Dict
@@ -92,6 +93,16 @@ class NumberEntity(Entity):
             while value_range <= step:
                 step /= 10.0
         return step
+
+    @property
+    def state(self) -> float:
+        """Return the entity state."""
+        return self.value
+
+    @property
+    @abstractmethod
+    def value(self) -> float:
+        """Return the entity value to represent the entity state."""
 
     def set_value(self, value: float) -> None:
         """Set new value."""

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -10,7 +10,7 @@ class MockDefaultNumberEntity(NumberEntity):
     @property
     def value(self):
         """Return the current value."""
-        return "0.5"
+        return 0.5
 
 
 class MockNumberEntity(NumberEntity):
@@ -24,7 +24,7 @@ class MockNumberEntity(NumberEntity):
     @property
     def value(self):
         """Return the current value."""
-        return "0.5"
+        return 0.5
 
 
 async def test_step(hass):

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -1,7 +1,7 @@
 """The tests for the Number component."""
-from unittest.mock import MagicMock
-
 from homeassistant.components.number import NumberEntity
+
+from tests.async_mock import MagicMock
 
 
 class MockNumberEntity(NumberEntity):
@@ -13,7 +13,7 @@ class MockNumberEntity(NumberEntity):
         return 1.0
 
     @property
-    def state(self):
+    def value(self):
         """Return the current value."""
         return "0.5"
 

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -4,6 +4,15 @@ from homeassistant.components.number import NumberEntity
 from tests.async_mock import MagicMock
 
 
+class MockDefaultNumberEntity(NumberEntity):
+    """Mock NumberEntity device to use in tests."""
+
+    @property
+    def value(self):
+        """Return the current value."""
+        return "0.5"
+
+
 class MockNumberEntity(NumberEntity):
     """Mock NumberEntity device to use in tests."""
 
@@ -20,7 +29,7 @@ class MockNumberEntity(NumberEntity):
 
 async def test_step(hass):
     """Test the step calculation."""
-    number = NumberEntity()
+    number = MockDefaultNumberEntity()
     assert number.step == 1.0
 
     number_2 = MockNumberEntity()
@@ -29,7 +38,7 @@ async def test_step(hass):
 
 async def test_sync_set_value(hass):
     """Test if async set_value calls sync set_value."""
-    number = NumberEntity()
+    number = MockDefaultNumberEntity()
     number.hass = hass
 
     number.set_value = MagicMock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add abstract property `value` to the number entity integration.
- We want to avoid platforms having to implement the `state` property. This should be implemented by the entity integration. This was missed in https://github.com/home-assistant/architecture/issues/453.
- Update number demo platform and tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/issues/453
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/744

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
