### PR TITLE
Allow any parameter of a light profile as an optional parameter

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 from datetime import timedelta
 import logging
 import os
-from typing import Tuple
+from typing import Dict, List, Tuple
 
 import voluptuous as vol
 
@@ -23,6 +23,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.loader import bind_hass
 import homeassistant.util.color as color_util
 
@@ -297,7 +298,7 @@ class Profile:
         self.hs_color = color_util.color_xy_to_hs(self.color_x, self.color_y)
 
     @classmethod
-    def from_csv_row(cls, csv_row: Tuple) -> "Profile":
+    def from_csv_row(cls, csv_row: List[str]) -> "Profile":
         """Create profile from a CSV row tuple."""
         return cls(*cls.SCHEMA(csv_row))
 
@@ -305,12 +306,12 @@ class Profile:
 class Profiles:
     """Representation of available color profiles."""
 
-    def __init__(self, hass):
+    def __init__(self, hass: HomeAssistantType):
         """Initialize profiles."""
         self.hass = hass
-        self.data = None
+        self.data: Dict[str, Profile] = {}
 
-    def _load_profile_data(self):
+    def _load_profile_data(self) -> Dict[str, Profile]:
         """Load built-in profiles and custom profiles."""
         profile_paths = [
             os.path.join(os.path.dirname(__file__), LIGHT_PROFILES_FILE),
@@ -339,12 +340,12 @@ class Profiles:
                     continue
         return profiles
 
-    async def async_initialize(self):
+    async def async_initialize(self) -> None:
         """Load and cache profiles."""
         self.data = await self.hass.async_add_executor_job(self._load_profile_data)
 
     @callback
-    def apply_default(self, entity_id, params):
+    def apply_default(self, entity_id: str, params: Dict) -> None:
         """Return the default turn-on profile for the given light."""
         for entity_id in (entity_id, "group.all_lights"):
             name = f"{entity_id}.default"
@@ -353,7 +354,7 @@ class Profiles:
                 return
 
     @callback
-    def apply_profile(self, name, params):
+    def apply_profile(self, name: str, params: Dict) -> None:
         """Apply a profile."""
         profile = self.data.get(name)
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -294,22 +294,24 @@ class Profile:
     transition: Optional[int] = None
     hs_color: Optional[Tuple[float, float]] = dataclasses.field(init=False)
 
-    _OPT_BRIGHTNESS = vol.Any(cv.byte, _coerce_none)  # pylint: disable=invalid-name
-    _OPT_TRANSITION = vol.Any(  # pylint: disable=invalid-name
-        VALID_TRANSITION, _coerce_none
-    )
     SCHEMA = vol.Schema(  # pylint: disable=invalid-name
         vol.Any(
-            vol.ExactSequence((str, _coerce_none, _coerce_none, cv.byte)),
-            vol.ExactSequence((str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS)),
             vol.ExactSequence(
-                (str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS, _OPT_TRANSITION)
+                (
+                    str,
+                    vol.Any(cv.small_float, _coerce_none),
+                    vol.Any(cv.small_float, _coerce_none),
+                    vol.Any(cv.byte, _coerce_none),
+                )
             ),
             vol.ExactSequence(
-                (str, _coerce_none, _coerce_none, _OPT_BRIGHTNESS, VALID_TRANSITION)
-            ),
-            vol.ExactSequence(
-                (str, _coerce_none, _coerce_none, cv.byte, _OPT_TRANSITION)
+                (
+                    str,
+                    vol.Any(cv.small_float, _coerce_none),
+                    vol.Any(cv.small_float, _coerce_none),
+                    vol.Any(cv.byte, _coerce_none),
+                    vol.Any(VALID_TRANSITION, _coerce_none),
+                )
             ),
         )
     )

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -282,8 +282,6 @@ def _coerce_none(value: str) -> None:
     if value:
         raise vol.Invalid("Not an empty string")
 
-    return None
-
 
 @dataclasses.dataclass
 class Profile:
@@ -296,9 +294,11 @@ class Profile:
     transition: Optional[int] = None
     hs_color: Optional[Tuple[float, float]] = dataclasses.field(init=False)
 
-    _OPT_BRIGHTNESS = vol.Any(cv.byte, _coerce_none)
-    _OPT_TRANSITION = vol.Any(VALID_TRANSITION, _coerce_none)
-    SCHEMA = vol.Schema(
+    _OPT_BRIGHTNESS = vol.Any(cv.byte, _coerce_none)  # pylint: disable=invalid-name
+    _OPT_TRANSITION = vol.Any(  # pylint: disable=invalid-name
+        VALID_TRANSITION, _coerce_none
+    )
+    SCHEMA = vol.Schema(  # pylint: disable=invalid-name
         vol.Any(
             vol.ExactSequence((str, _coerce_none, _coerce_none, cv.byte)),
             vol.ExactSequence((str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS)),
@@ -377,8 +377,8 @@ class Profiles:
     @callback
     def apply_default(self, entity_id: str, params: Dict) -> None:
         """Return the default turn-on profile for the given light."""
-        for entity_id in (entity_id, "group.all_lights"):
-            name = f"{entity_id}.default"
+        for _entity_id in (entity_id, "group.all_lights"):
+            name = f"{_entity_id}.default"
             if name in self.data:
                 self.apply_profile(name, params)
                 return

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -336,14 +336,11 @@ class Profiles:
     @callback
     def apply_default(self, entity_id, params):
         """Return the default turn-on profile for the given light."""
-        name = f"{entity_id}.default"
-        if name in self.data:
-            self.apply_profile(name, params)
-            return
-
-        name = "group.all_lights.default"
-        if name in self.data:
-            self.apply_profile(name, params)
+        for entity_id in (entity_id, "group.all_lights"):
+            name = f"{entity_id}.default"
+            if name in self.data:
+                self.apply_profile(name, params)
+                return
 
     @callback
     def apply_profile(self, name, params):

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -292,19 +292,20 @@ class Profile:
     name: str
     color_x: Optional[float] = dataclasses.field(repr=False)
     color_y: Optional[float] = dataclasses.field(repr=False)
-    brightness: int
+    brightness: Optional[int]
     transition: int = 0
     hs_color: Optional[Tuple[float, float]] = dataclasses.field(init=False)
 
+    _OPT_BRIGHTNESS = vol.Any(cv.byte, _coerce_none)
     SCHEMA = vol.Schema(
         vol.Any(
             vol.ExactSequence((str, _coerce_none, _coerce_none, cv.byte)),
-            vol.ExactSequence((str, cv.small_float, cv.small_float, cv.byte)),
+            vol.ExactSequence((str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS)),
             vol.ExactSequence(
-                (str, cv.small_float, cv.small_float, cv.byte, cv.positive_int)
+                (str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS, cv.positive_int)
             ),
             vol.ExactSequence(
-                (str, _coerce_none, _coerce_none, cv.byte, cv.positive_int)
+                (str, _coerce_none, _coerce_none, _OPT_BRIGHTNESS, cv.positive_int)
             ),
         )
     )
@@ -388,7 +389,8 @@ class Profiles:
 
         if profile.hs_color is not None:
             params.setdefault(ATTR_HS_COLOR, profile.hs_color)
-        params.setdefault(ATTR_BRIGHTNESS, profile.brightness)
+        if profile.brightness is not None:
+            params.setdefault(ATTR_BRIGHTNESS, profile.brightness)
         params.setdefault(ATTR_TRANSITION, profile.transition)
 
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -302,10 +302,10 @@ class Profile:
             vol.ExactSequence((str, _coerce_none, _coerce_none, cv.byte)),
             vol.ExactSequence((str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS)),
             vol.ExactSequence(
-                (str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS, cv.positive_int)
+                (str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS, VALID_TRANSITION)
             ),
             vol.ExactSequence(
-                (str, _coerce_none, _coerce_none, _OPT_BRIGHTNESS, cv.positive_int)
+                (str, _coerce_none, _coerce_none, _OPT_BRIGHTNESS, VALID_TRANSITION)
             ),
         )
     )

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -293,19 +293,23 @@ class Profile:
     color_x: Optional[float] = dataclasses.field(repr=False)
     color_y: Optional[float] = dataclasses.field(repr=False)
     brightness: Optional[int]
-    transition: int = 0
+    transition: Optional[int] = None
     hs_color: Optional[Tuple[float, float]] = dataclasses.field(init=False)
 
     _OPT_BRIGHTNESS = vol.Any(cv.byte, _coerce_none)
+    _OPT_TRANSITION = vol.Any(VALID_TRANSITION, _coerce_none)
     SCHEMA = vol.Schema(
         vol.Any(
             vol.ExactSequence((str, _coerce_none, _coerce_none, cv.byte)),
             vol.ExactSequence((str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS)),
             vol.ExactSequence(
-                (str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS, VALID_TRANSITION)
+                (str, cv.small_float, cv.small_float, _OPT_BRIGHTNESS, _OPT_TRANSITION)
             ),
             vol.ExactSequence(
                 (str, _coerce_none, _coerce_none, _OPT_BRIGHTNESS, VALID_TRANSITION)
+            ),
+            vol.ExactSequence(
+                (str, _coerce_none, _coerce_none, cv.byte, _OPT_TRANSITION)
             ),
         )
     )
@@ -391,7 +395,8 @@ class Profiles:
             params.setdefault(ATTR_HS_COLOR, profile.hs_color)
         if profile.brightness is not None:
             params.setdefault(ATTR_BRIGHTNESS, profile.brightness)
-        params.setdefault(ATTR_TRANSITION, profile.transition)
+        if profile.transition is not None:
+            params.setdefault(ATTR_TRANSITION, profile.transition)
 
 
 class LightEntity(ToggleEntity):

--- a/tests/components/light/conftest.py
+++ b/tests/components/light/conftest.py
@@ -20,7 +20,6 @@ def mock_light_profiles():
 
     with patch(
         "homeassistant.components.light.Profiles",
-        SCHEMA=Profiles.SCHEMA,
         side_effect=mock_profiles_class,
     ):
         yield data

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -724,13 +724,47 @@ async def test_profile_load_optional_hs_color(hass):
     """Test profile loading with profiles containing no xy color."""
 
     csv_file = """the first line is skipped
-    "no_color",,,100,1
-    "no_color_no_transition",,,110
-    "color",0.5119,0.4117.120,2
-    "color_no_transition",0.5119,0.4117,120
-    """
+no_color,,,100,1
+no_color_no_transition,,,110
+color,0.5119,0.4147,120,2
+color_no_transition,0.4448,0.4066,130
+invalid_profile_1,
+invalid_color_2,,0.1,1,2
+invalid_color_3,,0.1,1
+invalid_color_4,0.1,,1,3
+invalid_color_5,0.1,,1
+invalid_brightness,0,0,256,4
+invalid_brightness_2,0,0,256
+"""
 
     profiles = orig_Profiles(hass)
-    with patch("__builtins__.open", mock_open(read_data=csv_file)):
+    with patch("builtins.open", mock_open(read_data=csv_file)):
         await profiles.async_initialize()
         await hass.async_block_till_done()
+
+    assert profiles.data["no_color"].hs_color is None
+    assert profiles.data["no_color"].brightness == 100
+    assert profiles.data["no_color"].transition == 1
+
+    assert profiles.data["no_color_no_transition"].hs_color is None
+    assert profiles.data["no_color_no_transition"].brightness == 110
+    assert profiles.data["no_color_no_transition"].transition == 0
+
+    assert profiles.data["color"].hs_color == (35.932, 69.412)
+    assert profiles.data["color"].brightness == 120
+    assert profiles.data["color"].transition == 2
+
+    assert profiles.data["color_no_transition"].hs_color == (38.88, 49.02)
+    assert profiles.data["color_no_transition"].brightness == 130
+    assert profiles.data["color_no_transition"].transition == 0
+
+    for invalid_profile_name in (
+        "invalid_profile_1",
+        "invalid_color_2",
+        "invalid_color_3",
+        "invalid_color_4",
+        "invalid_color_5",
+        "invalid_brightness",
+        "invalid_brightness_2",
+    ):
+        assert invalid_profile_name not in profiles.data

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,4 +1,6 @@
 """The tests for the Light component."""
+from unittest.mock import MagicMock, mock_open, patch
+
 import pytest
 import voluptuous as vol
 
@@ -17,7 +19,6 @@ from homeassistant.const import (
 from homeassistant.exceptions import Unauthorized
 from homeassistant.setup import async_setup_component
 
-from tests.async_mock import MagicMock, mock_open, patch
 from tests.common import async_mock_service
 
 orig_Profiles = light.Profiles


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In one of the [issues](https://github.com/zigpy/zha-device-handlers/issues/240) users wanted to modify the default transition for the lights, but did not want to change the light's color, which was not possible with light profiles.  This PR makes two changes:
1. Make any parameter (color_x and color_y both have to be either missing or present) of the light profile as an optional profile
2. Make `transition` field of the `light_profiles.csv` a float number -- since transition parameter to `light.turn_on` service call is a float number. Mainly for more precise transitions for shorter durations

And if we to allow the `color_x, color_y` pairs to be optional, then it made sense to allow any parameter of the light profile to be optional.
Only parameters which are present in profile are applied.
Maintains backwards compatibility with 4 and 5 column csv files
At least one of the parameters must be present in the profile


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Example `light_profiles.csv`:
```csv
id,x,y,brightness,transition
profile_with_color_only,0.5119,0.4147,,
profile_with_brightness_only,,,200,
profile_with_transition_only,,,,2.5
profile_with_brigthness_and_transition,,,254,1.5
profile_with_all_parameters,0.5119,0.4147,100,0.5
```


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
