### PR TITLE
Fix KNX issue if 0 kelvin is reported by device

### DIFF
--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -86,7 +86,7 @@ class KNXLight(KnxEntity, LightEntity):
         """Return the color temperature in mireds."""
         if self._device.supports_color_temperature:
             kelvin = self._device.current_color_temperature
-            # Avoid division by zero if actuator reported 0 Kelvin (eg. uninitialized DALI-Gateway)
+            # Avoid division by zero if actuator reported 0 Kelvin (e.g., uninitialized DALI-Gateway)
             if kelvin is not None and kelvin > 0:
                 return color_util.color_temperature_kelvin_to_mired(kelvin)
         if self._device.supports_tunable_white:

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -86,8 +86,7 @@ class KNXLight(KnxEntity, LightEntity):
         """Return the color temperature in mireds."""
         if self._device.supports_color_temperature:
             kelvin = self._device.current_color_temperature
-            # Some KNX-Dali gateways report 0 kelvin if the value has not been set
-            # After setting the value for the first time everything looks as expected
+            # Avoid division by zero if actuator reported 0 Kelvin (eg. uninitialized DALI-Gateway)
             if kelvin is not None and kelvin > 0:
                 return color_util.color_temperature_kelvin_to_mired(kelvin)
         if self._device.supports_tunable_white:

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -86,7 +86,9 @@ class KNXLight(KnxEntity, LightEntity):
         """Return the color temperature in mireds."""
         if self._device.supports_color_temperature:
             kelvin = self._device.current_color_temperature
-            if kelvin is not None:
+            # Some KNX-Dali gateways report 0 kelvin if the value has not been set
+            # After setting the value for the first time everything looks as expected
+            if kelvin is not None and kelvin > 0:
                 return color_util.color_temperature_kelvin_to_mired(kelvin)
         if self._device.supports_tunable_white:
             relative_ct = self._device.current_tunable_white


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some KNX-Dali gateways report 0 kelvin if the color temperature has
not been set. HA tries to convert kelvin to mired and raises a division
by zero exception. This change fixes this issue and treads 0 as if the
value has not been set or reported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I did not find an issue to link the PR with.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
