### PR TITLE
Refactor ZHA core channel initialization

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -73,13 +73,9 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
         self._channel = channels[0]
         self._device_class = self.DEVICE_CLASS
 
-    async def get_device_class(self):
-        """Get the HA device class from the channel."""
-
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""
         await super().async_added_to_hass()
-        await self.get_device_class()
         self.async_accept_signal(
             self._channel, SIGNAL_ATTR_UPDATED, self.async_set_state
         )
@@ -168,10 +164,10 @@ class IASZone(BinarySensor):
 
     SENSOR_ATTR = "zone_status"
 
-    async def get_device_class(self) -> None:
-        """Get the HA device class from the channel."""
-        zone_type = await self._channel.get_attribute_value("zone_type")
-        self._device_class = CLASS_MAPPING.get(zone_type)
+    @property
+    def device_class(self) -> str:
+        """Return device class from component DEVICE_CLASSES."""
+        return CLASS_MAPPING.get(self._channel.cluster.get("zone_type"))
 
     async def async_update(self):
         """Attempt to retrieve on off state from the binary sensor."""

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -187,12 +187,15 @@ class ZigbeeChannel(LogMixin):
                     str(ex),
                 )
 
-    async def async_configure(self):
+    async def async_configure(self) -> None:
         """Set cluster binding and attribute reporting."""
         if not self._ch_pool.skip_configuration:
             await self.bind()
             if self.cluster.is_server:
                 await self.configure_reporting()
+            ch_specific_cfg = getattr(self, "async_configure_channel_specific", None)
+            if ch_specific_cfg:
+                await ch_specific_cfg()
             self.debug("finished channel configuration")
         else:
             self.debug("skipping channel configuration")

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -214,7 +214,7 @@ class ZigbeeChannel(LogMixin):
 
         ch_specific_init = getattr(self, "async_initialize_channel_specific", None)
         if ch_specific_init:
-            await ch_specific_init()
+            await ch_specific_init(from_cache=from_cache)
 
         self.debug("finished channel configuration")
         self._status = ChannelStatus.INITIALIZED

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -35,11 +35,6 @@ class DoorLockChannel(ZigbeeChannel):
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, attr_name, value
             )
 
-    async def async_initialize(self, from_cache):
-        """Initialize channel."""
-        await self.get_attribute_value(self._value_attribute, from_cache=from_cache)
-        await super().async_initialize(from_cache)
-
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(closures.Shade.cluster_id)
 class Shade(ZigbeeChannel):
@@ -85,8 +80,3 @@ class WindowCovering(ZigbeeChannel):
             self.async_send_signal(
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, attr_name, value
             )
-
-    async def async_initialize(self, from_cache):
-        """Initialize channel."""
-        await self.get_attribute_value(self._value_attribute, from_cache=from_cache)
-        await super().async_initialize(from_cache)

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -71,21 +71,6 @@ class BasicChannel(ZigbeeChannel):
         6: "Emergency mains and transfer switch",
     }
 
-    async def async_configure(self):
-        """Configure this channel."""
-        await super().async_configure()
-        await self.async_initialize(False)
-
-    async def async_initialize(self, from_cache):
-        """Initialize channel."""
-        if not self._ch_pool.skip_configuration or from_cache:
-            await self.get_attribute_value("power_source", from_cache=from_cache)
-        await super().async_initialize(from_cache)
-
-    def get_power_source(self):
-        """Get the power source."""
-        return self.cluster.get("power_source")
-
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryInput.cluster_id)
 class BinaryInput(ZigbeeChannel):

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -1,6 +1,6 @@
 """General channels module for Zigbee Home Automation."""
 import asyncio
-from typing import Any, List, Optional
+from typing import Any, Coroutine, List, Optional
 
 import zigpy.exceptions
 import zigpy.zcl.clusters.general as general
@@ -19,7 +19,7 @@ from ..const import (
     SIGNAL_SET_LEVEL,
     SIGNAL_UPDATE_DEVICE,
 )
-from .base import ChannelStatus, ClientChannel, ZigbeeChannel, parse_and_log_command
+from .base import ClientChannel, ZigbeeChannel, parse_and_log_command
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.Alarms.cluster_id)
@@ -174,11 +174,6 @@ class LevelControlChannel(ZigbeeChannel):
         """Dispatch level change."""
         self.async_send_signal(f"{self.unique_id}_{command}", level)
 
-    async def async_initialize(self, from_cache):
-        """Initialize channel."""
-        await self.get_attribute_value(self.CURRENT_LEVEL, from_cache=from_cache)
-        await super().async_initialize(from_cache)
-
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateInput.cluster_id)
 class MultistateInput(ZigbeeChannel):
@@ -269,12 +264,9 @@ class OnOffChannel(ZigbeeChannel):
             )
             self._state = bool(value)
 
-    async def async_initialize(self, from_cache):
+    async def async_initialize_channel_specific(self, from_cache: bool) -> None:
         """Initialize channel."""
-        await super().async_initialize(from_cache)
-        state = await self.get_attribute_value(self.ON_OFF, from_cache=True)
-        if state is not None:
-            self._state = bool(state)
+        self._state = self.on_off
 
     async def async_update(self):
         """Initialize channel."""
@@ -359,16 +351,13 @@ class PowerConfigurationChannel(ZigbeeChannel):
         {"attr": "battery_percentage_remaining", "config": REPORT_CONFIG_BATTERY_SAVE},
     )
 
-    async def async_initialize(self, from_cache):
-        """Initialize channel."""
+    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
+        """Initialize channel specific attrs."""
         attributes = [
             "battery_size",
-            "battery_percentage_remaining",
-            "battery_voltage",
             "battery_quantity",
         ]
-        await self.get_attributes(attributes, from_cache=from_cache)
-        self._status = ChannelStatus.INITIALIZED
+        return self.get_attributes(attributes, from_cache=from_cache)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.PowerProfile.cluster_id)

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -323,7 +323,7 @@ class PollControl(ZigbeeChannel):
     CHECKIN_FAST_POLL_TIMEOUT = 2 * 4  # 2s
     LONG_POLL = 6 * 4  # 6s
 
-    async def async_configure(self) -> None:
+    async def async_configure_channel_specific(self) -> None:
         """Configure channel: set check-in interval."""
         try:
             res = await self.cluster.write_attributes(
@@ -332,7 +332,6 @@ class PollControl(ZigbeeChannel):
             self.debug("%ss check-in interval set: %s", self.CHECKIN_INTERVAL / 4, res)
         except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
             self.debug("Couldn't set check-in interval: %s", ex)
-        await super().async_configure()
 
     @callback
     def cluster_command(

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -1,5 +1,5 @@
 """Home automation channels module for Zigbee Home Automation."""
-from typing import Optional
+from typing import Coroutine, Optional
 
 import zigpy.zcl.clusters.homeautomation as homeautomation
 
@@ -62,23 +62,17 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
                 result,
             )
 
-    async def async_initialize(self, from_cache):
-        """Initialize channel."""
-        await self.fetch_config(True)
-        await super().async_initialize(from_cache)
+    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
+        """Initialize channel specific attributes."""
 
-    async def fetch_config(self, from_cache):
-        """Fetch config from device and updates format specifier."""
-
-        # prime the cache
-        await self.get_attributes(
+        return self.get_attributes(
             [
                 "ac_power_divisor",
                 "power_divisor",
                 "ac_power_multiplier",
                 "power_multiplier",
             ],
-            from_cache=from_cache,
+            from_cache=True,
         )
 
     @property

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -362,7 +362,7 @@ class ThermostatChannel(ZigbeeChannel):
         )
 
     @retryable_req(delays=(1, 1, 3))
-    async def async_initialize(self, from_cache):
+    async def async_initialize_channel_specific(self, from_cache: bool) -> None:
         """Initialize channel."""
 
         cached = [a for a, cached in self._init_attrs.items() if cached]
@@ -370,7 +370,6 @@ class ThermostatChannel(ZigbeeChannel):
 
         await self._chunk_attr_read(cached, cached=True)
         await self._chunk_attr_read(uncached, cached=False)
-        await super().async_initialize(from_cache)
 
     async def async_set_operation_mode(self, mode) -> bool:
         """Set Operation mode."""

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -1,5 +1,5 @@
 """Lighting channels module for Zigbee Home Automation."""
-from typing import Optional
+from typing import Coroutine, Optional
 
 import zigpy.zcl.clusters.lighting as lighting
 
@@ -75,10 +75,9 @@ class ColorChannel(ZigbeeChannel):
         """Return the warmest color_temp that this channel supports."""
         return self.cluster.get("color_temp_physical_max", self.MAX_MIREDS)
 
-    async def async_configure(self) -> None:
+    def async_configure_channel_specific(self) -> Coroutine:
         """Configure channel."""
-        await self.fetch_color_capabilities(False)
-        await super().async_configure()
+        return self.fetch_color_capabilities(False)
 
     async def async_initialize(self, from_cache: bool) -> None:
         """Initialize channel."""

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -79,10 +79,9 @@ class ColorChannel(ZigbeeChannel):
         """Configure channel."""
         return self.fetch_color_capabilities(False)
 
-    async def async_initialize(self, from_cache: bool) -> None:
+    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
         """Initialize channel."""
-        await self.fetch_color_capabilities(True)
-        await super().async_initialize(from_cache)
+        return self.fetch_color_capabilities(True)
 
     async def fetch_color_capabilities(self, from_cache: bool) -> None:
         """Get the color configuration."""

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -20,7 +20,7 @@ from ..const import (
     WARNING_DEVICE_STROBE_HIGH,
     WARNING_DEVICE_STROBE_YES,
 )
-from .base import ZigbeeChannel
+from .base import ChannelStatus, ZigbeeChannel
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(security.IasAce.cluster_id)
@@ -155,14 +155,10 @@ class IASZoneChannel(ZigbeeChannel):
                 str(ex),
             )
 
-        try:
-            self.debug("Sending pro-active IAS enroll response")
-            await self._cluster.enroll_response(0, 0)
-        except ZigbeeException as ex:
-            self.debug(
-                "Failed to send pro-active IAS enroll response: %s",
-                str(ex),
-            )
+        self.debug("Sending pro-active IAS enroll response")
+        self._cluster.create_catching_task(self._cluster.enroll_response(0, 0))
+
+        self._status = ChannelStatus.CONFIGURED
         self.debug("finished IASZoneChannel configuration")
 
     @callback

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/integrations/zha/
 """
 import asyncio
+from typing import Coroutine
 
 from zigpy.exceptions import ZigbeeException
 import zigpy.zcl.clusters.security as security
@@ -173,8 +174,7 @@ class IASZoneChannel(ZigbeeChannel):
                 value,
             )
 
-    async def async_initialize(self, from_cache):
+    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
         """Initialize channel."""
-        attributes = ["zone_status", "zone_state"]
-        await self.get_attributes(attributes, from_cache=from_cache)
-        await super().async_initialize(from_cache)
+        attributes = ["zone_status", "zone_state", "zone_type"]
+        return self.get_attributes(attributes, from_cache=from_cache)

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -1,5 +1,5 @@
 """Smart energy channels module for Zigbee Home Automation."""
-from typing import Union
+from typing import Coroutine, Union
 
 import zigpy.zcl.clusters.smartenergy as smartenergy
 
@@ -96,10 +96,9 @@ class Metering(ZigbeeChannel):
         """Return multiplier for the value."""
         return self.cluster.get("multiplier")
 
-    async def async_configure(self) -> None:
+    def async_configure_channel_specific(self) -> Coroutine:
         """Configure channel."""
-        await self.fetch_config(False)
-        await super().async_configure()
+        return self.fetch_config(False)
 
     async def async_initialize(self, from_cache: bool) -> None:
         """Initialize channel."""

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -100,10 +100,9 @@ class Metering(ZigbeeChannel):
         """Configure channel."""
         return self.fetch_config(False)
 
-    async def async_initialize(self, from_cache: bool) -> None:
+    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
         """Initialize channel."""
-        await self.fetch_config(True)
-        await super().async_initialize(from_cache)
+        return self.fetch_config(True)
 
     @callback
     def attribute_updated(self, attrid: int, value: int) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor ZHA Core channel's `async_configure()` and `async_initialize()` methods and for channels that require some additional configuration and/or initialization, split those into separate `async_configure_channel_specific()` and `async_initialize_channel_specific()` methods.
This is part of a larger channel initialization refactoring which I decided to split into smaller PRs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
