### PR TITLE
Handle stale ozw discovery flow

### DIFF
--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -67,8 +67,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_hassio_confirm(self, user_input=None):
         """Confirm the add-on discovery."""
         if user_input is not None:
-            self.use_addon = True
-            return self._async_create_entry_from_vars()
+            return await self.async_step_on_supervisor(
+                user_input={CONF_USE_ADDON: True}
+            )
 
         return self.async_show_form(step_id="hassio_confirm")
 

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -58,10 +58,6 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
 
-        addon_config = await self._async_get_addon_config()
-        self.usb_path = addon_config[CONF_ADDON_DEVICE]
-        self.network_key = addon_config.get(CONF_ADDON_NETWORK_KEY, "")
-
         return await self.async_step_hassio_confirm()
 
     async def async_step_hassio_confirm(self, user_input=None):
@@ -108,6 +104,9 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.use_addon = True
 
         if await self._async_is_addon_running():
+            addon_config = await self._async_get_addon_config()
+            self.usb_path = addon_config[CONF_ADDON_DEVICE]
+            self.network_key = addon_config.get(CONF_ADDON_NETWORK_KEY, "")
             return self._async_create_entry_from_vars()
 
         if await self._async_is_addon_installed():

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -159,9 +159,10 @@ async def test_not_addon(hass, supervisor):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_addon_running(hass, supervisor, addon_running):
+async def test_addon_running(hass, supervisor, addon_running, addon_options):
     """Test add-on already running on Supervisor."""
-    hass.config.components.add("mqtt")
+    addon_options["device"] = "/test"
+    addon_options["network_key"] = "abc123"
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
@@ -182,8 +183,8 @@ async def test_addon_running(hass, supervisor, addon_running):
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE
     assert result["data"] == {
-        "usb_path": None,
-        "network_key": None,
+        "usb_path": "/test",
+        "network_key": "abc123",
         "use_addon": True,
         "integration_created_addon": False,
     }
@@ -193,7 +194,6 @@ async def test_addon_running(hass, supervisor, addon_running):
 
 async def test_addon_info_failure(hass, supervisor, addon_info):
     """Test add-on info failure."""
-    hass.config.components.add("mqtt")
     addon_info.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -213,7 +213,6 @@ async def test_addon_installed(
     hass, supervisor, addon_installed, addon_options, set_addon_options, start_addon
 ):
     """Test add-on already installed but not running on Supervisor."""
-    hass.config.components.add("mqtt")
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
@@ -250,7 +249,6 @@ async def test_set_addon_config_failure(
     hass, supervisor, addon_installed, addon_options, set_addon_options
 ):
     """Test add-on set config failure."""
-    hass.config.components.add("mqtt")
     set_addon_options.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -273,7 +271,6 @@ async def test_start_addon_failure(
     hass, supervisor, addon_installed, addon_options, set_addon_options, start_addon
 ):
     """Test add-on start failure."""
-    hass.config.components.add("mqtt")
     start_addon.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -302,7 +299,6 @@ async def test_addon_not_installed(
     start_addon,
 ):
     """Test add-on not installed."""
-    hass.config.components.add("mqtt")
     addon_installed.return_value["version"] = None
     await setup.async_setup_component(hass, "persistent_notification", {})
 
@@ -348,7 +344,6 @@ async def test_addon_not_installed(
 
 async def test_install_addon_failure(hass, supervisor, addon_installed, install_addon):
     """Test add-on install failure."""
-    hass.config.components.add("mqtt")
     addon_installed.return_value["version"] = None
     install_addon.side_effect = HassioAPIError()
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -488,3 +483,54 @@ async def test_abort_discovery_with_existing_entry(
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
+
+
+async def test_discovery_addon_not_running(
+    hass, supervisor, addon_installed, addon_options, set_addon_options, start_addon
+):
+    """Test discovery with add-on already installed but not running."""
+    addon_options["device"] = None
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=ADDON_DISCOVERY_INFO,
+    )
+
+    assert result["step_id"] == "hassio_confirm"
+    assert result["type"] == "form"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["step_id"] == "start_addon"
+    assert result["type"] == "form"
+
+
+async def test_discovery_addon_not_installed(
+    hass, supervisor, addon_installed, install_addon, addon_options
+):
+    """Test discovery with add-on not installed."""
+    addon_installed.return_value["version"] = None
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_HASSIO},
+        data=ADDON_DISCOVERY_INFO,
+    )
+
+    assert result["step_id"] == "hassio_confirm"
+    assert result["type"] == "form"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["step_id"] == "install_addon"
+    assert result["type"] == "progress"
+
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "start_addon"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Handle add-on being stopped or not installed when the discovery flow is continued by the user.
- Add and fix tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
