### PR TITLE
Update ReCollect docs to use proper name

### DIFF
--- a/homeassistant/components/recollect_waste/__init__.py
+++ b/homeassistant/components/recollect_waste/__init__.py
@@ -1,4 +1,4 @@
-"""The Recollect Waste integration."""
+"""The ReCollect Waste integration."""
 import asyncio
 from datetime import date, timedelta
 from typing import List
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         except RecollectError as err:
             raise UpdateFailed(
-                f"Error while requesting data from Recollect: {err}"
+                f"Error while requesting data from ReCollect: {err}"
             ) from err
 
     coordinator = DataUpdateCoordinator(

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Recollect Waste integration."""
+"""Config flow for ReCollect Waste integration."""
 from aiorecollect.client import Client
 from aiorecollect.errors import RecollectError
 import voluptuous as vol
@@ -19,7 +19,7 @@ DATA_SCHEMA = vol.Schema(
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Recollect Waste."""
+    """Handle a config flow for ReCollect Waste."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL

--- a/homeassistant/components/recollect_waste/const.py
+++ b/homeassistant/components/recollect_waste/const.py
@@ -1,4 +1,4 @@
-"""Define Recollect Waste constants."""
+"""Define ReCollect Waste constants."""
 import logging
 
 DOMAIN = "recollect_waste"

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -1,4 +1,4 @@
-"""Support for Recollect Waste sensors."""
+"""Support for ReCollect Waste sensors."""
 from typing import Callable
 
 import voluptuous as vol
@@ -20,7 +20,7 @@ ATTR_AREA_NAME = "area_name"
 ATTR_NEXT_PICKUP_TYPES = "next_pickup_types"
 ATTR_NEXT_PICKUP_DATE = "next_pickup_date"
 
-DEFAULT_ATTRIBUTION = "Pickup data provided by Recollect Waste"
+DEFAULT_ATTRIBUTION = "Pickup data provided by ReCollect Waste"
 DEFAULT_NAME = "recollect_waste"
 DEFAULT_ICON = "mdi:trash-can-outline"
 
@@ -43,7 +43,7 @@ async def async_setup_platform(
 ):
     """Import Awair configuration from YAML."""
     LOGGER.warning(
-        "Loading Recollect Waste via platform setup is deprecated. "
+        "Loading ReCollect Waste via platform setup is deprecated. "
         "Please remove it from your configuration."
     )
     hass.async_create_task(
@@ -58,13 +58,13 @@ async def async_setup_platform(
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: Callable
 ) -> None:
-    """Set up Recollect Waste sensors based on a config entry."""
+    """Set up ReCollect Waste sensors based on a config entry."""
     coordinator = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id]
-    async_add_entities([RecollectWasteSensor(coordinator, entry)])
+    async_add_entities([ReCollectWasteSensor(coordinator, entry)])
 
 
-class RecollectWasteSensor(CoordinatorEntity):
-    """Recollect Waste Sensor."""
+class ReCollectWasteSensor(CoordinatorEntity):
+    """ReCollect Waste Sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, entry: ConfigEntry) -> None:
         """Initialize the sensor."""

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Define tests for the Recollect Waste config flow."""
+"""Define tests for the ReCollect Waste config flow."""
 from aiorecollect.errors import RecollectError
 
 from homeassistant import data_entry_flow


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The CTO of ReCollect Waste reached out to me today and asked that we make sure to use the proper name ("ReCollect" and not "Recollect"). This PR makes that adjustment.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15933

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
