### PR TITLE
Support dynamic Google Cast groups

### DIFF
--- a/homeassistant/components/cast/discovery.py
+++ b/homeassistant/components/cast/discovery.py
@@ -25,6 +25,7 @@ def discover_chromecast(hass: HomeAssistant, info: ChromecastInfo):
         _LOGGER.error("Discovered chromecast without uuid %s", info)
         return
 
+    info = info.fill_out_missing_chromecast_info()
     if info.uuid in hass.data[KNOWN_CHROMECAST_INFO_KEY]:
         _LOGGER.debug("Discovered update for known chromecast %s", info)
     else:

--- a/homeassistant/components/cast/helpers.py
+++ b/homeassistant/components/cast/helpers.py
@@ -2,6 +2,7 @@
 from typing import Optional, Tuple
 
 import attr
+from pychromecast import dial
 from pychromecast.const import CAST_MANUFACTURERS
 
 from .const import DEFAULT_PORT
@@ -22,11 +23,29 @@ class ChromecastInfo:
     )  # always convert UUID to string if not None
     model_name: str = attr.ib(default="")
     friendly_name: Optional[str] = attr.ib(default=None)
+    is_dynamic_group = attr.ib(type=Optional[bool], default=None)
 
     @property
     def is_audio_group(self) -> bool:
         """Return if this is an audio group."""
         return self.port != DEFAULT_PORT
+
+    @property
+    def is_information_complete(self) -> bool:
+        """Return if all information is filled out."""
+        want_dynamic_group = self.is_audio_group
+        have_dynamic_group = self.is_dynamic_group is not None
+        have_all_except_dynamic_group = all(
+            attr.astuple(
+                self,
+                filter=attr.filters.exclude(
+                    attr.fields(ChromecastInfo).is_dynamic_group
+                ),
+            )
+        )
+        return have_all_except_dynamic_group and (
+            not want_dynamic_group or have_dynamic_group
+        )
 
     @property
     def host_port(self) -> Tuple[str, int]:
@@ -39,6 +58,67 @@ class ChromecastInfo:
         if not self.model_name:
             return None
         return CAST_MANUFACTURERS.get(self.model_name.lower(), "Google Inc.")
+
+    def fill_out_missing_chromecast_info(self) -> "ChromecastInfo":
+        """Return a new ChromecastInfo object with missing attributes filled in.
+
+        Uses blocking HTTP / HTTPS.
+        """
+        if self.is_information_complete:
+            # We have all information, no need to check HTTP API.
+            return self
+
+        # Fill out missing group information via HTTP API.
+        if self.is_audio_group:
+            is_dynamic_group = False
+            http_group_status = None
+            dynamic_groups = []
+            if self.uuid:
+                http_group_status = dial.get_multizone_status(
+                    self.host,
+                    services=self.services,
+                    zconf=ChromeCastZeroconf.get_zeroconf(),
+                )
+                if http_group_status is not None:
+                    dynamic_groups = [
+                        str(g.uuid) for g in http_group_status.dynamic_groups
+                    ]
+                    is_dynamic_group = self.uuid in dynamic_groups
+
+            return ChromecastInfo(
+                services=self.services,
+                host=self.host,
+                port=self.port,
+                uuid=self.uuid,
+                friendly_name=self.friendly_name,
+                model_name=self.model_name,
+                is_dynamic_group=is_dynamic_group,
+            )
+
+        # Fill out some missing information (friendly_name, uuid) via HTTP dial.
+        http_device_status = dial.get_device_status(
+            self.host, services=self.services, zconf=ChromeCastZeroconf.get_zeroconf()
+        )
+        if http_device_status is None:
+            # HTTP dial didn't give us any new information.
+            return self
+
+        return ChromecastInfo(
+            services=self.services,
+            host=self.host,
+            port=self.port,
+            uuid=(self.uuid or http_device_status.uuid),
+            friendly_name=(self.friendly_name or http_device_status.friendly_name),
+            model_name=self.model_name,
+        )
+
+    def same_dynamic_group(self, other: "ChromecastInfo") -> bool:
+        """Test chromecast info is same dynamic group."""
+        return (
+            self.is_audio_group
+            and other.is_dynamic_group
+            and self.friendly_name == other.friendly_name
+        )
 
 
 class ChromeCastZeroconf:
@@ -122,4 +202,46 @@ class CastStatusListener:
             self._mz_mgr.remove_multizone(self._uuid)
         else:
             self._mz_mgr.deregister_listener(self._uuid, self)
+        self._valid = False
+
+
+class DynamicGroupCastStatusListener:
+    """Helper class to handle pychromecast status callbacks.
+
+    Necessary because a CastDevice entity can create a new socket client
+    and therefore callbacks from multiple chromecast connections can
+    potentially arrive. This class allows invalidating past chromecast objects.
+    """
+
+    def __init__(self, cast_device, chromecast, mz_mgr):
+        """Initialize the status listener."""
+        self._cast_device = cast_device
+        self._uuid = chromecast.uuid
+        self._valid = True
+        self._mz_mgr = mz_mgr
+
+        chromecast.register_status_listener(self)
+        chromecast.socket_client.media_controller.register_status_listener(self)
+        chromecast.register_connection_listener(self)
+        self._mz_mgr.add_multizone(chromecast)
+
+    def new_cast_status(self, cast_status):
+        """Handle reception of a new CastStatus."""
+
+    def new_media_status(self, media_status):
+        """Handle reception of a new MediaStatus."""
+        if self._valid:
+            self._cast_device.new_dynamic_group_media_status(media_status)
+
+    def new_connection_status(self, connection_status):
+        """Handle reception of a new ConnectionStatus."""
+        if self._valid:
+            self._cast_device.new_dynamic_group_connection_status(connection_status)
+
+    def invalidate(self):
+        """Invalidate this status listener.
+
+        All following callbacks won't be forwarded.
+        """
+        self._mz_mgr.remove_multizone(self._uuid)
         self._valid = False

--- a/homeassistant/components/cast/helpers.py
+++ b/homeassistant/components/cast/helpers.py
@@ -1,5 +1,5 @@
 """Helpers to deal with Cast devices."""
-from typing import Optional, Tuple
+from typing import Optional
 
 import attr
 from pychromecast import dial
@@ -21,6 +21,7 @@ class ChromecastInfo:
     uuid: Optional[str] = attr.ib(
         converter=attr.converters.optional(str), default=None
     )  # always convert UUID to string if not None
+    _manufacturer = attr.ib(type=Optional[str], default=None)
     model_name: str = attr.ib(default="")
     friendly_name: Optional[str] = attr.ib(default=None)
     is_dynamic_group = attr.ib(type=Optional[bool], default=None)
@@ -48,13 +49,10 @@ class ChromecastInfo:
         )
 
     @property
-    def host_port(self) -> Tuple[str, int]:
-        """Return the host+port tuple."""
-        return self.host, self.port
-
-    @property
     def manufacturer(self) -> str:
         """Return the manufacturer."""
+        if self._manufacturer:
+            return self._manufacturer
         if not self.model_name:
             return None
         return CAST_MANUFACTURERS.get(self.model_name.lower(), "Google Inc.")
@@ -109,7 +107,8 @@ class ChromecastInfo:
             port=self.port,
             uuid=(self.uuid or http_device_status.uuid),
             friendly_name=(self.friendly_name or http_device_status.friendly_name),
-            model_name=self.model_name,
+            manufacturer=(self.manufacturer or http_device_status.manufacturer),
+            model_name=(self.model_name or http_device_status.model_name),
         )
 
     def same_dynamic_group(self, other: "ChromecastInfo") -> bool:

--- a/homeassistant/components/cast/helpers.py
+++ b/homeassistant/components/cast/helpers.py
@@ -70,7 +70,6 @@ class ChromecastInfo:
         if self.is_audio_group:
             is_dynamic_group = False
             http_group_status = None
-            dynamic_groups = []
             if self.uuid:
                 http_group_status = dial.get_multizone_status(
                     self.host,
@@ -78,10 +77,10 @@ class ChromecastInfo:
                     zconf=ChromeCastZeroconf.get_zeroconf(),
                 )
                 if http_group_status is not None:
-                    dynamic_groups = [
-                        str(g.uuid) for g in http_group_status.dynamic_groups
-                    ]
-                    is_dynamic_group = self.uuid in dynamic_groups
+                    is_dynamic_group = any(
+                        str(g.uuid) == self.uuid
+                        for g in http_group_status.dynamic_groups
+                    )
 
             return ChromecastInfo(
                 services=self.services,

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==7.7.0"],
+  "requirements": ["pychromecast==7.7.1"],
   "after_dependencies": ["cloud", "http", "media_source", "plex", "tts", "zeroconf"],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==7.6.0"],
+  "requirements": ["pychromecast==7.7.0"],
   "after_dependencies": ["cloud", "http", "media_source", "plex", "tts", "zeroconf"],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -63,10 +63,16 @@ from .const import (
     DOMAIN as CAST_DOMAIN,
     KNOWN_CHROMECAST_INFO_KEY,
     SIGNAL_CAST_DISCOVERED,
+    SIGNAL_CAST_REMOVED,
     SIGNAL_HASS_CAST_SHOW_VIEW,
 )
 from .discovery import setup_internal_discovery
-from .helpers import CastStatusListener, ChromecastInfo, ChromeCastZeroconf
+from .helpers import (
+    CastStatusListener,
+    ChromecastInfo,
+    ChromeCastZeroconf,
+    DynamicGroupCastStatusListener,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,6 +114,10 @@ def _async_create_cast_device(hass: HomeAssistantType, info: ChromecastInfo):
         return None
 
     # Found a cast with UUID
+    if info.is_dynamic_group:
+        # This is a dynamic group, do not add it.
+        return None
+
     added_casts = hass.data[ADDED_CAST_DEVICES_KEY]
     if info.uuid in added_casts:
         # Already added this one, the entity will take care of moved hosts
@@ -190,14 +200,23 @@ class CastDevice(MediaPlayerEntity):
         self.cast_status = None
         self.media_status = None
         self.media_status_received = None
+        self._dynamic_group_cast_info: ChromecastInfo = None
+        self._dynamic_group_cast: Optional[pychromecast.Chromecast] = None
+        self.dynamic_group_media_status = None
+        self.dynamic_group_media_status_received = None
         self.mz_media_status = {}
         self.mz_media_status_received = {}
         self.mz_mgr = None
         self._available = False
+        self._dynamic_group_available = False
         self._status_listener: Optional[CastStatusListener] = None
+        self._dynamic_group_status_listener: Optional[
+            DynamicGroupCastStatusListener
+        ] = None
         self._hass_cast_controller: Optional[HomeAssistantController] = None
 
         self._add_remove_handler = None
+        self._del_remove_handler = None
         self._cast_view_remove_handler = None
 
     async def async_added_to_hass(self):
@@ -205,10 +224,29 @@ class CastDevice(MediaPlayerEntity):
         self._add_remove_handler = async_dispatcher_connect(
             self.hass, SIGNAL_CAST_DISCOVERED, self._async_cast_discovered
         )
+        self._del_remove_handler = async_dispatcher_connect(
+            self.hass, SIGNAL_CAST_REMOVED, self._async_cast_removed
+        )
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_stop)
         self.hass.async_create_task(
             async_create_catching_coro(self.async_set_cast_info(self._cast_info))
         )
+        for info in self.hass.data[KNOWN_CHROMECAST_INFO_KEY]:
+            if self._cast_info.same_dynamic_group(
+                self.hass.data[KNOWN_CHROMECAST_INFO_KEY][info]
+            ):
+                _LOGGER.debug(
+                    "[%s %s (%s:%s)] Found dynamic group: %s",
+                    self.entity_id,
+                    self._cast_info.friendly_name,
+                    self._cast_info.host,
+                    self._cast_info.port,
+                    info,
+                )
+                self.hass.async_create_task(
+                    async_create_catching_coro(self.async_set_dynamic_group(info))
+                )
+                break
 
         self._cast_view_remove_handler = async_dispatcher_connect(
             self.hass, SIGNAL_HASS_CAST_SHOW_VIEW, self._handle_signal_show_view
@@ -224,6 +262,9 @@ class CastDevice(MediaPlayerEntity):
         if self._add_remove_handler:
             self._add_remove_handler()
             self._add_remove_handler = None
+        if self._del_remove_handler:
+            self._del_remove_handler()
+            self._del_remove_handler = None
         if self._cast_view_remove_handler:
             self._cast_view_remove_handler()
             self._cast_view_remove_handler = None
@@ -270,6 +311,69 @@ class CastDevice(MediaPlayerEntity):
         self._chromecast.start()
         self.async_write_ha_state()
 
+    async def async_set_dynamic_group(self, cast_info):
+        """Set the cast information and set up the chromecast object."""
+
+        _LOGGER.debug(
+            "[%s %s (%s:%s)] Connecting to dynamic group by host %s",
+            self.entity_id,
+            self._cast_info.friendly_name,
+            self._cast_info.host,
+            self._cast_info.port,
+            cast_info,
+        )
+
+        await self.async_del_dynamic_group()
+        self._dynamic_group_cast_info = cast_info
+
+        # pylint: disable=protected-access
+        chromecast = await self.hass.async_add_executor_job(
+            pychromecast._get_chromecast_from_host,
+            (
+                cast_info.host,
+                cast_info.port,
+                cast_info.uuid,
+                cast_info.model_name,
+                cast_info.friendly_name,
+            ),
+        )
+
+        self._dynamic_group_cast = chromecast
+
+        if CAST_MULTIZONE_MANAGER_KEY not in self.hass.data:
+            self.hass.data[CAST_MULTIZONE_MANAGER_KEY] = MultizoneManager()
+
+        mz_mgr = self.hass.data[CAST_MULTIZONE_MANAGER_KEY]
+
+        self._dynamic_group_status_listener = DynamicGroupCastStatusListener(
+            self, chromecast, mz_mgr
+        )
+        self._dynamic_group_available = False
+        self.dynamic_group_media_status = chromecast.media_controller.status
+        self._dynamic_group_cast.start()
+        self.async_write_ha_state()
+
+    async def async_del_dynamic_group(self):
+        """Remove the dynamic group."""
+        cast_info = self._dynamic_group_cast_info
+        _LOGGER.debug(
+            "[%s %s (%s:%s)] Remove dynamic group: %s",
+            self.entity_id,
+            self._cast_info.friendly_name,
+            self._cast_info.host,
+            self._cast_info.port,
+            cast_info.services if cast_info else None,
+        )
+
+        self._dynamic_group_available = False
+        self._dynamic_group_cast_info = None
+        if self._dynamic_group_cast is not None:
+            await self.hass.async_add_executor_job(self._dynamic_group_cast.disconnect)
+
+        self._dynamic_group_invalidate()
+
+        self.async_write_ha_state()
+
     async def _async_disconnect(self):
         """Disconnect Chromecast object if it is set."""
         if self._chromecast is None:
@@ -284,6 +388,8 @@ class CastDevice(MediaPlayerEntity):
         self.async_write_ha_state()
 
         await self.hass.async_add_executor_job(self._chromecast.disconnect)
+        if self._dynamic_group_cast is not None:
+            await self.hass.async_add_executor_job(self._dynamic_group_cast.disconnect)
 
         self._invalidate()
 
@@ -302,6 +408,15 @@ class CastDevice(MediaPlayerEntity):
         if self._status_listener is not None:
             self._status_listener.invalidate()
             self._status_listener = None
+
+    def _dynamic_group_invalidate(self):
+        """Invalidate some attributes."""
+        self._dynamic_group_cast = None
+        self.dynamic_group_media_status = None
+        self.dynamic_group_media_status_received = None
+        if self._dynamic_group_status_listener is not None:
+            self._dynamic_group_status_listener.invalidate()
+            self._dynamic_group_status_listener = None
 
     # ========== Callbacks ==========
     def new_cast_status(self, cast_status):
@@ -385,6 +500,44 @@ class CastDevice(MediaPlayerEntity):
             self._available = new_available
             self.schedule_update_ha_state()
 
+    def new_dynamic_group_media_status(self, media_status):
+        """Handle updates of the media status."""
+        self.dynamic_group_media_status = media_status
+        self.dynamic_group_media_status_received = dt_util.utcnow()
+        self.schedule_update_ha_state()
+
+    def new_dynamic_group_connection_status(self, connection_status):
+        """Handle updates of connection status."""
+        _LOGGER.debug(
+            "[%s %s (%s:%s)] Received dynamic group connection status: %s",
+            self.entity_id,
+            self._cast_info.friendly_name,
+            self._cast_info.host,
+            self._cast_info.port,
+            connection_status.status,
+        )
+        if connection_status.status == CONNECTION_STATUS_DISCONNECTED:
+            self._dynamic_group_available = False
+            self._dynamic_group_invalidate()
+            self.schedule_update_ha_state()
+            return
+
+        new_available = connection_status.status == CONNECTION_STATUS_CONNECTED
+        if new_available != self._dynamic_group_available:
+            # Connection status callbacks happen often when disconnected.
+            # Only update state when availability changed to put less pressure
+            # on state machine.
+            _LOGGER.debug(
+                "[%s %s (%s:%s)] Dynamic group availability changed: %s",
+                self.entity_id,
+                self._cast_info.friendly_name,
+                self._cast_info.host,
+                self._cast_info.port,
+                connection_status.status,
+            )
+            self._dynamic_group_available = new_available
+            self.schedule_update_ha_state()
+
     def multizone_new_media_status(self, group_uuid, media_status):
         """Handle updates of audio group media status."""
         _LOGGER.debug(
@@ -403,10 +556,17 @@ class CastDevice(MediaPlayerEntity):
         """
         Return media controller.
 
-        First try from our own cast, then groups which our cast is a member in.
+        First try from our own cast, then dynamic groups and finally
+        groups which our cast is a member in.
         """
         media_status = self.media_status
         media_controller = self._chromecast.media_controller
+
+        if (
+            media_status is None or media_status.player_state == "UNKNOWN"
+        ) and self._dynamic_group_cast is not None:
+            media_status = self.dynamic_group_media_status
+            media_controller = self._dynamic_group_cast.media_controller
 
         if media_status is None or media_status.player_state == "UNKNOWN":
             groups = self.mz_media_status
@@ -513,7 +673,7 @@ class CastDevice(MediaPlayerEntity):
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play media from a URL."""
-        # We do not want this to be forwarded to a group
+        # We do not want this to be forwarded to a group / dynamic group
         if media_type == CAST_DOMAIN:
             try:
                 app_data = json.loads(media_id)
@@ -583,10 +743,17 @@ class CastDevice(MediaPlayerEntity):
         """
         Return media status.
 
-        First try from our own cast, then groups which our cast is a member in.
+        First try from our own cast, then dynamic groups and finally
+        groups which our cast is a member in.
         """
         media_status = self.media_status
         media_status_received = self.media_status_received
+
+        if (
+            media_status is None or media_status.player_state == "UNKNOWN"
+        ) and self._dynamic_group_cast is not None:
+            media_status = self.dynamic_group_media_status
+            media_status_received = self.dynamic_group_media_status_received
 
         if media_status is None or media_status.player_state == "UNKNOWN":
             groups = self.mz_media_status
@@ -781,12 +948,30 @@ class CastDevice(MediaPlayerEntity):
             # We can't handle empty UUIDs
             return
 
+        if self._cast_info.same_dynamic_group(discover):
+            _LOGGER.debug("Discovered matching dynamic group: %s", discover)
+            await self.async_set_dynamic_group(discover)
+            return
+
         if self._cast_info.uuid != discover.uuid:
             # Discovered is not our device.
             return
 
         _LOGGER.debug("Discovered chromecast with same UUID: %s", discover)
         await self.async_set_cast_info(discover)
+
+    async def _async_cast_removed(self, discover: ChromecastInfo):
+        """Handle removal of Chromecast."""
+        if self._cast_info.uuid is None:
+            # We can't handle empty UUIDs
+            return
+
+        if (
+            self._dynamic_group_cast_info is not None
+            and self._dynamic_group_cast_info.uuid == discover.uuid
+        ):
+            _LOGGER.debug("Removed matching dynamic group: %s", discover)
+            await self.async_del_dynamic_group()
 
     async def _async_stop(self, event):
         """Disconnect socket on Home Assistant stop."""

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -67,12 +67,7 @@ from .const import (
     SIGNAL_HASS_CAST_SHOW_VIEW,
 )
 from .discovery import setup_internal_discovery
-from .helpers import (
-    CastStatusListener,
-    ChromecastInfo,
-    ChromeCastZeroconf,
-    DynamicGroupCastStatusListener,
-)
+from .helpers import CastStatusListener, ChromecastInfo, ChromeCastZeroconf
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,10 +109,6 @@ def _async_create_cast_device(hass: HomeAssistantType, info: ChromecastInfo):
         return None
 
     # Found a cast with UUID
-    if info.is_dynamic_group:
-        # This is a dynamic group, do not add it.
-        return None
-
     added_casts = hass.data[ADDED_CAST_DEVICES_KEY]
     if info.uuid in added_casts:
         # Already added this one, the entity will take care of moved hosts
@@ -125,6 +116,13 @@ def _async_create_cast_device(hass: HomeAssistantType, info: ChromecastInfo):
         return None
     # -> New cast device
     added_casts.add(info.uuid)
+
+    if info.is_dynamic_group:
+        # This is a dynamic group, do not add it but connect to the service.
+        group = DynamicCastGroup(hass, info)
+        group.async_setup()
+        return None
+
     return CastDevice(info)
 
 
@@ -200,23 +198,14 @@ class CastDevice(MediaPlayerEntity):
         self.cast_status = None
         self.media_status = None
         self.media_status_received = None
-        self._dynamic_group_cast_info: ChromecastInfo = None
-        self._dynamic_group_cast: Optional[pychromecast.Chromecast] = None
-        self.dynamic_group_media_status = None
-        self.dynamic_group_media_status_received = None
         self.mz_media_status = {}
         self.mz_media_status_received = {}
         self.mz_mgr = None
         self._available = False
-        self._dynamic_group_available = False
         self._status_listener: Optional[CastStatusListener] = None
-        self._dynamic_group_status_listener: Optional[
-            DynamicGroupCastStatusListener
-        ] = None
         self._hass_cast_controller: Optional[HomeAssistantController] = None
 
         self._add_remove_handler = None
-        self._del_remove_handler = None
         self._cast_view_remove_handler = None
 
     async def async_added_to_hass(self):
@@ -224,29 +213,11 @@ class CastDevice(MediaPlayerEntity):
         self._add_remove_handler = async_dispatcher_connect(
             self.hass, SIGNAL_CAST_DISCOVERED, self._async_cast_discovered
         )
-        self._del_remove_handler = async_dispatcher_connect(
-            self.hass, SIGNAL_CAST_REMOVED, self._async_cast_removed
-        )
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_stop)
+        self.async_set_cast_info(self._cast_info)
         self.hass.async_create_task(
-            async_create_catching_coro(self.async_set_cast_info(self._cast_info))
+            async_create_catching_coro(self.async_connect_to_chromecast())
         )
-        for info in self.hass.data[KNOWN_CHROMECAST_INFO_KEY]:
-            if self._cast_info.same_dynamic_group(
-                self.hass.data[KNOWN_CHROMECAST_INFO_KEY][info]
-            ):
-                _LOGGER.debug(
-                    "[%s %s (%s:%s)] Found dynamic group: %s",
-                    self.entity_id,
-                    self._cast_info.friendly_name,
-                    self._cast_info.host,
-                    self._cast_info.port,
-                    info,
-                )
-                self.hass.async_create_task(
-                    async_create_catching_coro(self.async_set_dynamic_group(info))
-                )
-                break
 
         self._cast_view_remove_handler = async_dispatcher_connect(
             self.hass, SIGNAL_HASS_CAST_SHOW_VIEW, self._handle_signal_show_view
@@ -262,22 +233,17 @@ class CastDevice(MediaPlayerEntity):
         if self._add_remove_handler:
             self._add_remove_handler()
             self._add_remove_handler = None
-        if self._del_remove_handler:
-            self._del_remove_handler()
-            self._del_remove_handler = None
         if self._cast_view_remove_handler:
             self._cast_view_remove_handler()
             self._cast_view_remove_handler = None
 
-    async def async_set_cast_info(self, cast_info):
-        """Set the cast information and set up the chromecast object."""
+    def async_set_cast_info(self, cast_info):
+        """Set the cast information."""
 
         self._cast_info = cast_info
 
-        if self._chromecast is not None:
-            # Only setup the chromecast once, added elements to services
-            # will automatically be picked up.
-            return
+    async def async_connect_to_chromecast(self):
+        """Set up the chromecast object."""
 
         _LOGGER.debug(
             "[%s %s] Connecting to cast device by service %s",
@@ -289,9 +255,9 @@ class CastDevice(MediaPlayerEntity):
             pychromecast.get_chromecast_from_service,
             (
                 self.services,
-                cast_info.uuid,
-                cast_info.model_name,
-                cast_info.friendly_name,
+                self._cast_info.uuid,
+                self._cast_info.model_name,
+                self._cast_info.friendly_name,
                 None,
                 None,
             ),
@@ -311,69 +277,6 @@ class CastDevice(MediaPlayerEntity):
         self._chromecast.start()
         self.async_write_ha_state()
 
-    async def async_set_dynamic_group(self, cast_info):
-        """Set the cast information and set up the chromecast object."""
-
-        _LOGGER.debug(
-            "[%s %s (%s:%s)] Connecting to dynamic group by host %s",
-            self.entity_id,
-            self._cast_info.friendly_name,
-            self._cast_info.host,
-            self._cast_info.port,
-            cast_info,
-        )
-
-        await self.async_del_dynamic_group()
-        self._dynamic_group_cast_info = cast_info
-
-        # pylint: disable=protected-access
-        chromecast = await self.hass.async_add_executor_job(
-            pychromecast._get_chromecast_from_host,
-            (
-                cast_info.host,
-                cast_info.port,
-                cast_info.uuid,
-                cast_info.model_name,
-                cast_info.friendly_name,
-            ),
-        )
-
-        self._dynamic_group_cast = chromecast
-
-        if CAST_MULTIZONE_MANAGER_KEY not in self.hass.data:
-            self.hass.data[CAST_MULTIZONE_MANAGER_KEY] = MultizoneManager()
-
-        mz_mgr = self.hass.data[CAST_MULTIZONE_MANAGER_KEY]
-
-        self._dynamic_group_status_listener = DynamicGroupCastStatusListener(
-            self, chromecast, mz_mgr
-        )
-        self._dynamic_group_available = False
-        self.dynamic_group_media_status = chromecast.media_controller.status
-        self._dynamic_group_cast.start()
-        self.async_write_ha_state()
-
-    async def async_del_dynamic_group(self):
-        """Remove the dynamic group."""
-        cast_info = self._dynamic_group_cast_info
-        _LOGGER.debug(
-            "[%s %s (%s:%s)] Remove dynamic group: %s",
-            self.entity_id,
-            self._cast_info.friendly_name,
-            self._cast_info.host,
-            self._cast_info.port,
-            cast_info.services if cast_info else None,
-        )
-
-        self._dynamic_group_available = False
-        self._dynamic_group_cast_info = None
-        if self._dynamic_group_cast is not None:
-            await self.hass.async_add_executor_job(self._dynamic_group_cast.disconnect)
-
-        self._dynamic_group_invalidate()
-
-        self.async_write_ha_state()
-
     async def _async_disconnect(self):
         """Disconnect Chromecast object if it is set."""
         if self._chromecast is None:
@@ -388,8 +291,6 @@ class CastDevice(MediaPlayerEntity):
         self.async_write_ha_state()
 
         await self.hass.async_add_executor_job(self._chromecast.disconnect)
-        if self._dynamic_group_cast is not None:
-            await self.hass.async_add_executor_job(self._dynamic_group_cast.disconnect)
 
         self._invalidate()
 
@@ -408,15 +309,6 @@ class CastDevice(MediaPlayerEntity):
         if self._status_listener is not None:
             self._status_listener.invalidate()
             self._status_listener = None
-
-    def _dynamic_group_invalidate(self):
-        """Invalidate some attributes."""
-        self._dynamic_group_cast = None
-        self.dynamic_group_media_status = None
-        self.dynamic_group_media_status_received = None
-        if self._dynamic_group_status_listener is not None:
-            self._dynamic_group_status_listener.invalidate()
-            self._dynamic_group_status_listener = None
 
     # ========== Callbacks ==========
     def new_cast_status(self, cast_status):
@@ -500,44 +392,6 @@ class CastDevice(MediaPlayerEntity):
             self._available = new_available
             self.schedule_update_ha_state()
 
-    def new_dynamic_group_media_status(self, media_status):
-        """Handle updates of the media status."""
-        self.dynamic_group_media_status = media_status
-        self.dynamic_group_media_status_received = dt_util.utcnow()
-        self.schedule_update_ha_state()
-
-    def new_dynamic_group_connection_status(self, connection_status):
-        """Handle updates of connection status."""
-        _LOGGER.debug(
-            "[%s %s (%s:%s)] Received dynamic group connection status: %s",
-            self.entity_id,
-            self._cast_info.friendly_name,
-            self._cast_info.host,
-            self._cast_info.port,
-            connection_status.status,
-        )
-        if connection_status.status == CONNECTION_STATUS_DISCONNECTED:
-            self._dynamic_group_available = False
-            self._dynamic_group_invalidate()
-            self.schedule_update_ha_state()
-            return
-
-        new_available = connection_status.status == CONNECTION_STATUS_CONNECTED
-        if new_available != self._dynamic_group_available:
-            # Connection status callbacks happen often when disconnected.
-            # Only update state when availability changed to put less pressure
-            # on state machine.
-            _LOGGER.debug(
-                "[%s %s (%s:%s)] Dynamic group availability changed: %s",
-                self.entity_id,
-                self._cast_info.friendly_name,
-                self._cast_info.host,
-                self._cast_info.port,
-                connection_status.status,
-            )
-            self._dynamic_group_available = new_available
-            self.schedule_update_ha_state()
-
     def multizone_new_media_status(self, group_uuid, media_status):
         """Handle updates of audio group media status."""
         _LOGGER.debug(
@@ -556,17 +410,10 @@ class CastDevice(MediaPlayerEntity):
         """
         Return media controller.
 
-        First try from our own cast, then dynamic groups and finally
-        groups which our cast is a member in.
+        First try from our own cast, then groups which our cast is a member in.
         """
         media_status = self.media_status
         media_controller = self._chromecast.media_controller
-
-        if (
-            media_status is None or media_status.player_state == "UNKNOWN"
-        ) and self._dynamic_group_cast is not None:
-            media_status = self.dynamic_group_media_status
-            media_controller = self._dynamic_group_cast.media_controller
 
         if media_status is None or media_status.player_state == "UNKNOWN":
             groups = self.mz_media_status
@@ -673,7 +520,7 @@ class CastDevice(MediaPlayerEntity):
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play media from a URL."""
-        # We do not want this to be forwarded to a group / dynamic group
+        # We do not want this to be forwarded to a group
         if media_type == CAST_DOMAIN:
             try:
                 app_data = json.loads(media_id)
@@ -743,17 +590,10 @@ class CastDevice(MediaPlayerEntity):
         """
         Return media status.
 
-        First try from our own cast, then dynamic groups and finally
-        groups which our cast is a member in.
+        First try from our own cast, then groups which our cast is a member in.
         """
         media_status = self.media_status
         media_status_received = self.media_status_received
-
-        if (
-            media_status is None or media_status.player_state == "UNKNOWN"
-        ) and self._dynamic_group_cast is not None:
-            media_status = self.dynamic_group_media_status
-            media_status_received = self.dynamic_group_media_status_received
 
         if media_status is None or media_status.player_state == "UNKNOWN":
             groups = self.mz_media_status
@@ -944,34 +784,12 @@ class CastDevice(MediaPlayerEntity):
 
     async def _async_cast_discovered(self, discover: ChromecastInfo):
         """Handle discovery of new Chromecast."""
-        if self._cast_info.uuid is None:
-            # We can't handle empty UUIDs
-            return
-
-        if self._cast_info.same_dynamic_group(discover):
-            _LOGGER.debug("Discovered matching dynamic group: %s", discover)
-            await self.async_set_dynamic_group(discover)
-            return
-
         if self._cast_info.uuid != discover.uuid:
             # Discovered is not our device.
             return
 
         _LOGGER.debug("Discovered chromecast with same UUID: %s", discover)
-        await self.async_set_cast_info(discover)
-
-    async def _async_cast_removed(self, discover: ChromecastInfo):
-        """Handle removal of Chromecast."""
-        if self._cast_info.uuid is None:
-            # We can't handle empty UUIDs
-            return
-
-        if (
-            self._dynamic_group_cast_info is not None
-            and self._dynamic_group_cast_info.uuid == discover.uuid
-        ):
-            _LOGGER.debug("Removed matching dynamic group: %s", discover)
-            await self.async_del_dynamic_group()
+        self.async_set_cast_info(discover)
 
     async def _async_stop(self, event):
         """Disconnect socket on Home Assistant stop."""
@@ -993,3 +811,131 @@ class CastDevice(MediaPlayerEntity):
             self._chromecast.register_handler(controller)
 
         self._hass_cast_controller.show_lovelace_view(view_path, url_path)
+
+
+class DynamicCastGroup:
+    """Representation of a Cast device on the network - for dynamic cast groups."""
+
+    def __init__(self, hass, cast_info: ChromecastInfo):
+        """Initialize the cast device."""
+
+        self.hass = hass
+        self._cast_info = cast_info
+        self.services = cast_info.services
+        self._chromecast: Optional[pychromecast.Chromecast] = None
+        self.mz_mgr = None
+        self._status_listener: Optional[CastStatusListener] = None
+
+        self._add_remove_handler = None
+        self._del_remove_handler = None
+
+    def async_setup(self):
+        """Create chromecast object."""
+        self._add_remove_handler = async_dispatcher_connect(
+            self.hass, SIGNAL_CAST_DISCOVERED, self._async_cast_discovered
+        )
+        self._del_remove_handler = async_dispatcher_connect(
+            self.hass, SIGNAL_CAST_REMOVED, self._async_cast_removed
+        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_stop)
+        self.async_set_cast_info(self._cast_info)
+        self.hass.async_create_task(
+            async_create_catching_coro(self.async_connect_to_chromecast())
+        )
+
+    async def async_tear_down(self) -> None:
+        """Disconnect Chromecast object."""
+        await self._async_disconnect()
+        if self._cast_info.uuid is not None:
+            # Remove the entity from the added casts so that it can dynamically
+            # be re-added again.
+            self.hass.data[ADDED_CAST_DEVICES_KEY].remove(self._cast_info.uuid)
+        if self._add_remove_handler:
+            self._add_remove_handler()
+            self._add_remove_handler = None
+        if self._del_remove_handler:
+            self._del_remove_handler()
+            self._del_remove_handler = None
+
+    def async_set_cast_info(self, cast_info):
+        """Set the cast information and set up the chromecast object."""
+
+        self._cast_info = cast_info
+
+    async def async_connect_to_chromecast(self):
+        """Set the cast information and set up the chromecast object."""
+
+        _LOGGER.debug(
+            "[%s %s] Connecting to cast device by service %s",
+            "Dynamic group",
+            self._cast_info.friendly_name,
+            self.services,
+        )
+        chromecast = await self.hass.async_add_executor_job(
+            pychromecast.get_chromecast_from_service,
+            (
+                self.services,
+                self._cast_info.uuid,
+                self._cast_info.model_name,
+                self._cast_info.friendly_name,
+                None,
+                None,
+            ),
+            ChromeCastZeroconf.get_zeroconf(),
+        )
+        self._chromecast = chromecast
+
+        if CAST_MULTIZONE_MANAGER_KEY not in self.hass.data:
+            self.hass.data[CAST_MULTIZONE_MANAGER_KEY] = MultizoneManager()
+
+        self.mz_mgr = self.hass.data[CAST_MULTIZONE_MANAGER_KEY]
+
+        self._status_listener = CastStatusListener(self, chromecast, self.mz_mgr, True)
+        self._chromecast.start()
+
+    async def _async_disconnect(self):
+        """Disconnect Chromecast object if it is set."""
+        if self._chromecast is None:
+            # Can't disconnect if not connected.
+            return
+        _LOGGER.debug(
+            "[%s %s] Disconnecting from chromecast socket",
+            "Dynamic group",
+            self._cast_info.friendly_name,
+        )
+
+        await self.hass.async_add_executor_job(self._chromecast.disconnect)
+
+        self._invalidate()
+
+    def _invalidate(self):
+        """Invalidate some attributes."""
+        self._chromecast = None
+        self.mz_mgr = None
+        if self._status_listener is not None:
+            self._status_listener.invalidate()
+            self._status_listener = None
+
+    async def _async_cast_discovered(self, discover: ChromecastInfo):
+        """Handle discovery of new Chromecast."""
+        if self._cast_info.uuid != discover.uuid:
+            # Discovered is not our device.
+            return
+
+        _LOGGER.debug("Discovered dynamic group with same UUID: %s", discover)
+        self.async_set_cast_info(discover)
+
+    async def _async_cast_removed(self, discover: ChromecastInfo):
+        """Handle removal of Chromecast."""
+        if self._cast_info.uuid != discover.uuid:
+            # Removed is not our device.
+            return
+
+        if not discover.services:
+            # Clean up the dynamic group
+            _LOGGER.debug("Clean up dynamic group: %s", discover)
+            await self.async_tear_down()
+
+    async def _async_stop(self, event):
+        """Disconnect socket on Home Assistant stop."""
+        await self._async_disconnect()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1304,7 +1304,7 @@ pycfdns==1.2.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==7.7.0
+pychromecast==7.7.1
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1304,7 +1304,7 @@ pycfdns==1.2.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==7.6.0
+pychromecast==7.7.0
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -661,7 +661,7 @@ pybotvac==0.0.19
 pycfdns==1.2.1
 
 # homeassistant.components.cast
-pychromecast==7.6.0
+pychromecast==7.7.0
 
 # homeassistant.components.coolmaster
 pycoolmasternet-async==0.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -661,7 +661,7 @@ pybotvac==0.0.19
 pycfdns==1.2.1
 
 # homeassistant.components.cast
-pychromecast==7.7.0
+pychromecast==7.7.1
 
 # homeassistant.components.coolmaster
 pycoolmasternet-async==0.1.2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for:
- Dynamic Google Cast groups
- Fetching manufacturer from local API

Dynamic groups will not be added as entities in Home Assistant, but a pychromecast Chromecast object will be created to keep track of media status of the dynamic group, which will then be shown on the group members.

This re-adds functionality which was previously removed by PRs: #34082, #33884, #33845

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39769

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
