### PR TITLE
Simplify nest event handling

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 
-from google_nest_sdm.event import AsyncEventCallback, EventMessage
 from google_nest_sdm.exceptions import AuthException, GoogleNestException
 from google_nest_sdm.google_nest_subscriber import GoogleNestSubscriber
 import voluptuous as vol

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -32,9 +32,7 @@ from .const import (
     DOMAIN,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
-    SIGNAL_NEST_UPDATE,
 )
-from .events import EVENT_NAME_MAP, NEST_EVENT
 from .legacy import async_setup_legacy, async_setup_legacy_entry
 
 _CONFIGURING = {}

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from google_nest_sdm.camera_traits import CameraImageTrait, CameraLiveStreamTrait
 from google_nest_sdm.device import Device
-from google_nest_sdm.event import EventMessage
 from google_nest_sdm.exceptions import GoogleNestException
 from haffmpeg.tools import IMAGE_JPEG
 
@@ -151,11 +150,9 @@ class NestCamera(Camera):
 
     async def async_added_to_hass(self):
         """Run when entity is added to register update signal handler."""
-
-        async def handle_event(event_message: EventMessage):
-            self.async_write_ha_state()
-
-        self.async_on_remove(self._device.add_event_callback(handle_event))
+        self.async_on_remove(
+            self._device.add_update_listener(self.async_write_ha_state)
+        )
 
     async def async_camera_image(self):
         """Return bytes of camera image."""

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -156,8 +156,8 @@ class NestCamera(Camera, AsyncEventCallback):
 
     async def async_handle_event(self, event_message: EventMessage):
         """Let Home Assistant know device state has been updated."""
-        if event_message.resource_update_traits:
-            self.async_write_ha_state()
+        # Note: This ignores resource_update_traits as there are really not
+        # any camera specific traits used besides the live stream
         events = event_message.resource_update_events
         if not events:
             return

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -165,18 +165,14 @@ class NestCamera(Camera, AsyncEventCallback):
         device_registry = await self.hass.helpers.device_registry.async_get_registry()
         device_id = self._device_info.device_id
         device_entry = device_registry.async_get_device(device_id, ())
-        if not device_entry:
-            _LOGGER.debug("Ignoring event for unregistered device '%s'", device_id)
-            return
         for event in events:
             event_type = EVENT_NAME_MAP.get(event)
-            if not event_type:
-                continue
-            message = {
-                "device_id": device_entry.id,
-                "type": event_type,
-            }
-            self.hass.bus.async_fire(NEST_EVENT, message)
+            if event_type and device_id:
+                message = {
+                    "device_id": device_entry.id,
+                    "type": event_type,
+                }
+                self.hass.bus.async_fire(NEST_EVENT, message)
 
     async def async_camera_image(self):
         """Return bytes of camera image."""

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -165,9 +165,11 @@ class NestCamera(Camera, AsyncEventCallback):
         device_registry = await self.hass.helpers.device_registry.async_get_registry()
         device_id = self._device_info.device_id
         device_entry = device_registry.async_get_device(device_id, ())
+        if not device_entry:
+            return
         for event in events:
             event_type = EVENT_NAME_MAP.get(event)
-            if event_type and device_id:
+            if event_type:
                 message = {
                     "device_id": device_entry.id,
                     "type": event_type,

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import FanTrait, TemperatureTrait
-from google_nest_sdm.event import EventMessage
 from google_nest_sdm.exceptions import GoogleNestException
 from google_nest_sdm.thermostat_traits import (
     ThermostatEcoTrait,
@@ -127,11 +126,9 @@ class ThermostatEntity(ClimateEntity):
     async def async_added_to_hass(self):
         """Run when entity is added to register update signal handler."""
         self._supported_features = self._get_supported_features()
-
-        async def handle_event(event_message: EventMessage):
-            self.async_write_ha_state()
-
-        self.async_on_remove(self._device.add_event_callback(handle_event))
+        self.async_on_remove(
+            self._device.add_update_listener(self.async_write_ha_state)
+        )
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import FanTrait, TemperatureTrait
-from google_nest_sdm.event import AsyncEventCallback, EventMessage
+from google_nest_sdm.event import EventMessage
 from google_nest_sdm.exceptions import GoogleNestException
 from google_nest_sdm.thermostat_traits import (
     ThermostatEcoTrait,
@@ -94,7 +94,7 @@ async def async_setup_sdm_entry(
     async_add_entities(entities)
 
 
-class ThermostatEntity(ClimateEntity, AsyncEventCallback):
+class ThermostatEntity(ClimateEntity):
     """A nest thermostat climate entity."""
 
     def __init__(self, device: Device):
@@ -127,11 +127,11 @@ class ThermostatEntity(ClimateEntity, AsyncEventCallback):
     async def async_added_to_hass(self):
         """Run when entity is added to register update signal handler."""
         self._supported_features = self._get_supported_features()
-        self.async_on_remove(self._device.add_event_callback(self))
 
-    async def async_handle_event(self, event_message: EventMessage):
-        """Let Home Assistant know device state has been updated."""
-        self.async_write_ha_state()
+        async def handle_event(event_message: EventMessage):
+            self.async_write_ha_state()
+
+        self.async_on_remove(self._device.add_event_callback(handle_event))
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -23,11 +23,16 @@ class DeviceInfo:
         self._device = device
 
     @property
+    def device_id(self):
+        """Return the Home Assistant device identifier."""
+        return {(DOMAIN, self._device.name)}
+
+    @property
     def device_info(self):
         """Return device specific attributes."""
         return {
             # The API "name" field is a unique device identifier.
-            "identifiers": {(DOMAIN, self._device.name)},
+            "identifiers": self.device_id,
             "name": self.device_name,
             "manufacturer": self.device_brand,
             "model": self.device_model,

--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -23,16 +23,11 @@ class DeviceInfo:
         self._device = device
 
     @property
-    def device_id(self):
-        """Return the Home Assistant device identifier."""
-        return {(DOMAIN, self._device.name)}
-
-    @property
     def device_info(self):
         """Return device specific attributes."""
         return {
             # The API "name" field is a unique device identifier.
-            "identifiers": self.device_id,
+            "identifiers": {(DOMAIN, self._device.name)},
             "name": self.device_name,
             "manufacturer": self.device_brand,
             "model": self.device_model,

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/nest",
   "requirements": [
       "python-nest==4.1.0",
-      "google-nest-sdm==0.2.4"
+      "google-nest-sdm==0.2.5"
   ],
   "codeowners": [
       "@awarecan",

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/nest",
   "requirements": [
       "python-nest==4.1.0",
-      "google-nest-sdm==0.2.1"
+      "google-nest-sdm==0.2.3"
   ],
   "codeowners": [
       "@awarecan",

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/nest",
   "requirements": [
       "python-nest==4.1.0",
-      "google-nest-sdm==0.2.3"
+      "google-nest-sdm==0.2.4"
   ],
   "codeowners": [
       "@awarecan",

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import HumidityTrait, TemperatureTrait
-from google_nest_sdm.event import AsyncEventCallback, EventMessage
+from google_nest_sdm.event import EventMessage
 from google_nest_sdm.exceptions import GoogleNestException
 
 from homeassistant.config_entries import ConfigEntry
@@ -54,7 +54,7 @@ async def async_setup_sdm_entry(
     async_add_entities(entities)
 
 
-class SensorBase(Entity, AsyncEventCallback):
+class SensorBase(Entity):
     """Representation of a dynamically updated Sensor."""
 
     def __init__(self, device: Device):
@@ -80,11 +80,11 @@ class SensorBase(Entity, AsyncEventCallback):
 
     async def async_added_to_hass(self):
         """Run when entity is added to register update signal handler."""
-        self.async_on_remove(self._device.add_event_callback(self))
 
-    async def async_handle_event(self, event_message: EventMessage):
-        """Let Home Assistant know device state has been updated."""
-        self.async_write_ha_state()
+        async def handle_event(event_message: EventMessage):
+            self.async_write_ha_state()
+
+        self.async_on_remove(self._device.add_event_callback(handle_event))
 
 
 class TemperatureSensor(SensorBase):

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import HumidityTrait, TemperatureTrait
-from google_nest_sdm.event import EventMessage
 from google_nest_sdm.exceptions import GoogleNestException
 
 from homeassistant.config_entries import ConfigEntry
@@ -80,11 +79,9 @@ class SensorBase(Entity):
 
     async def async_added_to_hass(self):
         """Run when entity is added to register update signal handler."""
-
-        async def handle_event(event_message: EventMessage):
-            self.async_write_ha_state()
-
-        self.async_on_remove(self._device.add_event_callback(handle_event))
+        self.async_on_remove(
+            self._device.add_update_listener(self.async_write_ha_state)
+        )
 
 
 class TemperatureSensor(SensorBase):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.3
+google-nest-sdm==0.2.4
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.1
+google-nest-sdm==0.2.3
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.4
+google-nest-sdm==0.2.5
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -355,7 +355,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.1
+google-nest-sdm==0.2.3
 
 # homeassistant.components.gree
 greeclimate==0.10.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -355,7 +355,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.3
+google-nest-sdm==0.2.4
 
 # homeassistant.components.gree
 greeclimate==0.10.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -355,7 +355,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.4
+google-nest-sdm==0.2.5
 
 # homeassistant.components.gree
 greeclimate==0.10.3

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -3,7 +3,7 @@
 import time
 
 from google_nest_sdm.device_manager import DeviceManager
-from google_nest_sdm.event import AsyncEventCallback, EventMessage
+from google_nest_sdm.event import EventMessage
 from google_nest_sdm.google_nest_subscriber import GoogleNestSubscriber
 
 from homeassistant.components.nest import DOMAIN
@@ -59,11 +59,6 @@ class FakeSubscriber(GoogleNestSubscriber):
     def __init__(self, device_manager: FakeDeviceManager):
         """Initialize Fake Subscriber."""
         self._device_manager = device_manager
-        self._callback = None
-
-    def set_update_callback(self, callback: AsyncEventCallback):
-        """Capture the callback set by Home Assistant."""
-        self._callback = callback
 
     async def start_async(self) -> DeviceManager:
         """Return the fake device manager."""
@@ -81,7 +76,6 @@ class FakeSubscriber(GoogleNestSubscriber):
         """Simulate a received pubsub message, invoked by tests."""
         # Update device state, then invoke HomeAssistant to refresh
         await self._device_manager.async_handle_event(event_message)
-        await self._callback.async_handle_event(event_message)
 
 
 async def async_setup_sdm_platform(hass, platform, devices={}, structures={}):

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -1,6 +1,7 @@
 """Common libraries for test setup."""
 
 import time
+from typing import Awaitable, Callable
 
 from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.event import EventMessage
@@ -60,6 +61,10 @@ class FakeSubscriber(GoogleNestSubscriber):
         """Initialize Fake Subscriber."""
         self._device_manager = device_manager
 
+    def set_update_callback(self, callback: Callable[[EventMessage], Awaitable[None]]):
+        """Capture the callback set by Home Assistant."""
+        self._callback = callback
+
     async def start_async(self) -> DeviceManager:
         """Return the fake device manager."""
         return self._device_manager
@@ -76,6 +81,7 @@ class FakeSubscriber(GoogleNestSubscriber):
         """Simulate a received pubsub message, invoked by tests."""
         # Update device state, then invoke HomeAssistant to refresh
         await self._device_manager.async_handle_event(event_message)
+        await self._callback(event_message)
 
 
 async def async_setup_sdm_platform(hass, platform, devices={}, structures={}):

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -7,7 +7,8 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
-from homeassistant.components.nest import DOMAIN, NEST_EVENT
+from homeassistant.components.nest import DOMAIN
+from homeassistant.components.nest.events import NEST_EVENT
 from homeassistant.setup import async_setup_component
 
 from .common import async_setup_sdm_platform


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This refactoring was initially motivated by a larger fix for images from events http://bit.ly/2WCMTbH but after initial review is not a blocker.  Now the motivation is just to implement this in fewer lines of code.

Use device specific update callbacks rather than a global callback for some of the simpler update cases.  The python google-nest-sdm supports two approaches for handling events: (1) a callback for listening for all event messages received by the subscriber and (2) a callback for each device when device specific messages.  This switches to use the device specific callback when entity traise are updated.

This also has the side effect of reducing unnecessary state changes.  Previously all entities would have their state updated any time a single entity was changed.  Now only the entities changed will be updated.


See https://github.com/allenporter/python-google-nest-sdm/compare/v0.2.1...v0.2.5 for diffs between versions.  The high level overview of changes between 0.2.1 and 0.2.5 are:
- Improvements for error handling 
- Tons of lint / formatting / pydoc fixes, borrowing style improvements from Home Assistant
- Changes to callback APIs to make Home Assistant code simpler
- Support for fetching image URLs in response to events (not used in Home Assistant yet)
- Error handling / reliability improvements for background subscriber (working towards Silver/Gold integration quality)

Note that all of the event handling has high test coverage within entities and device trigger tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #42793
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
