### PR TITLE
Remove hyperion entry from registry only when instances are fully removed

### DIFF
--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -29,7 +29,10 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.helpers.entity_registry import (
+    async_entries_for_config_entry,
+    async_get_registry,
+)
 from homeassistant.helpers.typing import (
     ConfigType,
     DiscoveryInfoType,
@@ -231,33 +234,38 @@ async def async_setup_entry(
     async def async_instances_to_entities_raw(instances: List[Dict[str, Any]]) -> None:
         registry = await async_get_registry(hass)
         entities_to_add: List[HyperionLight] = []
-        desired_unique_ids: Set[str] = set()
+        running_unique_ids: Set[str] = set()
+        stopped_unique_ids: Set[str] = set()
         server_id = cast(str, config_entry.unique_id)
 
         # In practice, an instance can be in 3 states as seen by this function:
         #
-        #    * Exists, and is running: Add it to hass.
-        #    * Exists, but is not running: Cannot add yet, but should not delete it either.
-        #      It will show up as "unavailable".
-        #    * No longer exists: Delete it from hass.
+        #    * Exists, and is running: Should be present in HASS/registry.
+        #    * Exists, but is not running: Cannot add it yet, but entity may have be
+        #      registered from a previous time it was running.
+        #    * No longer exists at all: Should not be present in HASS/registry.
 
         # Add instances that are missing.
         for instance in instances:
             instance_id = instance.get(const.KEY_INSTANCE)
-            if instance_id is None or not instance.get(const.KEY_RUNNING, False):
+            if instance_id is None:
                 continue
             unique_id = get_hyperion_unique_id(
                 server_id, instance_id, TYPE_HYPERION_LIGHT
             )
-            desired_unique_ids.add(unique_id)
-            if unique_id in current_entities:
+            if not instance.get(const.KEY_RUNNING, False):
+                stopped_unique_ids.add(unique_id)
+                continue
+            running_unique_ids.add(unique_id)
+
+            if unique_id in live_entities:
                 continue
             hyperion_client = await async_create_connect_hyperion_client(
                 host, port, instance=instance_id, token=token
             )
             if not hyperion_client:
                 continue
-            current_entities.add(unique_id)
+            live_entities.add(unique_id)
             entities_to_add.append(
                 HyperionLight(
                     unique_id,
@@ -267,19 +275,21 @@ async def async_setup_entry(
                 )
             )
 
-        # Delete instances that are no longer present on this server.
-        for unique_id in current_entities - desired_unique_ids:
-            current_entities.remove(unique_id)
+        # Remove entities that are are not running instances on Hyperion:
+        for unique_id in live_entities - running_unique_ids:
+            live_entities.remove(unique_id)
             async_dispatcher_send(hass, SIGNAL_INSTANCE_REMOVED.format(unique_id))
-            entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, unique_id)
-            if entity_id:
-                registry.async_remove(entity_id)
+
+        # Deregister instances that are no longer present on this server.
+        for entry in async_entries_for_config_entry(registry, config_entry.entry_id):
+            if entry.unique_id not in running_unique_ids.union(stopped_unique_ids):
+                registry.async_remove(entry.entity_id)
 
         async_add_entities(entities_to_add)
 
     # Readability note: This variable is kept alive in the context of the callback to
     # async_instances_to_entities below.
-    current_entities: Set[str] = set()
+    live_entities: Set[str] = set()
 
     await async_instances_to_entities_raw(
         hass.data[DOMAIN][config_entry.entry_id][CONF_ROOT_CLIENT].instances,

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -258,6 +258,8 @@ async def test_setup_config_entry_not_ready_load_state_fail(
 
 async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> None:
     """Test dynamic changes in the omstamce configuration."""
+    registry = await async_get_registry(hass)
+
     config_entry = add_test_config_entry(hass)
 
     master_client = create_mock_client()
@@ -276,28 +278,12 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
     assert hass.states.get(TEST_ENTITY_ID_1) is not None
     assert hass.states.get(TEST_ENTITY_ID_2) is not None
 
-    # Inject a new instances update (remove instance 1, add instance 3)
     assert master_client.set_callbacks.called
+
+    # == Inject a new instances update (stop instance 1, add instance 3)
     instance_callback = master_client.set_callbacks.call_args[0][0][
         f"{const.KEY_INSTANCE}-{const.KEY_UPDATE}"
     ]
-    with patch(
-        "homeassistant.components.hyperion.client.HyperionClient",
-        return_value=entity_client,
-    ):
-        instance_callback(
-            {
-                const.KEY_SUCCESS: True,
-                const.KEY_DATA: [TEST_INSTANCE_2, TEST_INSTANCE_3],
-            }
-        )
-        await hass.async_block_till_done()
-
-    assert hass.states.get(TEST_ENTITY_ID_1) is None
-    assert hass.states.get(TEST_ENTITY_ID_2) is not None
-    assert hass.states.get(TEST_ENTITY_ID_3) is not None
-
-    # Inject a new instances update (re-add instance 1, but not running)
     with patch(
         "homeassistant.components.hyperion.client.HyperionClient",
         return_value=entity_client,
@@ -318,7 +304,55 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
     assert hass.states.get(TEST_ENTITY_ID_2) is not None
     assert hass.states.get(TEST_ENTITY_ID_3) is not None
 
-    # Inject a new instances update (re-add instance 1, running)
+    # Instance 1 is stopped, it should still be registered.
+    assert registry.async_is_registered(TEST_ENTITY_ID_1)
+
+    # == Inject a new instances update (remove instance 1)
+    assert master_client.set_callbacks.called
+    instance_callback = master_client.set_callbacks.call_args[0][0][
+        f"{const.KEY_INSTANCE}-{const.KEY_UPDATE}"
+    ]
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient",
+        return_value=entity_client,
+    ):
+        instance_callback(
+            {
+                const.KEY_SUCCESS: True,
+                const.KEY_DATA: [TEST_INSTANCE_2, TEST_INSTANCE_3],
+            }
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get(TEST_ENTITY_ID_1) is None
+    assert hass.states.get(TEST_ENTITY_ID_2) is not None
+    assert hass.states.get(TEST_ENTITY_ID_3) is not None
+
+    # Instance 1 is removed, it should not still be registered.
+    assert not registry.async_is_registered(TEST_ENTITY_ID_1)
+
+    # == Inject a new instances update (re-add instance 1, but not running)
+    with patch(
+        "homeassistant.components.hyperion.client.HyperionClient",
+        return_value=entity_client,
+    ):
+        instance_callback(
+            {
+                const.KEY_SUCCESS: True,
+                const.KEY_DATA: [
+                    {**TEST_INSTANCE_1, "running": False},
+                    TEST_INSTANCE_2,
+                    TEST_INSTANCE_3,
+                ],
+            }
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get(TEST_ENTITY_ID_1) is None
+    assert hass.states.get(TEST_ENTITY_ID_2) is not None
+    assert hass.states.get(TEST_ENTITY_ID_3) is not None
+
+    # == Inject a new instances update (re-add instance 1, running)
     with patch(
         "homeassistant.components.hyperion.client.HyperionClient",
         return_value=entity_client,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Today, if an instance on a Hyperion server (which is mapped to an entity in HA) is 'stopped' but not fully removed, it is both removed from the state machine and from the registry. This means settings are lost.

This small fix will ensure that if an instance is stopped it is removed from the state machine ONLY but kept in the registry, so that when/if the instance is re-started in Hyperion the prior HA settings can persist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
