### PR TITLE
Fix ZHA switch group test

### DIFF
--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -7,6 +7,7 @@ import zigpy.zcl.clusters.general as general
 import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.switch import DOMAIN
+from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
 from .common import (
@@ -67,15 +68,16 @@ async def device_switch_1(hass, zigpy_device_mock, zha_device_joined):
     zigpy_device = zigpy_device_mock(
         {
             1: {
-                "in_clusters": [general.OnOff.cluster_id],
+                "in_clusters": [general.OnOff.cluster_id, general.Groups.cluster_id],
                 "out_clusters": [],
-                "device_type": zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                "device_type": zha.DeviceType.ON_OFF_SWITCH,
             }
         },
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True
+    await hass.async_block_till_done()
     return zha_device
 
 
@@ -86,15 +88,16 @@ async def device_switch_2(hass, zigpy_device_mock, zha_device_joined):
     zigpy_device = zigpy_device_mock(
         {
             1: {
-                "in_clusters": [general.OnOff.cluster_id],
+                "in_clusters": [general.OnOff.cluster_id, general.Groups.cluster_id],
                 "out_clusters": [],
-                "device_type": zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                "device_type": zha.DeviceType.ON_OFF_SWITCH,
             }
         },
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
     zha_device = await zha_device_joined(zigpy_device)
     zha_device.available = True
+    await hass.async_block_till_done()
     return zha_device
 
 
@@ -157,7 +160,7 @@ async def test_switch(hass, zha_device_joined_restored, zigpy_device):
     await async_test_rejoin(hass, zigpy_device, [cluster], (1,))
 
 
-async def async_test_zha_group_switch_entity(
+async def test_zha_group_switch_entity(
     hass, device_switch_1, device_switch_2, coordinator
 ):
     """Test the switch entity for a ZHA group."""
@@ -168,30 +171,38 @@ async def async_test_zha_group_switch_entity(
     device_switch_1._zha_gateway = zha_gateway
     device_switch_2._zha_gateway = zha_gateway
     member_ieee_addresses = [device_switch_1.ieee, device_switch_2.ieee]
+    members = [
+        GroupMember(device_switch_1.ieee, 1),
+        GroupMember(device_switch_2.ieee, 1),
+    ]
 
     # test creating a group with 2 members
-    zha_group = await zha_gateway.async_create_zigpy_group(
-        "Test Group", member_ieee_addresses
-    )
+    zha_group = await zha_gateway.async_create_zigpy_group("Test Group", members)
     await hass.async_block_till_done()
 
     assert zha_group is not None
     assert len(zha_group.members) == 2
     for member in zha_group.members:
-        assert member.ieee in member_ieee_addresses
+        assert member.device.ieee in member_ieee_addresses
+        assert member.group == zha_group
+        assert member.endpoint is not None
 
     entity_id = async_find_group_entity_id(hass, DOMAIN, zha_group)
     assert hass.states.get(entity_id) is not None
 
     group_cluster_on_off = zha_group.endpoint[general.OnOff.cluster_id]
-    dev1_cluster_on_off = device_switch_1.endpoints[1].on_off
-    dev2_cluster_on_off = device_switch_2.endpoints[1].on_off
+    dev1_cluster_on_off = device_switch_1.device.endpoints[1].on_off
+    dev2_cluster_on_off = device_switch_2.device.endpoints[1].on_off
 
-    # test that the lights were created and that they are unavailable
+    await async_enable_traffic(hass, [device_switch_1, device_switch_2], enabled=False)
+    await hass.async_block_till_done()
+
+    # test that the lights were created and that they are off
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # allow traffic to flow through the gateway and device
-    await async_enable_traffic(hass, zha_group.members)
+    await async_enable_traffic(hass, [device_switch_1, device_switch_2])
+    await hass.async_block_till_done()
 
     # test that the lights were created and are off
     assert hass.states.get(entity_id).state == STATE_OFF
@@ -207,7 +218,7 @@ async def async_test_zha_group_switch_entity(
         )
         assert len(group_cluster_on_off.request.mock_calls) == 1
         assert group_cluster_on_off.request.call_args == call(
-            False, ON, (), expect_reply=True, manufacturer=None, tsn=None
+            False, ON, (), expect_reply=True, manufacturer=None, tries=1, tsn=None
         )
     assert hass.states.get(entity_id).state == STATE_ON
 
@@ -222,28 +233,32 @@ async def async_test_zha_group_switch_entity(
         )
         assert len(group_cluster_on_off.request.mock_calls) == 1
         assert group_cluster_on_off.request.call_args == call(
-            False, OFF, (), expect_reply=True, manufacturer=None, tsn=None
+            False, OFF, (), expect_reply=True, manufacturer=None, tries=1, tsn=None
         )
     assert hass.states.get(entity_id).state == STATE_OFF
 
     # test some of the group logic to make sure we key off states correctly
-    await dev1_cluster_on_off.on()
-    await dev2_cluster_on_off.on()
+    await send_attributes_report(hass, dev1_cluster_on_off, {0: 1})
+    await send_attributes_report(hass, dev2_cluster_on_off, {0: 1})
+    await hass.async_block_till_done()
 
     # test that group light is on
     assert hass.states.get(entity_id).state == STATE_ON
 
-    await dev1_cluster_on_off.off()
+    await send_attributes_report(hass, dev1_cluster_on_off, {0: 0})
+    await hass.async_block_till_done()
 
     # test that group light is still on
     assert hass.states.get(entity_id).state == STATE_ON
 
-    await dev2_cluster_on_off.off()
+    await send_attributes_report(hass, dev2_cluster_on_off, {0: 0})
+    await hass.async_block_till_done()
 
     # test that group light is now off
     assert hass.states.get(entity_id).state == STATE_OFF
 
-    await dev1_cluster_on_off.on()
+    await send_attributes_report(hass, dev1_cluster_on_off, {0: 1})
+    await hass.async_block_till_done()
 
     # test that group light is now back on
     assert hass.states.get(entity_id).state == STATE_ON


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The test for switch group entities in ZHA was named wrong and it was not running as a result. This PR fixes the name and corrects issues with the test itself. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
