### PR TITLE
Always use base url on synology_dsm camera rtsp streams

### DIFF
--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -1,5 +1,6 @@
 """Support for Synology DSM cameras."""
 from typing import Dict
+from urllib.parse import urlparse, urlsplit
 
 from synology_dsm.api.surveillance_station import SynoSurveillanceStation
 from synology_dsm.api.surveillance_station.camera import SynoCamera
@@ -55,6 +56,7 @@ class SynoDSMCamera(SynologyDSMEntity, Camera):
             },
         )
         self._camera = camera
+        self._hostname = urlsplit(self._api.dsm._base_url).hostname
 
     @property
     def device_info(self) -> Dict[str, any]:
@@ -100,7 +102,11 @@ class SynoDSMCamera(SynologyDSMEntity, Camera):
         """Return the source of the stream."""
         if not self.available:
             return None
-        return self._camera.live_view.rtsp
+
+        url = urlparse(self._camera.live_view.rtsp)
+        return url._replace(
+            netloc=self._hostname.join(url.netloc.rsplit(url.hostname, 1))
+        ).geturl()
 
     def enable_motion_detection(self):
         """Enable motion detection in the camera."""


### PR DESCRIPTION
## Proposed change

Synology DSM does not allow choosing which LAN interface (out of the two these devices typically support) is returned on the RTSP stream of the Surveillance Station software. There are numerous posts, both on Synology forums as well as on the Home Assistant community ([example](https://community.home-assistant.io/t/synology-dsm-camera-stream-not-working/234555)), where users seek workarounds on getting their cameras to work with the right IP.

I think the solution is much simpler and can be resolved with a simple invisible tweak: if the device is reachable via the integration, and we know it is otherwise entities would not have been added, then always use that hostname or IP for the RTSP stream independently of what Synology Surveillance Station is returning.

This accommodates all sort of setups: from the basic IP in the same LAN to macvlans using containers where host communication must be done via a shim interface.

cc @Quentame 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

Code depends on external devices being present.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
