### PR TITLE
Hide HomeKit devices from discovery that are known to be problematic

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -21,6 +21,14 @@ HOMEKIT_BRIDGE_DOMAIN = "homekit"
 HOMEKIT_BRIDGE_SERIAL_NUMBER = "homekit.bridge"
 HOMEKIT_BRIDGE_MODEL = "Home Assistant HomeKit Bridge"
 
+HOMEKIT_IGNORE = [
+    # eufy Indoor Cam 2K Pan & Tilt
+    # https://github.com/home-assistant/core/issues/42307
+    "T8410",
+    # Hive Hub - vendor does not give user a pairing code
+    "HHKBridge1,1",
+]
+
 PAIRING_FILE = "pairing.json"
 
 MDNS_SUFFIX = "._hap._tcp.local."
@@ -255,6 +263,10 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         # Devices in HOMEKIT_IGNORE have native local integrations - users
         # should be encouraged to use native integration and not confused
         # by alternative HK API.
+        if model in HOMEKIT_IGNORE:
+            return self.async_abort(reason="ignored_model")
+
+        # If this is a HomeKit bridge exported by *this* HA instance ignore it.
         if await self._hkid_is_homekit_bridge(hkid):
             return self.async_abort(reason="ignored_model")
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -257,6 +257,21 @@ async def test_discovery_ignored_model(hass, controller):
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
+    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info["properties"]["md"] = "HHKBridge1,1"
+
+    # Device is discovered
+    result = await hass.config_entries.flow.async_init(
+        "homekit_controller", context={"source": "zeroconf"}, data=discovery_info
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "ignored_model"
+
+
+async def test_discovery_ignored_hk_bridge(hass, controller):
+    """Already paired."""
+    device = setup_mock_accessory(controller)
+    discovery_info = get_device_discovery_info(device)
 
     config_entry = MockConfigEntry(domain=config_flow.HOMEKIT_BRIDGE_DOMAIN, data={})
     formatted_mac = device_registry.format_mac("AA:BB:CC:DD:EE:FF")


### PR DESCRIPTION
## Proposed change

Some devices should not be detected as pairable by default. For example:

* Some Anker camera systems don't have stable device id's until they are paired (this seems to be a spec violation) so we can't ignore them. See #42307.
* Some HK devices would work with HA if only the vendor would tell the customer the pairing code needed to use their own device. For example the Hive heating system and Flic Bridge both support HomeKit but do not give users the pairing code, so they can't work in HA.

Classing this as a bug fix because of #42307.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42307
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
