### PR TITLE
Improve nest setup error handling

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -181,9 +181,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
         return False
     except ConfigurationException as err:
-        if DATA_SUBSCRIBER not in hass.data[DOMAIN].get("A", {}):
-            _LOGGER.error("Configuration error: %s", err)
-            hass.data[DOMAIN][DATA_SUBSCRIBER] = None
+        _LOGGER.error("Configuration error: %s", err)
         subscriber.stop_async()
         return False
     except GoogleNestException as err:

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -171,7 +171,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         await subscriber.start_async()
     except AuthException as err:
-
         _LOGGER.debug("Subscriber authentication error: %s", err)
         hass.async_create_task(
             hass.config_entries.flow.async_init(

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -19,7 +19,7 @@ CONFIG = {
         "client_secret": "some-client-secret",
         # Required fields for using SDM API
         "project_id": "some-project-id",
-        "subscriber_id": "some-subscriber-id",
+        "subscriber_id": "projects/example/subscriptions/subscriber-id-9876",
     },
 }
 
@@ -65,7 +65,7 @@ class FakeSubscriber(GoogleNestSubscriber):
         """Capture the callback set by Home Assistant."""
         self._callback = callback
 
-    async def start_async(self) -> DeviceManager:
+    async def start_async(self):
         """Return the fake device manager."""
         return self._device_manager
 

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -14,7 +14,7 @@ from tests.async_mock import patch
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 PROJECT_ID = "project-id-4321"
-SUBSCRIBER_ID = "subscriber-id-9876"
+SUBSCRIBER_ID = "projects/example/subscriptions/subscriber-id-9876"
 
 CONFIG = {
     DOMAIN: {

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -72,7 +72,8 @@ async def test_setup_configuration_failure(hass):
 async def test_setup_susbcriber_failure(hass):
     """Test configuration error."""
     await async_setup_component(hass, "persistent_notification", {})
-
+state = hass.states.get("persistent_notification.nest_setup")
+assert state is None
     with patch(
         "homeassistant.components.nest.GoogleNestSubscriber.start_async",
         side_effect=GoogleNestException(),

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -60,6 +60,8 @@ async def test_setup_configuration_failure(hass):
 
     state = hass.states.get("persistent_notification.nest_setup")
     assert state is not None
+    # This error comes from the python google-nest-sdm library, as a check added
+    # to prevent common misconfigurations (e.g. confusing topic and subscriber)
     assert state.attributes["title"] == "Nest configuration error"
     assert (
         "Subscription misconfigured. Expected subscriber_id"

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -5,6 +5,8 @@ The tests fake out the subscriber/devicemanager and simulate setup behavior
 and failure modes.
 """
 
+import logging
+
 from google_nest_sdm.exceptions import GoogleNestException
 
 from homeassistant.components.nest import DOMAIN
@@ -23,17 +25,15 @@ from tests.common import MockConfigEntry
 PLATFORM = "sensor"
 
 
-async def test_setup_success(hass):
+async def test_setup_success(hass, caplog):
     """Test successful setup."""
-    await async_setup_component(hass, "persistent_notification", {})
-    await async_setup_sdm_platform(hass, PLATFORM)
+    with caplog.at_level(logging.ERROR, logger="homeassistant.components.nest"):
+        await async_setup_sdm_platform(hass, PLATFORM)
+        assert not caplog.records
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state == ENTRY_STATE_LOADED
-
-    state = hass.states.get("persistent_notification.nest_setup")
-    assert state is None
 
 
 async def async_setup_sdm(hass, config=CONFIG):
@@ -45,10 +45,8 @@ async def async_setup_sdm(hass, config=CONFIG):
         await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_setup_configuration_failure(hass):
+async def test_setup_configuration_failure(hass, caplog):
     """Test configuration error."""
-    await async_setup_component(hass, "persistent_notification", {})
-
     config = CONFIG.copy()
     config[DOMAIN]["subscriber_id"] = "invalid-subscriber-format"
 
@@ -58,59 +56,35 @@ async def test_setup_configuration_failure(hass):
     assert len(entries) == 1
     assert entries[0].state == ENTRY_STATE_SETUP_ERROR
 
-    state = hass.states.get("persistent_notification.nest_setup")
-    assert state is not None
     # This error comes from the python google-nest-sdm library, as a check added
     # to prevent common misconfigurations (e.g. confusing topic and subscriber)
-    assert state.attributes["title"] == "Nest configuration error"
-    assert (
-        "Subscription misconfigured. Expected subscriber_id"
-        in state.attributes["message"]
-    )
+    assert "Subscription misconfigured. Expected subscriber_id" in caplog.text
 
 
-async def test_setup_susbcriber_failure(hass):
+async def test_setup_susbcriber_failure(hass, caplog):
     """Test configuration error."""
-    await async_setup_component(hass, "persistent_notification", {})
-
-    state = hass.states.get("persistent_notification.nest_setup")
-    assert state is None
-
     with patch(
         "homeassistant.components.nest.GoogleNestSubscriber.start_async",
         side_effect=GoogleNestException(),
-    ):
+    ), caplog.at_level(logging.ERROR, logger="homeassistant.components.nest"):
         await async_setup_sdm(hass)
+        assert "Subscriber error:" in caplog.text
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state == ENTRY_STATE_SETUP_RETRY
 
-    state = hass.states.get("persistent_notification.nest_setup")
-    assert state is not None
-    assert state.attributes["title"] == "Nest unavailable"
-    assert state.attributes["message"] == "Subscriber error:"
 
-
-async def test_setup_device_manager_failure(hass):
+async def test_setup_device_manager_failure(hass, caplog):
     """Test configuration error."""
-    await async_setup_component(hass, "persistent_notification", {})
-
-    state = hass.states.get("persistent_notification.nest_setup")
-    assert state is None
-
     with patch("homeassistant.components.nest.GoogleNestSubscriber.start_async"), patch(
         "homeassistant.components.nest.GoogleNestSubscriber.async_get_device_manager",
         side_effect=GoogleNestException(),
-    ):
+    ), caplog.at_level(logging.ERROR, logger="homeassistant.components.nest"):
         await async_setup_sdm(hass)
-        await hass.async_block_till_done()
+        assert len(caplog.messages) == 1
+        assert "Device manager error:" in caplog.text
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state == ENTRY_STATE_SETUP_RETRY
-
-    state = hass.states.get("persistent_notification.nest_setup")
-    assert state is not None
-    assert state.attributes["title"] == "Nest unavailable"
-    assert state.attributes["message"] == "Device manager error:"

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -72,8 +72,10 @@ async def test_setup_configuration_failure(hass):
 async def test_setup_susbcriber_failure(hass):
     """Test configuration error."""
     await async_setup_component(hass, "persistent_notification", {})
-state = hass.states.get("persistent_notification.nest_setup")
-assert state is None
+
+    state = hass.states.get("persistent_notification.nest_setup")
+    assert state is None
+
     with patch(
         "homeassistant.components.nest.GoogleNestSubscriber.start_async",
         side_effect=GoogleNestException(),

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -1,0 +1,111 @@
+"""
+Test for setup methods for the SDM API.
+
+The tests fake out the subscriber/devicemanager and simulate setup behavior
+and failure modes.
+"""
+
+from google_nest_sdm.exceptions import GoogleNestException
+
+from homeassistant.components.nest import DOMAIN
+from homeassistant.config_entries import (
+    ENTRY_STATE_LOADED,
+    ENTRY_STATE_SETUP_ERROR,
+    ENTRY_STATE_SETUP_RETRY,
+)
+from homeassistant.setup import async_setup_component
+
+from .common import CONFIG, CONFIG_ENTRY_DATA, async_setup_sdm_platform
+
+from tests.async_mock import patch
+from tests.common import MockConfigEntry
+
+PLATFORM = "sensor"
+
+
+async def test_setup_success(hass):
+    """Test successful setup."""
+    await async_setup_component(hass, "persistent_notification", {})
+    await async_setup_sdm_platform(hass, PLATFORM)
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state == ENTRY_STATE_LOADED
+
+    state = hass.states.get("persistent_notification.nest_setup")
+    assert state is None
+
+
+async def async_setup_sdm(hass, config=CONFIG):
+    """Prepare test setup."""
+    MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA).add_to_hass(hass)
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"
+    ):
+        await async_setup_component(hass, DOMAIN, config)
+
+
+async def test_setup_configuration_failure(hass):
+    """Test configuration error."""
+    await async_setup_component(hass, "persistent_notification", {})
+
+    config = CONFIG.copy()
+    config[DOMAIN]["subscriber_id"] = "invalid-subscriber-format"
+
+    await async_setup_sdm(hass, config)
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state == ENTRY_STATE_SETUP_ERROR
+
+    state = hass.states.get("persistent_notification.nest_setup")
+    assert state is not None
+    assert state.attributes["title"] == "Nest configuration error"
+    assert (
+        "Subscription misconfigured. Expected subscriber_id"
+        in state.attributes["message"]
+    )
+
+
+async def test_setup_susbcriber_failure(hass):
+    """Test configuration error."""
+    await async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "homeassistant.components.nest.GoogleNestSubscriber.start_async",
+        side_effect=GoogleNestException(),
+    ):
+        await async_setup_sdm(hass)
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state == ENTRY_STATE_SETUP_RETRY
+
+    state = hass.states.get("persistent_notification.nest_setup")
+    assert state is not None
+    assert state.attributes["title"] == "Nest unavailable"
+    assert state.attributes["message"] == "Subscriber error:"
+
+
+async def test_setup_device_manager_failure(hass):
+    """Test configuration error."""
+    await async_setup_component(hass, "persistent_notification", {})
+
+    state = hass.states.get("persistent_notification.nest_setup")
+    assert state is None
+
+    with patch("homeassistant.components.nest.GoogleNestSubscriber.start_async"), patch(
+        "homeassistant.components.nest.GoogleNestSubscriber.async_get_device_manager",
+        side_effect=GoogleNestException(),
+    ):
+        await async_setup_sdm(hass)
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state == ENTRY_STATE_SETUP_RETRY
+
+    state = hass.states.get("persistent_notification.nest_setup")
+    assert state is not None
+    assert state.attributes["title"] == "Nest unavailable"
+    assert state.attributes["message"] == "Device manager error:"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make the nest integration handle errors a bit cleaner by logging once to error logs.  This is meant to make the nest integration quieter, as one of the last remaining items on the silver integration quality scale.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

https://github.com/allenporter/python-google-nest-sdm/compare/v0.2.1...v0.2.2

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
