### PR TITLE
Use callbacks instead of polling in nuki

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -616,7 +616,7 @@ omit =
     homeassistant/components/notify_events/notify.py
     homeassistant/components/nsw_fuel_station/sensor.py
     homeassistant/components/nuimo_controller/*
-    homeassistant/components/nuki/lock.py
+    homeassistant/components/nuki/*
     homeassistant/components/nut/sensor.py
     homeassistant/components/nx584/alarm_control_panel.py
     homeassistant/components/nzbget/coordinator.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -308,7 +308,7 @@ homeassistant/components/notion/* @bachya
 homeassistant/components/nsw_fuel_station/* @nickw444
 homeassistant/components/nsw_rural_fire_service_feed/* @exxamalte
 homeassistant/components/nuheat/* @bdraco
-homeassistant/components/nuki/* @pschmitt @pvizeli
+homeassistant/components/nuki/* @pschmitt @pvizeli @steinerl
 homeassistant/components/numato/* @clssn
 homeassistant/components/number/* @home-assistant/core @Shulyaka
 homeassistant/components/nut/* @bdraco

--- a/homeassistant/components/nuki/const.py
+++ b/homeassistant/components/nuki/const.py
@@ -1,0 +1,13 @@
+"""Nuki.io constants."""
+
+ATTR_BATTERY_CRITICAL = "battery_critical"
+ATTR_DATA = "data"
+ATTR_NUKI_ID = "nuki_id"
+ATTR_UNLATCH = "unlatch"
+
+
+DEFAULT_PORT = 8080
+DEFAULT_TIMEOUT = 20
+
+
+ERROR_STATES = (0, 254, 255)

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -2,6 +2,7 @@
   "domain": "nuki",
   "name": "Nuki",
   "documentation": "https://www.home-assistant.io/integrations/nuki",
-  "requirements": ["pynuki==1.3.8"],
-  "codeowners": ["@pschmitt", "@pvizeli"]
+  "requirements": ["pynuki==1.4.1"],
+  "dependencies": ["webhook"],
+  "codeowners": ["@pschmitt", "@pvizeli", "@steinerl"]
 }

--- a/homeassistant/components/nuki/webhook.py
+++ b/homeassistant/components/nuki/webhook.py
@@ -1,0 +1,43 @@
+"""Nuki.io webhook handling."""
+import logging
+
+from homeassistant.components.webhook import (
+    async_register as webhook_register,
+    async_unregister as webhook_unregister,
+)
+from homeassistant.const import CONF_WEBHOOK_ID, EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from . import DOMAIN
+from .const import ATTR_DATA, ATTR_NUKI_ID
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def register_webhook(hass, config):
+    """Register webhook handler."""
+    webhook_register(hass, DOMAIN, "Nuki", config[CONF_WEBHOOK_ID], handle_webhook)
+
+    async def cleanup(_):
+        webhook_unregister(hass, config[CONF_WEBHOOK_ID])
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+
+
+async def handle_webhook(hass, webhook_id, request):
+    """Handle webhook callback."""
+    try:
+        data = await request.json()
+    except ValueError as err:
+        _LOGGER.error("Error in data: %s", err)
+        return None
+
+    _LOGGER.debug("Got webhook data: %s", data)
+
+    nuki_id = data.get("nukiId")
+
+    async_dispatcher_send(
+        hass,
+        f"signal-{DOMAIN}-webhook-{nuki_id}",
+        {ATTR_NUKI_ID: nuki_id, ATTR_DATA: data},
+    )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1560,7 +1560,7 @@ pynetgear==0.6.1
 pynetio==0.1.9.1
 
 # homeassistant.components.nuki
-pynuki==1.3.8
+pynuki==1.4.1
 
 # homeassistant.components.nut
 pynut2==2.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the Nuki component polls for changes.
This PR switches the component from polling to webhooks/callbacks without breaking old installations (defaults to polling).
To activate/use callbacks, the user is required to add a `webhook_id` to the configuration and also has to manually add the Home Assistant webhook URL to the Nuki Bridge via the [`Nuki Bridge HTTP API`](https://developer.nuki.io/page/nuki-bridge-http-api-1-12/4#heading--callback-add).

This PR also adds an event `nuki_bell_ring` which gets fired when someone rings the bell - applicable for Nuki Opener only


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
lock:
  - platform: nuki
    host: 192.168.1.120
    token: fe2345ef
    # webhook_id is required to activate `Local Push`
    webhook_id: nuki
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#15940

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
