### PR TITLE
Add explicit support for Luxembourg Smarty meter in dsmr integration

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -35,11 +35,15 @@ class DSMRConnection:
         self._port = port
         self._dsmr_version = dsmr_version
         self._telegram = {}
+        if dsmr_version == "5L":
+            self._equipment_identifier = obis_ref.LUXEMBOURG_EQUIPMENT_IDENTIFIER
+        else:
+            self._equipment_identifier = obis_ref.EQUIPMENT_IDENTIFIER
 
     def equipment_identifier(self):
         """Equipment identifier."""
-        if obis_ref.EQUIPMENT_IDENTIFIER in self._telegram:
-            dsmr_object = self._telegram[obis_ref.EQUIPMENT_IDENTIFIER]
+        if self._equipment_identifier in self._telegram:
+            dsmr_object = self._telegram[self._equipment_identifier]
             return getattr(dsmr_object, "value", None)
 
     def equipment_identifier_gas(self):
@@ -52,7 +56,7 @@ class DSMRConnection:
         """Test if we can validate connection with the device."""
 
         def update_telegram(telegram):
-            if obis_ref.EQUIPMENT_IDENTIFIER in telegram:
+            if self._equipment_identifier in telegram:
                 self._telegram = telegram
                 transport.close()
 

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -54,7 +54,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
         vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_DSMR_VERSION, default=DEFAULT_DSMR_VERSION): vol.All(
-            cv.string, vol.In(["5B", "5", "4", "2.2"])
+            cv.string, vol.In(["5L", "5B", "5", "4", "2.2"])
         ),
         vol.Optional(CONF_RECONNECT_INTERVAL, default=DEFAULT_RECONNECT_INTERVAL): int,
         vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): vol.Coerce(int),
@@ -85,7 +85,6 @@ async def async_setup_entry(
         ["Power Consumption", obis_ref.CURRENT_ELECTRICITY_USAGE],
         ["Power Production", obis_ref.CURRENT_ELECTRICITY_DELIVERY],
         ["Power Tariff", obis_ref.ELECTRICITY_ACTIVE_TARIFF],
-        ["Energy Consumption (total)", obis_ref.ELECTRICITY_IMPORTED_TOTAL],
         ["Energy Consumption (tarif 1)", obis_ref.ELECTRICITY_USED_TARIFF_1],
         ["Energy Consumption (tarif 2)", obis_ref.ELECTRICITY_USED_TARIFF_2],
         ["Energy Production (tarif 1)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_1],
@@ -112,6 +111,24 @@ async def async_setup_entry(
         ["Current Phase L3", obis_ref.INSTANTANEOUS_CURRENT_L3],
     ]
 
+    if dsmr_version == "5L":
+        obis_mapping.extend(
+            [
+                [
+                    "Energy Consumption (total)",
+                    obis_ref.LUXEMBOURG_ELECTRICITY_USED_TARIFF_GLOBAL,
+                ],
+                [
+                    "Energy Production (total)",
+                    obis_ref.LUXEMBOURG_ELECTRICITY_DELIVERED_TARIFF_GLOBAL,
+                ],
+            ]
+        )
+    else:
+        obis_mapping.extend(
+            [["Energy Consumption (total)", obis_ref.ELECTRICITY_IMPORTED_TOTAL]]
+        )
+
     # Generate device entities
     devices = [
         DSMREntity(name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config)
@@ -120,7 +137,7 @@ async def async_setup_entry(
 
     # Protocol version specific obis
     if CONF_SERIAL_ID_GAS in config:
-        if dsmr_version in ("4", "5"):
+        if dsmr_version in ("4", "5", "5L"):
             gas_obis = obis_ref.HOURLY_GAS_METER_READING
         elif dsmr_version in ("5B",):
             gas_obis = obis_ref.BELGIUM_HOURLY_GAS_METER_READING

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -242,3 +242,26 @@ async def test_options_flow(hass):
         await hass.async_block_till_done()
 
     assert entry.options == {"time_between_update": 15}
+
+
+async def test_import_luxembourg(hass, dsmr_connection_send_validate_fixture):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5L",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=entry_data,
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "/dev/ttyUSB0"
+    assert result["data"] == {**entry_data, **SERIAL_DATA}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Before connection validation in dsmr integration, Smarty meters used to work with the integration. This broke because Smarty is using a slightly different specification. As of library version 0.24, this is fully supported from the library. This PR adds explicit support for the Smarty meter restoring the functioning of it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42822
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16025

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
