### PR TITLE
Use new PocketCast dependency

### DIFF
--- a/homeassistant/components/pocketcasts/manifest.json
+++ b/homeassistant/components/pocketcasts/manifest.json
@@ -2,6 +2,6 @@
   "domain": "pocketcasts",
   "name": "Pocket Casts",
   "documentation": "https://www.home-assistant.io/integrations/pocketcasts",
-  "requirements": ["pocketcasts==0.1"],
+  "requirements": ["pycketcasts==1.0.0"],
   "codeowners": []
 }

--- a/homeassistant/components/pocketcasts/sensor.py
+++ b/homeassistant/components/pocketcasts/sensor.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 import logging
 
-import pocketcasts
+from pycketcasts import pocketcasts
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -29,8 +29,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     password = config.get(CONF_PASSWORD)
 
     try:
-        api = pocketcasts.Api(username, password)
-        _LOGGER.debug("Found %d podcasts", len(api.my_podcasts()))
+        api = pocketcasts.PocketCast(email=username, password=password)
+        _LOGGER.debug("Found %d podcasts", len(api.subscriptions))
         add_entities([PocketCastsSensor(api)], True)
     except OSError as err:
         _LOGGER.error("Connection to server failed: %s", err)
@@ -63,7 +63,7 @@ class PocketCastsSensor(Entity):
     def update(self):
         """Update sensor values."""
         try:
-            self._state = len(self._api.new_episodes_released())
+            self._state = len(self._api.new_releases)
             _LOGGER.debug("Found %d new episodes", self._state)
         except OSError as err:
             _LOGGER.warning("Failed to contact server: %s", err)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1150,7 +1150,7 @@ plumlightpad==0.0.11
 pmsensor==0.4
 
 # homeassistant.components.pocketcasts
-pocketcasts==0.1
+pycketcasts==1.0.0
 
 # homeassistant.components.poolsense
 poolsense==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1149,9 +1149,6 @@ plumlightpad==0.0.11
 # homeassistant.components.serial_pm
 pmsensor==0.4
 
-# homeassistant.components.pocketcasts
-pycketcasts==1.0.0
-
 # homeassistant.components.poolsense
 poolsense==0.0.8
 
@@ -1308,6 +1305,9 @@ pychannels==1.0.0
 
 # homeassistant.components.cast
 pychromecast==7.5.1
+
+# homeassistant.components.pocketcasts
+pycketcasts==1.0.0
 
 # homeassistant.components.cmus
 pycmus==0.1.1


### PR DESCRIPTION
## Proposed change
PocketCast integration has been broken for a while due to an outdated API library dependency: https://github.com/home-assistant/core/issues/28292
I wrote a new API library (https://github.com/nwithan8/pycketcasts) and am proposing leveraging it to get the PocketCasts integration working again.

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
There should be no visible difference to the end user. The new API library is structured very similarly to the old one.
Users will not need to provide any additional or different information than was already requested (PocketCast username and password)

- This PR fixes or closes issue: fixes #28292
- This PR is related to issue: #28292
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`. (see 
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum


To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
