### PR TITLE
Bump pyps4-2ndscreen to 1.2.0

### DIFF
--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -23,6 +23,7 @@ CONF_MODE = "Config Mode"
 CONF_AUTO = "Auto Discover"
 CONF_MANUAL = "Manual Entry"
 
+LOCAL_UDP_PORT = 1988
 UDP_PORT = 987
 TCP_PORT = 997
 PORT_MSG = {UDP_PORT: "port_987_bind_error", TCP_PORT: "port_997_bind_error"}
@@ -107,8 +108,9 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
         if user_input is None:
             # Search for device.
+            # If LOCAL_UDP_PORT cannot be used, a random port will be selected.
             devices = await self.hass.async_add_executor_job(
-                self.helper.has_devices, self.m_device
+                self.helper.has_devices, self.m_device, LOCAL_UDP_PORT
             )
 
             # Abort if can't find device.
@@ -147,7 +149,12 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             self.host = user_input[CONF_IP_ADDRESS]
 
             is_ready, is_login = await self.hass.async_add_executor_job(
-                self.helper.link, self.host, self.creds, self.pin, DEFAULT_ALIAS
+                self.helper.link,
+                self.host,
+                self.creds,
+                self.pin,
+                DEFAULT_ALIAS,
+                LOCAL_UDP_PORT,
             )
 
             if is_ready is False:

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -3,6 +3,6 @@
   "name": "Sony PlayStation 4",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ps4",
-  "requirements": ["pyps4-2ndscreen==1.1.1"],
+  "requirements": ["pyps4-2ndscreen==1.2.0"],
   "codeowners": ["@ktnrg45"]
 }

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 from pyps4_2ndscreen.errors import NotReady, PSDataIncomplete
+from pyps4_2ndscreen.media_art import TYPE_APP as PS_TYPE_APP
 import pyps4_2ndscreen.ps4 as pyps4
 
 from homeassistant.components.media_player import MediaPlayerEntity
@@ -262,7 +263,7 @@ class PS4Device(MediaPlayerEntity):
                 app_name = title.name
                 art = title.cover_art
                 # Assume media type is game if not app.
-                if title.game_type != "App":
+                if title.game_type != PS_TYPE_APP:
                     media_type = MEDIA_TYPE_GAME
                 else:
                     media_type = MEDIA_TYPE_APP

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1622,7 +1622,7 @@ pypoint==2.0.0
 pyprof2calltree==1.4.5
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.1.1
+pyps4-2ndscreen==1.2.0
 
 # homeassistant.components.qvr_pro
 pyqvrpro==0.52

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -823,7 +823,7 @@ pypoint==2.0.0
 pyprof2calltree==1.4.5
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.1.1
+pyps4-2ndscreen==1.2.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components import ps4
+from homeassistant.components.ps4.config_flow import LOCAL_UDP_PORT
 from homeassistant.components.ps4.const import (
     DEFAULT_ALIAS,
     DEFAULT_NAME,
@@ -360,7 +361,7 @@ async def test_0_pin(hass):
             result["flow_id"], mock_config
         )
     mock_call.assert_called_once_with(
-        MOCK_HOST, MOCK_CREDS, MOCK_CODE_LEAD_0_STR, DEFAULT_ALIAS
+        MOCK_HOST, MOCK_CREDS, MOCK_CODE_LEAD_0_STR, DEFAULT_ALIAS, LOCAL_UDP_PORT
     )
 
 

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -1,5 +1,7 @@
 """Tests for the PS4 media player platform."""
 from pyps4_2ndscreen.credential import get_ddp_message
+from pyps4_2ndscreen.ddp import DEFAULT_UDP_PORT
+from pyps4_2ndscreen.media_art import TYPE_APP as PS_TYPE_APP
 
 from homeassistant.components import ps4
 from homeassistant.components.media_player.const import (
@@ -8,6 +10,7 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_TITLE,
+    MEDIA_TYPE_APP,
     MEDIA_TYPE_GAME,
 )
 from homeassistant.components.ps4.const import (
@@ -149,7 +152,7 @@ async def setup_mock_component(hass, entry=None):
 async def mock_ddp_response(hass, mock_status_data):
     """Mock raw UDP response from device."""
     mock_protocol = hass.data[PS4_DATA].protocol
-
+    assert mock_protocol.local_port == DEFAULT_UDP_PORT
     mock_code = mock_status_data.get("status_code")
     mock_status = mock_status_data.get("status")
     mock_status_header = f"{mock_code} {mock_status}"
@@ -224,7 +227,7 @@ async def test_media_attributes_are_fetched(hass):
     mock_result = MagicMock()
     mock_result.name = MOCK_TITLE_NAME
     mock_result.cover_art = MOCK_TITLE_ART_URL
-    mock_result.game_type = "game"
+    mock_result.game_type = "not_an_app"
 
     with patch(mock_func, return_value=mock_result) as mock_fetch:
         await mock_ddp_response(hass, MOCK_STATUS_PLAYING)
@@ -240,6 +243,21 @@ async def test_media_attributes_are_fetched(hass):
     assert mock_attrs.get(ATTR_MEDIA_CONTENT_ID) == MOCK_TITLE_ID
     assert mock_attrs.get(ATTR_MEDIA_TITLE) == MOCK_TITLE_NAME
     assert mock_attrs.get(ATTR_MEDIA_CONTENT_TYPE) == MOCK_TITLE_TYPE
+
+    # Change state so that the next fetch is called.
+    await mock_ddp_response(hass, MOCK_STATUS_STANDBY)
+
+    # Test that content type of app is set.
+    mock_result.game_type = PS_TYPE_APP
+
+    with patch(mock_func, return_value=mock_result) as mock_fetch_app:
+        await mock_ddp_response(hass, MOCK_STATUS_PLAYING)
+
+    mock_state = hass.states.get(mock_entity_id)
+    mock_attrs = dict(mock_state.attributes)
+
+    assert len(mock_fetch_app.mock_calls) == 1
+    assert mock_attrs.get(ATTR_MEDIA_CONTENT_TYPE) == MEDIA_TYPE_APP
 
 
 async def test_media_attributes_are_loaded(hass, patch_load_json):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- **Improves media/title data retrieval speed and accuracy**
Each retrieval only requires one request now. Utilizes different REST API in which data is retrieved by the title_id rather than searching with the title name. The new API also attempts to resolve with mismatched title_ids and regions. 

- **Set default local polling UDP port to 1987 (in dependency); Config flow set to 1988**
This is to provide the capability to firewall traffic via ports. If the default ports cannot be used, the ports will fallback to a random port.

- **Improves device discovery used in config flow**

Release notes:

1.2.0: https://github.com/ktnrg45/pyps4-2ndscreen/releases/tag/1.2.0
Compare: https://github.com/ktnrg45/pyps4-2ndscreen/compare/1.1.1...1.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
TODO: Will update docs after review.

- This PR fixes or closes issue: fixes #41688
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#15947

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
