### PR TITLE
Follow Axis library changes and improve tests

### DIFF
--- a/homeassistant/components/axis/binary_sensor.py
+++ b/homeassistant/components/axis/binary_sensor.py
@@ -7,10 +7,12 @@ from axis.event_stream import (
     CLASS_LIGHT,
     CLASS_MOTION,
     CLASS_OUTPUT,
+    CLASS_PTZ,
     CLASS_SOUND,
     FenceGuard,
     LoiteringGuard,
     MotionGuard,
+    ObjectAnalytics,
     Vmd4,
 )
 
@@ -46,7 +48,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         """Add binary sensor from Axis device."""
         event = device.api.event[event_id]
 
-        if event.CLASS != CLASS_OUTPUT and not (
+        if event.CLASS not in (CLASS_OUTPUT, CLASS_PTZ) and not (
             event.CLASS == CLASS_LIGHT and event.TYPE == "Light"
         ):
             async_add_entities([AxisBinarySensor(event, device)])
@@ -114,6 +116,7 @@ class AxisBinarySensor(AxisEventBase, BinarySensorEntity):
                 (FenceGuard, self.device.api.vapix.fence_guard),
                 (LoiteringGuard, self.device.api.vapix.loitering_guard),
                 (MotionGuard, self.device.api.vapix.motion_guard),
+                (ObjectAnalytics, self.device.api.vapix.object_analytics),
                 (Vmd4, self.device.api.vapix.vmd4),
             ):
                 if (

--- a/homeassistant/components/axis/binary_sensor.py
+++ b/homeassistant/components/axis/binary_sensor.py
@@ -103,7 +103,7 @@ class AxisBinarySensor(AxisEventBase, BinarySensorEntity):
         """Return the name of the event."""
         if (
             self.event.CLASS == CLASS_INPUT
-            and self.event.id
+            and self.event.id in self.device.api.vapix.ports
             and self.device.api.vapix.ports[self.event.id].name
         ):
             return (

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -178,7 +178,7 @@ class AxisNetworkDevice:
         self.disconnect_from_stream()
 
         event = mqtt_json_to_event(message.payload)
-        self.api.event.process_event(event)
+        self.api.event.update([event])
 
     # Setup and teardown methods
 

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -195,8 +195,10 @@ class AxisNetworkDevice:
         except CannotConnect as err:
             raise ConfigEntryNotReady from err
 
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.error("Unknown error connecting with Axis device on %s", self.host)
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.error(
+                "Unknown error connecting with Axis device (%s): %s", self.host, err
+            )
             return False
 
         self.fw_version = self.api.vapix.firmware_version

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
-  "requirements": ["axis==41"],
+  "requirements": ["axis==42"],
   "zeroconf": [
     { "type": "_axis-video._tcp.local.", "macaddress": "00408C*" },
     { "type": "_axis-video._tcp.local.", "macaddress": "ACCC8E*" },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -306,7 +306,7 @@ av==8.0.2
 # avion==0.10
 
 # homeassistant.components.axis
-axis==41
+axis==42
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -177,7 +177,7 @@ auroranoaa==0.0.2
 av==8.0.2
 
 # homeassistant.components.axis
-axis==41
+axis==42
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/tests/components/axis/test_binary_sensor.py
+++ b/tests/components/axis/test_binary_sensor.py
@@ -62,8 +62,7 @@ async def test_binary_sensors(hass):
     config_entry = await setup_axis_integration(hass)
     device = hass.data[AXIS_DOMAIN][config_entry.unique_id]
 
-    for event in EVENTS:
-        device.api.event.process_event(event)
+    device.api.event.update(EVENTS)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 2

--- a/tests/components/axis/test_binary_sensor.py
+++ b/tests/components/axis/test_binary_sensor.py
@@ -21,6 +21,14 @@ EVENTS = [
     },
     {
         "operation": "Initialized",
+        "topic": "tns1:PTZController/tnsaxis:PTZPresets/Channel_1",
+        "source": "PresetToken",
+        "source_idx": "0",
+        "type": "on_preset",
+        "value": "1",
+    },
+    {
+        "operation": "Initialized",
         "topic": "tnsaxis:CameraApplicationPlatform/VMD/Camera1Profile1",
         "type": "active",
         "value": "1",

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test Axis config flow."""
 from unittest.mock import patch
 
+import respx
+
 from homeassistant import data_entry_flow
 from homeassistant.components.axis import config_flow
 from homeassistant.components.axis.const import (
@@ -25,7 +27,13 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-from .test_device import MAC, MODEL, NAME, setup_axis_integration, vapix_request
+from .test_device import (
+    MAC,
+    MODEL,
+    NAME,
+    mock_default_vapix_requests,
+    setup_axis_integration,
+)
 
 from tests.common import MockConfigEntry
 
@@ -41,7 +49,8 @@ async def test_flow_manual_configuration(hass):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == SOURCE_USER
 
-    with patch("axis.vapix.Vapix.request", new=vapix_request):
+    with respx.mock:
+        mock_default_vapix_requests(respx)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -80,7 +89,8 @@ async def test_manual_configuration_update_configuration(hass):
     with patch(
         "homeassistant.components.axis.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry, patch("axis.vapix.Vapix.request", new=vapix_request):
+    ) as mock_setup_entry, respx.mock:
+        mock_default_vapix_requests(respx, "2.3.4.5")
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -109,7 +119,8 @@ async def test_flow_fails_already_configured(hass):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == SOURCE_USER
 
-    with patch("axis.vapix.Vapix.request", new=vapix_request):
+    with respx.mock:
+        mock_default_vapix_requests(respx)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -196,7 +207,8 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(hass):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == SOURCE_USER
 
-    with patch("axis.vapix.Vapix.request", new=vapix_request):
+    with respx.mock:
+        mock_default_vapix_requests(respx)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -238,7 +250,8 @@ async def test_zeroconf_flow(hass):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == SOURCE_USER
 
-    with patch("axis.vapix.Vapix.request", new=vapix_request):
+    with respx.mock:
+        mock_default_vapix_requests(respx)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -304,7 +317,8 @@ async def test_zeroconf_flow_updated_configuration(hass):
     with patch(
         "homeassistant.components.axis.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry, patch("axis.vapix.Vapix.request", new=vapix_request):
+    ) as mock_setup_entry, respx.mock:
+        mock_default_vapix_requests(respx, "2.3.4.5")
         result = await hass.config_entries.flow.async_init(
             AXIS_DOMAIN,
             data={

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -1,7 +1,7 @@
 """Test Axis device."""
 from copy import deepcopy
 from unittest import mock
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import axis as axislib
 from axis.event_stream import OPERATION_INITIALIZED
@@ -423,12 +423,10 @@ async def test_shutdown():
 
     axis_device = axis.device.AxisNetworkDevice(hass, entry)
     axis_device.api = Mock()
-    axis_device.api.vapix.close = AsyncMock()
 
     await axis_device.shutdown(None)
 
     assert len(axis_device.api.stream.stop.mock_calls) == 1
-    assert len(axis_device.api.vapix.close.mock_calls) == 1
 
 
 async def test_get_device_fails(hass):

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -154,6 +154,14 @@ root.Brand.ProdVariant=
 root.Brand.WebURL=http://www.axis.com
 """
 
+IMAGE_RESPONSE = """root.Image.I0.Enabled=yes
+root.Image.I0.Name=View Area 1
+root.Image.I0.Source=0
+root.Image.I1.Enabled=no
+root.Image.I1.Name=View Area 2
+root.Image.I1.Source=0
+"""
+
 PORTS_RESPONSE = """root.Input.NbrOfInputs=1
 root.IOPort.I0.Configurable=no
 root.IOPort.I0.Direction=input
@@ -188,6 +196,8 @@ root.StreamProfile.S1.Name=profile_2
 root.StreamProfile.S1.Parameters=videocodec=h265
 """
 
+VIEW_AREAS_RESPONSE = {"apiVersion": "1.0", "method": "list", "data": {"viewAreas": []}}
+
 
 def mock_default_vapix_requests(respx: respx, host: str = DEFAULT_HOST) -> None:
     """Mock default Vapix requests responses."""
@@ -209,10 +219,19 @@ def mock_default_vapix_requests(respx: respx, host: str = DEFAULT_HOST) -> None:
     respx.post(f"http://{host}:80/axis-cgi/streamprofile.cgi").respond(
         json=STREAM_PROFILES_RESPONSE,
     )
+    respx.post(f"http://{host}:80/axis-cgi/viewarea/info.cgi").respond(
+        json=VIEW_AREAS_RESPONSE
+    )
     respx.get(
         f"http://{host}:80/axis-cgi/param.cgi?action=list&group=root.Brand"
     ).respond(
         text=BRAND_RESPONSE,
+        headers={"Content-Type": "text/plain"},
+    )
+    respx.get(
+        f"http://{host}:80/axis-cgi/param.cgi?action=list&group=root.Image"
+    ).respond(
+        text=IMAGE_RESPONSE,
         headers={"Content-Type": "text/plain"},
     )
     respx.get(

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -17,6 +17,7 @@ from axis.param_cgi import (
     IOPORT as IOPORT_URL,
     OUTPUT as OUTPUT_URL,
     PROPERTIES as PROPERTIES_URL,
+    PTZ as PTZ_URL,
     STREAM_PROFILES as STREAM_PROFILES_URL,
 )
 from axis.port_management import URL as PORT_MANAGEMENT_URL
@@ -126,6 +127,65 @@ MQTT_CLIENT_RESPONSE = {
     "data": {"status": {"state": "active", "connectionStatus": "Connected"}},
 }
 
+OBJECT_ANALYTICS = {
+    "apiVersion": "1.0",
+    "context": "Axis library",
+    "data": {
+        "devices": [{"id": 1, "rotation": 180, "type": "camera"}],
+        "metadataOverlay": [],
+        "perspectives": [],
+        "scenarios": [
+            {
+                "devices": [{"id": 1}],
+                "filters": [
+                    {"distance": 5, "type": "distanceSwayingObject"},
+                    {"time": 1, "type": "timeShortLivedLimit"},
+                    {"height": 3, "type": "sizePercentage", "width": 3},
+                ],
+                "id": 1,
+                "name": "Scenario 1",
+                "objectClassifications": [],
+                "perspectives": [],
+                "presets": [],
+                "triggers": [
+                    {
+                        "type": "includeArea",
+                        "vertices": [
+                            [-0.97, -0.97],
+                            [-0.97, 0.97],
+                            [0.97, 0.97],
+                            [0.97, -0.97],
+                        ],
+                    }
+                ],
+                "type": "motion",
+            },
+            {
+                "devices": [{"id": 1}],
+                "filters": [
+                    {"time": 1, "type": "timeShortLivedLimit"},
+                    {"height": 3, "type": "sizePercentage", "width": 3},
+                ],
+                "id": 2,
+                "name": "Scenario 2",
+                "objectClassifications": [{"type": "human"}],
+                "perspectives": [],
+                "presets": [],
+                "triggers": [
+                    {
+                        "alarmDirection": "leftToRight",
+                        "type": "fence",
+                        "vertices": [[0, -0.7], [0, 0.7]],
+                    }
+                ],
+                "type": "fence",
+            },
+        ],
+        "status": {},
+    },
+    "method": "getConfiguration",
+}
+
 PORT_MANAGEMENT_RESPONSE = {
     "apiVersion": "1.0",
     "method": "getPorts",
@@ -188,6 +248,9 @@ root.Properties.Image.Rotation=0,180
 root.Properties.System.SerialNumber=00408C12345
 """
 
+PTZ_RESPONSE = ""
+
+
 STREAM_PROFILES_RESPONSE = """root.StreamProfile.MaxGroups=26
 root.StreamProfile.S0.Description=profile_1_description
 root.StreamProfile.S0.Name=profile_1
@@ -220,6 +283,8 @@ async def vapix_request(self, session, url, **kwargs):
         return PORTS_RESPONSE
     if PROPERTIES_URL in url:
         return PROPERTIES_RESPONSE
+    if PTZ_URL in url:
+        return PTZ_RESPONSE
     if STREAM_PROFILES_URL in url:
         return STREAM_PROFILES_RESPONSE
 

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -33,10 +33,12 @@ MAC = "00408C12345"
 MODEL = "model"
 NAME = "name"
 
+DEFAULT_HOST = "1.2.3.4"
+
 ENTRY_OPTIONS = {CONF_EVENTS: True}
 
 ENTRY_CONFIG = {
-    CONF_HOST: "1.2.3.4",
+    CONF_HOST: DEFAULT_HOST,
     CONF_USERNAME: "root",
     CONF_PASSWORD: "pass",
     CONF_PORT: 80,
@@ -187,31 +189,25 @@ root.StreamProfile.S1.Parameters=videocodec=h265
 """
 
 
-def mock_default_vapix_requests(respx: respx, host: str = "1.2.3.4") -> None:
+def mock_default_vapix_requests(respx: respx, host: str = DEFAULT_HOST) -> None:
     """Mock default Vapix requests responses."""
     respx.post(f"http://{host}:80/axis-cgi/apidiscovery.cgi").respond(
         json=API_DISCOVERY_RESPONSE,
-        headers={"Content-Type": "application/json"},
     )
     respx.post(f"http://{host}:80/axis-cgi/basicdeviceinfo.cgi").respond(
         json=BASIC_DEVICE_INFO_RESPONSE,
-        headers={"Content-Type": "application/json"},
     )
     respx.post(f"http://{host}:80/axis-cgi/io/portmanagement.cgi").respond(
         json=PORT_MANAGEMENT_RESPONSE,
-        headers={"Content-Type": "application/json"},
     )
     respx.post(f"http://{host}:80/axis-cgi/lightcontrol.cgi").respond(
         json=LIGHT_CONTROL_RESPONSE,
-        headers={"Content-Type": "application/json"},
     )
     respx.post(f"http://{host}:80/axis-cgi/mqtt/client.cgi").respond(
         json=MQTT_CLIENT_RESPONSE,
-        headers={"Content-Type": "application/json"},
     )
     respx.post(f"http://{host}:80/axis-cgi/streamprofile.cgi").respond(
         json=STREAM_PROFILES_RESPONSE,
-        headers={"Content-Type": "application/json"},
     )
     respx.get(
         f"http://{host}:80/axis-cgi/param.cgi?action=list&group=root.Brand"
@@ -259,10 +255,7 @@ def mock_default_vapix_requests(respx: respx, host: str = "1.2.3.4") -> None:
         text=APPLICATIONS_LIST_RESPONSE,
         headers={"Content-Type": "text/xml"},
     )
-    respx.post(f"http://{host}:80/local/vmd/control.cgi").respond(
-        json=VMD4_RESPONSE,
-        headers={"Content-Type": "application/json"},
-    )
+    respx.post(f"http://{host}:80/local/vmd/control.cgi").respond(json=VMD4_RESPONSE)
 
 
 async def setup_axis_integration(hass, config=ENTRY_CONFIG, options=ENTRY_OPTIONS):

--- a/tests/components/axis/test_light.py
+++ b/tests/components/axis/test_light.py
@@ -74,7 +74,7 @@ async def test_lights(hass):
         "axis.light_control.LightControl.get_valid_intensity",
         return_value={"data": {"ranges": [{"high": 150}]}},
     ):
-        device.api.event.process_event(EVENT_ON)
+        device.api.event.update([EVENT_ON])
         await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(LIGHT_DOMAIN)) == 1
@@ -119,7 +119,7 @@ async def test_lights(hass):
         mock_deactivate.assert_called_once()
 
     # Event turn off light
-    device.api.event.process_event(EVENT_OFF)
+    device.api.event.update([EVENT_OFF])
     await hass.async_block_till_done()
 
     light_0 = hass.states.get(entity_id)

--- a/tests/components/axis/test_switch.py
+++ b/tests/components/axis/test_switch.py
@@ -68,8 +68,7 @@ async def test_switches_with_port_cgi(hass):
     device.api.vapix.ports["0"].close = AsyncMock()
     device.api.vapix.ports["1"].name = ""
 
-    for event in EVENTS:
-        device.api.event.process_event(event)
+    device.api.event.update(EVENTS)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2
@@ -116,8 +115,7 @@ async def test_switches_with_port_management(hass):
     device.api.vapix.ports["0"].close = AsyncMock()
     device.api.vapix.ports["1"].name = ""
 
-    for event in EVENTS:
-        device.api.event.process_event(event)
+    device.api.event.update(EVENTS)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Library changes: https://github.com/Kane610/axis/compare/v41...v42
https://github.com/Kane610/axis/releases/tag/v42

It looks like a lot but it is primarily refactoring, code clean up and improved tests.
There are no real new features introduced by library that is utilized in this PR.

Use respx helper.
Improve tests by using respx to mock web requests rather than catch all mock calls.
Ignore new supported events which does not yet have proper functionality in the integration.
Take name from object analytics API if exist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
