### PR TITLE
Fix generic_thermostat hvac mode after restore

### DIFF
--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -466,7 +466,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
     @property
     def _is_device_active(self):
         """If the toggleable device is currently active."""
-        if !self.hass.states.get(self.heater_entity_id):
+        if not self.hass.states.get(self.heater_entity_id):
             return None
 
         return self.hass.states.is_state(self.heater_entity_id, STATE_ON)

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -258,10 +258,11 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         # Set default state to off
         if not self._hvac_mode:
             self._hvac_mode = HVAC_MODE_OFF
-            # Prevent the device from keep running if HVAC_MODE_OFF
-            if self._is_device_active:
-                await self._async_heater_turn_off()
-                _LOGGER.info("turning off heater %s", self.heater_entity_id)
+
+        # Prevent the device from keep running if HVAC_MODE_OFF
+        if self._hvac_mode == HVAC_MODE_OFF and self._is_device_active:
+            await self._async_heater_turn_off()
+            _LOGGER.warning("turning off heater %s", self.heater_entity_id)
 
     @property
     def should_poll(self):
@@ -403,7 +404,11 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
     async def _async_control_heating(self, time=None, force=False):
         """Check if we need to turn heating on or off."""
         async with self._temp_lock:
-            if not self._active and None not in (self._cur_temp, self._target_temp, self._is_device_active):
+            if not self._active and None not in (
+                self._cur_temp,
+                self._target_temp,
+                self._is_device_active,
+            ):
                 self._active = True
                 _LOGGER.info(
                     "Obtained current and target temperature. "
@@ -461,10 +466,10 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
     @property
     def _is_device_active(self):
         """If the toggleable device is currently active."""
-        if self.hass.states.get(self.heater_entity_id):
-            return self.hass.states.is_state(self.heater_entity_id, STATE_ON)
-        else:
+        if !self.hass.states.get(self.heater_entity_id):
             return None
+
+        return self.hass.states.is_state(self.heater_entity_id, STATE_ON)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -461,7 +461,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
     @property
     def _is_device_active(self):
         """If the toggleable device is currently active."""
-        if (self.hass.states.get((self.heater_entity_id))):
+        if (self.hass.states.get(self.heater_entity_id)):
             return self.hass.states.is_state(self.heater_entity_id, STATE_ON)
         else:
             return None

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -461,7 +461,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
     @property
     def _is_device_active(self):
         """If the toggleable device is currently active."""
-        if (self.hass.states.get(self.heater_entity_id)):
+        if self.hass.states.get(self.heater_entity_id):
             return self.hass.states.is_state(self.heater_entity_id, STATE_ON)
         else:
             return None

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -1221,50 +1221,6 @@ async def test_no_restore_state(hass):
     assert state.state == HVAC_MODE_OFF
 
 
-async def test_turn_on_while_restarting(hass):
-    """Ensure that restored state is coherent with real situation.
-
-    Thermostat status must follow the heater status.
-    """
-    # thermostat previous state OFF
-    mock_restore_cache(
-        hass,
-        (
-            State(
-                "climate.test_thermostat",
-                HVAC_MODE_OFF,
-                {ATTR_TEMPERATURE: "18", ATTR_PRESET_MODE: PRESET_NONE},
-            ),
-        ),
-    )
-
-    hass.state = CoreState.starting
-
-    # switch on heater before thermostat restart
-    _setup_switch(hass, True)
-    assert STATE_ON == hass.states.get(ENT_SWITCH).state
-
-    await async_setup_component(
-        hass,
-        DOMAIN,
-        {
-            "climate": {
-                "platform": "generic_thermostat",
-                "name": "test_thermostat",
-                "heater": ENT_SWITCH,
-                "ac_mode": True,
-                "target_sensor": ENT_SENSOR,
-                "target_temp": 20,
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("climate.test_thermostat")
-    # NO initial_hvac_mode -> thermostat status must be ON
-    assert state.state == HVAC_MODE_COOL
-    assert STATE_ON == hass.states.get(ENT_SWITCH).state
-
-
 async def test_initial_hvac_off_force_heater_off(hass):
     """Ensure that restored state is coherent with real situation.
 

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -1221,6 +1221,135 @@ async def test_no_restore_state(hass):
     assert state.state == HVAC_MODE_OFF
 
 
+async def test_turn_on_while_restarting(hass):
+    """Ensure that restored state is coherent with real situation.
+
+    Thermostat status must follow the heater status.
+    """
+    # thermostat previous state OFF
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "climate.test_thermostat",
+                HVAC_MODE_OFF,
+                {ATTR_TEMPERATURE: "18", ATTR_PRESET_MODE: PRESET_NONE},
+            ),
+        ),
+    )
+
+    hass.state = CoreState.starting
+
+    # switch on heater before thermostat restart
+    _setup_switch(hass, True)
+    assert STATE_ON == hass.states.get(ENT_SWITCH).state
+
+    await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test_thermostat",
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "target_temp": 20,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.test_thermostat")
+    # NO initial_hvac_mode -> thermostat status must be ON
+    assert state.state == HVAC_MODE_HEAT
+    assert STATE_ON == hass.states.get(ENT_SWITCH).state
+
+
+async def test_initial_hvac_off_force_heater_off(hass):
+    """Ensure that restored state is coherent with real situation.
+
+    'initial_hvac_mode: off' will force HVAC status, but we must be sure
+    that heater don't keep on.
+    """
+    # switch is on
+    calls = _setup_switch(hass, True)
+    assert hass.states.get(ENT_SWITCH).state == STATE_ON
+
+    _setup_sensor(hass, 16)
+
+    await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test_thermostat",
+                "heater": ENT_SWITCH,
+                "target_sensor": ENT_SENSOR,
+                "target_temp": 20,
+                "initial_hvac_mode": HVAC_MODE_OFF,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.test_thermostat")
+    # 'initial_hvac_mode' will force state but must prevent heather keep working
+    assert state.state == HVAC_MODE_OFF
+    # heater must be switched off
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == HASS_DOMAIN
+    assert call.service == SERVICE_TURN_OFF
+    assert call.data["entity_id"] == ENT_SWITCH
+
+
+async def test_restore_will_turn_off_(hass):
+    """Ensure that restored state is coherent with real situation.
+
+    Thermostat status must trigger heater event if temp raises the target .
+    """
+    heater_switch = "input_boolean.test"
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "climate.test_thermostat",
+                HVAC_MODE_HEAT,
+                {ATTR_TEMPERATURE: "18", ATTR_PRESET_MODE: PRESET_NONE},
+            ),
+            State(heater_switch, STATE_ON, {}),
+        ),
+    )
+
+    hass.state = CoreState.starting
+
+    assert await async_setup_component(
+        hass, input_boolean.DOMAIN, {"input_boolean": {"test": None}}
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(heater_switch).state == STATE_ON
+
+    _setup_sensor(hass, 22)
+
+    await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            "climate": {
+                "platform": "generic_thermostat",
+                "name": "test_thermostat",
+                "heater": heater_switch,
+                "target_sensor": ENT_SENSOR,
+                "target_temp": 20,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.test_thermostat")
+    assert state.attributes[ATTR_TEMPERATURE] == 20
+    assert state.state == HVAC_MODE_HEAT
+    assert hass.states.get(heater_switch).state == STATE_ON
+
+
 async def test_restore_state_uncoherence_case(hass):
     """
     Test restore from a strange state.

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -1252,6 +1252,7 @@ async def test_turn_on_while_restarting(hass):
                 "platform": "generic_thermostat",
                 "name": "test_thermostat",
                 "heater": ENT_SWITCH,
+                "ac_mode": True,
                 "target_sensor": ENT_SENSOR,
                 "target_temp": 20,
             }
@@ -1260,7 +1261,7 @@ async def test_turn_on_while_restarting(hass):
     await hass.async_block_till_done()
     state = hass.states.get("climate.test_thermostat")
     # NO initial_hvac_mode -> thermostat status must be ON
-    assert state.state == HVAC_MODE_HEAT
+    assert state.state == HVAC_MODE_COOL
     assert STATE_ON == hass.states.get(ENT_SWITCH).state
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The generic_thermostat `hvac_mode` may be in a wrong state when the entity is restored from a previous state.
This PR incorporates better control of the `hvac_mode` status during the restoration process.

The 2 improvements intruded are:
* `hvac_mode` status follows the heater status (and not the stored `hvac_mode`)
* turn off the heater (if it is running and) if the `initial_hvac_mode` is OFF (which forces the initial state of the thermostat)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43803, 
- This PR is related to issue: 
  * #42056 maybe can fix this one also, but not sure about the "away" part
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
