### PR TITLE
Add album art support in the mpd component

### DIFF
--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -1,5 +1,6 @@
 """Support to interact with a Music Player Daemon."""
 from datetime import timedelta
+import hashlib
 import logging
 import os
 
@@ -107,6 +108,7 @@ class MpdDevice(MediaPlayerEntity):
         self._muted_volume = 0
         self._media_position_updated_at = None
         self._media_position = None
+        self._commands = None
 
         # set up MPD client
         self._client = MPDClient()
@@ -163,6 +165,7 @@ class MpdDevice(MediaPlayerEntity):
         try:
             if not self._is_connected:
                 await self._connect()
+                self._commands = list(await self._client.commands())
 
             await self._fetch_status()
         except (mpd.ConnectionError, OSError, BrokenPipeError, ValueError) as error:
@@ -251,6 +254,54 @@ class MpdDevice(MediaPlayerEntity):
     def media_album_name(self):
         """Return the album of current playing media (Music track only)."""
         return self._currentsong.get("album")
+
+    @property
+    def media_image_hash(self):
+        """Hash value for media image."""
+        file = self._currentsong.get("file")
+        if file:
+            return hashlib.sha256(file.encode("utf-8")).hexdigest()[:16]
+
+        return None
+
+    async def async_get_media_image(self):
+        """Fetch media image of current playing track."""
+        # not all MPD implementations and versions support the `albumart` and `fetchpicture` commands
+        can_albumart = "albumart" in self._commands
+        can_readpicture = "readpicture" in self._commands
+
+        file = self._currentsong.get("file")
+        if file:
+            response = None
+
+            # read artwork embedded into the media file
+            if can_readpicture:
+                try:
+                    response = await self._client.readpicture(file)
+                except mpd.CommandError as error:
+                    _LOGGER.warning(
+                        "Retrieving artwork through `readpicture` command failed: %s",
+                        error,
+                    )
+
+            # read artwork contained in the media directory (cover.{jpg,png,tiff,bmp}) if not embedded
+            if can_albumart and not response:
+                try:
+                    response = await self._client.albumart(file)
+                except mpd.CommandError as error:
+                    _LOGGER.warning(
+                        "Retrieving artwork through `albumart` command failed: %s",
+                        error,
+                    )
+
+            if response:
+                image = bytes(response.get("binary"))
+                mime = response.get(
+                    "type", "image/png"
+                )  # readpicture has type, albumart does not
+                return (image, mime)
+
+        return None, None
 
     @property
     def volume_level(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Uses `readpicture` to retrieve embedded artwork and `albumart` to
acquire cover art located in the media directory.

As the mpd component supports multiple different implementations (think
mopidy, PI MusicBox, etc.) we check for the availability of each command
before using them.

Tested against mpd 0.22.3, which includes support for both.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
media_players:
  - platform: mpd
    host: 127.0.0.1
```

and a media library that holds either media with embedded artwork or a cover.{jpg,png,bmp,tiff} in the same directory.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
