### PR TITLE
Expose spider device information

### DIFF
--- a/homeassistant/components/spider/climate.py
+++ b/homeassistant/components/spider/climate.py
@@ -48,7 +48,7 @@ class SpiderThermostat(ClimateEntity):
     def device_info(self):
         """Return the device_info of the device."""
         return {
-            "identifiers": {(DOMAIN, self.unique_id)},
+            "identifiers": {(DOMAIN, self.thermostat.id)},
             "name": self.thermostat.name,
             "manufacturer": self.thermostat.manufacturer,
             "model": self.thermostat.model,

--- a/homeassistant/components/spider/climate.py
+++ b/homeassistant/components/spider/climate.py
@@ -45,6 +45,16 @@ class SpiderThermostat(ClimateEntity):
         self.thermostat = thermostat
 
     @property
+    def device_info(self):
+        """Return the device_info of the device."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.thermostat.name,
+            "manufacturer": self.thermostat.manufacturer,
+            "model": self.thermostat.model,
+        }
+
+    @property
     def supported_features(self):
         """Return the list of supported features."""
         if self.thermostat.has_fan_mode:

--- a/homeassistant/components/spider/manifest.json
+++ b/homeassistant/components/spider/manifest.json
@@ -3,7 +3,7 @@
   "name": "Itho Daalderop Spider",
   "documentation": "https://www.home-assistant.io/integrations/spider",
   "requirements": [
-    "spiderpy==1.3.1"
+    "spiderpy==1.4.2"
   ],
   "codeowners": [
     "@peternijssen"

--- a/homeassistant/components/spider/switch.py
+++ b/homeassistant/components/spider/switch.py
@@ -5,7 +5,7 @@ from .const import DOMAIN
 
 
 async def async_setup_entry(hass, config, async_add_entities):
-    """Initialize a Spider thermostat."""
+    """Initialize a Spider Power Plug."""
     api = hass.data[DOMAIN][config.entry_id]
     async_add_entities(
         [
@@ -19,9 +19,19 @@ class SpiderPowerPlug(SwitchEntity):
     """Representation of a Spider Power Plug."""
 
     def __init__(self, api, power_plug):
-        """Initialize the Vera device."""
+        """Initialize the Spider Power Plug."""
         self.api = api
         self.power_plug = power_plug
+
+    @property
+    def device_info(self):
+        """Return the device_info of the device."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.power_plug.name,
+            "manufacturer": self.power_plug.manufacturer,
+            "model": self.power_plug.model,
+        }
 
     @property
     def unique_id(self):

--- a/homeassistant/components/spider/switch.py
+++ b/homeassistant/components/spider/switch.py
@@ -27,7 +27,7 @@ class SpiderPowerPlug(SwitchEntity):
     def device_info(self):
         """Return the device_info of the device."""
         return {
-            "identifiers": {(DOMAIN, self.unique_id)},
+            "identifiers": {(DOMAIN, self.power_plug.id)},
             "name": self.power_plug.name,
             "manufacturer": self.power_plug.manufacturer,
             "model": self.power_plug.model,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2087,7 +2087,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.2
 
 # homeassistant.components.spider
-spiderpy==1.3.1
+spiderpy==1.4.2
 
 # homeassistant.components.spotcrime
 spotcrime==1.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1021,7 +1021,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.2
 
 # homeassistant.components.spider
-spiderpy==1.3.1
+spiderpy==1.4.2
 
 # homeassistant.components.spotify
 spotipy==2.16.1


### PR DESCRIPTION
## Proposed change
Dependency update which also allows us to expose spider device information, but also fixes a bug in the library itself.

Changes: https://github.com/peternijssen/spiderpy/compare/1.3.1...1.4.2


## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
