### PR TITLE
Add options flow for Recollect Waste

### DIFF
--- a/homeassistant/components/recollect_waste/__init__.py
+++ b/homeassistant/components/recollect_waste/__init__.py
@@ -14,6 +14,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DATA_COORDINATOR, DOMAIN, LOGGER
 
+DATA_LISTENER = "listener"
+
 DEFAULT_NAME = "recollect_waste"
 DEFAULT_UPDATE_INTERVAL = timedelta(days=1)
 
@@ -22,7 +24,7 @@ PLATFORMS = ["sensor"]
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the RainMachine component."""
-    hass.data[DOMAIN] = {DATA_COORDINATOR: {}}
+    hass.data[DOMAIN] = {DATA_COORDINATOR: {}, DATA_LISTENER: {}}
     return True
 
 
@@ -64,7 +66,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
 
+    hass.data[DOMAIN][DATA_LISTENER][entry.entry_id] = entry.add_update_listener(
+        async_reload_entry
+    )
+
     return True
+
+
+async def async_reload_entry(hass, config_entry):
+    """Handle an options update."""
+    await hass.config_entries.async_reload(config_entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -79,5 +90,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     if unload_ok:
         hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
+        cancel_listener = hass.data[DOMAIN][DATA_LISTENER].pop(entry.entry_id)
+        cancel_listener()
 
     return unload_ok

--- a/homeassistant/components/recollect_waste/__init__.py
+++ b/homeassistant/components/recollect_waste/__init__.py
@@ -73,9 +73,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_reload_entry(hass, config_entry):
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Handle an options update."""
-    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -5,7 +5,12 @@ from aiorecollect.client import Client
 from aiorecollect.errors import RecollectError
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant.config_entries import (
+    CONN_CLASS_CLOUD_POLL,
+    ConfigEntry,
+    ConfigFlow,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -22,17 +27,17 @@ DATA_SCHEMA = vol.Schema(
 )
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class ConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ReCollect Waste."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+    CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
 
     @staticmethod
     @callback
-    def async_get_options_flow(entry: config_entries.ConfigEntry):
+    def async_get_options_flow(config_entry: ConfigEntry) -> "OptionsFlow":
         """Define the config flow to handle options."""
-        return RecollectWasteOptionsFlowHandler(entry)
+        return RecollectWasteOptionsFlowHandler(config_entry)
 
     async def async_step_import(self, import_config: dict = None) -> dict:
         """Handle configuration via YAML import."""
@@ -74,10 +79,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
-class RecollectWasteOptionsFlowHandler(config_entries.OptionsFlow):
+class RecollectWasteOptionsFlowHandler(OptionsFlow):
     """Handle a Recollect Waste options flow."""
 
-    def __init__(self, entry: config_entries.ConfigEntry):
+    def __init__(self, entry: ConfigEntry):
         """Initialize."""
         self._entry = entry
 

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow for ReCollect Waste integration."""
+from typing import Optional
+
 from aiorecollect.client import Client
 from aiorecollect.errors import RecollectError
 import voluptuous as vol
@@ -28,9 +30,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(entry: config_entries.ConfigEntry):
         """Define the config flow to handle options."""
-        return RecollectWasteOptionsFlowHandler(config_entry)
+        return RecollectWasteOptionsFlowHandler(entry)
 
     async def async_step_import(self, import_config: dict = None) -> dict:
         """Handle configuration via YAML import."""
@@ -75,11 +77,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class RecollectWasteOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Recollect Waste options flow."""
 
-    def __init__(self, config_entry):
+    def __init__(self, entry: config_entries.ConfigEntry):
         """Initialize."""
-        self.config_entry = config_entry
+        self._entry = entry
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(self, user_input: Optional[dict] = None):
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
@@ -90,7 +92,7 @@ class RecollectWasteOptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Optional(
                         CONF_FRIENDLY_NAME,
-                        default=self.config_entry.options.get(CONF_FRIENDLY_NAME),
+                        default=self._entry.options.get(CONF_FRIENDLY_NAME),
                     ): bool
                 }
             ),

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -4,6 +4,8 @@ from aiorecollect.errors import RecollectError
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.const import CONF_FRIENDLY_NAME
+from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
 from .const import (  # pylint:disable=unused-import
@@ -23,6 +25,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Define the config flow to handle options."""
+        return RecollectWasteOptionsFlowHandler(config_entry)
 
     async def async_step_import(self, import_config: dict = None) -> dict:
         """Handle configuration via YAML import."""
@@ -61,4 +69,29 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PLACE_ID: user_input[CONF_PLACE_ID],
                 CONF_SERVICE_ID: user_input[CONF_SERVICE_ID],
             },
+        )
+
+
+class RecollectWasteOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a Recollect Waste options flow."""
+
+    def __init__(self, config_entry):
+        """Initialize."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_FRIENDLY_NAME,
+                        default=self.config_entry.options.get(CONF_FRIENDLY_NAME),
+                    ): bool
+                }
+            ),
         )

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -5,12 +5,7 @@ from aiorecollect.client import Client
 from aiorecollect.errors import RecollectError
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    CONN_CLASS_CLOUD_POLL,
-    ConfigEntry,
-    ConfigFlow,
-    OptionsFlow,
-)
+from homeassistant import config_entries
 from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -27,15 +22,17 @@ DATA_SCHEMA = vol.Schema(
 )
 
 
-class ConfigFlow(ConfigFlow, domain=DOMAIN):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ReCollect Waste."""
 
     VERSION = 1
-    CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> "OptionsFlow":
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
         """Define the config flow to handle options."""
         return RecollectWasteOptionsFlowHandler(config_entry)
 
@@ -79,10 +76,10 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
 
-class RecollectWasteOptionsFlowHandler(OptionsFlow):
+class RecollectWasteOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Recollect Waste options flow."""
 
-    def __init__(self, entry: ConfigEntry):
+    def __init__(self, entry: config_entries.ConfigEntry):
         """Initialize."""
         self._entry = entry
 

--- a/homeassistant/components/recollect_waste/strings.json
+++ b/homeassistant/components/recollect_waste/strings.json
@@ -14,5 +14,15 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure Recollect Waste",
+        "data": {
+          "friendly_name": "Use friendly names for pickup types (when possible)"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/recollect_waste/translations/en.json
+++ b/homeassistant/components/recollect_waste/translations/en.json
@@ -14,5 +14,15 @@
                 }
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "friendly_name": "Use friendly names for pickup types (when possible)"
+                },
+                "title": "Configure Recollect Waste"
+            }
+        }
     }
 }

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -53,6 +53,9 @@ async def test_options_flow(hass):
     config_entry = MockConfigEntry(domain=DOMAIN, unique_id="12345, 12345", data=conf)
     config_entry.add_to_hass(hass)
 
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
     with patch(
         "homeassistant.components.recollect_waste.async_setup_entry", return_value=True
     ):

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -53,12 +53,11 @@ async def test_options_flow(hass):
     config_entry = MockConfigEntry(domain=DOMAIN, unique_id="12345, 12345", data=conf)
     config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
     with patch(
         "homeassistant.components.recollect_waste.async_setup_entry", return_value=True
     ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -57,7 +57,6 @@ async def test_options_flow(hass):
         "homeassistant.components.recollect_waste.async_setup_entry", return_value=True
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant.components.recollect_waste import (
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_FRIENDLY_NAME
 
 from tests.async_mock import patch
 from tests.common import MockConfigEntry
@@ -43,6 +44,29 @@ async def test_invalid_place_or_service_id(hass):
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {"base": "invalid_place_or_service_id"}
+
+
+async def test_options_flow(hass):
+    """Test config flow options."""
+    conf = {CONF_PLACE_ID: "12345", CONF_SERVICE_ID: "12345"}
+
+    config_entry = MockConfigEntry(domain=DOMAIN, unique_id="12345, 12345", data=conf)
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.recollect_waste.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_FRIENDLY_NAME: True}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert config_entry.options == {CONF_FRIENDLY_NAME: True}
 
 
 async def test_show_form(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a config options flow to Recollect Waste and exposes one option to start: the ability to display pickup types by their human-friendly names (if they exist).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
