### PR TITLE
Update pyarlo to 0.2.4

### DIFF
--- a/homeassistant/components/arlo/manifest.json
+++ b/homeassistant/components/arlo/manifest.json
@@ -2,7 +2,7 @@
   "domain": "arlo",
   "name": "Arlo",
   "documentation": "https://www.home-assistant.io/integrations/arlo",
-  "requirements": ["pyarlo==0.2.3"],
+  "requirements": ["pyarlo==0.2.4"],
   "dependencies": ["ffmpeg"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1271,7 +1271,7 @@ pyairvisual==5.0.4
 pyalmond==0.0.2
 
 # homeassistant.components.arlo
-pyarlo==0.2.3
+pyarlo==0.2.4
 
 # homeassistant.components.atag
 pyatag==0.3.4.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -640,7 +640,7 @@ pyairvisual==5.0.4
 pyalmond==0.0.2
 
 # homeassistant.components.arlo
-pyarlo==0.2.3
+pyarlo==0.2.4
 
 # homeassistant.components.atag
 pyatag==0.3.4.4


### PR DESCRIPTION
Updated pyarlo to 0.2.4 from pyarlo 0.2.3

**Changes from 0.2.3 to 0.2.4:**

- ArloMedia does not work when a doorbell device is linked in the account @tchellomello - #104
- Make the type of motion accessible @yoooou - #108
- New auth mechanism @yoooou - #115

See: https://github.com/tchellomello/python-arlo/pull/119 

## Proposed change
Version bump pyarlo to `0.2.4` from @tchellomello

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
