### PR TITLE
Opensky: richer event data, reduced data request to service and better error handling

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -322,6 +322,7 @@ homeassistant/components/onewire/* @garbled1 @epenet
 homeassistant/components/onvif/* @hunterjm
 homeassistant/components/openerz/* @misialq
 homeassistant/components/opengarage/* @danielhiversen
+homeassistant/components/opensky/* @tux2000
 homeassistant/components/opentherm_gw/* @mvn23
 homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff @freekode @nzapponi

--- a/homeassistant/components/opensky/manifest.json
+++ b/homeassistant/components/opensky/manifest.json
@@ -2,5 +2,5 @@
   "domain": "opensky",
   "name": "OpenSky Network",
   "documentation": "https://www.home-assistant.io/integrations/opensky",
-  "codeowners": []
+  "codeowners": ["@tux2000"]
 }

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -1,5 +1,6 @@
 """Sensor for the Open Sky Network."""
 from datetime import timedelta
+import logging
 
 import requests
 import voluptuous as vol
@@ -20,6 +21,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import distance as util_distance, location as util_location
 
+_LOGGER = logging.getLogger(__name__)
+
 CONF_ALTITUDE = "altitude"
 
 ATTR_CALLSIGN = "callsign"
@@ -34,7 +37,7 @@ DEFAULT_ALTITUDE = 0
 
 EVENT_OPENSKY_ENTRY = f"{DOMAIN}_entry"
 EVENT_OPENSKY_EXIT = f"{DOMAIN}_exit"
-SCAN_INTERVAL = timedelta(seconds=12)  # opensky public limit is 10 seconds
+SCAN_INTERVAL = timedelta(seconds=15)  # opensky public limit is 10 seconds
 
 OPENSKY_ATTRIBUTION = (
     "Information provided by the OpenSky Network (https://opensky-network.org)"
@@ -133,6 +136,7 @@ class OpenSkySensor(Entity):
         currently_tracked = set()
         flight_metadata = {}
         states = self._session.get(OPENSKY_API_URL).json().get(ATTR_STATES)
+        _LOGGER.debug(str(len(states)) + " flights parsed")
         for state in states:
             flight = dict(zip(OPENSKY_API_FIELDS, state))
             callsign = flight[ATTR_CALLSIGN].strip()

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -127,19 +127,17 @@ class OpenSkySensor(Entity):
 
     def _get_route(self, callsign):
         request = self._session.get(OPENSKY_ROUTE_API_URL + str(callsign))
-        _LOGGER.debug("Route API status: " + str(request.status_code))
+        _LOGGER.debug("Route API status: %d", request.status_code)
         if request.status_code == 200:
             return request.json()
-        else:
-            return None
+        return None
 
     def _get_plane_meta(self, icao24):
         request = self._session.get(OPENSKY_AIRPLANE_META_API_URL + str(icao24))
-        _LOGGER.debug("Plane Meta API status: " + str(request.status_code))
+        _LOGGER.debug("Plane Meta API status: %d", request.status_code)
         if request.status_code == 200:
             return request.json()
-        else:
-            return None
+        return None
 
     def _handle_boundary(self, flights, event, metadata):
         """Handle flights crossing region boundary."""
@@ -154,8 +152,8 @@ class OpenSkySensor(Entity):
 
             if flight in metadata and metadata[flight].get(ATTR_CALLSIGN) != "":
                 _LOGGER.debug(
-                    "Fetching route for callsign "
-                    + str(metadata[flight].get(ATTR_CALLSIGN))
+                    "Fetching route for callsign %s",
+                    str(metadata[flight].get(ATTR_CALLSIGN)),
                 )
                 route = self._get_route(metadata[flight].get(ATTR_CALLSIGN))
                 if route is not None:
@@ -167,7 +165,7 @@ class OpenSkySensor(Entity):
             else:
                 route = None
                 flightnumber = ""
-            _LOGGER.debug("Flight: " + flightnumber)
+            _LOGGER.debug("Flight: %s", flightnumber)
 
             if flight in metadata and metadata[flight].get(ATTR_ICAO24) != "":
                 planemeta = self._get_plane_meta(metadata[flight].get(ATTR_ICAO24))
@@ -186,7 +184,7 @@ class OpenSkySensor(Entity):
                 data = {**data, **route}
             if planemeta is not None:
                 data = {**data, **planemeta}
-            _LOGGER.debug("Fire event for: " + str(data))
+            _LOGGER.debug("Fire event for: %s", str(data))
             self._hass.bus.fire(event, data)
 
     def update(self):
@@ -194,7 +192,7 @@ class OpenSkySensor(Entity):
         currently_tracked = set()
         flight_metadata = {}
         states = self._session.get(OPENSKY_API_URL).json().get(ATTR_STATES)
-        _LOGGER.debug(str(len(states)) + " flights parsed")
+        _LOGGER.debug("%d flights parsed", len(states))
         for state in states:
             flight = dict(zip(OPENSKY_API_FIELDS, state))
             callsign = flight[ATTR_CALLSIGN].strip()

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -104,17 +104,14 @@ class OpenSkySensor(Entity):
         self._hass = hass
         self._name = name
         self._previously_tracked = None
-        self._lat_min, self._lon_min, self._lat_max, self._lon_max = self._get_bbox(
-            self._latitude, self._longitude, self._radius / 1000 + 100
-        )
+        self._lat_min, self._lon_min, self._lat_max, self._lon_max = self._get_bbox()
 
-    def _get_bbox(self, latitude_in_degrees, longitude_in_degrees, half_side_in_km):
+    def _get_bbox(self):
+        half_side_in_km = self._radius / 1000 + 100
         assert half_side_in_km > 0
-        assert latitude_in_degrees >= -90.0 and latitude_in_degrees <= 90.0
-        assert longitude_in_degrees >= -180.0 and longitude_in_degrees <= 180.0
 
-        lat = math.radians(latitude_in_degrees)
-        lon = math.radians(longitude_in_degrees)
+        lat = math.radians(self._latitude)
+        lon = math.radians(self._longitude)
 
         radius = 6371
         parallel_radius = radius * math.cos(lat)

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -216,6 +216,8 @@ class OpenSkySensor(Entity):
             if distance is None or distance > self._radius:
                 continue
             altitude = flight.get(ATTR_ALTITUDE)
+            if altitude is None:
+                continue
             if altitude > self._altitude and self._altitude != 0:
                 continue
             currently_tracked.add(callsign)

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -232,9 +232,9 @@ class OpenSkySensor(Entity):
         if request.status_code == 200:
             self._connectionproblems = 0
             states = request.json().get(ATTR_STATES)
-            _LOGGER.debug(str(len(states)) + " flights parsed")
             if states is None:
                 states = []
+            _LOGGER.debug(str(len(states)) + " flights parsed")
             for state in states:
                 flight = dict(zip(OPENSKY_API_FIELDS, state))
                 callsign = flight[ATTR_CALLSIGN].strip()
@@ -276,6 +276,7 @@ class OpenSkySensor(Entity):
             self._connectionproblems = self._connectionproblems + 1
         if self._connectionproblems > 10:
             _LOGGER.error("Persistent error retrieving data from the OpenSky API.")
+            self._connectionproblems = 0
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -234,7 +234,7 @@ class OpenSkySensor(Entity):
             states = request.json().get(ATTR_STATES)
             if states is None:
                 states = []
-            _LOGGER.debug(str(len(states)) + " flights parsed")
+            _LOGGER.debug("%d flights parsed", len(states))
             for state in states:
                 flight = dict(zip(OPENSKY_API_FIELDS, state))
                 callsign = flight[ATTR_CALLSIGN].strip()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR add additional API calls to opensky to obtain data on flight and airplane in the events that it generates (e.g. "there is an A320 above", "its the flight to London passing over"). It also reduced the load on Opensky and the local system due to only requesting data for the area that it is configured for. Finally there were some edge cases that did result in crashes of the plugin previously (e.g. when the Opensky Service returned status 502)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: opensky
    radius: 10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43571
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15775

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
