### PR TITLE
Add device info WS API

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,6 +104,7 @@ homeassistant/components/delijn/* @bollewolle @Emilv2
 homeassistant/components/demo/* @home-assistant/core
 homeassistant/components/denonavr/* @scarface-4711 @starkillerOG
 homeassistant/components/derivative/* @afaucogney
+homeassistant/components/device/* @home-assistant/core
 homeassistant/components/device_automation/* @home-assistant/core
 homeassistant/components/devolo_home_control/* @2Fake @Shutgun
 homeassistant/components/dexcom/* @gagebenne

--- a/homeassistant/components/device/__init__.py
+++ b/homeassistant/components/device/__init__.py
@@ -1,4 +1,4 @@
-"""Helpers for device automations."""
+"""Helpers for device."""
 import asyncio
 from functools import wraps
 import logging
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass, config):
-    """Set up device automation."""
+    """Set up device."""
     hass.components.websocket_api.async_register_command(
         websocket_device_get_device_info
     )
@@ -61,7 +61,7 @@ async def _async_get_device_info_from_domain(hass, domain, device_id, entry_id):
 
 
 async def _async_get_device_info(hass, device_id):
-    """List device automations."""
+    """List device info."""
     device_registry = await hass.helpers.device_registry.async_get_registry()
 
     domains = set()
@@ -89,7 +89,7 @@ async def _async_get_device_info(hass, device_id):
 
 
 def handle_device_errors(func):
-    """Handle device automation errors."""
+    """Handle device API errors."""
 
     @wraps(func)
     async def with_error_handling(hass, connection, msg):

--- a/homeassistant/components/device/__init__.py
+++ b/homeassistant/components/device/__init__.py
@@ -1,0 +1,118 @@
+"""Helpers for device automations."""
+import asyncio
+from functools import wraps
+import logging
+from types import ModuleType
+from typing import Any, MutableMapping
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import IntegrationNotFound
+from homeassistant.requirements import async_get_integration_with_requirements
+
+from .exceptions import DeviceNotFound, InvalidDevice
+
+# mypy: allow-untyped-calls, allow-untyped-defs
+
+DOMAIN = "device"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass, config):
+    """Set up device automation."""
+    hass.components.websocket_api.async_register_command(
+        websocket_device_get_device_info
+    )
+    return True
+
+
+async def async_get_device_platform(hass: HomeAssistant, domain: str) -> ModuleType:
+    """Load device platform for integration.
+
+    Throws InvalidDeviceConfig if the integration is not found or does not support device info.
+    """
+    try:
+        integration = await async_get_integration_with_requirements(hass, domain)
+        platform = integration.get_platform("device")
+    except IntegrationNotFound as err:
+        raise InvalidDevice(f"Integration '{domain}' not found") from err
+    except ImportError as err:
+        raise InvalidDevice(
+            f"Integration '{domain}' does not support device info"
+        ) from err
+
+    return platform
+
+
+async def _async_get_device_info_from_domain(hass, domain, device_id, entry_id):
+    """Get device info."""
+    try:
+        platform = await async_get_device_platform(hass, domain)
+    except InvalidDevice:
+        return None
+
+    if not hasattr(platform, "async_get_device_info"):
+        return None
+
+    return (entry_id, await getattr(platform, "async_get_device_info")(hass, device_id))
+
+
+async def _async_get_device_info(hass, device_id):
+    """List device automations."""
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+
+    domains = set()
+    infos: MutableMapping[str, Any] = {}
+    device = device_registry.async_get(device_id)
+
+    if device is None:
+        raise DeviceNotFound
+
+    for entry_id in device.config_entries:
+        config_entry = hass.config_entries.async_get_entry(entry_id)
+        domains.add((config_entry.domain, entry_id))
+
+    device_infos = await asyncio.gather(
+        *(
+            _async_get_device_info_from_domain(hass, domain, device_id, entry_id)
+            for domain, entry_id in domains
+        )
+    )
+    for device_info in device_infos:
+        if device_info is not None:
+            infos[device_info[0]] = device_info[1]
+
+    return infos
+
+
+def handle_device_errors(func):
+    """Handle device automation errors."""
+
+    @wraps(func)
+    async def with_error_handling(hass, connection, msg):
+        try:
+            await func(hass, connection, msg)
+        except DeviceNotFound:
+            connection.send_error(
+                msg["id"], websocket_api.const.ERR_NOT_FOUND, "Device not found"
+            )
+
+    return with_error_handling
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "device/info",
+        vol.Required("device_id"): str,
+    }
+)
+@websocket_api.async_response
+@handle_device_errors
+async def websocket_device_get_device_info(hass, connection, msg):
+    """Handle request for device actions."""
+    device_id = msg["device_id"]
+    info = await _async_get_device_info(hass, device_id)
+    connection.send_result(msg["id"], info)

--- a/homeassistant/components/device/exceptions.py
+++ b/homeassistant/components/device/exceptions.py
@@ -1,0 +1,10 @@
+"""Device automation exceptions."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class InvalidDevice(HomeAssistantError):
+    """When device is invalid."""
+
+
+class DeviceNotFound(HomeAssistantError):
+    """When referenced device not found."""

--- a/homeassistant/components/device/exceptions.py
+++ b/homeassistant/components/device/exceptions.py
@@ -1,4 +1,4 @@
-"""Device automation exceptions."""
+"""Device exceptions."""
 from homeassistant.exceptions import HomeAssistantError
 
 

--- a/homeassistant/components/device/manifest.json
+++ b/homeassistant/components/device/manifest.json
@@ -1,0 +1,7 @@
+{
+  "domain": "device",
+  "name": "Device",
+  "documentation": "https://www.home-assistant.io/integrations/device",
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/zha/device.py
+++ b/homeassistant/components/zha/device.py
@@ -1,0 +1,22 @@
+"""Device extensions for Zigbee Home Automation devices."""
+
+from zigpy.types.named import EUI64
+
+from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
+
+from .core.const import DATA_ZHA, DATA_ZHA_GATEWAY
+
+
+async def async_get_device_info(hass, device_id):
+    """Get ZHA device info."""
+    device_info = None
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    device = device_registry.async_get(device_id)
+    ieee = next(x[1] for x in device.connections if x[0] == CONNECTION_ZIGBEE)
+    ieee = EUI64.convert(ieee)
+
+    if ieee in zha_gateway.devices:
+        device_info = zha_gateway.devices[ieee].zha_device_info
+
+    return device_info

--- a/tests/components/zha/test_core_device.py
+++ b/tests/components/zha/test_core_device.py
@@ -1,0 +1,303 @@
+"""Test zha device switch."""
+from datetime import timedelta
+import time
+from unittest import mock
+
+import pytest
+import zigpy.profiles.zha
+import zigpy.zcl.clusters.general as general
+
+import homeassistant.components.zha.core.device as zha_core_device
+from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
+import homeassistant.helpers.device_registry as ha_dev_reg
+import homeassistant.util.dt as dt_util
+
+from .common import async_enable_traffic, make_zcl_header
+
+from tests.async_mock import patch
+from tests.common import async_fire_time_changed
+
+
+@pytest.fixture
+def zigpy_device(zigpy_device_mock):
+    """Device tracker zigpy device."""
+
+    def _dev(with_basic_channel: bool = True):
+        in_clusters = [general.OnOff.cluster_id]
+        if with_basic_channel:
+            in_clusters.append(general.Basic.cluster_id)
+
+        endpoints = {
+            3: {
+                "in_clusters": in_clusters,
+                "out_clusters": [],
+                "device_type": zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+            }
+        }
+        return zigpy_device_mock(endpoints)
+
+    return _dev
+
+
+@pytest.fixture
+def zigpy_device_mains(zigpy_device_mock):
+    """Device tracker zigpy device."""
+
+    def _dev(with_basic_channel: bool = True):
+        in_clusters = [general.OnOff.cluster_id]
+        if with_basic_channel:
+            in_clusters.append(general.Basic.cluster_id)
+
+        endpoints = {
+            3: {
+                "in_clusters": in_clusters,
+                "out_clusters": [],
+                "device_type": zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+            }
+        }
+        return zigpy_device_mock(
+            endpoints, node_descriptor=b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00"
+        )
+
+    return _dev
+
+
+@pytest.fixture
+def device_with_basic_channel(zigpy_device_mains):
+    """Return a zha device with a basic channel present."""
+    return zigpy_device_mains(with_basic_channel=True)
+
+
+@pytest.fixture
+def device_without_basic_channel(zigpy_device):
+    """Return a zha device with a basic channel present."""
+    return zigpy_device(with_basic_channel=False)
+
+
+@pytest.fixture
+async def ota_zha_device(zha_device_restored, zigpy_device_mock):
+    """ZHA device with OTA cluster fixture."""
+    zigpy_dev = zigpy_device_mock(
+        {
+            1: {
+                "in_clusters": [general.Basic.cluster_id],
+                "out_clusters": [general.Ota.cluster_id],
+                "device_type": 0x1234,
+            }
+        },
+        "00:11:22:33:44:55:66:77",
+        "test manufacturer",
+        "test model",
+    )
+
+    zha_device = await zha_device_restored(zigpy_dev)
+    return zha_device
+
+
+def _send_time_changed(hass, seconds):
+    """Send a time changed event."""
+    now = dt_util.utcnow() + timedelta(seconds=seconds)
+    async_fire_time_changed(hass, now)
+
+
+@patch(
+    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
+    new=mock.MagicMock(),
+)
+async def test_check_available_success(
+    hass, device_with_basic_channel, zha_device_restored
+):
+    """Check device availability success on 1st try."""
+
+    # pylint: disable=protected-access
+    zha_device = await zha_device_restored(device_with_basic_channel)
+    await async_enable_traffic(hass, [zha_device])
+    basic_ch = device_with_basic_channel.endpoints[3].basic
+
+    basic_ch.read_attributes.reset_mock()
+    device_with_basic_channel.last_seen = None
+    assert zha_device.available is True
+    _send_time_changed(hass, zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2)
+    await hass.async_block_till_done()
+    assert zha_device.available is False
+    assert basic_ch.read_attributes.await_count == 0
+
+    device_with_basic_channel.last_seen = (
+        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2
+    )
+    _seens = [time.time(), device_with_basic_channel.last_seen]
+
+    def _update_last_seen(*args, **kwargs):
+        device_with_basic_channel.last_seen = _seens.pop()
+
+    basic_ch.read_attributes.side_effect = _update_last_seen
+
+    # successfully ping zigpy device, but zha_device is not yet available
+    _send_time_changed(hass, 91)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 1
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is False
+
+    # There was traffic from the device: pings, but not yet available
+    _send_time_changed(hass, 91)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is False
+
+    # There was traffic from the device: don't try to ping, marked as available
+    _send_time_changed(hass, 91)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is True
+
+
+@patch(
+    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
+    new=mock.MagicMock(),
+)
+async def test_check_available_unsuccessful(
+    hass, device_with_basic_channel, zha_device_restored
+):
+    """Check device availability all tries fail."""
+
+    # pylint: disable=protected-access
+    zha_device = await zha_device_restored(device_with_basic_channel)
+    await async_enable_traffic(hass, [zha_device])
+    basic_ch = device_with_basic_channel.endpoints[3].basic
+
+    assert zha_device.available is True
+    assert basic_ch.read_attributes.await_count == 0
+
+    device_with_basic_channel.last_seen = (
+        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2
+    )
+
+    # unsuccessfuly ping zigpy device, but zha_device is still available
+    _send_time_changed(hass, 91)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 1
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is True
+
+    # still no traffic, but zha_device is still available
+    _send_time_changed(hass, 91)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is True
+
+    # not even trying to update, device is unavailble
+    _send_time_changed(hass, 91)
+    await hass.async_block_till_done()
+    assert basic_ch.read_attributes.await_count == 2
+    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
+    assert zha_device.available is False
+
+
+@patch(
+    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
+    new=mock.MagicMock(),
+)
+async def test_check_available_no_basic_channel(
+    hass, device_without_basic_channel, zha_device_restored, caplog
+):
+    """Check device availability for a device without basic cluster."""
+
+    # pylint: disable=protected-access
+    zha_device = await zha_device_restored(device_without_basic_channel)
+    await async_enable_traffic(hass, [zha_device])
+
+    assert zha_device.available is True
+
+    device_without_basic_channel.last_seen = (
+        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2
+    )
+
+    assert "does not have a mandatory basic cluster" not in caplog.text
+    _send_time_changed(hass, 91)
+    await hass.async_block_till_done()
+    assert zha_device.available is False
+    assert "does not have a mandatory basic cluster" in caplog.text
+
+
+async def test_ota_sw_version(hass, ota_zha_device):
+    """Test device entry gets sw_version updated via OTA channel."""
+
+    ota_ch = ota_zha_device.channels.pools[0].client_channels["1:0x0019"]
+    dev_registry = await ha_dev_reg.async_get_registry(hass)
+    entry = dev_registry.async_get(ota_zha_device.device_id)
+    assert entry.sw_version is None
+
+    cluster = ota_ch.cluster
+    hdr = make_zcl_header(1, global_command=False)
+    sw_version = 0x2345
+    cluster.handle_message(hdr, [1, 2, 3, sw_version, None])
+    await hass.async_block_till_done()
+    entry = dev_registry.async_get(ota_zha_device.device_id)
+    assert int(entry.sw_version, base=16) == sw_version
+
+
+@pytest.mark.parametrize(
+    "device, last_seen_delta, is_available",
+    (
+        ("zigpy_device", 0, True),
+        (
+            "zigpy_device",
+            zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2,
+            True,
+        ),
+        (
+            "zigpy_device",
+            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2,
+            True,
+        ),
+        (
+            "zigpy_device",
+            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 2,
+            False,
+        ),
+        ("zigpy_device_mains", 0, True),
+        (
+            "zigpy_device_mains",
+            zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2,
+            True,
+        ),
+        (
+            "zigpy_device_mains",
+            zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2,
+            False,
+        ),
+        (
+            "zigpy_device_mains",
+            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2,
+            False,
+        ),
+        (
+            "zigpy_device_mains",
+            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 2,
+            False,
+        ),
+    ),
+)
+async def test_device_restore_availability(
+    hass, request, device, last_seen_delta, is_available, zha_device_restored
+):
+    """Test initial availability for restored devices."""
+
+    zigpy_device = request.getfixturevalue(device)()
+    zha_device = await zha_device_restored(
+        zigpy_device, last_seen=time.time() - last_seen_delta
+    )
+    entity_id = "switch.fakemanufacturer_fakemodel_e769900a_on_off"
+
+    await hass.async_block_till_done()
+    # ensure the switch entity was created
+    assert hass.states.get(entity_id).state is not None
+    assert zha_device.available is is_available
+    if is_available:
+        assert hass.states.get(entity_id).state == STATE_OFF
+    else:
+        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/zha/test_core_device.py
+++ b/tests/components/zha/test_core_device.py
@@ -1,4 +1,4 @@
-"""Test zha device switch."""
+"""Test zha core device."""
 from datetime import timedelta
 import time
 from unittest import mock

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -1,303 +1,86 @@
-"""Test zha device switch."""
-from datetime import timedelta
-import time
-from unittest import mock
-
+"""Test ZHA device API."""
 import pytest
 import zigpy.profiles.zha
+import zigpy.types
 import zigpy.zcl.clusters.general as general
 
-import homeassistant.components.zha.core.device as zha_core_device
-from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
-import homeassistant.helpers.device_registry as ha_dev_reg
-import homeassistant.util.dt as dt_util
-
-from .common import async_enable_traffic, make_zcl_header
-
-from tests.async_mock import patch
-from tests.common import async_fire_time_changed
-
-
-@pytest.fixture
-def zigpy_device(zigpy_device_mock):
-    """Device tracker zigpy device."""
-
-    def _dev(with_basic_channel: bool = True):
-        in_clusters = [general.OnOff.cluster_id]
-        if with_basic_channel:
-            in_clusters.append(general.Basic.cluster_id)
-
-        endpoints = {
-            3: {
-                "in_clusters": in_clusters,
-                "out_clusters": [],
-                "device_type": zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
-            }
-        }
-        return zigpy_device_mock(endpoints)
-
-    return _dev
+from homeassistant.components.websocket_api import const
+from homeassistant.components.zha.api import ID, TYPE
+from homeassistant.components.zha.core.const import (
+    ATTR_ENDPOINT_NAMES,
+    ATTR_IEEE,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_NEIGHBORS,
+    ATTR_QUIRK_APPLIED,
+)
+from homeassistant.helpers.device_registry import async_get_registry
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture
-def zigpy_device_mains(zigpy_device_mock):
-    """Device tracker zigpy device."""
+async def mock_devices(hass, zigpy_device_mock, zha_device_joined_restored):
+    """IAS device fixture."""
 
-    def _dev(with_basic_channel: bool = True):
-        in_clusters = [general.OnOff.cluster_id]
-        if with_basic_channel:
-            in_clusters.append(general.Basic.cluster_id)
-
-        endpoints = {
-            3: {
-                "in_clusters": in_clusters,
-                "out_clusters": [],
-                "device_type": zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
-            }
-        }
-        return zigpy_device_mock(
-            endpoints, node_descriptor=b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00"
-        )
-
-    return _dev
-
-
-@pytest.fixture
-def device_with_basic_channel(zigpy_device_mains):
-    """Return a zha device with a basic channel present."""
-    return zigpy_device_mains(with_basic_channel=True)
-
-
-@pytest.fixture
-def device_without_basic_channel(zigpy_device):
-    """Return a zha device with a basic channel present."""
-    return zigpy_device(with_basic_channel=False)
-
-
-@pytest.fixture
-async def ota_zha_device(zha_device_restored, zigpy_device_mock):
-    """ZHA device with OTA cluster fixture."""
-    zigpy_dev = zigpy_device_mock(
+    zigpy_device = zigpy_device_mock(
         {
             1: {
                 "in_clusters": [general.Basic.cluster_id],
-                "out_clusters": [general.Ota.cluster_id],
-                "device_type": 0x1234,
+                "out_clusters": [general.OnOff.cluster_id],
+                "device_type": zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
             }
-        },
-        "00:11:22:33:44:55:66:77",
-        "test manufacturer",
-        "test model",
+        }
     )
 
-    zha_device = await zha_device_restored(zigpy_dev)
-    return zha_device
-
-
-def _send_time_changed(hass, seconds):
-    """Send a time changed event."""
-    now = dt_util.utcnow() + timedelta(seconds=seconds)
-    async_fire_time_changed(hass, now)
-
-
-@patch(
-    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
-    new=mock.MagicMock(),
-)
-async def test_check_available_success(
-    hass, device_with_basic_channel, zha_device_restored
-):
-    """Check device availability success on 1st try."""
-
-    # pylint: disable=protected-access
-    zha_device = await zha_device_restored(device_with_basic_channel)
-    await async_enable_traffic(hass, [zha_device])
-    basic_ch = device_with_basic_channel.endpoints[3].basic
-
-    basic_ch.read_attributes.reset_mock()
-    device_with_basic_channel.last_seen = None
-    assert zha_device.available is True
-    _send_time_changed(hass, zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2)
+    zha_device = await zha_device_joined_restored(zigpy_device)
+    zha_device.update_available(True)
     await hass.async_block_till_done()
-    assert zha_device.available is False
-    assert basic_ch.read_attributes.await_count == 0
+    return zigpy_device, zha_device
 
-    device_with_basic_channel.last_seen = (
-        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2
+
+async def test_device_info(hass, hass_ws_client, mock_devices):
+    """Test zha device info."""
+    ws_client = await hass_ws_client(hass)
+    await async_setup_component(hass, "device", {})
+    zigpy_device, zha_device = mock_devices
+
+    ieee_address = str(zha_device.ieee)
+
+    ha_device_registry = await async_get_registry(hass)
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+
+    msg_id = 100
+    await ws_client.send_json(
+        {ID: msg_id, TYPE: "device/info", "device_id": reg_device.id}
     )
-    _seens = [time.time(), device_with_basic_channel.last_seen]
-
-    def _update_last_seen(*args, **kwargs):
-        device_with_basic_channel.last_seen = _seens.pop()
-
-    basic_ch.read_attributes.side_effect = _update_last_seen
-
-    # successfully ping zigpy device, but zha_device is not yet available
-    _send_time_changed(hass, 91)
-    await hass.async_block_till_done()
-    assert basic_ch.read_attributes.await_count == 1
-    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
-    assert zha_device.available is False
-
-    # There was traffic from the device: pings, but not yet available
-    _send_time_changed(hass, 91)
-    await hass.async_block_till_done()
-    assert basic_ch.read_attributes.await_count == 2
-    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
-    assert zha_device.available is False
-
-    # There was traffic from the device: don't try to ping, marked as available
-    _send_time_changed(hass, 91)
-    await hass.async_block_till_done()
-    assert basic_ch.read_attributes.await_count == 2
-    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
-    assert zha_device.available is True
+    msg = await ws_client.receive_json()
+    config_entry = list(reg_device.config_entries)[0]
+    device_info = msg["result"]
+    attributes = [
+        ATTR_IEEE,
+        ATTR_MANUFACTURER,
+        ATTR_MODEL,
+        ATTR_NAME,
+        ATTR_QUIRK_APPLIED,
+        "entities",
+        ATTR_NEIGHBORS,
+        ATTR_ENDPOINT_NAMES,
+    ]
+    for attribute in attributes:
+        assert (
+            device_info[config_entry][attribute]
+            == zha_device.zha_device_info[attribute]
+        )
 
 
-@patch(
-    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
-    new=mock.MagicMock(),
-)
-async def test_check_available_unsuccessful(
-    hass, device_with_basic_channel, zha_device_restored
-):
-    """Check device availability all tries fail."""
-
-    # pylint: disable=protected-access
-    zha_device = await zha_device_restored(device_with_basic_channel)
-    await async_enable_traffic(hass, [zha_device])
-    basic_ch = device_with_basic_channel.endpoints[3].basic
-
-    assert zha_device.available is True
-    assert basic_ch.read_attributes.await_count == 0
-
-    device_with_basic_channel.last_seen = (
-        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2
-    )
-
-    # unsuccessfuly ping zigpy device, but zha_device is still available
-    _send_time_changed(hass, 91)
-    await hass.async_block_till_done()
-    assert basic_ch.read_attributes.await_count == 1
-    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
-    assert zha_device.available is True
-
-    # still no traffic, but zha_device is still available
-    _send_time_changed(hass, 91)
-    await hass.async_block_till_done()
-    assert basic_ch.read_attributes.await_count == 2
-    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
-    assert zha_device.available is True
-
-    # not even trying to update, device is unavailble
-    _send_time_changed(hass, 91)
-    await hass.async_block_till_done()
-    assert basic_ch.read_attributes.await_count == 2
-    assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
-    assert zha_device.available is False
-
-
-@patch(
-    "homeassistant.components.zha.core.channels.general.BasicChannel.async_initialize",
-    new=mock.MagicMock(),
-)
-async def test_check_available_no_basic_channel(
-    hass, device_without_basic_channel, zha_device_restored, caplog
-):
-    """Check device availability for a device without basic cluster."""
-
-    # pylint: disable=protected-access
-    zha_device = await zha_device_restored(device_without_basic_channel)
-    await async_enable_traffic(hass, [zha_device])
-
-    assert zha_device.available is True
-
-    device_without_basic_channel.last_seen = (
-        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2
-    )
-
-    assert "does not have a mandatory basic cluster" not in caplog.text
-    _send_time_changed(hass, 91)
-    await hass.async_block_till_done()
-    assert zha_device.available is False
-    assert "does not have a mandatory basic cluster" in caplog.text
-
-
-async def test_ota_sw_version(hass, ota_zha_device):
-    """Test device entry gets sw_version updated via OTA channel."""
-
-    ota_ch = ota_zha_device.channels.pools[0].client_channels["1:0x0019"]
-    dev_registry = await ha_dev_reg.async_get_registry(hass)
-    entry = dev_registry.async_get(ota_zha_device.device_id)
-    assert entry.sw_version is None
-
-    cluster = ota_ch.cluster
-    hdr = make_zcl_header(1, global_command=False)
-    sw_version = 0x2345
-    cluster.handle_message(hdr, [1, 2, 3, sw_version, None])
-    await hass.async_block_till_done()
-    entry = dev_registry.async_get(ota_zha_device.device_id)
-    assert int(entry.sw_version, base=16) == sw_version
-
-
-@pytest.mark.parametrize(
-    "device, last_seen_delta, is_available",
-    (
-        ("zigpy_device", 0, True),
-        (
-            "zigpy_device",
-            zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2,
-            True,
-        ),
-        (
-            "zigpy_device",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2,
-            True,
-        ),
-        (
-            "zigpy_device",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 2,
-            False,
-        ),
-        ("zigpy_device_mains", 0, True),
-        (
-            "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2,
-            True,
-        ),
-        (
-            "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2,
-            False,
-        ),
-        (
-            "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2,
-            False,
-        ),
-        (
-            "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 2,
-            False,
-        ),
-    ),
-)
-async def test_device_restore_availability(
-    hass, request, device, last_seen_delta, is_available, zha_device_restored
-):
-    """Test initial availability for restored devices."""
-
-    zigpy_device = request.getfixturevalue(device)()
-    zha_device = await zha_device_restored(
-        zigpy_device, last_seen=time.time() - last_seen_delta
-    )
-    entity_id = "switch.fakemanufacturer_fakemodel_e769900a_on_off"
-
-    await hass.async_block_till_done()
-    # ensure the switch entity was created
-    assert hass.states.get(entity_id).state is not None
-    assert zha_device.available is is_available
-    if is_available:
-        assert hass.states.get(entity_id).state == STATE_OFF
-    else:
-        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+async def test_device_not_found(hass, hass_ws_client):
+    """Test not found response from get device API."""
+    ws_client = await hass_ws_client(hass)
+    await async_setup_component(hass, "device", {})
+    await ws_client.send_json({ID: 6, TYPE: "device/info", "device_id": "12345678"})
+    msg = await ws_client.receive_json()
+    assert msg["id"] == 6
+    assert msg["type"] == const.TYPE_RESULT
+    assert not msg["success"]
+    assert msg["error"]["code"] == const.ERR_NOT_FOUND


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Several integrations offer device oriented extensions, the most notable are probably OZW and ZHA:
- Additional information, on top of what can be stored in the device registry
- Possibility to configure and remove devices

It would be beneficial if this could be unified to not require each integration to invent their own WS API, their own frontend cards etc.
As an initial step, add a new `device.py` platform which has `async def async_get_device_info(hass, device_id)`.

In this PR, ZHA is used for the MVP, where WS API "device/info" will return the same information for a ZHA device as what is returned by the custom API "zha/device".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
