### PR TITLE
Fix Fan support in nest climate by adding HVAC_MODE_FAN_ONLY support

### DIFF
--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -294,7 +294,6 @@ class ThermostatEntity(ClimateEntity):
         """Set new target hvac mode."""
         if hvac_mode not in self.hvac_modes:
             raise ValueError(f"Unsupported hvac_mode '{hvac_mode}'")
-            return
         if hvac_mode == HVAC_MODE_FAN_ONLY:
             await self.async_set_fan_mode(FAN_ON)
             return

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -23,6 +23,7 @@ from homeassistant.components.climate.const import (
     FAN_ON,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
+    HVAC_MODE_FAN_ONLY,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
@@ -196,11 +197,14 @@ class ThermostatEntity(ClimateEntity):
     @property
     def hvac_mode(self):
         """Return the current operation (e.g. heat, cool, idle)."""
+        hvac_mode = HVAC_MODE_OFF
         if ThermostatModeTrait.NAME in self._device.traits:
             trait = self._device.traits[ThermostatModeTrait.NAME]
             if trait.mode in THERMOSTAT_MODE_MAP:
-                return THERMOSTAT_MODE_MAP[trait.mode]
-        return HVAC_MODE_OFF
+                hvac_mode = THERMOSTAT_MODE_MAP[trait.mode]
+        if hvac_mode == HVAC_MODE_OFF and self.fan_mode == FAN_ON:
+            hvac_mode = HVAC_MODE_FAN_ONLY
+        return hvac_mode
 
     @property
     def hvac_modes(self):
@@ -209,6 +213,8 @@ class ThermostatEntity(ClimateEntity):
         for mode in self._get_device_hvac_modes:
             if mode in THERMOSTAT_MODE_MAP:
                 supported_modes.append(THERMOSTAT_MODE_MAP[mode])
+        if self.supported_features & SUPPORT_FAN_MODE:
+            supported_modes.append(HVAC_MODE_FAN_ONLY)
         return supported_modes
 
     @property
@@ -288,6 +294,10 @@ class ThermostatEntity(ClimateEntity):
         """Set new target hvac mode."""
         if hvac_mode not in self.hvac_modes:
             raise ValueError(f"Unsupported hvac_mode '{hvac_mode}'")
+            return
+        if hvac_mode == HVAC_MODE_FAN_ONLY:
+            await self.async_set_fan_mode(FAN_ON)
+            return
         api_mode = THERMOSTAT_INV_MODE_MAP[hvac_mode]
         trait = self._device.traits[ThermostatModeTrait.NAME]
         await trait.set_mode(api_mode)

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -295,8 +295,9 @@ class ThermostatEntity(ClimateEntity):
         if hvac_mode not in self.hvac_modes:
             raise ValueError(f"Unsupported hvac_mode '{hvac_mode}'")
         if hvac_mode == HVAC_MODE_FAN_ONLY:
+            # Turn the fan on but also turn off the hvac if it is on
             await self.async_set_fan_mode(FAN_ON)
-            return
+            hvac_mode = HVAC_MODE_OFF
         api_mode = THERMOSTAT_INV_MODE_MAP[hvac_mode]
         trait = self._device.traits[ThermostatModeTrait.NAME]
         await trait.set_mode(api_mode)

--- a/tests/components/nest/climate_sdm_test.py
+++ b/tests/components/nest/climate_sdm_test.py
@@ -931,11 +931,21 @@ async def test_thermostat_set_hvac_fan_only(hass, auth):
     await common.async_set_hvac_mode(hass, HVAC_MODE_FAN_ONLY)
     await hass.async_block_till_done()
 
-    assert auth.method == "post"
-    assert auth.url == "some-device-id:executeCommand"
-    assert auth.json == {
+    assert len(auth.captured_requests) == 2
+
+    (method, url, json) = auth.captured_requests.pop(0)
+    assert method == "post"
+    assert url == "some-device-id:executeCommand"
+    assert json == {
         "command": "sdm.devices.commands.Fan.SetTimer",
         "params": {"timerMode": "ON"},
+    }
+    (method, url, json) = auth.captured_requests.pop(0)
+    assert method == "post"
+    assert url == "some-device-id:executeCommand"
+    assert json == {
+        "command": "sdm.devices.commands.ThermostatMode.SetMode",
+        "params": {"mode": "OFF"},
     }
 
 

--- a/tests/components/nest/climate_sdm_test.py
+++ b/tests/components/nest/climate_sdm_test.py
@@ -27,6 +27,7 @@ from homeassistant.components.climate.const import (
     FAN_ON,
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
@@ -699,6 +700,7 @@ async def test_thermostat_fan_off(hass):
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
+        HVAC_MODE_FAN_ONLY,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_OFF
@@ -730,13 +732,49 @@ async def test_thermostat_fan_on(hass):
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_OFF
+    assert thermostat.state == HVAC_MODE_FAN_ONLY
     assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_OFF
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
+        HVAC_MODE_FAN_ONLY,
+        HVAC_MODE_OFF,
+    }
+    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
+    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+
+
+async def test_thermostat_cool_with_fan(hass):
+    """Test a thermostat cooling while the fan is on."""
+    await setup_climate(
+        hass,
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "ON",
+                "timerTimeout": "2019-05-10T03:22:54Z",
+            },
+            "sdm.devices.traits.ThermostatHvac": {
+                "status": "OFF",
+            },
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": "COOL",
+            },
+        },
+    )
+
+    assert len(hass.states.async_all()) == 1
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.state == HVAC_MODE_COOL
+    assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_OFF
+    assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
+        HVAC_MODE_HEAT,
+        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT_COOL,
+        HVAC_MODE_FAN_ONLY,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
@@ -766,7 +804,7 @@ async def test_thermostat_set_fan(hass, auth):
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_OFF
+    assert thermostat.state == HVAC_MODE_FAN_ONLY
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
     assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
 
@@ -845,13 +883,14 @@ async def test_thermostat_invalid_fan_mode(hass):
     assert len(hass.states.async_all()) == 1
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
-    assert thermostat.state == HVAC_MODE_OFF
+    assert thermostat.state == HVAC_MODE_FAN_ONLY
     assert thermostat.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_OFF
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVAC_MODE_HEAT,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT_COOL,
+        HVAC_MODE_FAN_ONLY,
         HVAC_MODE_OFF,
     }
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_ON
@@ -860,6 +899,44 @@ async def test_thermostat_invalid_fan_mode(hass):
     with pytest.raises(ValueError):
         await common.async_set_fan_mode(hass, FAN_LOW)
         await hass.async_block_till_done()
+
+
+async def test_thermostat_set_hvac_fan_only(hass, auth):
+    """Test a thermostat enabling the fan via hvac_mode."""
+    await setup_climate(
+        hass,
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "OFF",
+                "timerTimeout": "2019-05-10T03:22:54Z",
+            },
+            "sdm.devices.traits.ThermostatHvac": {
+                "status": "OFF",
+            },
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": "OFF",
+            },
+        },
+        auth=auth,
+    )
+
+    assert len(hass.states.async_all()) == 1
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.state == HVAC_MODE_OFF
+    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_OFF
+    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+
+    await common.async_set_hvac_mode(hass, HVAC_MODE_FAN_ONLY)
+    await hass.async_block_till_done()
+
+    assert auth.method == "post"
+    assert auth.url == "some-device-id:executeCommand"
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {"timerMode": "ON"},
+    }
 
 
 async def test_thermostat_target_temp(hass, auth):

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -14,19 +14,18 @@ class FakeAuth(AbstractAuth):
     from the API.
     """
 
-    # Tests can set fake responses here.
-    responses = []
-    # The last request is recorded here.
-    method = None
-    url = None
-    json = None
-
-    # Set up by fixture
-    client = None
-
     def __init__(self):
         """Initialize FakeAuth."""
         super().__init__(None, None)
+        # Tests can set fake responses here.
+        self.responses = []
+        # The last request is recorded here.
+        self.method = None
+        self.url = None
+        self.json = None
+        self.captured_requests = []
+        # Set up by fixture
+        self.client = None
 
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
@@ -37,6 +36,7 @@ class FakeAuth(AbstractAuth):
         self.method = method
         self.url = url
         self.json = json
+        self.captured_requests.append((method, url, json))
         return await self.client.get("/")
 
     async def response_handler(self, request):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for `hvac_mode` of `HVAC_MODE_FAN_ONLY` which is equivalent to setting the `fan_mode` to `FAN_ON`.

The impact of setting this is the fan shows up as a button on the climate card in lovelace.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44045
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
