### PR TITLE
Add code_arm_required to IFTTT alarm

### DIFF
--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -123,7 +123,7 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
     """Representation of an alarm control panel controlled through IFTTT."""
 
     def __init__(
-        self, 
+        self,
         name,
         code,
         code_arm_required,

--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -52,7 +52,7 @@ DEFAULT_EVENT_HOME = "alarm_arm_home"
 DEFAULT_EVENT_NIGHT = "alarm_arm_night"
 DEFAULT_EVENT_DISARM = "alarm_disarm"
 
-CONF_CODE_ARM_REQUIRED = 'code_arm_required'
+CONF_CODE_ARM_REQUIRED = "code_arm_required"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -87,7 +87,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     optimistic = config.get(CONF_OPTIMISTIC)
 
     alarmpanel = IFTTTAlarmPanel(
-        name, code, code_arm_required, event_away, event_home, event_night, event_disarm, optimistic
+        name, 
+        code, 
+        code_arm_required, 
+        event_away, 
+        event_home, 
+        event_night, 
+        event_disarm, 
+        optimistic,
     )
     hass.data[DATA_IFTTT_ALARM].append(alarmpanel)
     add_entities([alarmpanel])
@@ -116,7 +123,15 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
     """Representation of an alarm control panel controlled through IFTTT."""
 
     def __init__(
-        self, name, code, code_arm_required, event_away, event_home, event_night, event_disarm, optimistic
+        self, 
+        name, 
+        code, 
+        code_arm_required, 
+        event_away, 
+        event_home, 
+        event_night, 
+        event_disarm, 
+        optimistic,
     ):
         """Initialize the alarm control panel."""
         self._name = name

--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -87,13 +87,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     optimistic = config.get(CONF_OPTIMISTIC)
 
     alarmpanel = IFTTTAlarmPanel(
-        name, 
-        code, 
-        code_arm_required, 
-        event_away, 
-        event_home, 
-        event_night, 
-        event_disarm, 
+        name,
+        code,
+        code_arm_required,
+        event_away,
+        event_home,
+        event_night,
+        event_disarm,
         optimistic,
     )
     hass.data[DATA_IFTTT_ALARM].append(alarmpanel)
@@ -124,13 +124,13 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
 
     def __init__(
         self, 
-        name, 
-        code, 
-        code_arm_required, 
-        event_away, 
-        event_home, 
-        event_night, 
-        event_disarm, 
+        name,
+        code,
+        code_arm_required,
+        event_away,
+        event_home,
+        event_night,
+        event_disarm,
         optimistic,
     ):
         """Initialize the alarm control panel."""

--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -162,7 +162,7 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
     def code_arm_required(self):
         """Whether the code is required for arm actions."""
         return self._code_arm_required
-    
+
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         if not self._check_code(code):

--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -52,10 +52,13 @@ DEFAULT_EVENT_HOME = "alarm_arm_home"
 DEFAULT_EVENT_NIGHT = "alarm_arm_night"
 DEFAULT_EVENT_DISARM = "alarm_disarm"
 
+CONF_CODE_ARM_REQUIRED = 'code_arm_required'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_CODE): cv.string,
+        vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
         vol.Optional(CONF_EVENT_AWAY, default=DEFAULT_EVENT_AWAY): cv.string,
         vol.Optional(CONF_EVENT_HOME, default=DEFAULT_EVENT_HOME): cv.string,
         vol.Optional(CONF_EVENT_NIGHT, default=DEFAULT_EVENT_NIGHT): cv.string,
@@ -76,6 +79,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     name = config.get(CONF_NAME)
     code = config.get(CONF_CODE)
+    code_arm_required = config.get(CONF_CODE_ARM_REQUIRED)
     event_away = config.get(CONF_EVENT_AWAY)
     event_home = config.get(CONF_EVENT_HOME)
     event_night = config.get(CONF_EVENT_NIGHT)
@@ -83,7 +87,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     optimistic = config.get(CONF_OPTIMISTIC)
 
     alarmpanel = IFTTTAlarmPanel(
-        name, code, event_away, event_home, event_night, event_disarm, optimistic
+        name, code, code_arm_required, event_away, event_home, event_night, event_disarm, optimistic
     )
     hass.data[DATA_IFTTT_ALARM].append(alarmpanel)
     add_entities([alarmpanel])
@@ -112,11 +116,12 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
     """Representation of an alarm control panel controlled through IFTTT."""
 
     def __init__(
-        self, name, code, event_away, event_home, event_night, event_disarm, optimistic
+        self, name, code, code_arm_required, event_away, event_home, event_night, event_disarm, optimistic
     ):
         """Initialize the alarm control panel."""
         self._name = name
         self._code = code
+        self._code_arm_required = code_arm_required
         self._event_away = event_away
         self._event_home = event_home
         self._event_night = event_night
@@ -153,6 +158,11 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
             return FORMAT_NUMBER
         return FORMAT_TEXT
 
+    @property
+    def code_arm_required(self):
+        """Whether the code is required for arm actions."""
+        return self._code_arm_required
+    
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         if not self._check_code(code):
@@ -161,19 +171,19 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
-        if not self._check_code(code):
+        if self._code_arm_required and not self._check_code(code):
             return
         self.set_alarm_state(self._event_away, STATE_ALARM_ARMED_AWAY)
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
-        if not self._check_code(code):
+        if self._code_arm_required and not self._check_code(code):
             return
         self.set_alarm_state(self._event_home, STATE_ALARM_ARMED_HOME)
 
     def alarm_arm_night(self, code=None):
         """Send arm night command."""
-        if not self._check_code(code):
+        if self._code_arm_required and not self._check_code(code):
             return
         self.set_alarm_state(self._event_night, STATE_ALARM_ARMED_NIGHT)
 

--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -173,11 +173,6 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
             return FORMAT_NUMBER
         return FORMAT_TEXT
 
-    @property
-    def code_arm_required(self):
-        """Whether the code is required for arm actions."""
-        return self._code_arm_required
-
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         if not self._check_code(code):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Add code_arm_required to the ifttt alarm. This option bypasses the code check if code_arm_required is false.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
  - platform: ifttt
      name: YOUR_ALARM_NAME
      code_arm_required: false
      code: YOUR_ALARM_CODE
      event_arm_away: alarm_arm_away
      event_arm_night: alarm_arm_night
      event_disarm: alarm_disarm
      optimistic: false

```


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/15822

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
