### PR TITLE
Add TaHoma integration (base + Binary Sensor)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -921,6 +921,7 @@ omit =
     homeassistant/components/tahoma/__init__.py
     homeassistant/components/tahoma/binary_sensor.py
     homeassistant/components/tahoma/coordinator.py
+    homeassistant/components/tahoma/overkiz_executor.py
     homeassistant/components/tahoma/tahoma_entity.py
     homeassistant/components/tank_utility/sensor.py
     homeassistant/components/tankerkoenig/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -918,6 +918,10 @@ omit =
     homeassistant/components/systemmonitor/sensor.py
     homeassistant/components/tado/*
     homeassistant/components/tado/device_tracker.py
+    homeassistant/components/tahoma/__init__.py
+    homeassistant/components/tahoma/binary_sensor.py
+    homeassistant/components/tahoma/coordinator.py
+    homeassistant/components/tahoma/tahoma_device.py
     homeassistant/components/tank_utility/sensor.py
     homeassistant/components/tankerkoenig/*
     homeassistant/components/tapsaff/binary_sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -921,7 +921,7 @@ omit =
     homeassistant/components/tahoma/__init__.py
     homeassistant/components/tahoma/binary_sensor.py
     homeassistant/components/tahoma/coordinator.py
-    homeassistant/components/tahoma/tahoma_device.py
+    homeassistant/components/tahoma/tahoma_entity.py
     homeassistant/components/tank_utility/sensor.py
     homeassistant/components/tankerkoenig/*
     homeassistant/components/tapsaff/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -462,6 +462,7 @@ homeassistant/components/synology_srm/* @aerialls
 homeassistant/components/syslog/* @fabaff
 homeassistant/components/tado/* @michaelarnauts @bdraco @noltari
 homeassistant/components/tag/* @balloob @dmulcahey
+homeassistant/components/tahoma/* @imicknl @vlebourl @tetienne
 homeassistant/components/tankerkoenig/* @guillempages
 homeassistant/components/tapsaff/* @bazwilliams
 homeassistant/components/tasmota/* @emontnemery

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -83,10 +83,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await tahoma_coordinator.async_refresh()
 
-    devices = defaultdict(list)
+    platforms = defaultdict(list)
 
     hass.data[DOMAIN][entry.entry_id] = {
-        "devices": devices,
+        "platforms": platforms,
         "coordinator": tahoma_coordinator,
         "update_listener": entry.add_update_listener(update_listener),
     }
@@ -94,7 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for device in tahoma_coordinator.data.values():
         platform = TAHOMA_TYPES.get(device.widget) or TAHOMA_TYPES.get(device.ui_class)
         if platform:
-            devices[platform].append(device)
+            platforms[platform].append(device)
         elif (
             device.widget not in IGNORED_TAHOMA_TYPES
             and device.ui_class not in IGNORED_TAHOMA_TYPES
@@ -106,7 +106,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 device.widget,
             )
 
-    for platform in devices:
+    for platform in platforms:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
@@ -116,7 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    devices_per_platform = hass.data[DOMAIN][entry.entry_id]["devices"]
+    devices_per_platform = hass.data[DOMAIN][entry.entry_id]["platforms"]
 
     unload_ok = all(
         await asyncio.gather(

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -64,15 +64,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.exception(exception)
         return False
 
-    update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+    update_interval = timedelta(
+        seconds=entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+    )
 
     tahoma_coordinator = TahomaDataUpdateCoordinator(
         hass,
         _LOGGER,
-        name="event fetcher",
+        name="device events",
         client=client,
         devices=devices,
         update_interval=timedelta(seconds=update_interval),
+    )
+
+    _LOGGER.debug(
+        "Initialized DataUpdateCoordinator with %s interval.", str(update_interval)
     )
 
     await tahoma_coordinator.async_refresh()

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -1,0 +1,139 @@
+"""The Somfy TaHoma integration."""
+import asyncio
+from collections import defaultdict
+from datetime import timedelta
+import logging
+
+from aiohttp import ClientError, ServerDisconnectedError
+from pyhoma.client import TahomaClient
+from pyhoma.exceptions import (
+    BadCredentialsException,
+    MaintenanceException,
+    TooManyRequestsException,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import aiohttp_client
+
+from .const import (
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    IGNORED_TAHOMA_TYPES,
+    TAHOMA_TYPES,
+)
+from .coordinator import TahomaDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Somfy TaHoma component."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Somfy TaHoma from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    username = entry.data.get(CONF_USERNAME)
+    password = entry.data.get(CONF_PASSWORD)
+
+    session = aiohttp_client.async_create_clientsession(hass)
+    client = TahomaClient(username, password, session=session)
+
+    try:
+        await client.login()
+        devices = await client.get_devices()
+    except BadCredentialsException:
+        _LOGGER.error("invalid_auth")
+        return False
+    except TooManyRequestsException as exception:
+        _LOGGER.error("too_many_requests")
+        raise ConfigEntryNotReady from exception
+    except (TimeoutError, ClientError, ServerDisconnectedError) as exception:
+        _LOGGER.error("cannot_connect")
+        raise ConfigEntryNotReady from exception
+    except MaintenanceException as exception:
+        _LOGGER.error("server_in_maintenance")
+        raise ConfigEntryNotReady from exception
+    except Exception as exception:  # pylint: disable=broad-except
+        _LOGGER.exception(exception)
+        return False
+
+    update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+
+    tahoma_coordinator = TahomaDataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="event fetcher",
+        client=client,
+        devices=devices,
+        update_interval=timedelta(seconds=update_interval),
+    )
+
+    await tahoma_coordinator.async_refresh()
+
+    entities = defaultdict(list)
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        "entities": entities,
+        "coordinator": tahoma_coordinator,
+        "update_listener": entry.add_update_listener(update_listener),
+    }
+
+    for device in tahoma_coordinator.data.values():
+        platform = TAHOMA_TYPES.get(device.widget) or TAHOMA_TYPES.get(device.ui_class)
+        if platform:
+            entities[platform].append(device)
+        elif (
+            device.widget not in IGNORED_TAHOMA_TYPES
+            and device.ui_class not in IGNORED_TAHOMA_TYPES
+        ):
+            _LOGGER.debug(
+                "Unsupported TaHoma device detected (%s - %s - %s)",
+                device.controllable_name,
+                device.ui_class,
+                device.widget,
+            )
+
+    for platform in entities:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    entities_per_platform = hass.data[DOMAIN][entry.entry_id]["entities"]
+
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in entities_per_platform
+            ]
+        )
+    )
+
+    if unload_ok:
+        hass.data[DOMAIN][entry.entry_id]["update_listener"]()
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
+    """Update when config_entry options update."""
+    if entry.options[CONF_UPDATE_INTERVAL]:
+        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+        new_update_interval = timedelta(seconds=entry.options[CONF_UPDATE_INTERVAL])
+        coordinator.update_interval = new_update_interval
+        coordinator.original_update_interval = new_update_interval
+
+        await coordinator.async_refresh()

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         name="device events",
         client=client,
         devices=devices,
-        update_interval=timedelta(seconds=update_interval),
+        update_interval=update_interval,
     )
 
     _LOGGER.debug(

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -49,16 +49,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await client.login()
         devices = await client.get_devices()
     except BadCredentialsException:
-        _LOGGER.error("invalid_auth")
+        _LOGGER.error("Invalid authentication.")
         return False
     except TooManyRequestsException as exception:
-        _LOGGER.error("too_many_requests")
+        _LOGGER.error("Too many requests, try again later.")
         raise ConfigEntryNotReady from exception
     except (TimeoutError, ClientError, ServerDisconnectedError) as exception:
-        _LOGGER.error("cannot_connect")
+        _LOGGER.error("Failed to connect.")
         raise ConfigEntryNotReady from exception
     except MaintenanceException as exception:
-        _LOGGER.error("server_in_maintenance")
+        _LOGGER.error("Server is down for maintenance.")
         raise ConfigEntryNotReady from exception
     except Exception as exception:  # pylint: disable=broad-except
         _LOGGER.exception(exception)

--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -77,10 +77,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await tahoma_coordinator.async_refresh()
 
-    entities = defaultdict(list)
+    devices = defaultdict(list)
 
     hass.data[DOMAIN][entry.entry_id] = {
-        "entities": entities,
+        "devices": devices,
         "coordinator": tahoma_coordinator,
         "update_listener": entry.add_update_listener(update_listener),
     }
@@ -88,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for device in tahoma_coordinator.data.values():
         platform = TAHOMA_TYPES.get(device.widget) or TAHOMA_TYPES.get(device.ui_class)
         if platform:
-            entities[platform].append(device)
+            devices[platform].append(device)
         elif (
             device.widget not in IGNORED_TAHOMA_TYPES
             and device.ui_class not in IGNORED_TAHOMA_TYPES
@@ -100,7 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 device.widget,
             )
 
-    for platform in entities:
+    for platform in devices:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
@@ -110,13 +110,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    entities_per_platform = hass.data[DOMAIN][entry.entry_id]["entities"]
+    devices_per_platform = hass.data[DOMAIN][entry.entry_id]["devices"]
 
     unload_ok = all(
         await asyncio.gather(
             *[
                 hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in entities_per_platform
+                for platform in devices_per_platform
             ]
         )
     )

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Somfy TaHoma binary sensors."""
 from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_GAS,
+    DEVICE_CLASS_MOISTURE,
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
     DEVICE_CLASS_OPENING,
@@ -24,11 +26,6 @@ CORE_THREE_WAY_HANDLE_DIRECTION_STATE = "core:ThreeWayHandleDirectionState"
 CORE_VIBRATION_STATE = "core:VibrationState"
 CORE_WATER_DETECTION_STATE = "core:WaterDetectionState"
 
-DEVICE_CLASS_BUTTON = "button"
-DEVICE_CLASS_GAS = "gas"
-DEVICE_CLASS_RAIN = "rain"
-DEVICE_CLASS_WATER = "water"
-
 IO_VIBRATION_DETECTED_STATE = "io:VibrationDetectedState"
 
 STATE_OPEN = "open"
@@ -38,15 +35,15 @@ STATE_PRESSED = "pressed"
 
 TAHOMA_BINARY_SENSOR_DEVICE_CLASSES = {
     "AirFlowSensor": DEVICE_CLASS_GAS,
-    "CarButtonSensor": DEVICE_CLASS_BUTTON,
+    "CarButtonSensor": None,
     "ContactSensor": DEVICE_CLASS_OPENING,
     "MotionSensor": DEVICE_CLASS_MOTION,
     "OccupancySensor": DEVICE_CLASS_OCCUPANCY,
-    "RainSensor": DEVICE_CLASS_RAIN,
+    "RainSensor": DEVICE_CLASS_MOISTURE,
     "SirenStatus": DEVICE_CLASS_OPENING,
     "SmokeSensor": DEVICE_CLASS_SMOKE,
-    "WaterDetectionSensor": DEVICE_CLASS_WATER,
-    "WaterSensor": DEVICE_CLASS_WATER,
+    "WaterDetectionSensor": DEVICE_CLASS_MOISTURE,
+    "WaterSensor": DEVICE_CLASS_MOISTURE,
     "WindowHandle": DEVICE_CLASS_OPENING,
 }
 

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -71,7 +71,7 @@ class TahomaBinarySensor(TahomaEntity, BinarySensorEntity):
         """Return the state of the sensor."""
 
         return (
-            self.select_state(
+            self.executor.select_state(
                 CORE_ASSEMBLY_STATE,
                 CORE_BUTTON_STATE,
                 CORE_CONTACT_STATE,

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 )
 
 from .const import DOMAIN
-from .tahoma_device import TahomaDevice
+from .tahoma_entity import TahomaEntity
 
 CORE_ASSEMBLY_STATE = "core:AssemblyState"
 CORE_BUTTON_STATE = "core:ButtonState"
@@ -70,7 +70,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities)
 
 
-class TahomaBinarySensor(TahomaDevice, BinarySensorEntity):
+class TahomaBinarySensor(TahomaEntity, BinarySensorEntity):
     """Representation of a TaHoma Binary Sensor."""
 
     @property

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -102,15 +102,3 @@ class TahomaBinarySensor(TahomaEntity, BinarySensorEntity):
         return TAHOMA_BINARY_SENSOR_DEVICE_CLASSES.get(
             self.device.widget
         ) or TAHOMA_BINARY_SENSOR_DEVICE_CLASSES.get(self.device.ui_class)
-
-    @property
-    def icon(self) -> Optional[str]:
-        """Return the icon to use in the frontend, if any."""
-        if self.device_class == DEVICE_CLASS_WATER:
-            if self.is_on:
-                return ICON_WATER
-            return ICON_WATER_OFF
-
-        icons = {DEVICE_CLASS_GAS: ICON_WAVES, DEVICE_CLASS_RAIN: ICON_WEATHER_RAINY}
-
-        return icons.get(self.device_class)

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -58,7 +58,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities = [
         TahomaBinarySensor(device.deviceurl, coordinator)
-        for device in data["devices"].get(BINARY_SENSOR)
+        for device in data["platforms"].get(BINARY_SENSOR)
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -65,7 +65,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities = [
         TahomaBinarySensor(device.deviceurl, coordinator)
-        for device in data["entities"].get(BINARY_SENSOR)
+        for device in data["devices"].get(BINARY_SENSOR)
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -1,0 +1,116 @@
+"""Support for Somfy TaHoma binary sensors."""
+from typing import Optional
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_OCCUPANCY,
+    DEVICE_CLASS_OPENING,
+    DEVICE_CLASS_SMOKE,
+    DOMAIN as BINARY_SENSOR,
+    BinarySensorEntity,
+)
+
+from .const import DOMAIN
+from .tahoma_device import TahomaDevice
+
+CORE_ASSEMBLY_STATE = "core:AssemblyState"
+CORE_BUTTON_STATE = "core:ButtonState"
+CORE_CONTACT_STATE = "core:ContactState"
+CORE_GAS_DETECTION_STATE = "core:GasDetectionState"
+CORE_OCCUPANCY_STATE = "core:OccupancyState"
+CORE_OPENING_STATE = "core:OpeningState"
+CORE_OPEN_CLOSED_TILT_STATE = "core:OpenClosedTiltState"
+CORE_RAIN_STATE = "core:RainState"
+CORE_SMOKE_STATE = "core:SmokeState"
+CORE_THREE_WAY_HANDLE_DIRECTION_STATE = "core:ThreeWayHandleDirectionState"
+CORE_VIBRATION_STATE = "core:VibrationState"
+CORE_WATER_DETECTION_STATE = "core:WaterDetectionState"
+
+DEVICE_CLASS_BUTTON = "button"
+DEVICE_CLASS_GAS = "gas"
+DEVICE_CLASS_RAIN = "rain"
+DEVICE_CLASS_WATER = "water"
+
+ICON_WATER = "mdi:water"
+ICON_WATER_OFF = "mdi:water-off"
+ICON_WAVES = "mdi:waves"
+ICON_WEATHER_RAINY = "mdi:weather-rainy"
+
+IO_VIBRATION_DETECTED_STATE = "io:VibrationDetectedState"
+
+STATE_OPEN = "open"
+STATE_PERSON_INSIDE = "personInside"
+STATE_DETECTED = "detected"
+STATE_PRESSED = "pressed"
+
+TAHOMA_BINARY_SENSOR_DEVICE_CLASSES = {
+    "AirFlowSensor": DEVICE_CLASS_GAS,
+    "CarButtonSensor": DEVICE_CLASS_BUTTON,
+    "ContactSensor": DEVICE_CLASS_OPENING,
+    "MotionSensor": DEVICE_CLASS_MOTION,
+    "OccupancySensor": DEVICE_CLASS_OCCUPANCY,
+    "RainSensor": DEVICE_CLASS_RAIN,
+    "SirenStatus": DEVICE_CLASS_OPENING,
+    "SmokeSensor": DEVICE_CLASS_SMOKE,
+    "WaterDetectionSensor": DEVICE_CLASS_WATER,
+    "WaterSensor": DEVICE_CLASS_WATER,
+    "WindowHandle": DEVICE_CLASS_OPENING,
+}
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the TaHoma sensors from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+
+    entities = [
+        TahomaBinarySensor(device.deviceurl, coordinator)
+        for device in data["entities"].get(BINARY_SENSOR)
+    ]
+    async_add_entities(entities)
+
+
+class TahomaBinarySensor(TahomaDevice, BinarySensorEntity):
+    """Representation of a TaHoma Binary Sensor."""
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+
+        return (
+            self.select_state(
+                CORE_ASSEMBLY_STATE,
+                CORE_BUTTON_STATE,
+                CORE_CONTACT_STATE,
+                CORE_GAS_DETECTION_STATE,
+                CORE_OCCUPANCY_STATE,
+                CORE_OPENING_STATE,
+                CORE_OPEN_CLOSED_TILT_STATE,
+                CORE_RAIN_STATE,
+                CORE_SMOKE_STATE,
+                CORE_THREE_WAY_HANDLE_DIRECTION_STATE,
+                CORE_VIBRATION_STATE,
+                CORE_WATER_DETECTION_STATE,
+                IO_VIBRATION_DETECTED_STATE,
+            )
+            in [STATE_OPEN, STATE_PERSON_INSIDE, STATE_DETECTED, STATE_PRESSED]
+        )
+
+    @property
+    def device_class(self):
+        """Return the class of the device."""
+        return TAHOMA_BINARY_SENSOR_DEVICE_CLASSES.get(
+            self.device.widget
+        ) or TAHOMA_BINARY_SENSOR_DEVICE_CLASSES.get(self.device.ui_class)
+
+    @property
+    def icon(self) -> Optional[str]:
+        """Return the icon to use in the frontend, if any."""
+        if self.device_class == DEVICE_CLASS_WATER:
+            if self.is_on:
+                return ICON_WATER
+            return ICON_WATER_OFF
+
+        icons = {DEVICE_CLASS_GAS: ICON_WAVES, DEVICE_CLASS_RAIN: ICON_WEATHER_RAINY}
+
+        return icons.get(self.device_class)

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -29,11 +29,6 @@ DEVICE_CLASS_GAS = "gas"
 DEVICE_CLASS_RAIN = "rain"
 DEVICE_CLASS_WATER = "water"
 
-ICON_WATER = "mdi:water"
-ICON_WATER_OFF = "mdi:water-off"
-ICON_WAVES = "mdi:waves"
-ICON_WEATHER_RAINY = "mdi:weather-rainy"
-
 IO_VIBRATION_DETECTED_STATE = "io:VibrationDetectedState"
 
 STATE_OPEN = "open"

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -1,6 +1,4 @@
 """Support for Somfy TaHoma binary sensors."""
-from typing import Optional
-
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,

--- a/homeassistant/components/tahoma/binary_sensor.py
+++ b/homeassistant/components/tahoma/binary_sensor.py
@@ -55,7 +55,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities = [
         TahomaBinarySensor(device.deviceurl, coordinator)
-        for device in data["platforms"].get(BINARY_SENSOR)
+        for device in data["platforms"][BINARY_SENSOR]
     ]
     async_add_entities(entities)
 

--- a/homeassistant/components/tahoma/config_flow.py
+++ b/homeassistant/components/tahoma/config_flow.py
@@ -1,0 +1,107 @@
+"""Config flow for Somfy TaHoma integration."""
+import logging
+
+from aiohttp import ClientError
+from pyhoma.client import TahomaClient
+from pyhoma.exceptions import (
+    BadCredentialsException,
+    MaintenanceException,
+    TooManyRequestsException,
+)
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+
+from .const import CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, MIN_UPDATE_INTERVAL
+from .const import DOMAIN  # pylint: disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Somfy TaHoma."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Handle the flow."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_validate_input(self, user_input):
+        """Validate user credentials."""
+        username = user_input.get(CONF_USERNAME)
+        password = user_input.get(CONF_PASSWORD)
+
+        async with TahomaClient(username, password) as client:
+            await client.login()
+            return self.async_create_entry(title=username, data=user_input)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step via config flow."""
+        errors = {}
+
+        if user_input:
+            await self.async_set_unique_id(user_input.get(CONF_USERNAME))
+            self._abort_if_unique_id_configured()
+
+            try:
+                return await self.async_validate_input(user_input)
+            except TooManyRequestsException:
+                errors["base"] = "too_many_requests"
+            except BadCredentialsException:
+                errors["base"] = "invalid_auth"
+            except (TimeoutError, ClientError):
+                errors["base"] = "cannot_connect"
+            except MaintenanceException:
+                errors["base"] = "server_in_maintenance"
+            except Exception as exception:  # pylint: disable=broad-except
+                errors["base"] = "unknown"
+                _LOGGER.exception(exception)
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for TaHoma."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+        if self.options.get(CONF_UPDATE_INTERVAL) is None:
+            self.options[CONF_UPDATE_INTERVAL] = DEFAULT_UPDATE_INTERVAL
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Somfy TaHoma options."""
+        return await self.async_step_update_interval()
+
+    async def async_step_update_interval(self, user_input=None):
+        """Manage the options regarding interval updates."""
+        if user_input is not None:
+            self.options[CONF_UPDATE_INTERVAL] = user_input[CONF_UPDATE_INTERVAL]
+            return self.async_create_entry(title="", data=self.options)
+
+        return self.async_show_form(
+            step_id="update_interval",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_UPDATE_INTERVAL,
+                        default=self.options.get(CONF_UPDATE_INTERVAL),
+                    ): vol.All(cv.positive_int, vol.Clamp(min=MIN_UPDATE_INTERVAL))
+                }
+            ),
+        )

--- a/homeassistant/components/tahoma/config_flow.py
+++ b/homeassistant/components/tahoma/config_flow.py
@@ -91,8 +91,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_update_interval(self, user_input=None):
         """Manage the options regarding interval updates."""
         if user_input is not None:
-            self.options[CONF_UPDATE_INTERVAL] = user_input[CONF_UPDATE_INTERVAL]
-            return self.async_create_entry(title="", data=self.options)
+            return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="update_interval",

--- a/homeassistant/components/tahoma/config_flow.py
+++ b/homeassistant/components/tahoma/config_flow.py
@@ -79,10 +79,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
         """Initialize options flow."""
         self.config_entry = config_entry
-        self.options = dict(config_entry.options)
-
-        if self.options.get(CONF_UPDATE_INTERVAL) is None:
-            self.options[CONF_UPDATE_INTERVAL] = DEFAULT_UPDATE_INTERVAL
 
     async def async_step_init(self, user_input=None):
         """Manage the Somfy TaHoma options."""
@@ -99,7 +95,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         CONF_UPDATE_INTERVAL,
-                        default=self.options.get(CONF_UPDATE_INTERVAL),
+                        default=self.config_entry.options.get(
+                            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                        ),
                     ): vol.All(cv.positive_int, vol.Clamp(min=MIN_UPDATE_INTERVAL))
                 }
             ),

--- a/homeassistant/components/tahoma/const.py
+++ b/homeassistant/components/tahoma/const.py
@@ -1,0 +1,33 @@
+"""Constants for the Somfy TaHoma integration."""
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
+
+DOMAIN = "tahoma"
+
+MIN_UPDATE_INTERVAL = 30
+DEFAULT_UPDATE_INTERVAL = 30
+
+IGNORED_TAHOMA_TYPES = [
+    "ProtocolGateway",
+    "Pod",
+]
+
+# Used to map the Somfy widget and ui_class to the Home Assistant platform
+TAHOMA_TYPES = {
+    "AirFlowSensor": BINARY_SENSOR,  # widgetName, uiClass is AirSensor (sensor)
+    "CarButtonSensor": BINARY_SENSOR,
+    "ContactSensor": BINARY_SENSOR,
+    "MotionSensor": BINARY_SENSOR,
+    "OccupancySensor": BINARY_SENSOR,
+    "RainSensor": BINARY_SENSOR,
+    "SirenStatus": BINARY_SENSOR,  # widgetName, uiClass is Siren (switch)
+    "SmokeSensor": BINARY_SENSOR,
+    "WaterDetectionSensor": BINARY_SENSOR,  # widgetName, uiClass is HumiditySensor (sensor)
+    "WindowHandle": BINARY_SENSOR,
+}
+
+CORE_ON_OFF_STATE = "core:OnOffState"
+
+COMMAND_OFF = "off"
+COMMAND_ON = "on"
+
+CONF_UPDATE_INTERVAL = "update_interval"

--- a/homeassistant/components/tahoma/coordinator.py
+++ b/homeassistant/components/tahoma/coordinator.py
@@ -57,10 +57,6 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
         self.devices: Dict[str, Device] = {d.deviceurl: d for d in devices}
         self.executions: Dict[str, Dict[str, str]] = {}
 
-        _LOGGER.debug(
-            "Initialized DataUpdateCoordinator with %s interval.", str(update_interval)
-        )
-
     async def _async_update_data(self) -> Dict[str, Device]:
         """Fetch TaHoma data via event listener."""
         try:

--- a/homeassistant/components/tahoma/coordinator.py
+++ b/homeassistant/components/tahoma/coordinator.py
@@ -66,11 +66,11 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             events = await self.client.fetch_events()
         except BadCredentialsException as exception:
-            raise UpdateFailed("invalid_auth") from exception
+            raise UpdateFailed("Invalid authentication.") from exception
         except TooManyRequestsException as exception:
-            raise UpdateFailed("too_many_requests") from exception
+            raise UpdateFailed("Too many requests, try again later.") from exception
         except MaintenanceException as exception:
-            raise UpdateFailed("server_in_maintenance") from exception
+            raise UpdateFailed("Server is down for maintenance.") from exception
         except (ServerDisconnectedError, NotAuthenticatedException) as exception:
             _LOGGER.debug(exception)
             self.executions = {}

--- a/homeassistant/components/tahoma/coordinator.py
+++ b/homeassistant/components/tahoma/coordinator.py
@@ -1,0 +1,150 @@
+"""Helpers to help coordinate updates."""
+from datetime import timedelta
+import logging
+from typing import Dict, List, Optional, Union
+
+from aiohttp import ServerDisconnectedError
+from pyhoma.client import TahomaClient
+from pyhoma.enums import EventName, ExecutionState
+from pyhoma.exceptions import (
+    BadCredentialsException,
+    MaintenanceException,
+    NotAuthenticatedException,
+    TooManyRequestsException,
+)
+from pyhoma.models import DataType, Device, State
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+TYPES = {
+    DataType.NONE: None,
+    DataType.INTEGER: int,
+    DataType.DATE: int,
+    DataType.STRING: str,
+    DataType.FLOAT: float,
+    DataType.BOOLEAN: bool,
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching TaHoma data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        *,
+        name: str,
+        client: TahomaClient,
+        devices: List[Device],
+        update_interval: Optional[timedelta] = None,
+    ):
+        """Initialize global data updater."""
+        super().__init__(
+            hass,
+            logger,
+            name=name,
+            update_interval=update_interval,
+        )
+
+        self.data = {}
+        self.original_update_interval = update_interval
+        self.client = client
+        self.devices: Dict[str, Device] = {d.deviceurl: d for d in devices}
+        self.executions: Dict[str, Dict[str, str]] = {}
+
+        _LOGGER.debug(
+            "Initialized DataUpdateCoordinator with %s interval.", str(update_interval)
+        )
+
+    async def _async_update_data(self) -> Dict[str, Device]:
+        """Fetch TaHoma data via event listener."""
+        try:
+            events = await self.client.fetch_events()
+        except BadCredentialsException as exception:
+            raise UpdateFailed("invalid_auth") from exception
+        except TooManyRequestsException as exception:
+            raise UpdateFailed("too_many_requests") from exception
+        except MaintenanceException as exception:
+            raise UpdateFailed("server_in_maintenance") from exception
+        except (ServerDisconnectedError, NotAuthenticatedException) as exception:
+            _LOGGER.debug(exception)
+            self.executions = {}
+            await self.client.login()
+            self.devices = await self._get_devices()
+            return self.devices
+        except Exception as exception:
+            _LOGGER.debug(exception)
+            raise UpdateFailed(exception) from exception
+
+        for event in events:
+            _LOGGER.debug(
+                "%s/%s (device: %s, state: %s -> %s)",
+                event.name,
+                event.exec_id,
+                event.deviceurl,
+                event.old_state,
+                event.new_state,
+            )
+
+            if event.name == EventName.DEVICE_AVAILABLE:
+                self.devices[event.deviceurl].available = True
+
+            elif event.name in [
+                EventName.DEVICE_UNAVAILABLE,
+                EventName.DEVICE_DISABLED,
+            ]:
+                self.devices[event.deviceurl].available = False
+
+            elif event.name in [
+                EventName.DEVICE_CREATED,
+                EventName.DEVICE_UPDATED,
+            ]:
+                self.devices = await self._get_devices()
+
+            elif event.name == EventName.DEVICE_REMOVED:
+                registry = await device_registry.async_get_registry(self.hass)
+                registry.async_remove_device(event.deviceurl)
+                del self.devices[event.deviceurl]
+
+            elif event.name == EventName.DEVICE_STATE_CHANGED:
+                for state in event.device_states:
+                    device = self.devices[event.deviceurl]
+                    if state.name not in device.states:
+                        device.states[state.name] = state
+                    device.states[state.name].value = self._get_state(state)
+
+            elif event.name == EventName.EXECUTION_REGISTERED:
+                if event.exec_id not in self.executions:
+                    self.executions[event.exec_id] = {}
+
+                self.update_interval = timedelta(seconds=1)
+
+            elif (
+                event.name == EventName.EXECUTION_STATE_CHANGED
+                and event.exec_id in self.executions
+                and event.new_state in [ExecutionState.COMPLETED, ExecutionState.FAILED]
+            ):
+                del self.executions[event.exec_id]
+
+        if not self.executions:
+            self.update_interval = self.original_update_interval
+
+        return self.devices
+
+    async def _get_devices(self) -> Dict[str, Device]:
+        """Fetch devices."""
+        _LOGGER.debug("Fetching all devices and state via /setup/devices")
+        return {d.deviceurl: d for d in await self.client.get_devices(refresh=True)}
+
+    @staticmethod
+    def _get_state(state: State) -> Union[float, int, bool, str, None]:
+        """Cast string value to the right type."""
+        if state.type != DataType.NONE:
+            caster = TYPES.get(DataType(state.type))
+            return caster(state.value)
+        return state.value

--- a/homeassistant/components/tahoma/manifest.json
+++ b/homeassistant/components/tahoma/manifest.json
@@ -6,7 +6,6 @@
   "requirements": [
     "pyhoma==0.5.1"
   ],
-  "dependencies": [],
   "codeowners": [
     "@imicknl",
     "@vlebourl",

--- a/homeassistant/components/tahoma/manifest.json
+++ b/homeassistant/components/tahoma/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "pyhoma==0.5.1"
+    "pyhoma==0.5.8"
   ],
   "codeowners": [
     "@imicknl",

--- a/homeassistant/components/tahoma/manifest.json
+++ b/homeassistant/components/tahoma/manifest.json
@@ -1,0 +1,15 @@
+{
+  "domain": "tahoma",
+  "name": "Somfy TaHoma",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/tahoma",
+  "requirements": [
+    "pyhoma==0.5.1"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@imicknl",
+    "@vlebourl",
+    "@tetienne"
+  ]
+}

--- a/homeassistant/components/tahoma/overkiz_executor.py
+++ b/homeassistant/components/tahoma/overkiz_executor.py
@@ -1,0 +1,73 @@
+"""Class for helpers and community with the OverKiz API."""
+import logging
+from typing import Any, Optional
+
+from pyhoma.models import Command, Device
+
+from .coordinator import TahomaDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OverkizExecutor:
+    """Representation of an Overkiz device with execution handler."""
+
+    def __init__(self, device_url: str, coordinator: TahomaDataUpdateCoordinator):
+        """Initialize the executor."""
+        self.device_url = device_url
+        self.coordinator = coordinator
+
+    @property
+    def device(self) -> Device:
+        """Return TaHoma device linked to this entity."""
+        return self.coordinator.data[self.device_url]
+
+    def select_command(self, *commands: str) -> Optional[str]:
+        """Select first existing command in a list of commands."""
+        existing_commands = self.device.definition.commands
+        return next((c for c in commands if c in existing_commands), None)
+
+    def has_command(self, *commands: str) -> bool:
+        """Return True if a command exists in a list of commands."""
+        return self.select_command(*commands) is not None
+
+    def select_state(self, *states) -> Optional[str]:
+        """Select first existing active state in a list of states."""
+        if self.device.states:
+            return next(
+                (
+                    state.value
+                    for state in self.device.states
+                    if state.name in list(states)
+                ),
+                None,
+            )
+        return None
+
+    def has_state(self, *states: str) -> bool:
+        """Return True if a state exists in self."""
+        return self.select_state(*states) is not None
+
+    async def async_execute_command(self, command_name: str, *args: Any):
+        """Execute device command in async context."""
+        try:
+            exec_id = await self.coordinator.client.execute_command(
+                self.device.deviceurl,
+                Command(command_name, list(args)),
+                "Home Assistant",
+            )
+        except Exception as exception:  # pylint: disable=broad-except
+            _LOGGER.error(exception)
+            return
+
+        # ExecutionRegisteredEvent doesn't contain the deviceurl, thus we need to register it here
+        self.coordinator.executions[exec_id] = {
+            "deviceurl": self.device.deviceurl,
+            "command_name": command_name,
+        }
+
+        await self.coordinator.async_refresh()
+
+    async def async_cancel_command(self, exec_id: str):
+        """Cancel device command in async context."""
+        await self.coordinator.client.cancel_command(exec_id)

--- a/homeassistant/components/tahoma/strings.json
+++ b/homeassistant/components/tahoma/strings.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Enter your TaHoma credentials for the TaHoma App or the tahomalink.com platform.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "too_many_requests": "Too many requests, try again later.",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "server_in_maintenance": "Server is down for maintenance",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "update_interval": {
+        "title": "Update Interval",
+        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
+        "data": {
+          "update_interval": "Update interval (in seconds)"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/tahoma/strings.json
+++ b/homeassistant/components/tahoma/strings.json
@@ -13,7 +13,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "too_many_requests": "Too many requests, try again later.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "server_in_maintenance": "Server is down for maintenance",
+      "server_in_maintenance": "Server is down for maintenance.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/tahoma/tahoma_device.py
+++ b/homeassistant/components/tahoma/tahoma_device.py
@@ -1,0 +1,169 @@
+"""Parent class for every Somfy TaHoma device."""
+import logging
+from typing import Any, Dict, Optional
+
+from pyhoma.models import Command, Device
+
+from homeassistant.const import ATTR_BATTERY_LEVEL
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import TahomaDataUpdateCoordinator
+
+ATTR_RSSI_LEVEL = "rssi_level"
+
+CORE_AVAILABILITY_STATE = "core:AvailabilityState"
+CORE_BATTERY_STATE = "core:BatteryState"
+CORE_MANUFACTURER_NAME_STATE = "core:ManufacturerNameState"
+CORE_MODEL_STATE = "core:ModelState"
+CORE_RSSI_LEVEL_STATE = "core:RSSILevelState"
+CORE_SENSOR_DEFECT_STATE = "core:SensorDefectState"
+CORE_STATUS_STATE = "core:StatusState"
+
+STATE_AVAILABLE = "available"
+STATE_BATTERY_FULL = "full"
+STATE_BATTERY_NORMAL = "normal"
+STATE_BATTERY_LOW = "low"
+STATE_BATTERY_VERY_LOW = "verylow"
+STATE_DEAD = "dead"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TahomaDevice(CoordinatorEntity, Entity):
+    """Representation of a TaHoma device entity."""
+
+    def __init__(self, device_url: str, coordinator: TahomaDataUpdateCoordinator):
+        """Initialize the device."""
+        super().__init__(coordinator)
+        self.device_url = device_url
+
+    @property
+    def device(self) -> Device:
+        """Return TaHoma device linked to this entity."""
+        return self.coordinator.data[self.device_url]
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return self.device.label
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.device.available
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self.device.deviceurl
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return True if unable to access real state of the entity."""
+        return self.device.states is None or len(self.device.states) == 0
+
+    @property
+    def device_state_attributes(self) -> Dict[str, Any]:
+        """Return the state attributes of the device."""
+        attr = {
+            "ui_class": self.device.ui_class,
+            "widget": self.device.widget,
+            "controllable_name": self.device.controllable_name,
+        }
+
+        if self.has_state(CORE_RSSI_LEVEL_STATE):
+            attr[ATTR_RSSI_LEVEL] = self.select_state(CORE_RSSI_LEVEL_STATE)
+
+        if self.has_state(CORE_BATTERY_STATE):
+            battery_state = self.select_state(CORE_BATTERY_STATE)
+
+            if battery_state == STATE_BATTERY_FULL:
+                battery_state = 100
+            elif battery_state == STATE_BATTERY_NORMAL:
+                battery_state = 75
+            elif battery_state == STATE_BATTERY_LOW:
+                battery_state = 25
+            elif battery_state == STATE_BATTERY_VERY_LOW:
+                battery_state = 10
+
+            attr[ATTR_BATTERY_LEVEL] = battery_state
+
+        if self.select_state(CORE_SENSOR_DEFECT_STATE) == STATE_DEAD:
+            attr[ATTR_BATTERY_LEVEL] = 0
+
+        if self.device.attributes:
+            for attribute in self.device.attributes:
+                attr[attribute.name] = attribute.value
+
+        if self.device.states:
+            for state in self.device.states:
+                if "State" in state.name:
+                    attr[state.name] = state.value
+
+        return attr
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        """Return device registry information for this entity."""
+        manufacturer = self.select_state(CORE_MANUFACTURER_NAME_STATE) or "Somfy"
+        model = self.select_state(CORE_MODEL_STATE) or self.device.widget
+
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "manufacturer": manufacturer,
+            "name": self.name,
+            "model": model,
+            "sw_version": self.device.controllable_name,
+        }
+
+    def select_command(self, *commands: str) -> Optional[str]:
+        """Select first existing command in a list of commands."""
+        existing_commands = self.device.definition.commands
+        return next((c for c in commands if c in existing_commands), None)
+
+    def has_command(self, *commands: str) -> bool:
+        """Return True if a command exists in a list of commands."""
+        return self.select_command(*commands) is not None
+
+    def select_state(self, *states) -> Optional[str]:
+        """Select first existing active state in a list of states."""
+        if self.device.states:
+            return next(
+                (
+                    state.value
+                    for state in self.device.states
+                    if state.name in list(states)
+                ),
+                None,
+            )
+        return None
+
+    def has_state(self, *states: str) -> bool:
+        """Return True if a state exists in self."""
+        return self.select_state(*states) is not None
+
+    async def async_execute_command(self, command_name: str, *args: Any):
+        """Execute device command in async context."""
+        try:
+            exec_id = await self.coordinator.client.execute_command(
+                self.device.deviceurl,
+                Command(command_name, list(args)),
+                "Home Assistant",
+            )
+        except Exception as exception:  # pylint: disable=broad-except
+            _LOGGER.error(exception)
+            return
+
+        # ExecutionRegisteredEvent doesn't contain the deviceurl, thus we need to register it here
+        self.coordinator.executions[exec_id] = {
+            "deviceurl": self.device.deviceurl,
+            "command_name": command_name,
+        }
+
+        await self.coordinator.async_refresh()
+
+    async def async_cancel_command(self, exec_id: str):
+        """Cancel device command in async context."""
+        await self.coordinator.client.cancel_command(exec_id)

--- a/homeassistant/components/tahoma/tahoma_entity.py
+++ b/homeassistant/components/tahoma/tahoma_entity.py
@@ -31,7 +31,7 @@ STATE_DEAD = "dead"
 _LOGGER = logging.getLogger(__name__)
 
 
-class TahomaDevice(CoordinatorEntity, Entity):
+class TahomaEntity(CoordinatorEntity, Entity):
     """Representation of a TaHoma device entity."""
 
     def __init__(self, device_url: str, coordinator: TahomaDataUpdateCoordinator):

--- a/homeassistant/components/tahoma/tahoma_entity.py
+++ b/homeassistant/components/tahoma/tahoma_entity.py
@@ -29,7 +29,7 @@ class TahomaEntity(CoordinatorEntity, Entity):
         """Initialize the device."""
         super().__init__(coordinator)
         self.device_url = device_url
-        self.executor = OverkizExecutor(coordinator, device_url)
+        self.executor = OverkizExecutor(device_url, coordinator)
 
     @property
     def device(self) -> Device:

--- a/homeassistant/components/tahoma/tahoma_entity.py
+++ b/homeassistant/components/tahoma/tahoma_entity.py
@@ -67,12 +67,6 @@ class TahomaEntity(CoordinatorEntity, Entity):
     @property
     def device_state_attributes(self) -> Dict[str, Any]:
         """Return the state attributes of the device."""
-        attr = {
-            "ui_class": self.device.ui_class,
-            "widget": self.device.widget,
-            "controllable_name": self.device.controllable_name,
-        }
-
         if self.has_state(CORE_RSSI_LEVEL_STATE):
             attr[ATTR_RSSI_LEVEL] = self.select_state(CORE_RSSI_LEVEL_STATE)
 
@@ -92,15 +86,6 @@ class TahomaEntity(CoordinatorEntity, Entity):
 
         if self.select_state(CORE_SENSOR_DEFECT_STATE) == STATE_DEAD:
             attr[ATTR_BATTERY_LEVEL] = 0
-
-        if self.device.attributes:
-            for attribute in self.device.attributes:
-                attr[attribute.name] = attribute.value
-
-        if self.device.states:
-            for state in self.device.states:
-                if "State" in state.name:
-                    attr[state.name] = state.value
 
         return attr
 

--- a/homeassistant/components/tahoma/tahoma_entity.py
+++ b/homeassistant/components/tahoma/tahoma_entity.py
@@ -67,6 +67,8 @@ class TahomaEntity(CoordinatorEntity, Entity):
     @property
     def device_state_attributes(self) -> Dict[str, Any]:
         """Return the state attributes of the device."""
+        attr = {}
+
         if self.has_state(CORE_RSSI_LEVEL_STATE):
             attr[ATTR_RSSI_LEVEL] = self.select_state(CORE_RSSI_LEVEL_STATE)
 

--- a/homeassistant/components/tahoma/tahoma_entity.py
+++ b/homeassistant/components/tahoma/tahoma_entity.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional
 
 from pyhoma.models import Command, Device
 
-from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -14,19 +13,10 @@ from .coordinator import TahomaDataUpdateCoordinator
 ATTR_RSSI_LEVEL = "rssi_level"
 
 CORE_AVAILABILITY_STATE = "core:AvailabilityState"
-CORE_BATTERY_STATE = "core:BatteryState"
 CORE_MANUFACTURER_NAME_STATE = "core:ManufacturerNameState"
 CORE_MODEL_STATE = "core:ModelState"
-CORE_RSSI_LEVEL_STATE = "core:RSSILevelState"
-CORE_SENSOR_DEFECT_STATE = "core:SensorDefectState"
 CORE_STATUS_STATE = "core:StatusState"
 
-STATE_AVAILABLE = "available"
-STATE_BATTERY_FULL = "full"
-STATE_BATTERY_NORMAL = "normal"
-STATE_BATTERY_LOW = "low"
-STATE_BATTERY_VERY_LOW = "verylow"
-STATE_DEAD = "dead"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,33 +53,6 @@ class TahomaEntity(CoordinatorEntity, Entity):
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
         return self.device.states is None or len(self.device.states) == 0
-
-    @property
-    def device_state_attributes(self) -> Dict[str, Any]:
-        """Return the state attributes of the device."""
-        attr = {}
-
-        if self.has_state(CORE_RSSI_LEVEL_STATE):
-            attr[ATTR_RSSI_LEVEL] = self.select_state(CORE_RSSI_LEVEL_STATE)
-
-        if self.has_state(CORE_BATTERY_STATE):
-            battery_state = self.select_state(CORE_BATTERY_STATE)
-
-            if battery_state == STATE_BATTERY_FULL:
-                battery_state = 100
-            elif battery_state == STATE_BATTERY_NORMAL:
-                battery_state = 75
-            elif battery_state == STATE_BATTERY_LOW:
-                battery_state = 25
-            elif battery_state == STATE_BATTERY_VERY_LOW:
-                battery_state = 10
-
-            attr[ATTR_BATTERY_LEVEL] = battery_state
-
-        if self.select_state(CORE_SENSOR_DEFECT_STATE) == STATE_DEAD:
-            attr[ATTR_BATTERY_LEVEL] = 0
-
-        return attr
 
     @property
     def device_info(self) -> Dict[str, Any]:

--- a/homeassistant/components/tahoma/tahoma_entity.py
+++ b/homeassistant/components/tahoma/tahoma_entity.py
@@ -54,7 +54,7 @@ class TahomaEntity(CoordinatorEntity, Entity):
     @property
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
-        return self.device.states is None or len(self.device.states) == 0
+        return not self.device.states
 
     @property
     def device_info(self) -> Dict[str, Any]:

--- a/homeassistant/components/tahoma/translations/en.json
+++ b/homeassistant/components/tahoma/translations/en.json
@@ -1,0 +1,34 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "description": "Enter your TaHoma credentials for the TaHoma App or the tahomalink.com platform.",
+                "data": {
+                    "username": "Username",
+                    "password": "Password"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "too_many_requests": "Too many requests, try again later.",
+            "invalid_auth": "Invalid authentication",
+            "server_in_maintenance": "Server is down for maintenance.",
+            "unknown": "Unexpected error"
+        },
+        "abort": {
+            "already_configured": "Device is already configured"
+        }
+    },
+    "options": {
+        "step": {
+            "update_interval": {
+                "title": "Update Interval",
+                "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
+                "data": {
+                    "update_interval": "Update interval (in seconds)"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -216,6 +216,7 @@ FLOWS = [
     "syncthru",
     "synology_dsm",
     "tado",
+    "tahoma",
     "tasmota",
     "tellduslive",
     "tesla",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1433,6 +1433,9 @@ pyhik==0.2.8
 # homeassistant.components.hive
 pyhiveapi==0.3.4.4
 
+# homeassistant.components.tahoma
+pyhoma==0.5.1
+
 # homeassistant.components.homematic
 pyhomematic==0.1.71
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1434,7 +1434,7 @@ pyhik==0.2.8
 pyhiveapi==0.3.4.4
 
 # homeassistant.components.tahoma
-pyhoma==0.5.1
+pyhoma==0.5.8
 
 # homeassistant.components.homematic
 pyhomematic==0.1.71

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -750,6 +750,9 @@ pyhaversion==3.4.2
 # homeassistant.components.heos
 pyheos==0.7.2
 
+# homeassistant.components.tahoma
+pyhoma==0.5.1
+
 # homeassistant.components.homematic
 pyhomematic==0.1.71
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -751,7 +751,7 @@ pyhaversion==3.4.2
 pyheos==0.7.2
 
 # homeassistant.components.tahoma
-pyhoma==0.5.1
+pyhoma==0.5.8
 
 # homeassistant.components.homematic
 pyhomematic==0.1.71

--- a/tests/components/tahoma/__init__.py
+++ b/tests/components/tahoma/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Somfy TaHoma integration."""

--- a/tests/components/tahoma/test_config_flow.py
+++ b/tests/components/tahoma/test_config_flow.py
@@ -1,0 +1,167 @@
+"""Test the Somfy TaHoma config flow."""
+from aiohttp import ClientError
+from asynctest import patch
+from pyhoma.exceptions import (
+    BadCredentialsException,
+    MaintenanceException,
+    TooManyRequestsException,
+)
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.tahoma import config_flow
+from homeassistant.components.tahoma.const import DOMAIN
+from homeassistant.config_entries import ENTRY_STATE_LOADED
+
+from tests.common import MockConfigEntry
+
+TEST_EMAIL = "test@testdomain.com"
+TEST_PASSWORD = "test-password"
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch("pyhoma.client.TahomaClient.login", return_value=True), patch(
+        "homeassistant.components.tahoma.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.tahoma.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == TEST_EMAIL
+    assert result2["data"] == {
+        "username": TEST_EMAIL,
+        "password": TEST_PASSWORD,
+    }
+
+    await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "side_effect, error",
+    [
+        (BadCredentialsException, "invalid_auth"),
+        (TooManyRequestsException, "too_many_requests"),
+        (TimeoutError, "cannot_connect"),
+        (ClientError, "cannot_connect"),
+        (MaintenanceException, "server_in_maintenance"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_form_invalid(hass, side_effect, error):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("pyhoma.client.TahomaClient.login", side_effect=side_effect):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": error}
+
+
+async def test_abort_on_duplicate_entry(hass):
+    """Test config flow aborts Config Flow on duplicate entries."""
+    MockConfigEntry(
+        domain=config_flow.DOMAIN,
+        unique_id=TEST_EMAIL,
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("pyhoma.client.TahomaClient.login", return_value=True), patch(
+        "homeassistant.components.tahoma.async_setup", return_value=True
+    ), patch("homeassistant.components.tahoma.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "already_configured"
+
+
+async def test_allow_multiple_unique_entries(hass):
+    """Test config flow allows Config Flow unique entries."""
+    MockConfigEntry(
+        domain=config_flow.DOMAIN,
+        unique_id="test2@testdomain.com",
+        data={"username": "test2@testdomain.com", "password": TEST_PASSWORD},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("pyhoma.client.TahomaClient.login", return_value=True), patch(
+        "homeassistant.components.tahoma.async_setup", return_value=True
+    ), patch("homeassistant.components.tahoma.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        )
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == TEST_EMAIL
+    assert result2["data"] == {
+        "username": TEST_EMAIL,
+        "password": TEST_PASSWORD,
+    }
+
+
+async def test_options_flow(hass):
+    """Test options flow."""
+
+    entry = MockConfigEntry(
+        domain=config_flow.DOMAIN,
+        unique_id=TEST_EMAIL,
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+    )
+
+    with patch("pyhoma.client.TahomaClient.login", return_value=True), patch(
+        "homeassistant.components.tahoma.async_setup", return_value=True
+    ), patch("homeassistant.components.tahoma.async_setup_entry", return_value=True):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.state == ENTRY_STATE_LOADED
+
+    result = await hass.config_entries.options.async_init(
+        entry.entry_id, context={"source": "test"}, data=None
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "update_interval"
+
+    assert entry.options == {}
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "update_interval": 12000,
+        },
+    )
+
+    assert entry.options == {"update_interval": 12000}

--- a/tests/components/tahoma/test_config_flow.py
+++ b/tests/components/tahoma/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Somfy TaHoma config flow."""
+from unittest.mock import patch
+
 from aiohttp import ClientError
-from asynctest import patch
 from pyhoma.exceptions import (
     BadCredentialsException,
     MaintenanceException,


### PR DESCRIPTION
## Proposed change
Since #41267 is not easy to review, we (@vlebourl, @tetienne and me) will split the work done in https://github.com/imicknl/ha-tahoma in multiple small PR's. This PR includes some of the ground work for other platforms, but all non necessary code has been removed to keep it as small as possible.

- Add new Somfy TaHoma domain and integration, using Config Flow and DataUpdateCoordinator.
- Support for Binary Sensors, other platforms will be added in other PR's.

Would be great to PR this to a feature branch, instead of dev, since I would like to have all platforms (especially cover) included in a core release.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issues: 
	- fixes #37389
	- fixes #37291
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14920

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.
	- [x] 37717
	- [x] 40626

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
