### PR TITLE
Cleanup ZHA fan channel

### DIFF
--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -179,7 +179,7 @@ class FanGroup(BaseFan, ZhaGroupEntity):
         else:
             self._state = states[0].state
 
-    @callback
-    def async_restore_last_state(self, last_state):
-        """Restore previous state."""
-        self._state = VALUE_TO_SPEED.get(last_state.state, self._state)
+    async def async_added_to_hass(self) -> None:
+        """Run when about to be added to hass."""
+        await super().async_added_to_hass()
+        await self.async_update()

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -172,14 +172,15 @@ class FanGroup(BaseFan, ZhaGroupEntity):
         all_states = [self.hass.states.get(x) for x in self._entity_ids]
         states: List[State] = list(filter(None, all_states))
         on_states: List[State] = [state for state in states if state.state != SPEED_OFF]
+
         self._available = any(state.state != STATE_UNAVAILABLE for state in states)
         # for now just use first non off state since its kind of arbitrary
         if not on_states:
             self._state = SPEED_OFF
         else:
-            self._state = states[0].state
+            self._state = on_states[0].state
 
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
-        await super().async_added_to_hass()
         await self.async_update()
+        await super().async_added_to_hass()

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -62,7 +62,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         hass,
         SIGNAL_ADD_ENTITIES,
         functools.partial(
-            discovery.async_add_entities, async_add_entities, entities_to_create
+            discovery.async_add_entities,
+            async_add_entities,
+            entities_to_create,
+            update_before_add=False,
         ),
     )
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
@@ -175,3 +178,8 @@ class FanGroup(BaseFan, ZhaGroupEntity):
             self._state = SPEED_OFF
         else:
             self._state = states[0].state
+
+    @callback
+    def async_restore_last_state(self, last_state):
+        """Restore previous state."""
+        self._state = VALUE_TO_SPEED.get(last_state.state, self._state)

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -3,6 +3,7 @@ import pytest
 import zigpy.profiles.zha as zha
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.hvac as hvac
+import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components import fan
 from homeassistant.components.fan import (
@@ -16,6 +17,7 @@ from homeassistant.components.fan import (
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.zha.core.discovery import GROUP_PROBE
+from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -35,7 +37,7 @@ from .common import (
     send_attributes_report,
 )
 
-from tests.async_mock import call
+from tests.async_mock import AsyncMock, call, patch
 
 IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
 IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
@@ -63,7 +65,7 @@ async def coordinator(hass, zigpy_device_mock, zha_device_joined):
     zigpy_device = zigpy_device_mock(
         {
             1: {
-                "in_clusters": [],
+                "in_clusters": [general.Groups.cluster_id],
                 "out_clusters": [],
                 "device_type": zha.DeviceType.COLOR_DIMMABLE_LIGHT,
             }
@@ -84,14 +86,20 @@ async def device_fan_1(hass, zigpy_device_mock, zha_device_joined):
     zigpy_device = zigpy_device_mock(
         {
             1: {
-                "in_clusters": [general.OnOff.cluster_id, hvac.Fan.cluster_id],
+                "in_clusters": [
+                    general.Groups.cluster_id,
+                    general.OnOff.cluster_id,
+                    hvac.Fan.cluster_id,
+                ],
                 "out_clusters": [],
-            }
+                "device_type": zha.DeviceType.ON_OFF_LIGHT,
+            },
         },
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True
+    await hass.async_block_till_done()
     return zha_device
 
 
@@ -103,17 +111,20 @@ async def device_fan_2(hass, zigpy_device_mock, zha_device_joined):
         {
             1: {
                 "in_clusters": [
+                    general.Groups.cluster_id,
                     general.OnOff.cluster_id,
                     hvac.Fan.cluster_id,
                     general.LevelControl.cluster_id,
                 ],
                 "out_clusters": [],
-            }
+                "device_type": zha.DeviceType.ON_OFF_LIGHT,
+            },
         },
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True
+    await hass.async_block_till_done()
     return zha_device
 
 
@@ -195,9 +206,11 @@ async def async_set_speed(hass, entity_id, speed=None):
     await hass.services.async_call(DOMAIN, SERVICE_SET_SPEED, data, blocking=True)
 
 
-async def async_test_zha_group_fan_entity(
-    hass, device_fan_1, device_fan_2, coordinator
-):
+@patch(
+    "zigpy.zcl.clusters.hvac.Fan.write_attributes",
+    new=AsyncMock(return_value=zcl_f.WriteAttributesResponse.deserialize(b"\x00")[0]),
+)
+async def test_zha_group_fan_entity(hass, device_fan_1, device_fan_2, coordinator):
     """Test the fan entity for a ZHA group."""
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
@@ -206,19 +219,20 @@ async def async_test_zha_group_fan_entity(
     device_fan_1._zha_gateway = zha_gateway
     device_fan_2._zha_gateway = zha_gateway
     member_ieee_addresses = [device_fan_1.ieee, device_fan_2.ieee]
+    members = [GroupMember(device_fan_1.ieee, 1), GroupMember(device_fan_2.ieee, 1)]
 
     # test creating a group with 2 members
-    zha_group = await zha_gateway.async_create_zigpy_group(
-        "Test Group", member_ieee_addresses
-    )
+    zha_group = await zha_gateway.async_create_zigpy_group("Test Group", members)
     await hass.async_block_till_done()
 
     assert zha_group is not None
     assert len(zha_group.members) == 2
     for member in zha_group.members:
-        assert member.ieee in member_ieee_addresses
+        assert member.device.ieee in member_ieee_addresses
+        assert member.group == zha_group
+        assert member.endpoint is not None
 
-    entity_domains = GROUP_PROBE.determine_entity_domains(zha_group)
+    entity_domains = GROUP_PROBE.determine_entity_domains(hass, zha_group)
     assert len(entity_domains) == 2
 
     assert LIGHT_DOMAIN in entity_domains
@@ -228,14 +242,17 @@ async def async_test_zha_group_fan_entity(
     assert hass.states.get(entity_id) is not None
 
     group_fan_cluster = zha_group.endpoint[hvac.Fan.cluster_id]
-    dev1_fan_cluster = device_fan_1.endpoints[1].fan
-    dev2_fan_cluster = device_fan_2.endpoints[1].fan
 
-    # test that the lights were created and that they are unavailable
+    dev1_fan_cluster = device_fan_1.device.endpoints[1].fan
+    dev2_fan_cluster = device_fan_2.device.endpoints[1].fan
+
+    await async_enable_traffic(hass, [device_fan_1, device_fan_2], enabled=False)
+    await hass.async_block_till_done()
+    # test that the fans were created and that they are unavailable
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # allow traffic to flow through the gateway and device
-    await async_enable_traffic(hass, zha_group.members)
+    await async_enable_traffic(hass, [device_fan_1, device_fan_2])
 
     # test that the fan group entity was created and is off
     assert hass.states.get(entity_id).state == STATE_OFF
@@ -243,37 +260,37 @@ async def async_test_zha_group_fan_entity(
     # turn on from HA
     group_fan_cluster.write_attributes.reset_mock()
     await async_turn_on(hass, entity_id)
+    await hass.async_block_till_done()
     assert len(group_fan_cluster.write_attributes.mock_calls) == 1
-    assert group_fan_cluster.write_attributes.call_args == call({"fan_mode": 2})
-    assert hass.states.get(entity_id).state == SPEED_MEDIUM
+    assert group_fan_cluster.write_attributes.call_args[0][0] == {"fan_mode": 2}
 
     # turn off from HA
     group_fan_cluster.write_attributes.reset_mock()
     await async_turn_off(hass, entity_id)
     assert len(group_fan_cluster.write_attributes.mock_calls) == 1
-    assert group_fan_cluster.write_attributes.call_args == call({"fan_mode": 0})
-    assert hass.states.get(entity_id).state == STATE_OFF
+    assert group_fan_cluster.write_attributes.call_args[0][0] == {"fan_mode": 0}
 
     # change speed from HA
     group_fan_cluster.write_attributes.reset_mock()
     await async_set_speed(hass, entity_id, speed=fan.SPEED_HIGH)
     assert len(group_fan_cluster.write_attributes.mock_calls) == 1
-    assert group_fan_cluster.write_attributes.call_args == call({"fan_mode": 3})
-    assert hass.states.get(entity_id).state == SPEED_HIGH
+    assert group_fan_cluster.write_attributes.call_args[0][0] == {"fan_mode": 3}
 
     # test some of the group logic to make sure we key off states correctly
-    await dev1_fan_cluster.async_set_speed(SPEED_OFF)
-    await dev2_fan_cluster.async_set_speed(SPEED_OFF)
+    await send_attributes_report(hass, dev1_fan_cluster, {0: 0})
+    await send_attributes_report(hass, dev2_fan_cluster, {0: 0})
 
     # test that group fan is off
     assert hass.states.get(entity_id).state == STATE_OFF
 
-    await dev1_fan_cluster.async_set_speed(SPEED_MEDIUM)
+    await send_attributes_report(hass, dev2_fan_cluster, {0: 2})
+    await hass.async_block_till_done()
 
     # test that group fan is speed medium
-    assert hass.states.get(entity_id).state == SPEED_MEDIUM
+    assert hass.states.get(entity_id).state == STATE_ON
 
-    await dev1_fan_cluster.async_set_speed(SPEED_OFF)
+    await send_attributes_report(hass, dev2_fan_cluster, {0: 0})
+    await hass.async_block_till_done()
 
     # test that group fan is now off
     assert hass.states.get(entity_id).state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup of ZHA Core Fan channel to use cached zigpy attribute values for initial state

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
