### PR TITLE
Initialize numeric_state trigger tests

### DIFF
--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -61,6 +61,9 @@ async def test_if_not_fires_on_entity_removal(hass, calls):
 
 async def test_if_fires_on_entity_change_below(hass, calls):
     """Test the firing with changed entity."""
+    hass.states.async_set("test.entity", 11)
+    await hass.async_block_till_done()
+
     context = Context()
     assert await async_setup_component(
         hass,
@@ -270,6 +273,9 @@ async def test_if_fires_on_initial_entity_above(hass, calls):
 
 async def test_if_fires_on_entity_change_above(hass, calls):
     """Test the firing with changed entity."""
+    hass.states.async_set("test.entity", 9)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -378,6 +384,9 @@ async def test_if_not_above_fires_on_entity_change_to_equal(hass, calls):
 
 async def test_if_fires_on_entity_change_below_range(hass, calls):
     """Test the firing with changed entity."""
+    hass.states.async_set("test.entity", 11)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -500,6 +509,9 @@ async def test_if_not_fires_if_entity_not_match(hass, calls):
 
 async def test_if_fires_on_entity_change_below_with_attribute(hass, calls):
     """Test attributes change."""
+    hass.states.async_set("test.entity", 11, {"test_attribute": 11})
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -544,6 +556,9 @@ async def test_if_not_fires_on_entity_change_not_below_with_attribute(hass, call
 
 async def test_if_fires_on_attribute_change_with_attribute_below(hass, calls):
     """Test attributes change."""
+    hass.states.async_set("test.entity", "entity", {"test_attribute": 11})
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -636,6 +651,10 @@ async def test_if_not_fires_on_entity_change_with_not_attribute_below(hass, call
 
 async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(hass, calls):
     """Test attributes change."""
+    hass.states.async_set(
+        "test.entity", "entity", {"test_attribute": 11, "not_test_attribute": 11}
+    )
+    await hass.async_block_till_done()
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -661,6 +680,8 @@ async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(hass,
 
 async def test_template_list(hass, calls):
     """Test template list."""
+    hass.states.async_set("test.entity", "entity", {"test_attribute": [11, 15, 11]})
+    await hass.async_block_till_done()
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -791,6 +812,9 @@ async def test_if_action(hass, calls):
 
 async def test_if_fails_setup_bad_for(hass, calls):
     """Test for setup failure for bad for."""
+    hass.states.async_set("test.entity", 5)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -863,6 +887,10 @@ async def test_if_not_fires_on_entity_change_with_for(hass, calls):
 
 async def test_if_not_fires_on_entities_change_with_for_after_stop(hass, calls):
     """Test for not firing on entities change with for after stop."""
+    hass.states.async_set("test.entity_1", 0)
+    hass.states.async_set("test.entity_2", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -906,6 +934,9 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(hass, calls):
 
 async def test_if_fires_on_entity_change_with_for_attribute_change(hass, calls):
     """Test for firing on entity change with for and attribute change."""
+    hass.states.async_set("test.entity", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -941,6 +972,9 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(hass, calls):
 
 async def test_if_fires_on_entity_change_with_for(hass, calls):
     """Test for firing on entity change with for."""
+    hass.states.async_set("test.entity", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -967,6 +1001,9 @@ async def test_if_fires_on_entity_change_with_for(hass, calls):
 
 async def test_wait_template_with_trigger(hass, calls):
     """Test using wait template with 'trigger.entity_id'."""
+    hass.states.async_set("test.entity", "0")
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1004,6 +1041,10 @@ async def test_wait_template_with_trigger(hass, calls):
 
 async def test_if_fires_on_entities_change_no_overlap(hass, calls):
     """Test for firing on entities change with no overlap."""
+    hass.states.async_set("test.entity_1", 0)
+    hass.states.async_set("test.entity_2", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1047,6 +1088,10 @@ async def test_if_fires_on_entities_change_no_overlap(hass, calls):
 
 async def test_if_fires_on_entities_change_overlap(hass, calls):
     """Test for firing on entities change with overlap."""
+    hass.states.async_set("test.entity_1", 0)
+    hass.states.async_set("test.entity_2", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1101,6 +1146,9 @@ async def test_if_fires_on_entities_change_overlap(hass, calls):
 
 async def test_if_fires_on_change_with_for_template_1(hass, calls):
     """Test for firing on  change with for template."""
+    hass.states.async_set("test.entity", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1128,6 +1176,9 @@ async def test_if_fires_on_change_with_for_template_1(hass, calls):
 
 async def test_if_fires_on_change_with_for_template_2(hass, calls):
     """Test for firing on  change with for template."""
+    hass.states.async_set("test.entity", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1155,6 +1206,9 @@ async def test_if_fires_on_change_with_for_template_2(hass, calls):
 
 async def test_if_fires_on_change_with_for_template_3(hass, calls):
     """Test for firing on  change with for template."""
+    hass.states.async_set("test.entity", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1182,6 +1236,9 @@ async def test_if_fires_on_change_with_for_template_3(hass, calls):
 
 async def test_invalid_for_template(hass, calls):
     """Test for invalid for template."""
+    hass.states.async_set("test.entity", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1207,6 +1264,10 @@ async def test_invalid_for_template(hass, calls):
 
 async def test_if_fires_on_entities_change_overlap_for_template(hass, calls):
     """Test for firing on entities change with overlap and for template."""
+    hass.states.async_set("test.entity_1", 0)
+    hass.states.async_set("test.entity_2", 0)
+    await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `numeric_state` trigger tests currently rely on the trigger firing if the condition is true at startup. This PR adds initial states so it is actually the threshold crossing that is being tested.

This is a preparation step before fixing #40331.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
