### PR TITLE
Add reminder support to todoist.new_task service

### DIFF
--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -189,7 +189,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 due_date = datetime(due.year, due.month, due.day)
             # Format it in the manner Todoist expects
             due_date = dt.as_utc(due_date)
-            date_format = "%Y-%m-%dT%H:%M"
+            date_format = "%Y-%m-%dT%H:%M%S"
             due_date = datetime.strftime(due_date, date_format)
             _due["date"] = due_date
 

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -210,7 +210,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 due_date = datetime(due.year, due.month, due.day)
             # Format it in the manner Todoist expects
             due_date = dt.as_utc(due_date)
-            date_format = "%Y-%m-%dT%H:%M"
+            date_format = "%Y-%m-%dT%H:%M:%S"
             due_date = datetime.strftime(due_date, date_format)
             _reminder_due["date"] = due_date
 

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -39,6 +39,9 @@ from .const import (
     PROJECT_ID,
     PROJECT_NAME,
     PROJECTS,
+    REMINDER_DATE,
+    REMINDER_DATE_LANG,
+    REMINDER_DATE_STRING,
     SERVICE_NEW_TASK,
     START,
     SUMMARY,
@@ -56,6 +59,11 @@ NEW_TASK_SERVICE_SCHEMA = vol.Schema(
         vol.Exclusive(DUE_DATE_STRING, "due_date"): cv.string,
         vol.Optional(DUE_DATE_LANG): vol.All(cv.string, vol.In(DUE_DATE_VALID_LANGS)),
         vol.Exclusive(DUE_DATE, "due_date"): cv.string,
+        vol.Exclusive(REMINDER_DATE_STRING, "reminder_date"): cv.string,
+        vol.Optional(REMINDER_DATE_LANG): vol.All(
+            cv.string, vol.In(DUE_DATE_VALID_LANGS)
+        ),
+        vol.Exclusive(REMINDER_DATE, "reminder_date"): cv.string,
     }
 )
 
@@ -187,6 +195,27 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         if _due:
             item.update(due=_due)
+
+        _reminder_due: dict = {}
+        if REMINDER_DATE_STRING in call.data:
+            _reminder_due["string"] = call.data[REMINDER_DATE_STRING]
+
+        if REMINDER_DATE_LANG in call.data:
+            _reminder_due["lang"] = call.data[REMINDER_DATE_LANG]
+
+        if REMINDER_DATE in call.data:
+            due_date = dt.parse_datetime(call.data[REMINDER_DATE])
+            if due_date is None:
+                due = dt.parse_date(call.data[REMINDER_DATE])
+                due_date = datetime(due.year, due.month, due.day)
+            # Format it in the manner Todoist expects
+            due_date = dt.as_utc(due_date)
+            date_format = "%Y-%m-%dT%H:%M"
+            due_date = datetime.strftime(due_date, date_format)
+            _reminder_due["date"] = due_date
+
+        if _reminder_due:
+            api.reminders.add(item["id"], due=_reminder_due)
 
         # Commit changes
         api.commit()

--- a/homeassistant/components/todoist/const.py
+++ b/homeassistant/components/todoist/const.py
@@ -24,6 +24,10 @@ DUE = "due"
 DUE_DATE_STRING = "due_date_string"
 # Service Call: The language of DUE_DATE_STRING
 DUE_DATE_LANG = "due_date_lang"
+# Service Call: When should user be reminded of this task (in natural language)?
+REMINDER_DATE_STRING = "reminder_date_string"
+# Service Call: The language of REMINDER_DATE_STRING
+REMINDER_DATE_LANG = "reminder_date_lang"
 # Service Call: The available options of DUE_DATE_LANG
 DUE_DATE_VALID_LANGS = [
     "en",
@@ -44,6 +48,8 @@ DUE_DATE_VALID_LANGS = [
 # Attribute: When is this task due?
 # Service Call: When is this task due?
 DUE_DATE = "due_date"
+# Service Call: When should user be reminded of this task?
+REMINDER_DATE = "reminder_date"
 # Attribute: Is this task due today?
 DUE_TODAY = "due_today"
 # Calendar Platform: When a calendar event ends

--- a/homeassistant/components/todoist/services.yaml
+++ b/homeassistant/components/todoist/services.yaml
@@ -29,5 +29,5 @@ new_task:
       description: The language of reminder_date_string.
       example: en
     reminder_date:
-      description: When should user be reminded of this task, in format YYYY-MM-DD.
-      example: "2019-10-22"
+      description: When should user be reminded of this task, in format YYYY-MM-DDTHH:MM:SS, in UTC timezone.
+      example: "2019-10-22T10:30:00"

--- a/homeassistant/components/todoist/services.yaml
+++ b/homeassistant/components/todoist/services.yaml
@@ -20,7 +20,7 @@ new_task:
       description: The language of due_date_string.
       example: en
     due_date:
-      description: The day this task is due, in format YYYY-MM-DD.
+      description: The time this task is due, in format YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS, in UTC timezone.
       example: "2019-10-22"
     reminder_date_string:
       description: When should user be reminded of this task, in natural language.

--- a/homeassistant/components/todoist/services.yaml
+++ b/homeassistant/components/todoist/services.yaml
@@ -22,3 +22,12 @@ new_task:
     due_date:
       description: The day this task is due, in format YYYY-MM-DD.
       example: "2019-10-22"
+    reminder_date_string:
+      description: When should user be reminded of this task, in natural language.
+      example: Tomorrow
+    reminder_date_lang:
+      description: The language of reminder_date_string.
+      example: en
+    reminder_date:
+      description: When should user be reminded of this task, in format YYYY-MM-DD.
+      example: "2019-10-22"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Change adds [reminder](https://get.todoist.help/hc/en-us/articles/205348301-Reminders) support to `todoist.new_task` service. Parameters mirror due date parameters, except that they set the reminder, not due date.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/15884

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. (But there is also no test for existing todoist code)

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
