### PR TITLE
Remove zerproc threaded upstream reconnect logic

### DIFF
--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -36,7 +36,7 @@ def connect_lights(lights: List[pyzerproc.Light]) -> List[pyzerproc.Light]:
     connected = []
     for light in lights:
         try:
-            light.connect(auto_reconnect=True)
+            light.connect()
             connected.append(light)
         except pyzerproc.ZerprocException:
             _LOGGER.debug("Unable to connect to '%s'", light.address, exc_info=True)
@@ -193,6 +193,8 @@ class ZerprocLight(LightEntity):
     def update(self):
         """Fetch new state data for this light."""
         try:
+            if not self._light.connected:
+                self._light.connect()
             state = self._light.get_state()
         except pyzerproc.ZerprocException:
             if self._available:

--- a/homeassistant/components/zerproc/manifest.json
+++ b/homeassistant/components/zerproc/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zerproc",
   "requirements": [
-    "pyzerproc==0.2.5"
+    "pyzerproc==0.3.0"
   ],
   "codeowners": [
     "@emlove"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1903,7 +1903,7 @@ pyxeoma==1.4.1
 pyzbar==0.1.7
 
 # homeassistant.components.zerproc
-pyzerproc==0.2.5
+pyzerproc==0.3.0
 
 # homeassistant.components.qnap
 qnapstats==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -932,7 +932,7 @@ pywebpush==1.9.2
 pywilight==0.0.65
 
 # homeassistant.components.zerproc
-pyzerproc==0.2.5
+pyzerproc==0.3.0
 
 # homeassistant.components.rachio
 rachiopy==1.0.3

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -24,19 +24,27 @@ from homeassistant.const import (
 )
 import homeassistant.util.dt as dt_util
 
-from tests.async_mock import patch
+from tests.async_mock import MagicMock, patch
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture
-async def mock_light(hass):
+async def mock_entry(hass):
+    """Create a mock light entity."""
+    return MockConfigEntry(domain=DOMAIN)
+
+
+@pytest.fixture
+async def mock_light(hass, mock_entry):
     """Create a mock light entity."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    mock_entry = MockConfigEntry(domain=DOMAIN)
     mock_entry.add_to_hass(hass)
 
-    light = pyzerproc.Light("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
+    light = MagicMock(spec=pyzerproc.Light)
+    light.address = "AA:BB:CC:DD:EE:FF"
+    light.name = "LEDBlue-CCDDEEFF"
+    light.connected = False
 
     mock_state = pyzerproc.LightState(False, (0, 0, 0))
 
@@ -49,31 +57,36 @@ async def mock_light(hass):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
+    light.connected = True
+
     return light
 
 
-async def test_init(hass):
+async def test_init(hass, mock_entry):
     """Test platform setup."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    mock_entry = MockConfigEntry(domain=DOMAIN)
     mock_entry.add_to_hass(hass)
 
-    mock_light_1 = pyzerproc.Light("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
-    mock_light_2 = pyzerproc.Light("11:22:33:44:55:66", "LEDBlue-33445566")
+    mock_light_1 = MagicMock(spec=pyzerproc.Light)
+    mock_light_1.address = "AA:BB:CC:DD:EE:FF"
+    mock_light_1.name = "LEDBlue-CCDDEEFF"
+    mock_light_1.connected = True
+
+    mock_light_2 = MagicMock(spec=pyzerproc.Light)
+    mock_light_2.address = "11:22:33:44:55:66"
+    mock_light_2.name = "LEDBlue-33445566"
+    mock_light_2.connected = True
 
     mock_state_1 = pyzerproc.LightState(False, (0, 0, 0))
     mock_state_2 = pyzerproc.LightState(True, (0, 80, 255))
 
+    mock_light_1.get_state.return_value = mock_state_1
+    mock_light_2.get_state.return_value = mock_state_2
+
     with patch(
         "homeassistant.components.zerproc.light.pyzerproc.discover",
         return_value=[mock_light_1, mock_light_2],
-    ), patch.object(mock_light_1, "connect"), patch.object(
-        mock_light_2, "connect"
-    ), patch.object(
-        mock_light_1, "get_state", return_value=mock_state_1
-    ), patch.object(
-        mock_light_2, "get_state", return_value=mock_state_2
     ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
@@ -98,22 +111,17 @@ async def test_init(hass):
         ATTR_XY_COLOR: (0.138, 0.08),
     }
 
-    with patch.object(hass.loop, "stop"), patch.object(
-        mock_light_1, "disconnect"
-    ) as mock_disconnect_1, patch.object(
-        mock_light_2, "disconnect"
-    ) as mock_disconnect_2:
+    with patch.object(hass.loop, "stop"):
         await hass.async_stop()
 
-    assert mock_disconnect_1.called
-    assert mock_disconnect_2.called
+    assert mock_light_1.disconnect.called
+    assert mock_light_2.disconnect.called
 
 
-async def test_discovery_exception(hass):
+async def test_discovery_exception(hass, mock_entry):
     """Test platform setup."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    mock_entry = MockConfigEntry(domain=DOMAIN)
     mock_entry.add_to_hass(hass)
 
     with patch(
@@ -127,14 +135,16 @@ async def test_discovery_exception(hass):
     assert len(hass.data[DOMAIN]["addresses"]) == 0
 
 
-async def test_connect_exception(hass):
+async def test_connect_exception(hass, mock_entry):
     """Test platform setup."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    mock_entry = MockConfigEntry(domain=DOMAIN)
     mock_entry.add_to_hass(hass)
 
-    mock_light = pyzerproc.Light("AA:BB:CC:DD:EE:FF", "LEDBlue-CCDDEEFF")
+    mock_light = MagicMock(spec=pyzerproc.Light)
+    mock_light.address = "AA:BB:CC:DD:EE:FF"
+    mock_light.name = "LEDBlue-CCDDEEFF"
+    mock_light.connected = False
 
     with patch(
         "homeassistant.components.zerproc.light.pyzerproc.discover",
@@ -147,6 +157,14 @@ async def test_connect_exception(hass):
 
     # The exception should be captured and no entities should be added
     assert len(hass.data[DOMAIN]["addresses"]) == 0
+
+
+async def test_remove_entry(hass, mock_light, mock_entry):
+    """Test platform setup."""
+    with patch.object(mock_light, "disconnect") as mock_disconnect:
+        await hass.config_entries.async_remove(mock_entry.entry_id)
+
+    assert mock_disconnect.called
 
 
 async def test_light_turn_on(hass, mock_light):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the zerproc reconnection logic. The upstream `auto_reconnect` feature has been removed, since it spawns new threads to handle it and has flaky behavior. Instead, on update we'll reconnect to the light if the connection was lost to ensure all communication happens in the update thread.

### Upstream changelog
https://github.com/emlove/pyzerproc#030-2020-12-03
https://github.com/emlove/pyzerproc/compare/0.2.5...0.3.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
