### PR TITLE
Add start torrent and stop torrent service for transmission integration

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -39,6 +39,8 @@ from .const import (
     EVENT_STARTED_TORRENT,
     SERVICE_ADD_TORRENT,
     SERVICE_REMOVE_TORRENT,
+    SERVICE_START_TORRENT,
+    SERVICE_STOP_TORRENT,
 )
 from .errors import AuthenticationError, CannotConnect, UnknownError
 
@@ -54,6 +56,20 @@ SERVICE_REMOVE_TORRENT_SCHEMA = vol.Schema(
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_ID): cv.positive_int,
         vol.Optional(ATTR_DELETE_DATA, default=DEFAULT_DELETE_DATA): cv.boolean,
+    }
+)
+
+SERVICE_START_TORRENT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_ID): cv.positive_int,
+    }
+)
+
+SERVICE_STOP_TORRENT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_ID): cv.positive_int,
     }
 )
 
@@ -115,6 +131,8 @@ async def async_unload_entry(hass, config_entry):
     if not hass.data[DOMAIN]:
         hass.services.async_remove(DOMAIN, SERVICE_ADD_TORRENT)
         hass.services.async_remove(DOMAIN, SERVICE_REMOVE_TORRENT)
+        hass.services.async_remove(DOMAIN, SERVICE_START_TORRENT)
+        hass.services.async_remove(DOMAIN, SERVICE_STOP_TORRENT)
 
     return True
 
@@ -206,6 +224,34 @@ class TransmissionClient:
                     "Could not add torrent: unsupported type or no permission"
                 )
 
+        def start_torrent(service):
+            """Start torrent."""
+            tm_client = None
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.data[CONF_NAME] == service.data[CONF_NAME]:
+                    tm_client = self.hass.data[DOMAIN][entry.entry_id]
+                    break
+            if tm_client is None:
+                _LOGGER.error("Transmission instance is not found")
+                return
+            torrent_id = service.data[CONF_ID]
+            tm_client.tm_api.start_torrent(torrent_id)
+            tm_client.api.update()
+
+        def stop_torrent(service):
+            """Stop torrent."""
+            tm_client = None
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.data[CONF_NAME] == service.data[CONF_NAME]:
+                    tm_client = self.hass.data[DOMAIN][entry.entry_id]
+                    break
+            if tm_client is None:
+                _LOGGER.error("Transmission instance is not found")
+                return
+            torrent_id = service.data[CONF_ID]
+            tm_client.tm_api.stop_torrent(torrent_id)
+            tm_client.api.update()
+
         def remove_torrent(service):
             """Remove torrent."""
             tm_client = None
@@ -230,6 +276,20 @@ class TransmissionClient:
             SERVICE_REMOVE_TORRENT,
             remove_torrent,
             schema=SERVICE_REMOVE_TORRENT_SCHEMA,
+        )
+
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_START_TORRENT,
+            start_torrent,
+            schema=SERVICE_START_TORRENT_SCHEMA,
+        )
+
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_STOP_TORRENT,
+            stop_torrent,
+            schema=SERVICE_STOP_TORRENT_SCHEMA,
         )
 
         self.config_entry.add_update_listener(self.async_options_updated)

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -36,6 +36,8 @@ ATTR_TORRENT = "torrent"
 
 SERVICE_ADD_TORRENT = "add_torrent"
 SERVICE_REMOVE_TORRENT = "remove_torrent"
+SERVICE_START_TORRENT = "start_torrent"
+SERVICE_STOP_TORRENT = "stop_torrent"
 
 DATA_UPDATED = "transmission_data_updated"
 

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -20,3 +20,23 @@ remove_torrent:
     delete_data:
       description: Delete torrent data
       example: false
+
+start_torrent:
+  description: Start a torrent
+  fields:
+    name:
+      description: Instance name as entered during entry config
+      example: Transmission
+    id:
+      description: ID of a torrent
+      example: 123
+
+stop_torrent:
+  description: Stop a torrent
+  fields:
+    name:
+      description: Instance name as entered during entry config
+      example: Transmission
+    id:
+      description: ID of a torrent
+      example: 123


### PR DESCRIPTION
## Proposed change

Add 2 new services `start_torrent` and `stop_torrent` for transmission integration.

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request: [#15815](https://github.com/home-assistant/home-assistant.io/pull/15815/files)

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io](www.home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

