### PR TITLE
[WIP] Adds config flow to pioneer component

### DIFF
--- a/homeassistant/components/pioneer/__init__.py
+++ b/homeassistant/components/pioneer/__init__.py
@@ -1,1 +1,54 @@
 """The pioneer component."""
+import asyncio
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_SOURCES, DOMAIN
+from .media_player import PioneerDevice
+
+PLATFORMS = ["media_player"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Pioneer component."""
+    hass.data[DOMAIN] = {}
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Pioneer AVR from a config entry."""
+    device = PioneerDevice(
+        name=entry.data[CONF_NAME],
+        host=entry.data[CONF_HOST],
+        port=entry.data[CONF_PORT],
+        timeout=entry.data[CONF_TIMEOUT],
+        sources=entry.data[CONF_SOURCES],
+        unique_id=entry.unique_id,
+    )
+
+    hass.data[DOMAIN][entry.entry_id] = device
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/pioneer/config_flow.py
+++ b/homeassistant/components/pioneer/config_flow.py
@@ -1,0 +1,151 @@
+"""Config flow for the Pioneer platform."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.config_entries import CONN_CLASS_LOCAL_POLL, ConfigFlow
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TIMEOUT
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    CONF_SOURCES,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+    POSSIBLE_SOURCES,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    def __init__(self):
+        """Initialize Pioneer config flow."""
+        self._host = None
+        self._name = DEFAULT_NAME
+        self._port = DEFAULT_PORT
+        self._timeout = DEFAULT_TIMEOUT
+        self._selected_sources = {}
+        self._renamed_sources = {}
+
+    VERSION = 1
+    CONNECTION_CLASS = CONN_CLASS_LOCAL_POLL
+
+    @property
+    def connection_parameters_schema(self):
+        """Return schema for the receiver's connection parameters."""
+        return vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Required(CONF_HOST): cv.string,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+            }
+        )
+
+    @property
+    def select_sources_schema(self):
+        """Return schema for possible sources to be available for the media player."""
+        return vol.Schema(
+            {
+                vol.Optional(source_name, default=properties["common"]): cv.boolean
+                for source_name, properties in sorted(
+                    POSSIBLE_SOURCES.items(), key=self.__tuple_key_casefold()
+                )
+            }
+        )
+
+    @property
+    def rename_sources_schema(self):
+        """Return schema based on the user previously selected sources."""
+        return vol.Schema(
+            {
+                vol.Optional(source_name): cv.string
+                for source_name in sorted(
+                    self._selected_sources.keys(), key=self.__tuple_key_casefold()
+                )
+            }
+        )
+
+    async def async_step_user(self, user_input=None):
+        """User initiated config flow."""
+        if user_input is None:
+            return self.async_show_form(step_id="user")
+
+        return self.async_show_form(
+            step_id="connection_details", data_schema=self.connection_parameters_schema
+        )
+
+    async def async_step_connection_details(self, user_input=None):
+        """In this step the user must enter the host and port of the receiver."""
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="connection_details",
+                data_schema=self.connection_parameters_schema,
+            )
+        elif user_input[CONF_HOST] is not None:
+            await self.async_set_unique_id(user_input[CONF_HOST])
+            self._abort_if_unique_id_configured()
+
+            self._host = user_input[CONF_HOST]
+            self._name = user_input[CONF_NAME]
+            self._port = user_input[CONF_PORT]
+            self._timeout = user_input[CONF_TIMEOUT]
+
+            return self.async_show_form(
+                step_id="select_sources", data_schema=self.select_sources_schema
+            )
+
+    async def async_step_select_sources(self, user_input=None):
+        """In this step the user can select which sources will be shown (they differ from receiver to receiver)."""
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="select_sources", data_schema=self.select_sources_schema
+            )
+
+        self._selected_sources = {
+            source_name: POSSIBLE_SOURCES[source_name]["code"]
+            for source_name, v in user_input.items()
+            if v is True
+        }
+
+        _LOGGER.debug(self._selected_sources)
+
+        return self.async_show_form(
+            step_id="rename_sources", data_schema=self.rename_sources_schema
+        )
+
+    async def async_step_rename_sources(self, user_input=None):
+        """In this step the user can rename sources (e.g., HDMI1 to Kodi) keeping the underlying protocol's code."""
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="rename_sources", data_schema=self.rename_sources_schema
+            )
+
+        self._renamed_sources = {
+            user_input.get(source_name, source_name): value
+            for source_name, value in self._selected_sources.items()
+        }
+
+        _LOGGER.debug(self._renamed_sources)
+
+        return self.async_create_entry(
+            title=self._name,
+            data={
+                CONF_NAME: self._name,
+                CONF_HOST: self._host,
+                CONF_PORT: self._port,
+                CONF_TIMEOUT: self._timeout,
+                CONF_SOURCES: self._renamed_sources,
+            },
+        )
+
+    @staticmethod
+    def __tuple_key_casefold():
+        return lambda x: x[0].casefold()

--- a/homeassistant/components/pioneer/const.py
+++ b/homeassistant/components/pioneer/const.py
@@ -1,0 +1,44 @@
+"""Define constants for the Pioneer component."""
+
+DOMAIN = "pioneer"
+
+CONF_SOURCES = "sources"
+
+DEFAULT_NAME = "Pioneer AVR"
+DEFAULT_PORT = 23  # telnet 'default'. Some Pioneer AVRs use 8102
+DEFAULT_TIMEOUT = 0
+DEFAULT_SOURCES = {}
+DEFAULT_MAX_VOLUME = 185
+
+MAX_VOLUME = 185
+MAX_SOURCE_NUMBERS = 60
+
+# Most common sources based on https://www.home-assistant.io/integrations/pioneer/
+POSSIBLE_SOURCES = {
+    "PHONO": {"code": "00", "common": False},
+    "CD": {"code": "01", "common": True},
+    "Tuner": {"code": "02", "common": True},
+    "CD-R/TAPE": {"code": "03", "common": False},
+    "DVD": {"code": "04", "common": True},
+    "TV": {"code": "05", "common": True},
+    "Sat/Cbl": {"code": "06", "common": True},
+    "Video 1": {"code": "10", "common": False},
+    "Video 2": {"code": "14", "common": False},
+    "DVR/BDR": {"code": "15", "common": True},
+    "iPod/USB": {"code": "17", "common": True},
+    "HDMI1": {"code": "19", "common": True},
+    "HDMI2": {"code": "20", "common": False},
+    "HDMI3": {"code": "21", "common": False},
+    "HDMI4": {"code": "22", "common": False},
+    "HDMI5": {"code": "23", "common": False},
+    "HDMI6": {"code": "24", "common": False},
+    "BD": {"code": "25", "common": True},
+    "HOME MEDIA GALLERY(Internet Radio)": {"code": "26", "common": False},
+    "Adapter": {"code": "33", "common": True},
+    "Netradio": {"code": "38", "common": True},
+    "Pandora": {"code": "41", "common": False},
+    "Media Server": {"code": "44", "common": True},
+    "Favorites": {"code": "45", "common": True},
+    "HDMI/MHL": {"code": "48", "common": False},
+    "Game": {"code": "49", "common": True},
+}

--- a/homeassistant/components/pioneer/manifest.json
+++ b/homeassistant/components/pioneer/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "pioneer",
   "name": "Pioneer",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/pioneer",
   "codeowners": []
 }

--- a/homeassistant/components/pioneer/strings.json
+++ b/homeassistant/components/pioneer/strings.json
@@ -1,0 +1,92 @@
+{
+  "title": "Pioneer",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Pioneer network receiver",
+        "description": "The pioneer platform allows you to control Pioneer Network Receivers. Please note, however, that the more recent Pioneer models work with [Onkyo](https://www.home-assistant.io/integrations/onkyo) platform instead."
+      },
+      "connection_details": {
+        "title": "Pioneer network receiver: Connection parameters",
+        "description": "If you need help with the configuration have a look here: https://www.home-assistant.io/integrations/pioneer/.\n\nGive your receiver a name and enter its IP and port below. Leave port and timeout empty if unsure (some Pioneer receivers use `8102`). ",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "timeout": "Connection timeout (in seconds)"
+        }
+      },
+      "select_sources": {
+        "title": "Pioneer network receiver: Select sources",
+        "description": "In this screen you can select the sources that will be available for your receiver.\n\nDepending on your receiver model some options below may not be available. The most common combination of sources has been preselected for you.\n\nYou can find further combinations per receiver type here: https://www.home-assistant.io/integrations/pioneer/.",
+        "data": {
+          "PHONO": "PHONO",
+          "CD": "CD",
+          "Tuner": "Tuner",
+          "CD-R/TAPE": "CD-R/TAPE",
+          "DVD": "DVD",
+          "TV": "TV",
+          "Sat/Cbl": "Sat/Cbl",
+          "Video 1": "Video 1",
+          "Video 2": "Video 2",
+          "DVR/BDR": "DVR/BDR",
+          "iPod/USB": "iPod/USB",
+          "HDMI1": "HDMI1",
+          "HDMI2": "HDMI2",
+          "HDMI3": "HDMI3",
+          "HDMI4": "HDMI4",
+          "HDMI5": "HDMI5",
+          "HDMI6": "HDMI6",
+          "BD": "BD",
+          "HOME MEDIA GALLERY(Internet Radio)": "HOME MEDIA GALLERY(Internet Radio)",
+          "Adapter": "Adapter",
+          "Netradio": "Netradio",
+          "Pandora": "Pandora",
+          "Media Server": "Media Server",
+          "Favorites": "Favorites",
+          "HDMI/MHL": "HDMI/MHL",
+          "Game": "Game"
+        }
+      },
+      "rename_sources": {
+        "title": "Pioneer network receiver: Rename sources",
+        "description": "In this screen you can provide alternative names to the sources selected in the previous screen (e.g., you may want to rename `HDMI1` to `Kodi`).\n\nFields left blank will keep their original names.",
+        "data": {
+          "PHONO": "PHONO",
+          "CD": "CD",
+          "Tuner": "Tuner",
+          "CD-R/TAPE": "CD-R/TAPE",
+          "DVD": "DVD",
+          "TV": "TV",
+          "Sat/Cbl": "Sat/Cbl",
+          "Video 1": "Video 1",
+          "Video 2": "Video 2",
+          "DVR/BDR": "DVR/BDR",
+          "iPod/USB": "iPod/USB",
+          "HDMI1": "HDMI1",
+          "HDMI2": "HDMI2",
+          "HDMI3": "HDMI3",
+          "HDMI4": "HDMI4",
+          "HDMI5": "HDMI5",
+          "HDMI6": "HDMI6",
+          "BD": "BD",
+          "HOME MEDIA GALLERY(Internet Radio)": "HOME MEDIA GALLERY(Internet Radio)",
+          "Adapter": "Adapter",
+          "Netradio": "Netradio",
+          "Pandora": "Pandora",
+          "Media Server": "Media Server",
+          "Favorites": "Favorites",
+          "HDMI/MHL": "HDMI/MHL",
+          "Game": "Game"
+        }
+      },
+      "confirm": {
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+    }
+  }
+}

--- a/homeassistant/components/pioneer/translations/en.json
+++ b/homeassistant/components/pioneer/translations/en.json
@@ -1,0 +1,92 @@
+{
+    "config": {
+        "abort": {
+            "no_devices_found": "No devices found on the network",
+            "single_instance_allowed": "Already configured. Only a single configuration possible."
+        },
+        "step": {
+            "confirm": {
+                "description": "Do you want to start set up?"
+            },
+            "connection_details": {
+                "data": {
+                    "host": "Host",
+                    "name": "Name",
+                    "port": "Port",
+                    "timeout": "Connection timeout (in seconds)"
+                },
+                "description": "If you need help with the configuration have a look here: https://www.home-assistant.io/integrations/pioneer/.\n\nGive your receiver a name and enter its IP and port below. Leave port and timeout empty if unsure (some Pioneer receivers use `8102`). ",
+                "title": "Pioneer network receiver: Connection parameters"
+            },
+            "rename_sources": {
+                "data": {
+                    "Adapter": "Adapter",
+                    "BD": "BD",
+                    "CD": "CD",
+                    "CD-R/TAPE": "CD-R/TAPE",
+                    "DVD": "DVD",
+                    "DVR/BDR": "DVR/BDR",
+                    "Favorites": "Favorites",
+                    "Game": "Game",
+                    "HDMI/MHL": "HDMI/MHL",
+                    "HDMI1": "HDMI1",
+                    "HDMI2": "HDMI2",
+                    "HDMI3": "HDMI3",
+                    "HDMI4": "HDMI4",
+                    "HDMI5": "HDMI5",
+                    "HDMI6": "HDMI6",
+                    "HOME MEDIA GALLERY(Internet Radio)": "HOME MEDIA GALLERY(Internet Radio)",
+                    "Media Server": "Media Server",
+                    "Netradio": "Netradio",
+                    "PHONO": "PHONO",
+                    "Pandora": "Pandora",
+                    "Sat/Cbl": "Sat/Cbl",
+                    "TV": "TV",
+                    "Tuner": "Tuner",
+                    "Video 1": "Video 1",
+                    "Video 2": "Video 2",
+                    "iPod/USB": "iPod/USB"
+                },
+                "description": "In this screen you can provide alternative names to the sources selected in the previous screen (e.g., you may want to rename `HDMI1` to `Kodi`).\n\nFields left blank will keep their original names.",
+                "title": "Pioneer network receiver: Rename sources"
+            },
+            "select_sources": {
+                "data": {
+                    "Adapter": "Adapter",
+                    "BD": "BD",
+                    "CD": "CD",
+                    "CD-R/TAPE": "CD-R/TAPE",
+                    "DVD": "DVD",
+                    "DVR/BDR": "DVR/BDR",
+                    "Favorites": "Favorites",
+                    "Game": "Game",
+                    "HDMI/MHL": "HDMI/MHL",
+                    "HDMI1": "HDMI1",
+                    "HDMI2": "HDMI2",
+                    "HDMI3": "HDMI3",
+                    "HDMI4": "HDMI4",
+                    "HDMI5": "HDMI5",
+                    "HDMI6": "HDMI6",
+                    "HOME MEDIA GALLERY(Internet Radio)": "HOME MEDIA GALLERY(Internet Radio)",
+                    "Media Server": "Media Server",
+                    "Netradio": "Netradio",
+                    "PHONO": "PHONO",
+                    "Pandora": "Pandora",
+                    "Sat/Cbl": "Sat/Cbl",
+                    "TV": "TV",
+                    "Tuner": "Tuner",
+                    "Video 1": "Video 1",
+                    "Video 2": "Video 2",
+                    "iPod/USB": "iPod/USB"
+                },
+                "description": "In this screen you can select the sources that will be available for your receiver.\n\nDepending on your receiver model some options below may not be available. The most common combination of sources has been preselected for you.\n\nYou can find further combinations per receiver type here: https://www.home-assistant.io/integrations/pioneer/.",
+                "title": "Pioneer network receiver: Select sources"
+            },
+            "user": {
+                "description": "The pioneer platform allows you to control Pioneer Network Receivers. Please note, however, that the more recent Pioneer models work with [Onkyo](https://www.home-assistant.io/integrations/onkyo) platform instead.",
+                "title": "Pioneer network receiver"
+            }
+        }
+    },
+    "title": "Pioneer"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -149,6 +149,7 @@ FLOWS = [
     "ozw",
     "panasonic_viera",
     "pi_hole",
+    "pioneer",
     "plaato",
     "plex",
     "plugwise",

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -829,6 +829,9 @@ def custom_serializer(schema: Any) -> Any:
     if schema is boolean:
         return {"type": "boolean"}
 
+    if schema is socket_timeout:
+        return {"type": "int"}
+
     if isinstance(schema, multi_select):
         return {"type": "multi_select", "options": schema.options}
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -616,6 +616,13 @@ def test_positive_time_period_dict_in_serializer():
     }
 
 
+def test_socket_timeout_in_serializer():
+    """Test positive_time_period_dict with custom_serializer."""
+    assert cv.custom_serializer(cv.socket_timeout) == {
+        "type": "int",
+    }
+
+
 @pytest.fixture
 def schema():
     """Create a schema used for testing deprecation."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Configuring Pioneer network receivers via YAML isn't supported anymore. Now they need to be added via the UI Under Configuration > Integrations > Add new integration.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds `config_flow` to the `pioneer` integration. This was requested as part of change #44075 by @frenck  and @MartinHjelmare .

The provided config flow attempts to allow everything that was possible until now via YAML, which made it a bit challenging: I couldn't find a nice way to create a from that would accept key/value pairs where the keys are user provided strings (in order to achieve level of customization of sources and soure names that was possible until now), but i'm happy with the current way this is solved now.

![image](https://user-images.githubusercontent.com/1915763/102689078-c43f1f80-41fb-11eb-8a45-a995d665078e.png)

![image](https://user-images.githubusercontent.com/1915763/102689085-cc975a80-41fb-11eb-92ee-1c03702e9908.png)

![image](https://user-images.githubusercontent.com/1915763/102689092-d325d200-41fb-11eb-9e1c-4c9d9184778a.png)

![image](https://user-images.githubusercontent.com/1915763/102689097-d751ef80-41fb-11eb-9aae-60bd5555b687.png)

![image](https://user-images.githubusercontent.com/1915763/102689102-de78fd80-41fb-11eb-9ced-317309b2292c.png)


I'd qualify this as a "more or less mature work in progress". I'd be interested on feedback in the following:

- input on possible tests and test coverage
- how the configuration flow is solved now
- socket timeout has been added to the custom serializer, is that ok?
- the port input field is a slider, due to its datatype: should i use another validator/datatype?
- `__init__` of `PioneerDevice` has a breaking change (`unique_id`), but i guess that's inevitable
- output of `python3 -m script.translations develop --integration=pioneer` is being committed too. Not sure if that's desired

Once the PR is reviewied i will gladly modify the documentation accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #44075
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
