### PR TITLE
Add reverse repeatmode mapping constant to Spotify

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -82,10 +82,14 @@ SUPPORT_SPOTIFY = (
     | SUPPORT_VOLUME_SET
 )
 
-REPEAT_MODE_MAPPING = {
+REPEAT_MODE_MAPPING_TO_HA = {
     "context": REPEAT_MODE_ALL,
     "off": REPEAT_MODE_OFF,
     "track": REPEAT_MODE_ONE,
+}
+
+REPEAT_MODE_MAPPING_TO_SPOTIFY = {
+    value: key for key, value in REPEAT_MODE_MAPPING_TO_HA.items()
 }
 
 BROWSE_LIMIT = 48
@@ -390,7 +394,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
     def repeat(self) -> Optional[str]:
         """Return current repeat mode."""
         repeat_state = self._currently_playing.get("repeat_state")
-        return REPEAT_MODE_MAPPING.get(repeat_state)
+        return REPEAT_MODE_MAPPING_TO_HA.get(repeat_state)
 
     @property
     def supported_features(self) -> int:
@@ -469,9 +473,9 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
     @spotify_exception_handler
     def set_repeat(self, repeat: str) -> None:
         """Set repeat mode."""
-        for spotify, home_assistant in REPEAT_MODE_MAPPING.items():
-            if home_assistant == repeat:
-                self._spotify.repeat(spotify)
+        if repeat not in REPEAT_MODE_MAPPING_TO_SPOTIFY:
+            raise ValueError(f"Unsupported repeat mode: {repeat}")
+        self._spotify.repeat(REPEAT_MODE_MAPPING_TO_SPOTIFY[repeat])
 
     @spotify_exception_handler
     def update(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Addresses a review comment by @MartinHjelmare in <https://github.com/home-assistant/core/pull/43247#pullrequestreview-535967084>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
