### PR TITLE
Soma cover battery level attribute

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -833,8 +833,9 @@ omit =
     homeassistant/components/solaredge_local/sensor.py
     homeassistant/components/solarlog/*
     homeassistant/components/solax/sensor.py
-    homeassistant/components/soma/cover.py
     homeassistant/components/soma/__init__.py
+    homeassistant/components/soma/cover.py
+    homeassistant/components/soma/sensor.py
     homeassistant/components/somfy/*
     homeassistant/components/somfy_mylink/*
     homeassistant/components/sonos/*

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -74,7 +74,7 @@ class SomaEntity(Entity):
         self.device = device
         self.api = api
         self.current_position = 50
-        self.state_attrs = None
+        self.state_attrs = {}
         self.is_available = True
 
     @property
@@ -140,6 +140,5 @@ class SomaEntity(Entity):
             battery = 0
         elif battery > 100:
             battery = 100
-        self.state_attrs = {}
         self.state_attrs[ATTR_BATTERY_LEVEL] = battery
         self.is_available = True

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -135,7 +135,7 @@ class SomaEntity(Entity):
             )
             self.is_available = False
             return
-        battery = response["battery_level"] - 320
+        battery = 2.5 * response["battery_level"] - 922
         if battery < 0:
             battery = 0
         elif battery > 100:

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -136,9 +136,6 @@ class SomaEntity(Entity):
             self.is_available = False
             return
         battery = round(2.111 * response["battery_level"] - 763.3)
-        if battery < 0:
-            battery = 0
-        elif battery > 100:
-            battery = 100
+        battery = max(min(100, battery), 0)
         self.battery_state = battery
         self.is_available = True

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_BATTERY_LEVEL, CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-SOMA_COMPONENTS = ["cover"]
+SOMA_COMPONENTS = ["cover", "sensor"]
 
 
 async def async_setup(hass, config):
@@ -74,7 +74,7 @@ class SomaEntity(Entity):
         self.device = device
         self.api = api
         self.current_position = 50
-        self.state_attrs = {}
+        self.battery_state = 0
         self.is_available = True
 
     @property
@@ -135,10 +135,10 @@ class SomaEntity(Entity):
             )
             self.is_available = False
             return
-        battery = 2.5 * response["battery_level"] - 922
+        battery = round(2.111 * response["battery_level"] - 763.3)
         if battery < 0:
             battery = 0
         elif battery > 100:
             battery = 100
-        self.state_attrs[ATTR_BATTERY_LEVEL] = battery
+        self.battery_state = battery
         self.is_available = True

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -135,7 +135,7 @@ class SomaEntity(Entity):
             )
             self.is_available = False
             return
-        battery = round(2.111 * response["battery_level"] - 763.3)
-        battery = max(min(100, battery), 0)
+        _battery = round(2 * (response["battery_level"] - 360))
+        battery = max(min(100, _battery), 0)
         self.battery_state = battery
         self.is_available = True

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -135,6 +135,10 @@ class SomaEntity(Entity):
             )
             self.is_available = False
             return
+        # https://support.somasmarthome.com/hc/en-us/articles/360026064234-HTTP-API
+        # battery_level response is expected to be min = 360, max 410 for
+        # 0-100% levels above 410 are consider 100% and below 360, 0% as the
+        # device considers 360 the minimum to move the motor.
         _battery = round(2 * (response["battery_level"] - 360))
         battery = max(min(100, _battery), 0)
         self.battery_state = battery

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT, ATTR_BATTERY_LEVEL
+from homeassistant.const import ATTR_BATTERY_LEVEL, CONF_HOST, CONF_PORT
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType

--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -67,3 +67,8 @@ class SomaCover(SomaEntity, CoverEntity):
     def is_closed(self):
         """Return if the cover is closed."""
         return self.current_position == 0
+
+    @property
+    def device_state_attributes(self):
+        """Get additional state attributes."""
+        return self.state_attrs

--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -67,8 +67,3 @@ class SomaCover(SomaEntity, CoverEntity):
     def is_closed(self):
         """Return if the cover is closed."""
         return self.current_position == 0
-
-    @property
-    def device_state_attributes(self):
-        """Get additional state attributes."""
-        return self.state_attrs

--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -5,6 +5,7 @@ from homeassistant.helpers.entity import Entity
 from . import DEVICES, SomaEntity
 from .const import API, DOMAIN
 
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Soma sensor platform."""
 

--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -1,8 +1,9 @@
 """Support for Soma sensors."""
-from homeassistant.components.soma import API, DEVICES, DOMAIN, SomaEntity
 from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE
 from homeassistant.helpers.entity import Entity
 
+from . import DEVICES, SomaEntity
+from .const import API, DOMAIN
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Soma sensor platform."""

--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -1,0 +1,38 @@
+"""Support for Soma sensors."""
+from homeassistant.components.soma import API, DEVICES, DOMAIN, SomaEntity
+from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE
+from homeassistant.helpers.entity import Entity
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Soma sensor platform."""
+
+    devices = hass.data[DOMAIN][DEVICES]
+
+    async_add_entities(
+        [SomaSensor(sensor, hass.data[DOMAIN][API]) for sensor in devices], True
+    )
+
+
+class SomaSensor(SomaEntity, Entity):
+    """Representation of a Soma cover device."""
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_BATTERY
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self.device["name"] + " battery level"
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self.battery_state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement this sensor expresses itself in."""
+        return PERCENTAGE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add battery charge level (0-100) to Soma cover. I had a Soma Smart Shades 2 which is automated to open/close based on light levels with Home Assistant stop working. I worked out this was because the battery had become too low, and I hadn't noticed. So this change exposes the battery level, using the get_battery_level call which is already available via the pysoma API used by the integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

The Soma API is documented here - https://support.somasmarthome.com/hc/en-us/articles/360026064234-HTTP-API
I have tried to make the reported battery percentage match the Soma iOS Smart Shade app, from a couple of data points I had - comparing the level reported by the API with the percentage given in the app.
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
