### PR TITLE
Suppress vizio logging API call failures to prevent no-op logs

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -184,10 +184,10 @@ class VizioDevice(MediaPlayerEntity):
     async def async_update(self) -> None:
         """Retrieve latest state of the device."""
         if not self._model:
-            self._model = await self._device.get_model_name()
+            self._model = await self._device.get_model_name(log_api_exception=False)
 
         if not self._sw_version:
-            self._sw_version = await self._device.get_version()
+            self._sw_version = await self._device.get_version(log_api_exception=False)
 
         is_on = await self._device.get_power_state(log_api_exception=False)
 
@@ -236,7 +236,9 @@ class VizioDevice(MediaPlayerEntity):
                 if not self._available_sound_modes:
                     self._available_sound_modes = (
                         await self._device.get_setting_options(
-                            VIZIO_AUDIO_SETTINGS, VIZIO_SOUND_MODE
+                            VIZIO_AUDIO_SETTINGS,
+                            VIZIO_SOUND_MODE,
+                            log_api_exception=False,
                         )
                     )
             else:
@@ -306,6 +308,7 @@ class VizioDevice(MediaPlayerEntity):
             setting_type,
             setting_name,
             new_value,
+            log_api_exception=False,
         )
 
     async def async_added_to_hass(self) -> None:
@@ -453,52 +456,58 @@ class VizioDevice(MediaPlayerEntity):
         """Select sound mode."""
         if sound_mode in self._available_sound_modes:
             await self._device.set_setting(
-                VIZIO_AUDIO_SETTINGS, VIZIO_SOUND_MODE, sound_mode
+                VIZIO_AUDIO_SETTINGS,
+                VIZIO_SOUND_MODE,
+                sound_mode,
+                log_api_exception=False,
             )
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""
-        await self._device.pow_on()
+        await self._device.pow_on(log_api_exception=False)
 
     async def async_turn_off(self) -> None:
         """Turn the device off."""
-        await self._device.pow_off()
+        await self._device.pow_off(log_api_exception=False)
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         if mute:
-            await self._device.mute_on()
+            await self._device.mute_on(log_api_exception=False)
             self._is_volume_muted = True
         else:
-            await self._device.mute_off()
+            await self._device.mute_off(log_api_exception=False)
             self._is_volume_muted = False
 
     async def async_media_previous_track(self) -> None:
         """Send previous channel command."""
-        await self._device.ch_down()
+        await self._device.ch_down(log_api_exception=False)
 
     async def async_media_next_track(self) -> None:
         """Send next channel command."""
-        await self._device.ch_up()
+        await self._device.ch_up(log_api_exception=False)
 
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         if source in self._available_inputs:
-            await self._device.set_input(source)
+            await self._device.set_input(source, log_api_exception=False)
         elif source in self._get_additional_app_names():
             await self._device.launch_app_config(
                 **next(
                     app["config"]
                     for app in self._additional_app_configs
                     if app["name"] == source
-                )
+                ),
+                log_api_exception=False,
             )
         elif source in self._available_apps:
-            await self._device.launch_app(source, self._all_apps)
+            await self._device.launch_app(
+                source, self._all_apps, log_api_exception=False
+            )
 
     async def async_volume_up(self) -> None:
         """Increase volume of the device."""
-        await self._device.vol_up(num=self._volume_step)
+        await self._device.vol_up(num=self._volume_step, log_api_exception=False)
 
         if self._volume_level is not None:
             self._volume_level = min(
@@ -507,7 +516,7 @@ class VizioDevice(MediaPlayerEntity):
 
     async def async_volume_down(self) -> None:
         """Decrease volume of the device."""
-        await self._device.vol_down(num=self._volume_step)
+        await self._device.vol_down(num=self._volume_step, log_api_exception=False)
 
         if self._volume_level is not None:
             self._volume_level = max(
@@ -519,10 +528,10 @@ class VizioDevice(MediaPlayerEntity):
         if self._volume_level is not None:
             if volume > self._volume_level:
                 num = int(self._max_volume * (volume - self._volume_level))
-                await self._device.vol_up(num=num)
+                await self._device.vol_up(num=num, log_api_exception=False)
                 self._volume_level = volume
 
             elif volume < self._volume_level:
                 num = int(self._max_volume * (self._volume_level - volume))
-                await self._device.vol_down(num=num)
+                await self._device.vol_down(num=num, log_api_exception=False)
                 self._volume_level = volume

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -858,6 +858,7 @@ async def test_zeroconf_ignore(
 
 async def test_zeroconf_no_unique_id(
     hass: HomeAssistantType,
+    vizio_guess_device_type: pytest.fixture,
     vizio_no_unique_id: pytest.fixture,
 ) -> None:
     """Test zeroconf discovery aborts when unique_id is None."""

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -40,6 +40,7 @@ from homeassistant.components.vizio.const import (
     CONF_ADDITIONAL_CONFIGS,
     CONF_APPS,
     CONF_VOLUME_STEP,
+    DEFAULT_VOLUME_STEP,
     DOMAIN,
     SERVICE_UPDATE_SETTING,
     VIZIO_SCHEMA,
@@ -259,6 +260,7 @@ async def _test_service(
     **kwargs,
 ) -> None:
     """Test generic Vizio media player entity service."""
+    kwargs["log_api_exception"] = False
     service_data = {ATTR_ENTITY_ID: ENTITY_ID}
     if additional_service_data:
         service_data.update(additional_service_data)
@@ -378,13 +380,27 @@ async def test_services(
         {ATTR_INPUT_SOURCE: "USB"},
         "USB",
     )
-    await _test_service(hass, MP_DOMAIN, "vol_up", SERVICE_VOLUME_UP, None)
-    await _test_service(hass, MP_DOMAIN, "vol_down", SERVICE_VOLUME_DOWN, None)
     await _test_service(
-        hass, MP_DOMAIN, "vol_up", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 1}
+        hass, MP_DOMAIN, "vol_up", SERVICE_VOLUME_UP, None, num=DEFAULT_VOLUME_STEP
     )
     await _test_service(
-        hass, MP_DOMAIN, "vol_down", SERVICE_VOLUME_SET, {ATTR_MEDIA_VOLUME_LEVEL: 0}
+        hass, MP_DOMAIN, "vol_down", SERVICE_VOLUME_DOWN, None, num=DEFAULT_VOLUME_STEP
+    )
+    await _test_service(
+        hass,
+        MP_DOMAIN,
+        "vol_up",
+        SERVICE_VOLUME_SET,
+        {ATTR_MEDIA_VOLUME_LEVEL: 1},
+        num=(100 - 15),
+    )
+    await _test_service(
+        hass,
+        MP_DOMAIN,
+        "vol_down",
+        SERVICE_VOLUME_SET,
+        {ATTR_MEDIA_VOLUME_LEVEL: 0},
+        num=(15 - 0),
     )
     await _test_service(hass, MP_DOMAIN, "ch_up", SERVICE_MEDIA_NEXT_TRACK, None)
     await _test_service(hass, MP_DOMAIN, "ch_down", SERVICE_MEDIA_PREVIOUS_TRACK, None)
@@ -394,6 +410,9 @@ async def test_services(
         "set_setting",
         SERVICE_SELECT_SOUND_MODE,
         {ATTR_SOUND_MODE: "Music"},
+        "audio",
+        "eq",
+        "Music",
     )
     # Test that the update_setting service does config validation/transformation correctly
     await _test_service(


### PR DESCRIPTION
## Proposed change
`pyvizio` by default will log errors when API calls fail. The Vizio API has changed in newer models such that certain endpoints have changed. I have no way of knowing which API I am talking to, so for these calls, I call the API twice to try the two different locations. This was resulting in logging messages that indicated that an endpoint didn't exist, but there is nothing for the user to do. I have suppressed all logging messages for now - I had already done this for most API calls but I missed a couple.

I've tagged this for 2012.12.2 in case it goes out but this does NOT require a patch release if there is no other good reason to release one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://www.reddit.com/r/homeassistant/comments/kgccda/vizio_integration/

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
