### PR TITLE
Motion Blinds upgrade to local push

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -1,21 +1,32 @@
 """The motion_blinds component."""
-from asyncio import TimeoutError as AsyncioTimeoutError
+import asyncio
 from datetime import timedelta
 import logging
 from socket import timeout
 
+from motionblinds import MotionMulticast
+
 from homeassistant import config_entries, core
-from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_GATEWAY, MANUFACTURER
+from .const import (
+    DOMAIN,
+    KEY_COORDINATOR,
+    KEY_GATEWAY,
+    KEY_MULTICAST_LISTENER,
+    MANUFACTURER,
+    MOTION_PLATFORMS,
+)
 from .gateway import ConnectMotionGateway
 
 _LOGGER = logging.getLogger(__name__)
-
-MOTION_PLATFORMS = ["cover", "sensor"]
 
 
 async def async_setup(hass: core.HomeAssistant, config: dict):
@@ -31,8 +42,26 @@ async def async_setup_entry(
     host = entry.data[CONF_HOST]
     key = entry.data[CONF_API_KEY]
 
+    # Create multicast Listener
+    multicast = hass.data[DOMAIN].setdefault(
+        KEY_MULTICAST_LISTENER,
+        MotionMulticast(),
+    )
+
+    if len(hass.data[DOMAIN]) == 1:
+        # start listening for local pushes (only once)
+        await hass.async_add_executor_job(multicast.Start_listen)
+
+        # register stop callback to shutdown listening for local pushes
+        def stop_motion_multicast(event):
+            """Stop multicast thread."""
+            _LOGGER.debug("Shutting down Motion Listener")
+            multicast.Stop_listen()
+
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_motion_multicast)
+
     # Connect to motion gateway
-    connect_gateway_class = ConnectMotionGateway(hass)
+    connect_gateway_class = ConnectMotionGateway(hass, multicast)
     if not await connect_gateway_class.async_connect_gateway(host, key):
         raise ConfigEntryNotReady
     motion_gateway = connect_gateway_class.gateway_device
@@ -41,14 +70,19 @@ async def async_setup_entry(
         """Call all updates using one async_add_executor_job."""
         motion_gateway.Update()
         for blind in motion_gateway.device_list.values():
-            blind.Update()
+            try:
+                blind.Update()
+            except timeout:
+                # let the error be logged and handled by the motionblinds library
+                pass
 
     async def async_update_data():
         """Fetch data from the gateway and blinds."""
         try:
             await hass.async_add_executor_job(update_gateway)
-        except timeout as socket_timeout:
-            raise AsyncioTimeoutError from socket_timeout
+        except timeout:
+            # let the error be logged and handled by the motionblinds library
+            pass
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -57,7 +91,7 @@ async def async_setup_entry(
         name=entry.title,
         update_method=async_update_data,
         # Polling interval. Will only be polled if there are subscribers.
-        update_interval=timedelta(seconds=10),
+        update_interval=timedelta(seconds=600),
     )
 
     # Fetch initial data so we have data when entities subscribe
@@ -91,11 +125,22 @@ async def async_unload_entry(
     hass: core.HomeAssistant, config_entry: config_entries.ConfigEntry
 ):
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_forward_entry_unload(
-        config_entry, "cover"
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(config_entry, component)
+                for component in MOTION_PLATFORMS
+            ]
+        )
     )
 
     if unload_ok:
         hass.data[DOMAIN].pop(config_entry.entry_id)
+
+    if len(hass.data[DOMAIN]) == 1:
+        # No motion gateways left, stop Motion multicast
+        _LOGGER.debug("Shutting down Motion Listener")
+        multicast = hass.data[DOMAIN].pop(KEY_MULTICAST_LISTENER)
+        await hass.async_add_executor_job(multicast.Stop_listen)
 
     return unload_ok

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -40,7 +40,8 @@ async def async_setup_entry(
 
     # Create multicast Listener
     if KEY_MULTICAST_LISTENER not in hass.data[DOMAIN]:
-        hass.data[DOMAIN][KEY_MULTICAST_LISTENER] = MotionMulticast()
+        multicast = MotionMulticast()
+        hass.data[DOMAIN][KEY_MULTICAST_LISTENER] = multicast
         # start listening for local pushes (only once)
         await hass.async_add_executor_job(multicast.Start_listen)
 

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
 
     # Create multicast Listener
     if KEY_MULTICAST_LISTENER not in hass.data[DOMAIN]:
-        hass.data[DOMAIN][KEY_MULTICAST_LISTENER] = MotionMulticast(),
+        hass.data[DOMAIN][KEY_MULTICAST_LISTENER] = MotionMulticast()
         # start listening for local pushes (only once)
         await hass.async_add_executor_job(multicast.Start_listen)
 

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -7,11 +7,7 @@ from socket import timeout
 from motionblinds import MotionMulticast
 
 from homeassistant import config_entries, core
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    EVENT_HOMEASSISTANT_STOP,
-)
+from homeassistant.const import CONF_API_KEY, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -39,12 +39,8 @@ async def async_setup_entry(
     key = entry.data[CONF_API_KEY]
 
     # Create multicast Listener
-    multicast = hass.data[DOMAIN].setdefault(
-        KEY_MULTICAST_LISTENER,
-        MotionMulticast(),
-    )
-
-    if len(hass.data[DOMAIN]) == 1:
+    if KEY_MULTICAST_LISTENER not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][KEY_MULTICAST_LISTENER] = MotionMulticast(),
         # start listening for local pushes (only once)
         await hass.async_add_executor_job(multicast.Start_listen)
 

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -7,12 +7,11 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 
 # pylint: disable=unused-import
-from .const import DOMAIN
+from .const import DEFAULT_GATEWAY_NAME, DOMAIN
 from .gateway import ConnectMotionGateway
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_GATEWAY_NAME = "Motion Gateway"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -26,7 +25,7 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Motion Blinds config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     def __init__(self):
         """Initialize the Motion Blinds flow."""
@@ -48,7 +47,7 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_connect(self, user_input=None):
         """Connect to the Motion Gateway."""
 
-        connect_gateway_class = ConnectMotionGateway(self.hass)
+        connect_gateway_class = ConnectMotionGateway(self.hass, None)
         if not await connect_gateway_class.async_connect_gateway(self.host, self.key):
             return self.async_abort(reason="connection_error")
         motion_gateway = connect_gateway_class.gateway_device

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -1,6 +1,10 @@
 """Constants for the Motion Blinds component."""
 DOMAIN = "motion_blinds"
-MANUFACTURER = "Motion, Coulisse B.V."
+MANUFACTURER = "Motion Blinds, Coulisse B.V."
+DEFAULT_GATEWAY_NAME = "Motion Blinds Gateway"
+
+MOTION_PLATFORMS = ["cover", "sensor"]
 
 KEY_GATEWAY = "gateway"
 KEY_COORDINATOR = "coordinator"
+KEY_MULTICAST_LISTENER = "multicast_listener"

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -10,9 +10,10 @@ _LOGGER = logging.getLogger(__name__)
 class ConnectMotionGateway:
     """Class to async connect to a Motion Gateway."""
 
-    def __init__(self, hass):
+    def __init__(self, hass, multicast):
         """Initialize the entity."""
         self._hass = hass
+        self._multicast = multicast
         self._gateway_device = None
 
     @property
@@ -24,11 +25,15 @@ class ConnectMotionGateway:
         """Update all information of the gateway."""
         self.gateway_device.GetDeviceList()
         self.gateway_device.Update()
+        for blind in self.gateway_device.device_list.values():
+            blind.Update_from_cache()
 
     async def async_connect_gateway(self, host, key):
         """Connect to the Motion Gateway."""
         _LOGGER.debug("Initializing with host %s (key %s...)", host, key[:3])
-        self._gateway_device = MotionGateway(ip=host, key=key)
+        self._gateway_device = MotionGateway(
+            ip=host, key=key, multicast=self._multicast
+        )
         try:
             # update device info and get the connected sub devices
             await self._hass.async_add_executor_job(self.update_gateway)

--- a/homeassistant/components/motion_blinds/manifest.json
+++ b/homeassistant/components/motion_blinds/manifest.json
@@ -3,6 +3,6 @@
   "name": "Motion Blinds",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/motion_blinds",
-  "requirements": ["motionblinds==0.1.6"],
+  "requirements": ["motionblinds==0.4.7"],
   "codeowners": ["@starkillerOG"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -952,7 +952,7 @@ minio==4.0.9
 mitemp_bt==0.0.3
 
 # homeassistant.components.motion_blinds
-motionblinds==0.1.6
+motionblinds==0.4.7
 
 # homeassistant.components.tts
 mutagen==1.45.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -474,7 +474,7 @@ millheater==0.4.0
 minio==4.0.9
 
 # homeassistant.components.motion_blinds
-motionblinds==0.1.6
+motionblinds==0.4.7
 
 # homeassistant.components.tts
 mutagen==1.45.1

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -8,10 +8,11 @@ from homeassistant.components.motion_blinds.config_flow import DEFAULT_GATEWAY_N
 from homeassistant.components.motion_blinds.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 
-from tests.async_mock import patch
+from tests.async_mock import Mock, patch
 
 TEST_HOST = "1.2.3.4"
 TEST_API_KEY = "12ab345c-d67e-8f"
+TEST_DEVICE_LIST = {"mac": Mock()}
 
 
 @pytest.fixture(name="motion_blinds_connect", autouse=True)
@@ -23,6 +24,9 @@ def motion_blinds_connect_fixture():
     ), patch(
         "homeassistant.components.motion_blinds.gateway.MotionGateway.Update",
         return_value=True,
+    ), patch(
+        "homeassistant.components.motion_blinds.gateway.MotionGateway.device_list",
+        TEST_DEVICE_LIST,
     ), patch(
         "homeassistant.components.motion_blinds.async_setup_entry", return_value=True
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a broken up part of the bigger PR https://github.com/home-assistant/core/pull/43656, that turned out to be to big to revieuw at once.

1) Add multicast push callbacks to instantly receive updates from the motion gateway and its connected blinds.

2) Rework the Update function upstream to actually fetch the status data from the blind itself instead of only the cache of the gateway. Now communication goes like this: HomeAssistant -(wifi)-> motion gateway -(433MHz)-> blind -(433MHz)-> gateway -(wifi)-> HomeAssistant.
Before the communication was: HomeAssistant -(wifi)-> motion gateway -(wifi)-> HomeAssistant
This ensures the positions cann't get out of sync and the battery status is actually fetched (was not the case before, it only refresehd when the app was opened which caused communication with the blind so the gateway cache would update).

Github comparison for upstream library changes: https://github.com/starkillerOG/motion-blinds/compare/d07477f8f0c0a73c474dfe5b385ad569af41c6b8..0.4.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Config flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
