### PR TITLE
ZHA Add Coordinator to LightLink cluster groups

### DIFF
--- a/homeassistant/components/zha/core/channels/lightlink.py
+++ b/homeassistant/components/zha/core/channels/lightlink.py
@@ -1,11 +1,41 @@
 """Lightlink channels module for Zigbee Home Automation."""
+import asyncio
+
+import zigpy.exceptions
 import zigpy.zcl.clusters.lightlink as lightlink
 
 from .. import registries
-from .base import ZigbeeChannel
+from .base import ChannelStatus, ZigbeeChannel
 
 
 @registries.CHANNEL_ONLY_CLUSTERS.register(lightlink.LightLink.cluster_id)
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(lightlink.LightLink.cluster_id)
 class LightLink(ZigbeeChannel):
     """Lightlink channel."""
+
+    async def async_configure(self) -> None:
+        """Add Coordinator to LightLink group ."""
+
+        if self._ch_pool.skip_configuration:
+            self._status = ChannelStatus.CONFIGURED
+            return
+
+        application = self._ch_pool.endpoint.device.application
+        try:
+            coordinator = application.get_device(application.ieee)
+        except KeyError:
+            self.warning("Aborting - unable to locate required coordinator device.")
+            return
+
+        try:
+            supported_groups, idx, groups = await self.cluster.get_group_identifiers(0)
+        except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as exc:
+            self.warning("Couldn't get list of groups: %s", str(exc))
+            return
+
+        if groups:
+            for group in groups:
+                self.debug("Adding coordinator to 0x%04x group id", group.group_id)
+                await coordinator.add_to_group(group.group_id)
+        else:
+            await coordinator.add_to_group(0x0000, name="Default Lightlink Group")

--- a/homeassistant/components/zha/core/channels/lightlink.py
+++ b/homeassistant/components/zha/core/channels/lightlink.py
@@ -28,7 +28,7 @@ class LightLink(ZigbeeChannel):
             return
 
         try:
-            supported_groups, idx, groups = await self.cluster.get_group_identifiers(0)
+            _, _, groups = await self.cluster.get_group_identifiers(0)
         except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as exc:
             self.warning("Couldn't get list of groups: %s", str(exc))
             return

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -14,7 +14,7 @@ import homeassistant.components.zha.core.registries as registries
 
 from .common import get_zha_gateway, make_zcl_header
 
-import tests.async_mock
+from tests.async_mock import AsyncMock, patch
 from tests.common import async_capture_events
 
 
@@ -38,9 +38,26 @@ async def zha_gateway(hass, setup_zha):
 
 
 @pytest.fixture
-def channel_pool():
+def zigpy_coordinator_device(zigpy_device_mock):
+    """Coordinator device fixture."""
+
+    coordinator = zigpy_device_mock(
+        {1: {"in_clusters": [0x1000], "out_clusters": [], "device_type": 0x1234}},
+        "00:11:22:33:44:55:66:77",
+        "test manufacturer",
+        "test model",
+    )
+    with patch.object(coordinator, "add_to_group", AsyncMock(return_value=[0])):
+        yield coordinator
+
+
+@pytest.fixture
+def channel_pool(zigpy_coordinator_device):
     """Endpoint Channels fixture."""
     ch_pool_mock = mock.MagicMock(spec_set=zha_channels.ChannelPool)
+    ch_pool_mock.endpoint.device.application.get_device.return_value = (
+        zigpy_coordinator_device
+    )
     type(ch_pool_mock).skip_configuration = mock.PropertyMock(return_value=False)
     ch_pool_mock.id = 1
     return ch_pool_mock
@@ -117,7 +134,6 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
         (0x0406, 1, {"occupancy"}),
         (0x0702, 1, {"instantaneous_demand"}),
         (0x0B04, 1, {"active_power"}),
-        (0x1000, 1, {}),
     ],
 )
 async def test_in_channel_config(
@@ -174,7 +190,6 @@ async def test_in_channel_config(
         (0x0406, 1),
         (0x0702, 1),
         (0x0B04, 1),
-        (0x1000, 1),
     ],
 )
 async def test_out_channel_config(
@@ -386,12 +401,12 @@ async def test_ep_channels_configure(channel):
     ch_1 = channel(zha_const.CHANNEL_ON_OFF, 6)
     ch_2 = channel(zha_const.CHANNEL_LEVEL, 8)
     ch_3 = channel(zha_const.CHANNEL_COLOR, 768)
-    ch_3.async_configure = tests.async_mock.AsyncMock(side_effect=asyncio.TimeoutError)
-    ch_3.async_initialize = tests.async_mock.AsyncMock(side_effect=asyncio.TimeoutError)
+    ch_3.async_configure = AsyncMock(side_effect=asyncio.TimeoutError)
+    ch_3.async_initialize = AsyncMock(side_effect=asyncio.TimeoutError)
     ch_4 = channel(zha_const.CHANNEL_ON_OFF, 6)
     ch_5 = channel(zha_const.CHANNEL_LEVEL, 8)
-    ch_5.async_configure = tests.async_mock.AsyncMock(side_effect=asyncio.TimeoutError)
-    ch_5.async_initialize = tests.async_mock.AsyncMock(side_effect=asyncio.TimeoutError)
+    ch_5.async_configure = AsyncMock(side_effect=asyncio.TimeoutError)
+    ch_5.async_initialize = AsyncMock(side_effect=asyncio.TimeoutError)
 
     channels = mock.MagicMock(spec_set=zha_channels.Channels)
     type(channels).semaphore = mock.PropertyMock(return_value=asyncio.Semaphore(3))
@@ -427,8 +442,8 @@ async def test_poll_control_configure(poll_control_ch):
 
 async def test_poll_control_checkin_response(poll_control_ch):
     """Test poll control channel checkin response."""
-    rsp_mock = tests.async_mock.AsyncMock()
-    set_interval_mock = tests.async_mock.AsyncMock()
+    rsp_mock = AsyncMock()
+    set_interval_mock = AsyncMock()
     cluster = poll_control_ch.cluster
     patch_1 = mock.patch.object(cluster, "checkin_response", rsp_mock)
     patch_2 = mock.patch.object(cluster, "set_long_poll_interval", set_interval_mock)
@@ -449,7 +464,7 @@ async def test_poll_control_checkin_response(poll_control_ch):
 
 async def test_poll_control_cluster_command(hass, poll_control_device):
     """Test poll control channel response to cluster command."""
-    checkin_mock = tests.async_mock.AsyncMock()
+    checkin_mock = AsyncMock()
     poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
     cluster = poll_control_ch.cluster
     events = async_capture_events(hass, "zha_event")
@@ -474,3 +489,60 @@ async def test_poll_control_cluster_command(hass, poll_control_device):
     assert data["args"][2] is mock.sentinel.args3
     assert data["unique_id"] == "00:11:22:33:44:55:66:77:1:0x0020"
     assert data["device_id"] == poll_control_device.device_id
+
+
+@pytest.fixture
+def zigpy_zll_device(zigpy_device_mock):
+    """ZLL device fixture."""
+
+    return zigpy_device_mock(
+        {1: {"in_clusters": [0x1000], "out_clusters": [], "device_type": 0x1234}},
+        "00:11:22:33:44:55:66:77",
+        "test manufacturer",
+        "test model",
+    )
+
+
+async def test_zll_device_groups(
+    zigpy_zll_device, channel_pool, zigpy_coordinator_device
+):
+    """Test adding coordinator to ZLL groups."""
+
+    cluster = zigpy_zll_device.endpoints[1].lightlink
+    channel = zha_channels.lightlink.LightLink(cluster, channel_pool)
+
+    with patch.object(
+        cluster, "command", AsyncMock(return_value=[1, 0, []])
+    ) as cmd_mock:
+        await channel.async_configure()
+        assert cmd_mock.await_count == 1
+        assert (
+            cluster.server_commands[cmd_mock.await_args[0][0]][0]
+            == "get_group_identifiers"
+        )
+        assert cluster.bind.call_count == 0
+        assert zigpy_coordinator_device.add_to_group.await_count == 1
+        assert zigpy_coordinator_device.add_to_group.await_args[0][0] == 0x0000
+
+    zigpy_coordinator_device.add_to_group.reset_mock()
+    group_1 = zigpy.zcl.clusters.lightlink.GroupInfoRecord(0xABCD, 0x00)
+    group_2 = zigpy.zcl.clusters.lightlink.GroupInfoRecord(0xAABB, 0x00)
+    with patch.object(
+        cluster, "command", AsyncMock(return_value=[1, 0, [group_1, group_2]])
+    ) as cmd_mock:
+        await channel.async_configure()
+        assert cmd_mock.await_count == 1
+        assert (
+            cluster.server_commands[cmd_mock.await_args[0][0]][0]
+            == "get_group_identifiers"
+        )
+        assert cluster.bind.call_count == 0
+        assert zigpy_coordinator_device.add_to_group.await_count == 2
+        assert (
+            zigpy_coordinator_device.add_to_group.await_args_list[0][0][0]
+            == group_1.group_id
+        )
+        assert (
+            zigpy_coordinator_device.add_to_group.await_args_list[1][0][0]
+            == group_2.group_id
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactor LightLink channel to retrieve ZLL groups during configuration phase and add coordinator to those groups. This allows new devices (which use ZLL groups to send commands) to send zha_events, without making a quirk first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
