### PR TITLE
Periodically attempt to discover new wemo devices

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -11,9 +11,12 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAI
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_call_later
 
 from .const import DOMAIN
 
@@ -90,7 +93,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass, entry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up a wemo config entry."""
     config = hass.data[DOMAIN].pop("config")
 
@@ -98,14 +101,17 @@ async def async_setup_entry(hass, entry):
     registry = hass.data[DOMAIN]["registry"] = pywemo.SubscriptionRegistry()
     await hass.async_add_executor_job(registry.start)
 
+    wemo_dispatcher = WemoDispatcher(entry)
+    wemo_discovery = WemoDiscovery(hass, wemo_dispatcher)
+
+    @callback
     def stop_wemo(event):
         """Shutdown Wemo subscriptions and subscription thread on exit."""
         _LOGGER.debug("Shutting down WeMo event subscriptions")
         registry.stop()
+        wemo_discovery.async_stop_discovery()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)
-
-    devices = {}
 
     static_conf = config.get(CONF_STATIC, [])
     if static_conf:
@@ -116,28 +122,31 @@ async def async_setup_entry(hass, entry):
                 for host, port in static_conf
             ]
         ):
-            if device is None:
-                continue
-
-            devices.setdefault(device.serialnumber, device)
+            if device:
+                wemo_dispatcher.async_add_unique_device(hass, device)
 
     if config.get(CONF_DISCOVERY, DEFAULT_DISCOVERY):
-        _LOGGER.debug("Scanning network for WeMo devices...")
-        for device in await hass.async_add_executor_job(pywemo.discover_devices):
-            devices.setdefault(
-                device.serialnumber,
-                device,
-            )
+        await wemo_discovery.async_discover_and_schedule()
 
-    loaded_components = set()
+    return True
 
-    for device in devices.values():
-        _LOGGER.debug(
-            "Adding WeMo device at %s:%i (%s)",
-            device.host,
-            device.port,
-            device.serialnumber,
-        )
+
+class WemoDispatcher:
+    """Dispatch WeMo devices to the correct platform."""
+
+    def __init__(self, config_entry: ConfigEntry):
+        """Initialize the WemoDispatcher."""
+        self._config_entry = config_entry
+        self._added_serial_numbers = set()
+        self._loaded_components = set()
+
+    @callback
+    def async_add_unique_device(
+        self, hass: HomeAssistant, device: pywemo.WeMoDevice
+    ) -> None:
+        """Add a WeMo device to hass if it has not already been added."""
+        if device.serialnumber in self._added_serial_numbers:
+            return
 
         component = WEMO_MODEL_DISPATCH.get(device.model_name, SWITCH_DOMAIN)
 
@@ -146,11 +155,13 @@ async def async_setup_entry(hass, entry):
         # - Component is being loaded, add to backlog
         # - Component is loaded, backlog is gone, dispatch discovery
 
-        if component not in loaded_components:
+        if component not in self._loaded_components:
             hass.data[DOMAIN]["pending"][component] = [device]
-            loaded_components.add(component)
+            self._loaded_components.add(component)
             hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, component)
+                hass.config_entries.async_forward_entry_setup(
+                    self._config_entry, component
+                )
             )
 
         elif component in hass.data[DOMAIN]["pending"]:
@@ -163,7 +174,47 @@ async def async_setup_entry(hass, entry):
                 device,
             )
 
-    return True
+        self._added_serial_numbers.add(device.serialnumber)
+
+
+class WemoDiscovery:
+    """Use SSDP to discover WeMo devices."""
+
+    ADDITIONAL_SECONDS_BETWEEN_SCANS = 10
+    MAX_SECONDS_BETWEEN_SCANS = 300
+
+    def __init__(self, hass: HomeAssistant, wemo_dispatcher: WemoDispatcher) -> None:
+        """Initialize the WemoDiscovery."""
+        self._hass = hass
+        self._wemo_dispatcher = wemo_dispatcher
+        self._stop = None
+        self._scan_delay = 0
+
+    async def async_discover_and_schedule(self, *_) -> None:
+        """Periodically scan the network looking for WeMo devices."""
+        _LOGGER.debug("Scanning network for WeMo devices...")
+        try:
+            for device in await self._hass.async_add_executor_job(
+                pywemo.discover_devices
+            ):
+                self._wemo_dispatcher.async_add_unique_device(self._hass, device)
+        finally:
+            # Run discovery more frequently after hass has just started.
+            self._scan_delay = min(
+                self._scan_delay + self.ADDITIONAL_SECONDS_BETWEEN_SCANS,
+                self.MAX_SECONDS_BETWEEN_SCANS,
+            )
+            self._stop = async_call_later(
+                self._hass,
+                self._scan_delay,
+                self.async_discover_and_schedule,
+            )
+
+    @callback
+    def async_stop_discovery(self) -> None:
+        """Stop the periodic background scanning."""
+        if self._stop:
+            self._stop()
 
 
 def validate_static_config(host, port):

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -215,6 +215,7 @@ class WemoDiscovery:
         """Stop the periodic background scanning."""
         if self._stop:
             self._stop()
+            self._stop = None
 
 
 def validate_static_config(host, port):

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -104,14 +104,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     wemo_dispatcher = WemoDispatcher(entry)
     wemo_discovery = WemoDiscovery(hass, wemo_dispatcher)
 
-    @callback
-    def stop_wemo(event):
+    async def async_stop_wemo(event):
         """Shutdown Wemo subscriptions and subscription thread on exit."""
         _LOGGER.debug("Shutting down WeMo event subscriptions")
-        registry.stop()
+        await hass.async_add_executor_job(registry.stop)
         wemo_discovery.async_stop_discovery()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_wemo)
 
     static_conf = config.get(CONF_STATIC, [])
     if static_conf:

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -1,4 +1,6 @@
 """Fixtures for pywemo."""
+import asyncio
+
 import pytest
 import pywemo
 
@@ -26,9 +28,11 @@ def pywemo_registry_fixture():
     registry = create_autospec(pywemo.SubscriptionRegistry, instance=True)
 
     registry.callbacks = {}
+    registry.semaphore = asyncio.Semaphore(value=0)
 
     def on_func(device, type_filter, callback):
         registry.callbacks[device.name] = callback
+        registry.semaphore.release()
 
     registry.on.side_effect = on_func
 

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pywemo
 
-from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC
+from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC, WemoDiscovery
 from homeassistant.components.wemo.const import DOMAIN
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
@@ -122,7 +122,13 @@ async def test_discovery(hass, pywemo_registry):
         await pywemo_registry.semaphore.acquire()  # Returns after platform setup.
         mock_discovery.assert_called()
         pywemo_devices.append(create_device(2))
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=11))
+
+        # Test that discovery runs periodically and the async_dispatcher_send code works.
+        async_fire_time_changed(
+            hass,
+            dt.utcnow()
+            + timedelta(seconds=WemoDiscovery.ADDITIONAL_SECONDS_BETWEEN_SCANS + 1),
+        )
         await hass.async_block_till_done()
 
     # Verify that the expected number of devices were setup.

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -130,6 +130,6 @@ async def test_discovery(hass, pywemo_registry):
     entity_entries = list(entity_reg.entities.values())
     assert len(entity_entries) == 3
 
-    # Verify that discovery stops when hass is stopped.
+    # Verify that hass stops cleanly.
     await hass.async_stop()
     await hass.async_block_till_done()

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -1,9 +1,14 @@
 """Tests for the wemo component."""
+import pywemo
+
 from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC
 from homeassistant.components.wemo.const import DOMAIN
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
-from .conftest import MOCK_HOST, MOCK_PORT
+from .conftest import MOCK_HOST, MOCK_NAME, MOCK_PORT, MOCK_SERIAL_NUMBER
+
+from tests.async_mock import Mock, create_autospec, patch
 
 
 async def test_config_no_config(hass):
@@ -87,3 +92,59 @@ async def test_static_config_with_invalid_host(hass):
         },
     )
     assert not setup_success
+
+
+async def test_discovery(hass, pywemo_registry):
+    """Verify that discovery dispatches devices to the platform for setup."""
+
+    def create_device(counter):
+        """Create a unique mock Motion detector device for each counter value."""
+        device = create_autospec(pywemo.Motion, instance=True)
+        device.host = f"{MOCK_HOST}_{counter}"
+        device.port = MOCK_PORT + counter
+        device.name = f"{MOCK_NAME}_{counter}"
+        device.serialnumber = f"{MOCK_SERIAL_NUMBER}_{counter}"
+        device.model_name = "Motion"
+        device.get_state.return_value = 0  # Default to Off
+        return device
+
+    pywemo_devices = [create_device(0), create_device(1)]
+    mock_stop = Mock()
+    expected_device_count = 4
+
+    def async_call_later(hass, delay, action):
+        async def async_run_action_after_platform_setup():
+            """Run the 'action' after the platform has been setup.
+
+            This forces the async_dispatcher_send logic to be tested.
+            """
+            await pywemo_registry.semaphore.acquire()  # Returns after platform setup.
+            count = len(pywemo_devices)
+            if count < expected_device_count:
+                pywemo_devices.append(create_device(count))
+                await action(dt_util.utcnow())
+
+        hass.async_create_task(async_run_action_after_platform_setup())
+        return mock_stop
+
+    # Setup the component and start discovery.
+    with patch(
+        "pywemo.discover_devices", return_value=pywemo_devices
+    ) as mock_discovery, patch(
+        "homeassistant.components.wemo.async_call_later", side_effect=async_call_later
+    ):
+        assert await async_setup_component(
+            hass, DOMAIN, {DOMAIN: {CONF_DISCOVERY: True}}
+        )
+        await hass.async_block_till_done()
+        mock_discovery.assert_called()
+
+    # Verify that the expected number of devices were setup.
+    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_entries = list(entity_reg.entities.values())
+    assert len(entity_entries) == expected_device_count
+
+    # Verify that discovery stops when hass is stopped.
+    await hass.async_stop()
+    await hass.async_block_till_done()
+    mock_stop.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Wemo component currently uses the pywemo library for discovery. The discovery happens once, during initialization of the single component-wide config flow entry. If a device is temporarily offline whens the pywemo discovery runs, it will not be added to hass. This discovery mechanism does not work well when there are many Wemo devices on a network and there is wifi interfearance which causes some devices to be slow to respond or appear offline. Since discovery only happens once, it can leave Wemo devices in an unavailable state for the lifetime of the hass instance. This can only be corrected by restarting hass. And sometimes it is necessary to restart hass multiple times, until the pywemo discovery is finally able to reach all devices.

This PR allows the pywemo discovery to run periodically in the background. In this way, devices that weren't available when hass first started will get detected and added when they become available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

An alternative for this PR could be to add support for multiple config entries and use the built-in hass discovery mechanism (https://github.com/esev/home-assistant-core/commit/31688a9f487dab5209204c356a41d25911ba3f9a). This would also allow users to configure the Wemo component through the UI and allow for deprecation of config in configuration.yaml ([ADR-0010](https://github.com/home-assistant/architecture/blob/master/adr/0010-integration-configuration.md#decision)). This alternative was not chosen because it is more complex, and components with multiple config entries are not recommended (https://github.com/home-assistant/core/pull/44192#issuecomment-745045666).

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
