### PR TITLE
Esphome fan direction

### DIFF
--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -132,7 +132,7 @@ class EsphomeFan(EsphomeEntity, FanEntity):
         """Return the current fan direction."""
         if not self._static_info.supports_direction:
             return None
-        return self._state.direction
+        return _fan_directions.from_esphome(self._state.direction)
 
     @property
     def speed_list(self) -> Optional[List[str]]:

--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -1,13 +1,16 @@
 """Support for ESPHome fans."""
 from typing import List, Optional
 
-from aioesphomeapi import FanInfo, FanSpeed, FanState
+from aioesphomeapi import FanDirection, FanInfo, FanSpeed, FanState
 
 from homeassistant.components.fan import (
+    DIRECTION_FORWARD,
+    DIRECTION_REVERSE,
     SPEED_HIGH,
     SPEED_LOW,
     SPEED_MEDIUM,
     SPEED_OFF,
+    SUPPORT_DIRECTION,
     SUPPORT_OSCILLATE,
     SUPPORT_SET_SPEED,
     FanEntity,
@@ -44,6 +47,14 @@ def _fan_speeds():
         FanSpeed.LOW: SPEED_LOW,
         FanSpeed.MEDIUM: SPEED_MEDIUM,
         FanSpeed.HIGH: SPEED_HIGH,
+    }
+
+
+@esphome_map_enum
+def _fan_directions():
+    return {
+        FanDirection.FORWARD: DIRECTION_FORWARD,
+        FanDirection.REVERSE: DIRECTION_REVERSE,
     }
 
 
@@ -88,6 +99,12 @@ class EsphomeFan(EsphomeEntity, FanEntity):
             key=self._static_info.key, oscillating=oscillating
         )
 
+    async def async_set_direction(self, direction: str):
+        """Set direction of the fan."""
+        await self._client.fan_command(
+            key=self._static_info.key, direction=_fan_directions.from_hass(direction)
+        )
+
     # https://github.com/PyCQA/pylint/issues/3150 for all @esphome_state_property
     # pylint: disable=invalid-overridden-method
 
@@ -110,6 +127,13 @@ class EsphomeFan(EsphomeEntity, FanEntity):
             return None
         return self._state.oscillating
 
+    @esphome_state_property
+    def current_direction(self) -> None:
+        """Return the current fan direction."""
+        if not self._static_info.supports_direction:
+            return None
+        return self._state.direction
+
     @property
     def speed_list(self) -> Optional[List[str]]:
         """Get the list of available speeds."""
@@ -125,4 +149,6 @@ class EsphomeFan(EsphomeEntity, FanEntity):
             flags |= SUPPORT_OSCILLATE
         if self._static_info.supports_speed:
             flags |= SUPPORT_SET_SPEED
+        if self._static_info.supports_direction:
+            flags |= SUPPORT_DIRECTION
         return flags

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==2.6.3"],
+  "requirements": ["aioesphomeapi==2.6.4"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "codeowners": ["@OttoWinter"],
   "after_dependencies": ["zeroconf", "tag"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -154,7 +154,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.3
+aioesphomeapi==2.6.4
 
 # homeassistant.components.flo
 aioflo==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -88,7 +88,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.3
+aioesphomeapi==2.6.4
 
 # homeassistant.components.flo
 aioflo==0.4.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This patch adds support for changing the fan direction for esphome based fans.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Related esphome PR esphome/esphome#1051
- Related aioesphome PR esphome/aioesphomeapi#8
- Upstream diff of aioesphome v2.6.3..v2.6.4 https://github.com/esphome/aioesphomeapi/compare/v2.6.3...v2.6.4
- ESPHome changelog https://esphome.io/changelog/v1.15.0.html

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
