### PR TITLE
Connect concurrently to discovered Zerproc lights

### DIFF
--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -1,4 +1,5 @@
 """Zerproc light platform."""
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Callable, List, Optional
@@ -29,6 +30,16 @@ SUPPORT_ZERPROC = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
 DISCOVERY_INTERVAL = timedelta(seconds=60)
 
 
+async def connect_light(light: pyzerproc.Light):
+    """Return the given light if it connects successfully."""
+    try:
+        await light.connect()
+    except pyzerproc.ZerprocException:
+        _LOGGER.debug("Unable to connect to '%s'", light.address, exc_info=True)
+        return None
+    return light
+
+
 async def discover_entities(hass: HomeAssistant) -> List[Entity]:
     """Attempt to discover new lights."""
     lights = await pyzerproc.discover()
@@ -39,12 +50,10 @@ async def discover_entities(hass: HomeAssistant) -> List[Entity]:
     ]
 
     entities = []
-    for light in new_lights:
-        try:
-            await light.connect()
-        except pyzerproc.ZerprocException:
-            _LOGGER.debug("Unable to connect to '%s'", light.address, exc_info=True)
-            continue
+    connected_lights = filter(
+        None, await asyncio.gather(*(connect_light(light) for light in new_lights))
+    )
+    for light in connected_lights:
         # Double-check the light hasn't been added in the meantime
         if light.address not in hass.data[DOMAIN]["addresses"]:
             hass.data[DOMAIN]["addresses"].add(light.address)

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -30,7 +30,7 @@ SUPPORT_ZERPROC = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
 DISCOVERY_INTERVAL = timedelta(seconds=60)
 
 
-async def connect_light(light: pyzerproc.Light):
+async def connect_light(light: pyzerproc.Light) -> Optional[pyzerproc.Light]:
     """Return the given light if it connects successfully."""
     try:
         await light.connect()

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -141,22 +141,28 @@ async def test_connect_exception(hass, mock_entry):
 
     mock_entry.add_to_hass(hass)
 
-    mock_light = MagicMock(spec=pyzerproc.Light)
-    mock_light.address = "AA:BB:CC:DD:EE:FF"
-    mock_light.name = "LEDBlue-CCDDEEFF"
-    mock_light.is_connected.return_value = False
+    mock_light_1 = MagicMock(spec=pyzerproc.Light)
+    mock_light_1.address = "AA:BB:CC:DD:EE:FF"
+    mock_light_1.name = "LEDBlue-CCDDEEFF"
+    mock_light_1.is_connected.return_value = False
+
+    mock_light_2 = MagicMock(spec=pyzerproc.Light)
+    mock_light_2.address = "11:22:33:44:55:66"
+    mock_light_2.name = "LEDBlue-33445566"
+    mock_light_2.is_connected.return_value = False
 
     with patch(
         "homeassistant.components.zerproc.light.pyzerproc.discover",
-        return_value=[mock_light],
+        return_value=[mock_light_1, mock_light_2],
     ), patch.object(
-        mock_light, "connect", side_effect=pyzerproc.ZerprocException("TEST")
+        mock_light_1, "connect", side_effect=pyzerproc.ZerprocException("TEST")
     ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-    # The exception should be captured and no entities should be added
-    assert len(hass.data[DOMAIN]["addresses"]) == 0
+    # The exception connecting to light 1 should be captured, but light 2
+    # should still be added
+    assert len(hass.data[DOMAIN]["addresses"]) == 1
 
 
 async def test_remove_entry(hass, mock_light, mock_entry):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is a small code quality improvement for Zerproc. Instead of iterating through each light during discovery, we'll attempt to connect to them concurrently, and gather the results.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
