### PR TITLE
Add Webex presence sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -129,7 +129,7 @@ omit =
     homeassistant/components/circuit/*
     homeassistant/components/cisco_ios/device_tracker.py
     homeassistant/components/cisco_mobility_express/device_tracker.py
-    homeassistant/components/cisco_webex_teams/notify.py
+    homeassistant/components/cisco_webex_teams/*
     homeassistant/components/citybikes/sensor.py
     homeassistant/components/clementine/media_player.py
     homeassistant/components/clickatell/notify.py

--- a/homeassistant/components/cisco_webex_teams/manifest.json
+++ b/homeassistant/components/cisco_webex_teams/manifest.json
@@ -2,6 +2,6 @@
   "domain": "cisco_webex_teams",
   "name": "Cisco Webex Teams",
   "documentation": "https://www.home-assistant.io/integrations/cisco_webex_teams",
-  "requirements": ["webexteamssdk==1.1.1"],
+  "requirements": ["webexteamssdk==1.6"],
   "codeowners": ["@fbradyirl"]
 }

--- a/homeassistant/components/cisco_webex_teams/sensor.py
+++ b/homeassistant/components/cisco_webex_teams/sensor.py
@@ -1,0 +1,89 @@
+"""Platform for sensor integration."""
+import logging
+import voluptuous as vol
+from webexteamssdk import WebexTeamsAPI
+
+from homeassistant.const import CONF_TOKEN, CONF_EMAIL, CONF_NAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_PRESENCE,
+    PLATFORM_SCHEMA,
+    Entity
+)
+
+DEFAULT_NAME = "Webex Presence"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_TOKEN): cv.string,
+        vol.Required(CONF_EMAIL): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
+)
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the sensor platform."""
+    api = WebexTeamsAPI(access_token=config[CONF_TOKEN])
+    # Validate the token and email work as expected
+    people_list = list(api.people.list(email=config[CONF_EMAIL]))
+    if len(people_list) > 0:
+        person = people_list[0]
+        name = f"{DEFAULT_NAME} {config[CONF_EMAIL]}" if config[CONF_NAME] == DEFAULT_NAME else DEFAULT_NAME
+        add_entities([WebexPresenceSensor(
+            api=api,
+            person=person,
+            name=name)
+        ])
+    else:
+        _LOGGER.error("Cannot find any Webex user with email: %s", config[CONF_EMAIL])
+        return
+
+
+class WebexPresenceSensor(Entity):
+    """Representation of a Webex Presence Sensor."""
+
+    def __init__(self, api, person, name):
+        """Initialize the sensor."""
+        self._state = None
+        self._attributes = {}
+        self._api = api
+        self._user_id = person.id
+        self._name = name
+
+        self.update_with_data(person)
+
+        _LOGGER.debug("WebexPresenceSensor init with _user_id: %s", self._user_id)
+
+    @property
+    def name(self):
+        """Return the name of the binary sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the status of the binary sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @property
+    def device_class(self):
+        """Return the device class of this binary sensor."""
+        return DEVICE_CLASS_PRESENCE
+
+    def update(self):
+        """Update device state."""
+        self.update_with_data(self._api.people.get(self._user_id))
+
+    def update_with_data(self, person):
+        """Update local data with the latest person."""
+        self._attributes = person.to_dict()
+        # available states documented here
+        # https://developer.webex.com/docs/api/v1/people/list-people
+        self._state = person.status
+        _LOGGER.debug("WebexPeopleSensor person state: %s", self._state)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2278,7 +2278,7 @@ watchdog==0.8.3
 waterfurnace==1.1.0
 
 # homeassistant.components.cisco_webex_teams
-webexteamssdk==1.1.1
+webexteamssdk==1.6
 
 # homeassistant.components.gpmdp
 websocket-client==0.54.0


### PR DESCRIPTION
## Summary
Adding a new sensor to the `cisco_webex_teams` folder.

## Proposed change
Using [Webex Developer API](https://developer.webex.com/docs/api/v1/people/get-person-details)'s, it is possible to get the current status of any users which are sharing presence. This sensor polls that API for a specific user, and sets state in HA based on user status. It also sets lots of other attributes as returned in the payload.

<img width="1190" alt="Screenshot 2020-12-17 at 17 25 33" src="https://user-images.githubusercontent.com/254309/102521832-507f0480-408d-11eb-86e7-0f6f3596c80b.png">

* This enables a HA user to automate things like, changing a light colour based on being in a meeting, presenting, inactive or active.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: cisco_webex_teams
    token: N2Y4NDRXXXXXX
    email: mywebexemail@aol.com

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
