### PR TITLE
Improve TDBU motion blinds control

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -47,7 +47,6 @@ SET_ABSOLUTE_POSITION_SCHEMA = CALL_SCHEMA.extend(
 
 SERVICE_TO_METHOD = {
     SERVICE_SET_ABSOLUTE_POSITION: {
-        "method": SERVICE_SET_ABSOLUTE_POSITION,
         "schema": SET_ABSOLUTE_POSITION_SCHEMA,
     }
 }
@@ -57,9 +56,8 @@ def setup(hass: core.HomeAssistant, config: dict):
     """Set up the Motion Blinds component."""
 
     def service_handler(service):
-        method = SERVICE_TO_METHOD.get(service.service)
         data = service.data.copy()
-        data["method"] = method["method"]
+        data["method"] = service.service
         dispatcher_send(hass, DOMAIN, data)
 
     for service in SERVICE_TO_METHOD:

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -5,28 +5,67 @@ import logging
 from socket import timeout
 
 from motionblinds import MotionMulticast
+import voluptuous as vol
 
 from homeassistant import config_entries, core
-from homeassistant.const import CONF_API_KEY, CONF_HOST, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_API_KEY,
+    CONF_HOST,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
+    ATTR_ABSOLUTE_POSITION,
+    ATTR_WIDTH,
     DOMAIN,
     KEY_COORDINATOR,
     KEY_GATEWAY,
     KEY_MULTICAST_LISTENER,
     MANUFACTURER,
     MOTION_PLATFORMS,
+    SERVICE_SET_ABSOLUTE_POSITION,
 )
 from .gateway import ConnectMotionGateway
 
 _LOGGER = logging.getLogger(__name__)
 
+CALL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids})
 
-async def async_setup(hass: core.HomeAssistant, config: dict):
+SET_ABSOLUTE_POSITION_SCHEMA = CALL_SCHEMA.extend(
+    {
+        vol.Required(ATTR_ABSOLUTE_POSITION): vol.All(
+            cv.positive_int, vol.Range(max=100)
+        ),
+        vol.Optional(ATTR_WIDTH): vol.All(cv.positive_int, vol.Range(max=100)),
+    }
+)
+
+SERVICE_TO_METHOD = {
+    SERVICE_SET_ABSOLUTE_POSITION: {
+        "method": SERVICE_SET_ABSOLUTE_POSITION,
+        "schema": SET_ABSOLUTE_POSITION_SCHEMA,
+    }
+}
+
+
+def setup(hass: core.HomeAssistant, config: dict):
     """Set up the Motion Blinds component."""
+
+    def service_handler(service):
+        method = SERVICE_TO_METHOD.get(service.service)
+        data = service.data.copy()
+        data["method"] = method["method"]
+        dispatcher_send(hass, DOMAIN, data)
+
+    for service in SERVICE_TO_METHOD:
+        schema = SERVICE_TO_METHOD[service]["schema"]
+        hass.services.register(DOMAIN, service, service_handler, schema=schema)
+
     return True
 
 

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -8,3 +8,8 @@ MOTION_PLATFORMS = ["cover", "sensor"]
 KEY_GATEWAY = "gateway"
 KEY_COORDINATOR = "coordinator"
 KEY_MULTICAST_LISTENER = "multicast_listener"
+
+ATTR_WIDTH = "width"
+ATTR_ABSOLUTE_POSITION = "absolute_position"
+
+SERVICE_SET_ABSOLUTE_POSITION = "set_absolute_position"

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -15,10 +15,19 @@ from homeassistant.components.cover import (
     DEVICE_CLASS_SHUTTER,
     CoverEntity,
 )
+from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, ENTITY_MATCH_NONE
 from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_GATEWAY, MANUFACTURER
+from .const import (
+    ATTR_ABSOLUTE_POSITION,
+    ATTR_WIDTH,
+    DOMAIN,
+    KEY_COORDINATOR,
+    KEY_GATEWAY,
+    MANUFACTURER,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,6 +92,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     TDBU_DEVICE_MAP[blind.type],
                     config_entry,
                     "Bottom",
+                )
+            )
+            entities.append(
+                MotionTDBUDevice(
+                    coordinator,
+                    blind,
+                    TDBU_DEVICE_MAP[blind.type],
+                    config_entry,
+                    "Combined",
                 )
             )
 
@@ -158,9 +176,27 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
         self.schedule_update_ha_state(force_refresh=False)
 
     async def async_added_to_hass(self):
-        """Subscribe to multicast pushes."""
+        """Subscribe to multicast pushes and register signal handler."""
         self._blind.Register_callback(self.unique_id, self._push_callback)
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, DOMAIN, self.signal_handler)
+        )
         await super().async_added_to_hass()
+
+    def signal_handler(self, data):
+        """Handle domain-specific signal by calling appropriate method."""
+        entity_ids = data[ATTR_ENTITY_ID]
+
+        if entity_ids == ENTITY_MATCH_NONE:
+            return
+
+        if entity_ids == ENTITY_MATCH_ALL or self.entity_id in entity_ids:
+            params = {
+                key: value
+                for key, value in data.items()
+                if key not in ["entity_id", "method"]
+            }
+            getattr(self, data["method"])(**params)
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""
@@ -178,6 +214,11 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
+        self._blind.Set_position(100 - position)
+
+    def set_absolute_position(self, **kwargs):
+        """Move the cover to a specific absolute position (see TDBU)."""
+        position = kwargs[ATTR_ABSOLUTE_POSITION]
         self._blind.Set_position(100 - position)
 
     def stop_cover(self, **kwargs):
@@ -226,7 +267,7 @@ class MotionTDBUDevice(MotionPositionDevice):
         self._motor = motor
         self._motor_key = motor[0]
 
-        if self._motor not in ["Bottom", "Top"]:
+        if self._motor not in ["Bottom", "Top", "Combined"]:
             _LOGGER.error("Unknown motor '%s'", self._motor)
 
     @property
@@ -246,10 +287,10 @@ class MotionTDBUDevice(MotionPositionDevice):
 
         None is unknown, 0 is open, 100 is closed.
         """
-        if self._blind.position is None:
+        if self._blind.scaled_position is None:
             return None
 
-        return 100 - self._blind.position[self._motor_key]
+        return 100 - self._blind.scaled_position[self._motor_key]
 
     @property
     def is_closed(self):
@@ -257,7 +298,22 @@ class MotionTDBUDevice(MotionPositionDevice):
         if self._blind.position is None:
             return None
 
+        if self._motor == "Combined":
+            return self._blind.width == 100
+
         return self._blind.position[self._motor_key] == 100
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        attributes = {}
+        if self._blind.position is not None:
+            attributes[ATTR_ABSOLUTE_POSITION] = (
+                100 - self._blind.position[self._motor_key]
+            )
+        if self._blind.width is not None:
+            attributes[ATTR_WIDTH] = self._blind.width
+        return attributes
 
     def open_cover(self, **kwargs):
         """Open the cover."""
@@ -268,9 +324,18 @@ class MotionTDBUDevice(MotionPositionDevice):
         self._blind.Close(motor=self._motor_key)
 
     def set_cover_position(self, **kwargs):
-        """Move the cover to a specific position."""
+        """Move the cover to a specific scaled position."""
         position = kwargs[ATTR_POSITION]
-        self._blind.Set_position(100 - position, motor=self._motor_key)
+        self._blind.Set_scaled_position(100 - position, motor=self._motor_key)
+
+    def set_absolute_position(self, **kwargs):
+        """Move the cover to a specific absolute position."""
+        position = kwargs[ATTR_ABSOLUTE_POSITION]
+        target_width = kwargs.get(ATTR_WIDTH, None)
+
+        self._blind.Set_position(
+            100 - position, motor=self._motor_key, width=target_width
+        )
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""

--- a/homeassistant/components/motion_blinds/services.yaml
+++ b/homeassistant/components/motion_blinds/services.yaml
@@ -1,0 +1,14 @@
+# Describes the format for available motion blinds services
+
+set_absolute_position:
+  description: "Set the absolute position of the cover."
+  fields:
+    entity_id:
+      description: Name of the motion blind cover entity to control.
+      example: "cover.TopDownBottomUp-Bottom-0001"
+    absolute_position:
+      description: Absolute position to move to.
+      example: 70
+    width:
+      description: Optionally specify the width that is covered, only for TDBU Combined entities.
+      example: 30


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

1 Add improved control for Top Down Bottom Up (TDBU) motion blinds.
The sliders for postion are now scaled such that 0 and 100 cover exactly the allowed space in which the blind can move at the moment. (Bottom is able to move from 0 to the absolute position of the Top, and Top can move from the absolute postion of the Bottom to 100)
Also adds a "combined" entity for a TDBU blind, with that entity you can move Top and Bottom at the same time and shift the whole thing up or down.

2 Add motion_blinds.set_absolute_position service. For most blinds this does the same as cover.set_cover_position service, but for TDBU blinds it will set the absolute position relative to the window itself instead of the scaled position relative to the space in which the blind is allowed to move which cover.set_cover_position does for TDBU blinds.

Also include extra documentation for the TDBU blind.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Config flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#15756

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
