### PR TITLE
Cleanup and optimization for Zerproc

### DIFF
--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -116,11 +116,14 @@ class ZerprocLight(LightEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        await self._light.disconnect()
+        try:
+            await self._light.disconnect()
+        except pyzerproc.ZerprocException:
+            pass
 
     async def on_hass_shutdown(self, event):
         """Execute when Home Assistant is shutting down."""
-        await self._light.disconnect()
+        await self.async_will_remove_from_hass()
 
     @property
     def name(self):
@@ -192,7 +195,7 @@ class ZerprocLight(LightEntity):
     async def async_update(self):
         """Fetch new state data for this light."""
         try:
-            if not await self._light.is_connected():
+            if not self._available:
                 await self._light.connect()
             state = await self._light.get_state()
         except pyzerproc.ZerprocException:

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -110,20 +110,16 @@ class ZerprocLight(LightEntity):
         """Run when entity about to be added to hass."""
         self.async_on_remove(
             self.hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STOP, self.on_hass_shutdown
+                EVENT_HOMEASSISTANT_STOP, self.async_will_remove_from_hass
             )
         )
 
-    async def async_will_remove_from_hass(self) -> None:
+    async def async_will_remove_from_hass(self, *args) -> None:
         """Run when entity will be removed from hass."""
         try:
             await self._light.disconnect()
         except pyzerproc.ZerprocException:
             pass
-
-    async def on_hass_shutdown(self, event):
-        """Execute when Home Assistant is shutting down."""
-        await self.async_will_remove_from_hass()
 
     @property
     def name(self):

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -119,7 +119,9 @@ class ZerprocLight(LightEntity):
         try:
             await self._light.disconnect()
         except pyzerproc.ZerprocException:
-            pass
+            _LOGGER.debug(
+                "Exception disconnected from %s", self.entity_id, exc_info=True
+            )
 
     @property
     def name(self):

--- a/homeassistant/components/zerproc/manifest.json
+++ b/homeassistant/components/zerproc/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zerproc",
   "requirements": [
-    "pyzerproc==0.4.3"
+    "pyzerproc==0.4.7"
   ],
   "codeowners": [
     "@emlove"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1904,7 +1904,7 @@ pyxeoma==1.4.1
 pyzbar==0.1.7
 
 # homeassistant.components.zerproc
-pyzerproc==0.4.3
+pyzerproc==0.4.7
 
 # homeassistant.components.qnap
 qnapstats==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -939,7 +939,7 @@ pywemo==0.5.3
 pywilight==0.0.65
 
 # homeassistant.components.zerproc
-pyzerproc==0.4.3
+pyzerproc==0.4.7
 
 # homeassistant.components.rachio
 rachiopy==1.0.3

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -173,6 +173,16 @@ async def test_remove_entry(hass, mock_light, mock_entry):
     assert mock_disconnect.called
 
 
+async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):
+    """Assert that disconnect exceptions are caught."""
+    with patch.object(
+        mock_light, "disconnect", side_effect=pyzerproc.ZerprocException("Mock error")
+    ) as mock_disconnect:
+        await hass.config_entries.async_remove(mock_entry.entry_id)
+
+    assert mock_disconnect.called
+
+
 async def test_light_turn_on(hass, mock_light):
     """Test ZerprocLight turn_on."""
     utcnow = dt_util.utcnow()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR resolves some final cleanup and performance issues with the Zerproc async migration. Most notably, the `is_connected` call could potentially take a long time to return if the device is disconnected, resulting in update calls taking longer than 30s when the light was not connected. Additionally, the `connect` method was taking a long time to time out, and a default timeout has been added upstream.

Upstream changelog: https://github.com/emlove/pyzerproc#047-2020-12-20

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
