### PR TITLE
Bump up dependencies on pyserial and pyserial-asyncio

### DIFF
--- a/homeassistant/components/acer_projector/manifest.json
+++ b/homeassistant/components/acer_projector/manifest.json
@@ -2,6 +2,6 @@
   "domain": "acer_projector",
   "name": "Acer Projector",
   "documentation": "https://www.home-assistant.io/integrations/acer_projector",
-  "requirements": ["pyserial==3.4"],
+  "requirements": ["pyserial==3.5"],
   "codeowners": []
 }

--- a/homeassistant/components/serial/manifest.json
+++ b/homeassistant/components/serial/manifest.json
@@ -2,6 +2,6 @@
   "domain": "serial",
   "name": "Serial",
   "documentation": "https://www.home-assistant.io/integrations/serial",
-  "requirements": ["pyserial-asyncio==0.4"],
+  "requirements": ["pyserial-asyncio==0.5"],
   "codeowners": ["@fabaff"]
 }

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -5,8 +5,8 @@
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "requirements": [
     "bellows==0.21.0",
-    "pyserial==3.4",
-    "pyserial-asyncio==0.4",
+    "pyserial==3.5",
+    "pyserial-asyncio==0.5",
     "zha-quirks==0.0.48",
     "zigpy-cc==0.5.2",
     "zigpy-deconz==0.11.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1662,11 +1662,11 @@ pysensibo==1.0.3
 
 # homeassistant.components.serial
 # homeassistant.components.zha
-pyserial-asyncio==0.4
+pyserial-asyncio==0.5
 
 # homeassistant.components.acer_projector
 # homeassistant.components.zha
-pyserial==3.4
+pyserial==3.5
 
 # homeassistant.components.sesame
 pysesame2==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -836,11 +836,11 @@ pyruckus==0.12
 
 # homeassistant.components.serial
 # homeassistant.components.zha
-pyserial-asyncio==0.4
+pyserial-asyncio==0.5
 
 # homeassistant.components.acer_projector
 # homeassistant.components.zha
-pyserial==3.4
+pyserial==3.5
 
 # homeassistant.components.signal_messenger
 pysignalclirestapi==0.3.4

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -29,7 +29,7 @@ def serial_connect_fail(self):
 
 def com_port():
     """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo()
+    port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")
     port.serial_number = "1234"
     port.manufacturer = "Virtual serial port"
     port.device = "/dev/ttyUSB1234"

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -19,7 +19,7 @@ from tests.common import MockConfigEntry
 
 def com_port():
     """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo()
+    port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")
     port.serial_number = "1234"
     port.manufacturer = "Virtual serial port"
     port.device = "/dev/ttyUSB1234"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump up dependencies on:
- `pyserial==3.5` [Release Notes](https://github.com/pyserial/pyserial/releases/tag/v3.5)
- `pyserial-asyncio==0.5` [Release Notes](https://github.com/pyserial/pyserial-asyncio/releases/tag/v0.5), changed syntax to async/await

Since multiple packages depend on one or another of the serial modules, effectively this bump up dependencies for:
- [ZHA](https://www.home-assistant.io/integrations/zha/)
  - `pyserial==3.5` [Release Notes](https://github.com/pyserial/pyserial/releases/tag/v3.5)
  - `pyserial-asyncio==0.5` [Release Notes](https://github.com/pyserial/pyserial-asyncio/releases/tag/v0.5)
- [Serial](https://www.home-assistant.io/integrations/serial/)
  - `pyserial-asyncio==0.5` [Release Notes](https://github.com/pyserial/pyserial-asyncio/releases/tag/v0.5)
- [acer_projector](https://www.home-assistant.io/integrations/acer_projector/)
  - `pyserial==3.5` [Release Notes](https://github.com/pyserial/pyserial/releases/tag/v3.5)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
