### PR TITLE
Add PulseAudio integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -806,6 +806,8 @@ omit =
     homeassistant/components/prowl/notify.py
     homeassistant/components/proxmoxve/*
     homeassistant/components/proxy/camera.py
+    homeassistant/components/pulseaudio/__init__.py
+    homeassistant/components/pulseaudio/media_player.py
     homeassistant/components/pulseaudio_loopback/switch.py
     homeassistant/components/pushbullet/notify.py
     homeassistant/components/pushbullet/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -386,6 +386,7 @@ homeassistant/components/progettihwsw/* @ardaseremet
 homeassistant/components/prometheus/* @knyar
 homeassistant/components/proxmoxve/* @k4ds3 @jhollowe @Corbeno
 homeassistant/components/ps4/* @ktnrg45
+homeassistant/components/pulseaudio/* @breiti
 homeassistant/components/push/* @dgomes
 homeassistant/components/pvoutput/* @fabaff
 homeassistant/components/pvpc_hourly_pricing/* @azogue

--- a/homeassistant/components/pulseaudio/__init__.py
+++ b/homeassistant/components/pulseaudio/__init__.py
@@ -1,0 +1,218 @@
+"""The PulseAudio integration."""
+import asyncio
+from queue import Empty, Queue
+from threading import Event, Thread
+
+from pulsectl import Pulse, PulseError, PulseVolumeInfo, _pulsectl
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_SERVER, DOMAIN
+
+UNDO_UPDATE_LISTENER = "undo_update_listener"
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+
+PLATFORMS = ["media_player"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the PulseAudio component."""
+    return True
+
+
+class PulseAudioInterface:
+    """Interface to PulseAudio.
+
+    Handles all interactions with server from a single thread.
+    """
+
+    _queue: Queue = Queue()
+    _connected: bool = False
+    _sink_list = None
+    _source_list = None
+    _module_list = None
+
+    def __init__(self, hass, server: str):
+        """Initialize."""
+
+        def pulse_thread(cmd_queue: Queue, server: str):
+            pulse = Pulse(server=server)
+            while True:
+                try:
+                    try:
+                        (func, ev) = cmd_queue.get(block=True, timeout=2)
+
+                        if (func, ev) == (None, None):
+                            return
+
+                        func(pulse)
+                        ev.set()
+
+                    except Empty:
+                        pass
+
+                    self._connected = pulse.connected
+                    if not self._connected:
+                        pulse.connect()
+
+                    self._module_list = pulse.module_list()
+                    self._sink_list = pulse.sink_list()
+                    self._source_list = pulse.source_list()
+
+                except (PulseError, _pulsectl.LibPulse.CallError):
+                    self._connected = False
+                    pulse.disconnect()
+
+        self.hass = hass
+
+        self._thread = Thread(
+            target=pulse_thread, name="PulseAudio_" + server, args=(self._queue, server)
+        )
+
+        self._thread.start()
+
+    def stop(self):
+        """Stop the PulseAudio thread."""
+        self._queue.put((None, None))
+        self._thread.join()
+
+    async def _async_pulse_call(self, func):
+        """Execute function in the context of the PulseAudio thread."""
+        ev = Event()
+        self._queue.put((func, ev))
+        await self.hass.async_add_executor_job(ev.wait)
+
+    async def async_sink_volume_set(self, sink, volume: float):
+        """Set volume for sink."""
+        await self._async_pulse_call(
+            lambda pulse, sink=sink, volume=volume: pulse.sink_volume_set(
+                sink.index, PulseVolumeInfo(volume, len(sink.volume.values))
+            )
+        )
+
+    async def async_sink_mute(self, sink, mute):
+        """Mute sink."""
+        await self._async_pulse_call(
+            lambda pulse, index=sink.index, mute=mute: pulse.sink_mute(index, mute)
+        )
+
+    def _get_module_idx(self, sink_name, source_name):
+        """Get index of loopback module from source to sink."""
+        for module in self._module_list:
+            if not module.name == "module-loopback":
+                continue
+
+            if f"sink={sink_name}" not in module.argument:
+                continue
+
+            if f"source={source_name}" not in module.argument:
+                continue
+
+            return module.index
+
+        return None
+
+    async def async_connect_source(self, sink, source_name, sources):
+        """Connect a source to a sink."""
+        for source in sources:
+            idx = self._get_module_idx(sink.name, source)
+            if source == source_name:
+                if not idx:
+                    await self._async_pulse_call(
+                        lambda pulse, sink=sink.name, source=source: pulse.module_load(
+                            "module-loopback", args=f"sink={sink} source={source}"
+                        )
+                    )
+            else:
+                if not idx:
+                    continue
+
+                await self._async_pulse_call(
+                    lambda pulse, idx=idx: pulse.module_unload(idx)
+                )
+
+    def get_connected_source(self, sink, sources):
+        """Get source that is connected to sink."""
+        if sink:
+            for source in sources:
+                idx = self._get_module_idx(sink.name, source)
+                if idx:
+                    return source
+        return None
+
+    def get_sink_by_name(self, name):
+        """Get PulseAudio sink by name."""
+        if not self._sink_list:
+            return None
+
+        return [s for s in self._sink_list if s.name == name][0]
+
+    @property
+    def connected(self):
+        """Return true when connected to server."""
+        return self._connected
+
+
+interfaces = {}
+
+
+def get_pulse_interface(hass, server: str) -> PulseAudioInterface:
+    """Get interface to server."""
+    if server not in interfaces:
+        interfaces[server] = PulseAudioInterface(hass, server)
+    return interfaces[server]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up the PulseAudio components from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    server = entry.data[CONF_SERVER]
+
+    undo_listener = entry.add_update_listener(async_update_listener)
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        CONF_SERVER: server,
+        UNDO_UPDATE_LISTENER: undo_listener,
+    }
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(config_entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+
+    hass.data[DOMAIN][config_entry.entry_id][UNDO_UPDATE_LISTENER]()
+
+    entity_registry = await er.async_get_registry(hass)
+    entries = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+    for entry in entries:
+        entity_registry.async_remove(entry.entity_id)
+
+    if unload_ok:
+        data = hass.data[DOMAIN].pop(config_entry.entry_id)
+        if data[CONF_SERVER] in interfaces:
+            interfaces.pop(data[CONF_SERVER]).stop()
+
+    return unload_ok
+
+
+async def async_update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Handle options update."""
+    await hass.config_entries.async_reload(config_entry.entry_id)

--- a/homeassistant/components/pulseaudio/config_flow.py
+++ b/homeassistant/components/pulseaudio/config_flow.py
@@ -1,0 +1,152 @@
+"""Config flow for PulseAudio integration."""
+from __future__ import annotations
+
+import logging
+
+from pulsectl import Pulse, PulseError
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+
+from .const import CONF_MEDIAPLAYER_SINKS, CONF_MEDIAPLAYER_SOURCES, CONF_SERVER
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_SERVER, default="localhost:4713"): str}
+)
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+def _verify_server(server: str) -> tuple[bool, set | None, set | None]:
+    """Verify PulseAudio connection."""
+    try:
+        pulse = Pulse(server=server)
+        if pulse.connected:
+            return (True, pulse.sink_list(), pulse.source_list())
+
+    except PulseError:
+        pass
+
+    return (False, None, None)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    result, sinks, sources = await hass.async_add_executor_job(
+        _verify_server, data["server"]
+    )
+
+    if not result:
+        raise CannotConnect
+
+    return {"sinks": sinks, "sources": sources}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for PulseAudio."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    server = ""
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors = {}
+
+        for entry in self._async_current_entries():
+            if entry.data[CONF_SERVER] == user_input["server"]:
+                return self.async_abort(reason="already_configured")
+
+        try:
+            await validate_input(self.hass, user_input)
+            self.server = user_input["server"]
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        else:
+            return self.async_create_entry(title=self.server, data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for PulseAudio."""
+
+    server = ""
+    sinks: set[str] = set()
+    sources: set[str] = set()
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize PulseAudio options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        errors = {}
+
+        sink_names = []
+        source_names = []
+
+        try:
+            info = await validate_input(self.hass, self.config_entry.data)
+            self.server = self.config_entry.options.get("server")
+            self.sinks = info["sinks"]
+            self.sources = info["sources"]
+
+            for sink in self.sinks:
+                sink_names.append(sink.name)
+
+            for source in self.sources:
+                source_names.append(source.name)
+
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MEDIAPLAYER_SINKS,
+                        default=self.config_entry.options.get(CONF_MEDIAPLAYER_SINKS),
+                    ): cv.multi_select(sink_names),
+                    vol.Required(
+                        CONF_MEDIAPLAYER_SOURCES,
+                        default=self.config_entry.options.get(CONF_MEDIAPLAYER_SOURCES),
+                    ): cv.multi_select(source_names),
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/pulseaudio/const.py
+++ b/homeassistant/components/pulseaudio/const.py
@@ -1,0 +1,6 @@
+"""Constants for the PulseAudio integration."""
+
+DOMAIN = "pulseaudio"
+CONF_SERVER = "server"
+CONF_MEDIAPLAYER_SINKS = "mediaplayer_sinks"
+CONF_MEDIAPLAYER_SOURCES = "mediaplayer_sources"

--- a/homeassistant/components/pulseaudio/manifest.json
+++ b/homeassistant/components/pulseaudio/manifest.json
@@ -1,0 +1,17 @@
+{
+  "domain": "pulseaudio",
+  "name": "PulseAudio",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/pulseaudio",
+  "requirements": [
+    "pulsectl==20.2.4"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@breiti"
+  ],
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/pulseaudio/media_player.py
+++ b/homeassistant/components/pulseaudio/media_player.py
@@ -1,0 +1,161 @@
+"""Support to interact with a Music Player Daemon."""
+from homeassistant.components.media_player import MediaPlayerEntity
+from homeassistant.components.media_player.const import (
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_STEP,
+)
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from . import get_pulse_interface
+from .const import CONF_MEDIAPLAYER_SINKS, CONF_MEDIAPLAYER_SOURCES, CONF_SERVER, DOMAIN
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the DenonAVR receiver from a config entry."""
+    entities = []
+
+    sinks = config_entry.options.get(CONF_MEDIAPLAYER_SINKS)
+    sources = config_entry.options.get(CONF_MEDIAPLAYER_SOURCES)
+    server = hass.data[DOMAIN][config_entry.entry_id][CONF_SERVER]
+    interface = get_pulse_interface(hass, server)
+
+    if sinks:
+        for sink in sinks:
+            entities.append(PulseDevice(server, interface, sink, sink, sources))
+
+        async_add_entities(entities)
+
+
+class PulseDevice(MediaPlayerEntity):
+    """Representation of a Pulse server."""
+
+    # pylint: disable=no-member
+    def __init__(self, server, interface, name, sink_name, sources):
+        """Initialize the Pulse device."""
+        self._server = server
+        self._name = name
+        self._sink = None
+        self._sink_name = sink_name
+        self._source_names = sources
+        self._status = None
+        self._current_source = None
+        self._last_source = None
+        self._interface = interface
+        self._volume = 0.0
+        self._muted = False
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the zone."""
+        return f"{self._server}-{self._sink_name}"
+
+    @property
+    def available(self):
+        """Return true when connected to server."""
+        return self._sink and self._interface.connected
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self._current_source:
+            return STATE_ON
+        return STATE_OFF
+
+    @property
+    def volume_level(self):
+        """Return the volume level."""
+        return self._volume
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return (
+            SUPPORT_VOLUME_SET
+            | SUPPORT_VOLUME_STEP
+            | SUPPORT_VOLUME_MUTE
+            | SUPPORT_SELECT_SOURCE
+            | SUPPORT_TURN_OFF
+            | SUPPORT_TURN_ON
+        )
+
+    @property
+    def media_title(self):
+        """Return the content ID of current playing media."""
+        return self._current_source
+
+    @property
+    def source(self):
+        """Name of the current input source."""
+        return self._current_source
+
+    @property
+    def source_list(self):
+        """Return the list of available input sources."""
+        return self._source_names
+
+    async def async_select_source(self, source):
+        """Choose a different available playlist and play it."""
+        self._current_source = source
+        self.async_schedule_update_ha_state()
+        await self._interface.async_connect_source(
+            self._sink, source, self._source_names
+        )
+
+    async def async_set_volume_level(self, volume):
+        """Set volume of media player."""
+        self._volume = volume
+        await self._interface.async_sink_volume_set(self._sink, volume)
+        self.async_schedule_update_ha_state()
+
+    async def async_mute_volume(self, mute):
+        """Mute."""
+        self._muted = True
+        await self._interface.async_sink_mute(self._sink, mute)
+        self.async_schedule_update_ha_state()
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self._muted
+
+    async def async_turn_off(self):
+        """Service to send the Pulse the command to stop playing."""
+        await self._interface.async_connect_source(self._sink, None, self._source_names)
+
+    async def async_turn_on(self):
+        """Service to send the Pulse the command to start playing."""
+
+        if self._current_source is not None:
+            return
+
+        if self._last_source:
+            source = self._last_source
+        else:
+            source = self._source_names[0]
+
+        await self._interface.async_connect_source(
+            self._sink, source, self._source_names
+        )
+
+    async def async_update(self):
+        """Update internal status of the entity."""
+        self._sink = self._interface.get_sink_by_name(self._sink_name)
+
+        if self._sink:
+            self._current_source = self._interface.get_connected_source(
+                self._sink, self._source_names
+            )
+            if self._current_source:
+                self._last_source = self._current_source
+
+            self._volume = self._sink.volume.value_flat
+            self._muted = self._sink.mute == 1

--- a/homeassistant/components/pulseaudio/strings.json
+++ b/homeassistant/components/pulseaudio/strings.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "PulseAudio connection",
+        "description": "Enter connection string to your PulseAudio server.",
+        "data": {
+          "server": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pulse Audio Options",
+        "description": "Media Player configuration",
+        "data": {
+            "mediaplayer_sinks": "Select sinks to create media players",
+            "mediaplayer_sources": "Select sources to use as input"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/pulseaudio/translations/en.json
+++ b/homeassistant/components/pulseaudio/translations/en.json
@@ -1,0 +1,31 @@
+{
+    "config": {
+      "step": {
+        "user": {
+            "title": "PulseAudio connection",
+            "description": "Enter connection string to your PulseAudio server",
+            "data": {
+              "server": "Server"
+            }
+        }
+      },
+      "error": {
+        "cannot_connect": "Failed to connect"
+      },
+      "abort": {
+        "already_configured": "Server is already configured"
+      }
+    },
+    "options": {
+      "step": {
+        "init": {
+          "title": "Pulse Audio Options",
+          "description": "Media Player configuration",
+          "data": {
+            "mediaplayer_sinks": "Select sinks to create media players",
+            "mediaplayer_sources": "Select sources to use as input"
+            }
+        }
+      }
+    }
+  }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -206,6 +206,7 @@ FLOWS = [
     "profiler",
     "progettihwsw",
     "ps4",
+    "pulseaudio",
     "pvpc_hourly_pricing",
     "rachio",
     "rainmachine",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1216,6 +1216,7 @@ psutil==5.8.0
 # homeassistant.components.wink
 pubnubsub-handler==1.0.9
 
+# homeassistant.components.pulseaudio
 # homeassistant.components.pulseaudio_loopback
 pulsectl==20.2.4
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -680,6 +680,10 @@ progettihwsw==0.1.1
 # homeassistant.components.prometheus
 prometheus_client==0.7.1
 
+# homeassistant.components.pulseaudio
+# homeassistant.components.pulseaudio_loopback
+pulsectl==20.2.4
+
 # homeassistant.components.androidtv
 pure-python-adb[async]==0.3.0.dev0
 

--- a/tests/components/pulseaudio/__init__.py
+++ b/tests/components/pulseaudio/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PulseAudio integration."""

--- a/tests/components/pulseaudio/test_config_flow.py
+++ b/tests/components/pulseaudio/test_config_flow.py
@@ -1,0 +1,217 @@
+"""Test the PulseAudio config flow."""
+from unittest.mock import PropertyMock, patch
+
+from pulsectl import PulseError
+import pytest
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.pulseaudio.const import (
+    CONF_MEDIAPLAYER_SINKS,
+    CONF_MEDIAPLAYER_SOURCES,
+    CONF_SERVER,
+    DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+TEST_SERVER = "localhost"
+TEST_UNIQUE_ID = f"{DOMAIN}-{TEST_SERVER}"
+
+
+@pytest.fixture(name="pulseaudio_connect", autouse=True)
+def pulseaudio_connect_fixture():
+    """Mock PulseAudio connection."""
+
+    class PulseItemMock:
+        def __init__(self, name: str):
+            self.name = name
+
+    with patch("pulsectl.Pulse.__init__", return_value=None), patch(
+        "pulsectl.Pulse.sink_list",
+        return_value=[PulseItemMock("sink1"), PulseItemMock("sink2")],
+    ), patch(
+        "pulsectl.Pulse.source_list",
+        return_value=[PulseItemMock("source1"), PulseItemMock("source2")],
+    ), patch(
+        "pulsectl.Pulse.module_list",
+        return_value=[],
+    ), patch(
+        "pulsectl.Pulse.connected",
+        new_callable=PropertyMock,
+        create=True,
+        return_value=True,
+    ):
+        yield
+
+
+async def test_config_flow_connect_success(hass: HomeAssistant):
+    """Unsuccessful flow manually initialized by the user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_SERVER: "localhost"},
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "localhost"
+    assert result["data"] == {
+        CONF_SERVER: "localhost",
+    }
+
+    await hass.config_entries.async_unload(result["result"].entry_id)
+
+
+async def test_config_flow_cannot_connect(hass: HomeAssistant):
+    """Unsuccessful flow manually initialized by the user."""
+    with patch(
+        "pulsectl.Pulse.connected",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_SERVER: "localhost"},
+        )
+
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_config_flow_already_configured(hass: HomeAssistant):
+    """Test already configured config flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_UNIQUE_ID,
+        data={
+            CONF_SERVER: TEST_SERVER,
+            CONF_MEDIAPLAYER_SINKS: [],
+            CONF_MEDIAPLAYER_SOURCES: [],
+        },
+        title=TEST_SERVER,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_SERVER: "localhost"},
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_config_flow_options(hass: HomeAssistant):
+    """Test options config flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_UNIQUE_ID,
+        data={
+            CONF_SERVER: TEST_SERVER,
+            CONF_MEDIAPLAYER_SINKS: [],
+            CONF_MEDIAPLAYER_SOURCES: [],
+        },
+        title=TEST_SERVER,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MEDIAPLAYER_SINKS: ["sink1"],
+            CONF_MEDIAPLAYER_SOURCES: ["source2"],
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert config_entry.options == {
+        CONF_MEDIAPLAYER_SINKS: ["sink1"],
+        CONF_MEDIAPLAYER_SOURCES: ["source2"],
+    }
+    assert await config_entry.async_unload(hass)
+
+
+async def test_config_flow_options_connect_error(hass: HomeAssistant):
+    """Test options config flow with PulseError."""
+
+    with patch("pulsectl.Pulse.__init__", side_effect=PulseError()):
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id=TEST_UNIQUE_ID,
+            data={
+                CONF_SERVER: TEST_SERVER,
+                CONF_MEDIAPLAYER_SINKS: [],
+                CONF_MEDIAPLAYER_SOURCES: [],
+            },
+            title=TEST_SERVER,
+        )
+        config_entry.add_to_hass(hass)
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["errors"] == {"base": "cannot_connect"}
+
+        assert await config_entry.async_unload(hass)
+
+
+async def test_config_flow_options_error(hass: HomeAssistant):
+    """Test options config flow with Exception."""
+
+    with patch("pulsectl.Pulse.__init__", side_effect=IndexError()):
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id=TEST_UNIQUE_ID,
+            data={
+                CONF_SERVER: TEST_SERVER,
+                CONF_MEDIAPLAYER_SINKS: [],
+                CONF_MEDIAPLAYER_SOURCES: [],
+            },
+            title=TEST_SERVER,
+        )
+        config_entry.add_to_hass(hass)
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["errors"] == {"base": "unknown"}
+
+        assert await config_entry.async_unload(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for PulseAudio media_player, which allows the user to configure media players for PulseAudio sinks that can switch beween a configurable list of PulseAudio sources and control the volume. This can be used to a create a nice multiroom audio setup based on PulseAudio.

I'm aware that there is also the pulseaudio_loopback component, but this does not yet support config flow (https://github.com/home-assistant/core/pull/35973). As this is my first contact with this, I opted to start with the template instead of implementing it for an existing component. As "pulseaudio_loopback" is a very specific name for the functionality it provides, I thought that "pulseaudio" would be a better name anyway for a component that supports (in the future) multiple platforms. The loopback switch functionality could be integrated in this component later, but the template says the initial PR should be limited to one platform.

This component also moves all interaction with the server into a single thread, which prevents what seems to be a very rare race-condition in libpulse that gets triggered by pulseaudio_loopback when a lot of entities are configured and that crashes the Homeassistant process (I've seen this only in the Docker container, and could not reproduce this in a Debian system). I've been running this code for some months now and did not experience a single problem.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
