### PR TITLE
Add torrent id to Transmission events

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -332,37 +332,41 @@ class TransmissionData:
     def check_completed_torrent(self):
         """Get completed torrent functionality."""
         current_completed_torrents = [
-            var for var in self.torrents if var.status == "seeding"
+            torrent for torrent in self.torrents if torrent.status == "seeding"
         ]
         freshly_completed_torrents = set(current_completed_torrents).difference(
             self.completed_torrents
         )
         self.completed_torrents = current_completed_torrents
 
-        for var in freshly_completed_torrents:
+        for torrent in freshly_completed_torrents:
             self.hass.bus.fire(
-                EVENT_DOWNLOADED_TORRENT, {"name": var.name, "id": var.id}
+                EVENT_DOWNLOADED_TORRENT, {"name": torrent.name, "id": torrent.id}
             )
 
     def check_started_torrent(self):
         """Get started torrent functionality."""
         current_started_torrents = [
-            var for var in self.torrents if var.status == "downloading"
+            torrent for torrent in self.torrents if torrent.status == "downloading"
         ]
         freshly_started_torrents = set(current_started_torrents).difference(
             self.started_torrents
         )
         self.started_torrents = current_started_torrents
 
-        for var in freshly_started_torrents:
-            self.hass.bus.fire(EVENT_STARTED_TORRENT, {"name": var.name, "id": var.id})
+        for torrent in freshly_started_torrents:
+            self.hass.bus.fire(
+                EVENT_STARTED_TORRENT, {"name": torrent.name, "id": torrent.id}
+            )
 
     def check_removed_torrent(self):
         """Get removed torrent functionality."""
         freshly_removed_torrents = set(self.all_torrents).difference(self.torrents)
         self.all_torrents = self.torrents
-        for var in freshly_removed_torrents:
-            self.hass.bus.fire(EVENT_REMOVED_TORRENT, {"name": var.name, "id": var.id})
+        for torrent in freshly_removed_torrents:
+            self.hass.bus.fire(
+                EVENT_REMOVED_TORRENT, {"name": torrent.name, "id": torrent.id}
+            )
 
     def start_torrents(self):
         """Start all torrents."""

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -331,44 +331,38 @@ class TransmissionData:
 
     def check_completed_torrent(self):
         """Get completed torrent functionality."""
-        actual_torrents = self.torrents
-        actual_completed_torrents = [
-            var.name for var in actual_torrents if var.status == "seeding"
+        current_completed_torrents = [
+            var for var in self.torrents if var.status == "seeding"
         ]
-
-        tmp_completed_torrents = list(
-            set(actual_completed_torrents).difference(self.completed_torrents)
+        freshly_completed_torrents = set(current_completed_torrents).difference(
+            self.completed_torrents
         )
+        self.completed_torrents = current_completed_torrents
 
-        for var in tmp_completed_torrents:
-            self.hass.bus.fire(EVENT_DOWNLOADED_TORRENT, {"name": var})
-
-        self.completed_torrents = actual_completed_torrents
+        for var in freshly_completed_torrents:
+            self.hass.bus.fire(
+                EVENT_DOWNLOADED_TORRENT, {"name": var.name, "id": var.id}
+            )
 
     def check_started_torrent(self):
         """Get started torrent functionality."""
-        actual_torrents = self.torrents
-        actual_started_torrents = [
-            var.name for var in actual_torrents if var.status == "downloading"
+        current_started_torrents = [
+            var for var in self.torrents if var.status == "downloading"
         ]
-
-        tmp_started_torrents = list(
-            set(actual_started_torrents).difference(self.started_torrents)
+        freshly_started_torrents = set(current_started_torrents).difference(
+            self.started_torrents
         )
+        self.started_torrents = current_started_torrents
 
-        for var in tmp_started_torrents:
-            self.hass.bus.fire(EVENT_STARTED_TORRENT, {"name": var})
-        self.started_torrents = actual_started_torrents
+        for var in freshly_started_torrents:
+            self.hass.bus.fire(EVENT_STARTED_TORRENT, {"name": var.name, "id": var.id})
 
     def check_removed_torrent(self):
         """Get removed torrent functionality."""
-        actual_torrents = self.torrents
-        actual_all_torrents = [var.name for var in actual_torrents]
-
-        removed_torrents = list(set(self.all_torrents).difference(actual_all_torrents))
-        for var in removed_torrents:
-            self.hass.bus.fire(EVENT_REMOVED_TORRENT, {"name": var})
-        self.all_torrents = actual_all_torrents
+        freshly_removed_torrents = set(self.all_torrents).difference(self.torrents)
+        self.all_torrents = self.torrents
+        for var in freshly_removed_torrents:
+            self.hass.bus.fire(EVENT_REMOVED_TORRENT, {"name": var.name, "id": var.id})
 
     def start_torrents(self):
         """Start all torrents."""

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -1,6 +1,7 @@
 """Support for the Transmission BitTorrent client API."""
 from datetime import timedelta
 import logging
+from typing import List
 
 import transmissionrpc
 from transmissionrpc.error import TransmissionError
@@ -152,13 +153,13 @@ class TransmissionClient:
         """Initialize the Transmission RPC API."""
         self.hass = hass
         self.config_entry = config_entry
-        self.tm_api = None
-        self._tm_data = None
+        self.tm_api = None  # type: transmissionrpc.Client
+        self._tm_data = None  # type: TransmissionData
         self.unsub_timer = None
 
     @property
-    def api(self):
-        """Return the tm_data object."""
+    def api(self) -> "TransmissionData":
+        """Return the TransmissionData object."""
         return self._tm_data
 
     async def async_setup(self):
@@ -278,18 +279,18 @@ class TransmissionClient:
 class TransmissionData:
     """Get the latest data and update the states."""
 
-    def __init__(self, hass, config, api):
+    def __init__(self, hass, config, api: transmissionrpc.Client):
         """Initialize the Transmission RPC API."""
         self.hass = hass
         self.config = config
-        self.data = None
-        self.torrents = []
-        self.session = None
-        self.available = True
-        self._api = api
-        self.completed_torrents = []
-        self.started_torrents = []
-        self.all_torrents = []
+        self.data = None  # type: transmissionrpc.Session
+        self.available = True  # type: bool
+        self._all_torrents = []  # type: List[transmissionrpc.Torrent]
+        self._api = api  # type: transmissionrpc.Client
+        self._completed_torrents = []  # type: List[transmissionrpc.Torrent]
+        self._session = None  # type: transmissionrpc.Session
+        self._started_torrents = []  # type: List[transmissionrpc.Torrent]
+        self._torrents = []  # type: List[transmissionrpc.Torrent]
 
     @property
     def host(self):
@@ -301,12 +302,17 @@ class TransmissionData:
         """Update signal per transmission entry."""
         return f"{DATA_UPDATED}-{self.host}"
 
+    @property
+    def torrents(self) -> List[transmissionrpc.Torrent]:
+        """Get the list of torrents."""
+        return self._torrents
+
     def update(self):
         """Get the latest data from Transmission instance."""
         try:
             self.data = self._api.session_stats()
-            self.torrents = self._api.get_torrents()
-            self.session = self._api.get_session()
+            self._torrents = self._api.get_torrents()
+            self._session = self._api.get_session()
 
             self.check_completed_torrent()
             self.check_started_torrent()
@@ -321,23 +327,23 @@ class TransmissionData:
 
     def init_torrent_list(self):
         """Initialize torrent lists."""
-        self.torrents = self._api.get_torrents()
-        self.completed_torrents = [
-            x.name for x in self.torrents if x.status == "seeding"
+        self._torrents = self._api.get_torrents()
+        self._completed_torrents = [
+            torrent for torrent in self._torrents if torrent.status == "seeding"
         ]
-        self.started_torrents = [
-            x.name for x in self.torrents if x.status == "downloading"
+        self._started_torrents = [
+            torrent for torrent in self._torrents if torrent.status == "downloading"
         ]
 
     def check_completed_torrent(self):
         """Get completed torrent functionality."""
         current_completed_torrents = [
-            torrent for torrent in self.torrents if torrent.status == "seeding"
+            torrent for torrent in self._torrents if torrent.status == "seeding"
         ]
         freshly_completed_torrents = set(current_completed_torrents).difference(
-            self.completed_torrents
+            self._completed_torrents
         )
-        self.completed_torrents = current_completed_torrents
+        self._completed_torrents = current_completed_torrents
 
         for torrent in freshly_completed_torrents:
             self.hass.bus.fire(
@@ -347,12 +353,12 @@ class TransmissionData:
     def check_started_torrent(self):
         """Get started torrent functionality."""
         current_started_torrents = [
-            torrent for torrent in self.torrents if torrent.status == "downloading"
+            torrent for torrent in self._torrents if torrent.status == "downloading"
         ]
         freshly_started_torrents = set(current_started_torrents).difference(
-            self.started_torrents
+            self._started_torrents
         )
-        self.started_torrents = current_started_torrents
+        self._started_torrents = current_started_torrents
 
         for torrent in freshly_started_torrents:
             self.hass.bus.fire(
@@ -361,8 +367,8 @@ class TransmissionData:
 
     def check_removed_torrent(self):
         """Get removed torrent functionality."""
-        freshly_removed_torrents = set(self.all_torrents).difference(self.torrents)
-        self.all_torrents = self.torrents
+        freshly_removed_torrents = set(self._all_torrents).difference(self._torrents)
+        self._all_torrents = self._torrents
         for torrent in freshly_removed_torrents:
             self.hass.bus.fire(
                 EVENT_REMOVED_TORRENT, {"name": torrent.name, "id": torrent.id}
@@ -370,13 +376,13 @@ class TransmissionData:
 
     def start_torrents(self):
         """Start all torrents."""
-        if len(self.torrents) <= 0:
+        if len(self._torrents) <= 0:
             return
         self._api.start_all()
 
     def stop_torrents(self):
         """Stop all active torrents."""
-        torrent_ids = [torrent.id for torrent in self.torrents]
+        torrent_ids = [torrent.id for torrent in self._torrents]
         self._api.stop_torrent(torrent_ids)
 
     def set_alt_speed_enabled(self, is_enabled):
@@ -385,7 +391,7 @@ class TransmissionData:
 
     def get_alt_speed_enabled(self):
         """Get the alternative speed flag."""
-        if self.session is None:
+        if self._session is None:
             return None
 
-        return self.session.alt_speed_enabled
+        return self._session.alt_speed_enabled

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -1,9 +1,14 @@
 """Support for monitoring the Transmission BitTorrent client API."""
+from typing import List
+
+from transmissionrpc.torrent import Torrent
+
 from homeassistant.const import CONF_NAME, DATA_RATE_MEGABYTES_PER_SECOND, STATE_IDLE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
+from . import TransmissionClient
 from .const import (
     CONF_LIMIT,
     CONF_ORDER,
@@ -38,7 +43,7 @@ class TransmissionSensor(Entity):
 
     def __init__(self, tm_client, client_name, sensor_name, sub_type=None):
         """Initialize the sensor."""
-        self._tm_client = tm_client
+        self._tm_client = tm_client  # type: TransmissionClient
         self._client_name = client_name
         self._name = sensor_name
         self._sub_type = sub_type
@@ -165,7 +170,7 @@ class TransmissionTorrentsSensor(TransmissionSensor):
         self._state = len(torrents)
 
 
-def _filter_torrents(torrents, statuses=None):
+def _filter_torrents(torrents: List[Torrent], statuses=None) -> List[Torrent]:
     return [
         torrent
         for torrent in torrents


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make torrent "id" attribute available in fired events as requested here: https://community.home-assistant.io/t/transmission-add-torrent-id-to-event-data/254822

Eliminate unnecessary cast to lists, iterate sets directly.

Update objects before firing event that says they were updated!

Clarify existing code with better variable names and make consistent across the three methods that check for changes and fire events.

TODO:
- ~~update docs - @AlecRust can you look at this?  I don't use events so I am not sure how to explain it!~~
- next PR use device triggers?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15905

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
