### PR TITLE
Add full end-to-end config flow for Nest SDM API

### DIFF
--- a/homeassistant/components/nest/const.py
+++ b/homeassistant/components/nest/const.py
@@ -1,6 +1,7 @@
 """Constants used by the Nest component."""
 
 DOMAIN = "nest"
+DATA_NEST_CONFIG = "nest_config"
 DATA_SDM = "sdm"
 DATA_SUBSCRIBER = "subscriber"
 
@@ -16,3 +17,6 @@ SDM_SCOPES = [
     "https://www.googleapis.com/auth/pubsub",
 ]
 API_URL = "https://smartdevicemanagement.googleapis.com/v1"
+
+CONF_PROJECT_ID = "project_id"
+CONF_SUBSCRIBER_ID = "subscriber_id"

--- a/homeassistant/components/nest/legacy/local_auth.py
+++ b/homeassistant/components/nest/legacy/local_auth.py
@@ -7,14 +7,18 @@ from nest.nest import AUTHORIZE_URL, AuthorizationError, NestAuth
 from homeassistant.const import HTTP_UNAUTHORIZED
 from homeassistant.core import callback
 
-from ..config_flow import CodeInvalid, NestAuthError, register_flow_implementation
+from ..config_flow import (
+    CodeInvalid,
+    NestAuthError,
+    register_legacy_flow_implementation,
+)
 from .const import DOMAIN
 
 
 @callback
 def initialize(hass, client_id, client_secret):
     """Initialize a local auth provider."""
-    register_flow_implementation(
+    register_legacy_flow_implementation(
         hass,
         DOMAIN,
         "configuration.yaml",

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -4,6 +4,22 @@
       "pick_implementation": {
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       },
+      "device_access": {
+          "title": "Device Access Registration",
+          "description": "You must register for Device Access and create a project in order to manage your Nest devices. See [Device Access Registration](https://www.home-assistant.io/integrations/nest/#device-access-registration) for the detailed steps. Click submit to start the OAuth authorization flow to connect devices.",
+          "data": {
+              "project_id": "Device Access Project ID",
+              "client_id": "OAuth Client ID",
+              "client_secret": "OAuth Client Secret"
+          }
+      },
+      "pubsub": {
+          "title": "Configure Pub/Sub Subscriber",
+          "description": "The Cloud Pub/Sub Subscriber keeps Home Assistant informed of events or device changes in real time.  See [Pub/Sub subscriber setup](https://www.home-assistant.io/integrations/nest/#pubsub-subscriber-setup) for instructions on how to register.",
+          "data": {
+              "subscriber_id": "Subscription Name"
+          }
+      },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
         "description": "The Nest integration needs to re-authenticate your account"

--- a/homeassistant/components/nest/translations/en.json
+++ b/homeassistant/components/nest/translations/en.json
@@ -1,7 +1,6 @@
 {
     "config": {
         "abort": {
-            "authorize_url_fail": "Unknown error generating an authorize url.",
             "authorize_url_timeout": "Timeout generating authorize URL.",
             "missing_configuration": "The component is not configured. Please follow the documentation.",
             "no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",
@@ -19,6 +18,15 @@
             "unknown": "Unexpected error"
         },
         "step": {
+            "device_access": {
+                "data": {
+                    "client_id": "OAuth Client ID",
+                    "client_secret": "OAuth Client Secret",
+                    "project_id": "Device Access Project ID"
+                },
+                "description": "You must register for Device Access and create a project in order to manage your Nest devices. See [Device Access Registration](https://www.home-assistant.io/integrations/nest/#device-access-registration) for the detailed steps. Click submit to start the OAuth authorization flow to connect devices.",
+                "title": "Device Access Registration"
+            },
             "init": {
                 "data": {
                     "flow_impl": "Provider"
@@ -35,6 +43,13 @@
             },
             "pick_implementation": {
                 "title": "Pick Authentication Method"
+            },
+            "pubsub": {
+                "data": {
+                    "subscriber_id": "Subscription Name"
+                },
+                "description": "The Cloud Pub/Sub Subscriber keeps Home Assistant informed of events or device changes in real time.  See [Pub/Sub subscriber setup](https://www.home-assistant.io/integrations/nest/#pubsub-subscriber-setup) for instructions on how to register.",
+                "title": "Configure Pub/Sub Subscriber"
             },
             "reauth_confirm": {
                 "description": "The Nest integration needs to re-authenticate your account",

--- a/tests/components/nest/test_config_flow_legacy.py
+++ b/tests/components/nest/test_config_flow_legacy.py
@@ -219,3 +219,21 @@ async def test_step_import_with_token_cache(hass):
     entry = hass.config_entries.async_entries(DOMAIN)[0]
 
     assert entry.data == {"impl_domain": "nest", "tokens": {"access_token": "yo"}}
+
+
+async def test_user_step(hass):
+    """Test that the user step redirects to the init step."""
+    gen_authorize_url = AsyncMock(return_value="https://example.com")
+    convert_code = AsyncMock(return_value={"access_token": "yoo"})
+    config_flow.register_legacy_flow_implementation(
+        hass, "test", "Test", gen_authorize_url, convert_code
+    )
+    config_flow.register_legacy_flow_implementation(
+        hass, "test-other", "Test Other", None, None
+    )
+
+    flow = config_flow.NestFlowHandler()
+    flow.hass = hass
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"

--- a/tests/components/nest/test_config_flow_legacy.py
+++ b/tests/components/nest/test_config_flow_legacy.py
@@ -22,6 +22,11 @@ async def test_abort_if_no_implementation_registered(hass):
 
 async def test_abort_if_single_instance_allowed(hass):
     """Test we abort if Nest is already setup."""
+    gen_authorize_url = AsyncMock(return_value="https://example.com")
+    convert_code = Mock(side_effect=config_flow.CodeInvalid)
+    config_flow.register_legacy_flow_implementation(
+        hass, "test", "Test", gen_authorize_url, convert_code
+    )
     flow = config_flow.NestFlowHandler()
     flow.hass = hass
 
@@ -36,10 +41,10 @@ async def test_full_flow_implementation(hass):
     """Test registering an implementation and finishing flow works."""
     gen_authorize_url = AsyncMock(return_value="https://example.com")
     convert_code = AsyncMock(return_value={"access_token": "yoo"})
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, convert_code
     )
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test-other", "Test Other", None, None
     )
 
@@ -64,7 +69,7 @@ async def test_full_flow_implementation(hass):
 async def test_not_pick_implementation_if_only_one(hass):
     """Test we allow picking implementation if we have two."""
     gen_authorize_url = AsyncMock(return_value="https://example.com")
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, None
     )
 
@@ -78,7 +83,7 @@ async def test_not_pick_implementation_if_only_one(hass):
 async def test_abort_if_timeout_generating_auth_url(hass):
     """Test we abort if generating authorize url fails."""
     gen_authorize_url = Mock(side_effect=asyncio.TimeoutError)
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, None
     )
 
@@ -92,7 +97,7 @@ async def test_abort_if_timeout_generating_auth_url(hass):
 async def test_abort_if_exception_generating_auth_url(hass):
     """Test we abort if generating authorize url blows up."""
     gen_authorize_url = Mock(side_effect=ValueError)
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, None
     )
 
@@ -107,7 +112,7 @@ async def test_verify_code_timeout(hass):
     """Test verify code timing out."""
     gen_authorize_url = AsyncMock(return_value="https://example.com")
     convert_code = Mock(side_effect=asyncio.TimeoutError)
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, convert_code
     )
 
@@ -127,7 +132,7 @@ async def test_verify_code_invalid(hass):
     """Test verify code invalid."""
     gen_authorize_url = AsyncMock(return_value="https://example.com")
     convert_code = Mock(side_effect=config_flow.CodeInvalid)
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, convert_code
     )
 
@@ -147,7 +152,7 @@ async def test_verify_code_unknown_error(hass):
     """Test verify code unknown error."""
     gen_authorize_url = AsyncMock(return_value="https://example.com")
     convert_code = Mock(side_effect=config_flow.NestAuthError)
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, convert_code
     )
 
@@ -167,7 +172,7 @@ async def test_verify_code_exception(hass):
     """Test verify code blows up."""
     gen_authorize_url = AsyncMock(return_value="https://example.com")
     convert_code = Mock(side_effect=ValueError)
-    config_flow.register_flow_implementation(
+    config_flow.register_legacy_flow_implementation(
         hass, "test", "Test", gen_authorize_url, convert_code
     )
 

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -211,7 +211,7 @@ async def test_full_flow_from_yaml(hass, flow_fixture):
 
 
 async def test_reauth(hass, flow_fixture):
-    """Test Nest reauthentication from configuration.yaml."""
+    """Test Nest reauthentication."""
     old_data = EXPECTED_CONFIG_ENTRY_DATA.copy()
     old_data["token"] = {"access_token": "some-revoked-token"}
     old_entry = MockConfigEntry(
@@ -317,6 +317,18 @@ async def test_reauth_from_yaml(hass, flow_fixture):
     entry.data["token"].pop("expires_at")
     assert entry.unique_id == DOMAIN
     assert dict(entry.data) == EXPECTED_CONFIG_ENTRY_DATA
+
+
+async def test_reauth_missing_input(hass, flow_fixture):
+    """Test Nest reauthentication with invalid parameters passed."""
+    assert await setup.async_setup_component(hass, DOMAIN, EMPTY_CONFIG)
+
+    result = await flow_fixture.async_init(
+        config_entries.SOURCE_REAUTH,
+        data=None,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "missing_configuration"
 
 
 async def test_single_config_entry_from_yaml(hass, flow_fixture):

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -1,9 +1,25 @@
-"""Test the Google Nest Device Access config flow."""
+"""Test the Google Nest Device Access config flow.
+
+The Nest SDM API integration supports two approaches for configuration:
+  - Using config flow only, the new preferred approach
+  - Using configuration.yaml, the old way similar to how the legacy works
+    with nest integration works.
+
+This file exercises tests in both approaches.  The tests for configuration.yaml
+approach have a suffix of "_from_yaml".
+"""
 
 import pytest
+from voluptuous.error import MultipleInvalid
 
-from homeassistant import config_entries, setup
-from homeassistant.components.nest.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.nest.const import (
+    CONF_PROJECT_ID,
+    CONF_SUBSCRIBER_ID,
+    DOMAIN,
+    OAUTH2_AUTHORIZE,
+    OAUTH2_TOKEN,
+)
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
@@ -16,14 +32,45 @@ CLIENT_SECRET = "5678"
 PROJECT_ID = "project-id-4321"
 SUBSCRIBER_ID = "subscriber-id-9876"
 
-CONFIG = {
+# Used in either ConfigEntry data or configuration.yaml
+DEVICE_ACCESS_CONFIG = {
+    CONF_PROJECT_ID: PROJECT_ID,
+    CONF_CLIENT_ID: CLIENT_ID,
+    CONF_CLIENT_SECRET: CLIENT_SECRET,
+}
+SUBSCRIBER_CONFIG = {
+    CONF_SUBSCRIBER_ID: SUBSCRIBER_ID,
+}
+
+# A configuration.yaml without a "nest:" clause
+EMPTY_CONFIG = {
+    "http": {"base_url": "https://example.com"},
+}
+
+
+# A configuration.yaml with a "nest:" clause, the old way to configure the
+# integration.
+CONFIG_FROM_YAML = {
     DOMAIN: {
-        "project_id": PROJECT_ID,
-        "subscriber_id": SUBSCRIBER_ID,
-        CONF_CLIENT_ID: CLIENT_ID,
-        CONF_CLIENT_SECRET: CLIENT_SECRET,
+        **DEVICE_ACCESS_CONFIG,
+        **SUBSCRIBER_CONFIG,
     },
     "http": {"base_url": "https://example.com"},
+}
+
+OAUTH_RESPONSE = {
+    "refresh_token": "mock-refresh-token",
+    "access_token": "mock-access-token",
+    "type": "Bearer",
+    "expires_in": 60,
+}
+
+EXPECTED_CONFIG_ENTRY_DATA = {
+    "auth_implementation": "nest",
+    "token": OAUTH_RESPONSE,
+    **DEVICE_ACCESS_CONFIG,
+    **SUBSCRIBER_CONFIG,
+    "sdm": {},
 }
 
 
@@ -34,8 +81,8 @@ def get_config_entry(hass):
     return entries[0]
 
 
-class OAuthFixture:
-    """Simulate the oauth flow used by the config flow."""
+class FlowFixture:
+    """Facilitate testing of a ConfigFlow."""
 
     def __init__(self, hass, aiohttp_client, aioclient_mock):
         """Initialize OAuthFixture."""
@@ -43,19 +90,46 @@ class OAuthFixture:
         self.aiohttp_client = aiohttp_client
         self.aioclient_mock = aioclient_mock
 
-    async def async_oauth_flow(self, result):
-        """Invoke the oauth flow with fake responses."""
+        # Preserve every step of the flow
+        self.result = None
+
+        # Set to true when setup is complete
+        self.setup_called = False
+
+    async def async_init(
+        self, source: str = config_entries.SOURCE_USER, data: dict = None
+    ):
+        """Initialize the Config Flow."""
+        self.result = await self.hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": source}, data=data
+        )
+        return self.result
+
+    async def async_next(self, user_input: dict):
+        """Advance to the next step in the config flow."""
+        with patch(
+            "homeassistant.components.nest.async_setup_entry", return_value=True
+        ) as mock_setup:
+            self.result = await self.hass.config_entries.flow.async_configure(
+                self.result["flow_id"], user_input=user_input
+            )
+            self.setup_called = len(mock_setup.mock_calls) > 0
+        return self.result
+
+    async def async_oauth_flow(self):
+        """Verify auth redirect and prepare fake OAuth responses."""
         state = config_entry_oauth2_flow._encode_jwt(
             self.hass,
             {
-                "flow_id": result["flow_id"],
+                "flow_id": self.result["flow_id"],
                 "redirect_uri": "https://example.com/auth/external/callback",
             },
         )
 
         oauth_authorize = OAUTH2_AUTHORIZE.format(project_id=PROJECT_ID)
-        assert result["type"] == "external"
-        assert result["url"] == (
+        assert self.result["type"] == data_entry_flow.RESULT_TYPE_EXTERNAL_STEP
+        assert self.result["step_id"] == "auth"
+        assert self.result["url"] == (
             f"{oauth_authorize}?response_type=code&client_id={CLIENT_ID}"
             "&redirect_uri=https://example.com/auth/external/callback"
             f"&state={state}&scope=https://www.googleapis.com/auth/sdm.service"
@@ -68,56 +142,128 @@ class OAuthFixture:
         assert resp.status == 200
         assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
-        self.aioclient_mock.post(
-            OAUTH2_TOKEN,
-            json={
-                "refresh_token": "mock-refresh-token",
-                "access_token": "mock-access-token",
-                "type": "Bearer",
-                "expires_in": 60,
-            },
-        )
-
-        with patch(
-            "homeassistant.components.nest.async_setup_entry", return_value=True
-        ) as mock_setup:
-            await self.hass.config_entries.flow.async_configure(result["flow_id"])
-            assert len(mock_setup.mock_calls) == 1
+        self.aioclient_mock.post(OAUTH2_TOKEN, json=OAUTH_RESPONSE)
 
 
 @pytest.fixture
-async def oauth(hass, aiohttp_client, aioclient_mock, current_request_with_host):
-    """Create the simulated oauth flow."""
-    return OAuthFixture(hass, aiohttp_client, aioclient_mock)
+async def flow_fixture(hass, aiohttp_client, aioclient_mock, current_request_with_host):
+    """Create the flow test fixture."""
+    return FlowFixture(hass, aiohttp_client, aioclient_mock)
 
 
-async def test_full_flow(hass, oauth):
+async def test_full_flow(hass, flow_fixture):
     """Check full flow."""
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    assert await setup.async_setup_component(hass, DOMAIN, EMPTY_CONFIG)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    await oauth.async_oauth_flow(result)
+    result = await flow_fixture.async_init()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "device_access"
+    # No default values
+    with pytest.raises(MultipleInvalid):
+        assert result["data_schema"]({}) == ""
 
+    result = await flow_fixture.async_next(user_input=DEVICE_ACCESS_CONFIG)
+    await flow_fixture.async_oauth_flow()
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pubsub"
+    # No default values
+    with pytest.raises(MultipleInvalid):
+        assert result["data_schema"]({}) == ""
+
+    result = await flow_fixture.async_next(user_input=SUBSCRIBER_CONFIG)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert flow_fixture.setup_called
+
+    # Verify existing tokens are replaced
     entry = get_config_entry(hass)
-    assert entry.title == "Configuration.yaml"
-    assert "token" in entry.data
     entry.data["token"].pop("expires_at")
     assert entry.unique_id == DOMAIN
+    assert dict(entry.data) == EXPECTED_CONFIG_ENTRY_DATA
+
+
+async def test_full_flow_from_yaml(hass, flow_fixture):
+    """Check full flow from a configuration.yaml."""
+    assert await setup.async_setup_component(hass, DOMAIN, CONFIG_FROM_YAML)
+
+    result = await flow_fixture.async_init()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "device_access"
+    # Default values populated from yaml config
+    assert result["data_schema"]({}) == DEVICE_ACCESS_CONFIG
+
+    result = await flow_fixture.async_next(user_input=DEVICE_ACCESS_CONFIG)
+    await flow_fixture.async_oauth_flow()
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pubsub"
+    # Verify default values are populated from yaml config
+    assert result["data_schema"]({}) == SUBSCRIBER_CONFIG
+
+    result = await flow_fixture.async_next(user_input=SUBSCRIBER_CONFIG)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert flow_fixture.setup_called
+
+    entry = get_config_entry(hass)
+    entry.data["token"].pop("expires_at")
+    assert entry.unique_id == DOMAIN
+    assert dict(entry.data) == EXPECTED_CONFIG_ENTRY_DATA
+
+
+async def test_reauth(hass, flow_fixture):
+    """Test Nest reauthentication from configuration.yaml."""
+    old_data = EXPECTED_CONFIG_ENTRY_DATA.copy()
+    old_data["token"] = {"access_token": "some-revoked-token"}
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=old_data,
+        unique_id=DOMAIN,
+    )
+    old_entry.add_to_hass(hass)
+
+    assert await setup.async_setup_component(hass, DOMAIN, EMPTY_CONFIG)
+
+    entry = get_config_entry(hass)
     assert entry.data["token"] == {
-        "refresh_token": "mock-refresh-token",
-        "access_token": "mock-access-token",
-        "type": "Bearer",
-        "expires_in": 60,
+        "access_token": "some-revoked-token",
     }
 
+    # Initiate the reauth flow
+    result = await flow_fixture.async_init(
+        config_entries.SOURCE_REAUTH,
+        data=old_entry.data,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
 
-async def test_reauth(hass, oauth):
-    """Test Nest reauthentication."""
+    # Start normal config flow
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "device_access"
+    # Default values populated from existing config entry
+    assert result["data_schema"]({}) == DEVICE_ACCESS_CONFIG
 
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    result = await flow_fixture.async_next(user_input=DEVICE_ACCESS_CONFIG)
+    await flow_fixture.async_oauth_flow()
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pubsub"
+    # Verify default values are populated from existing config entry
+    assert result["data_schema"]({}) == SUBSCRIBER_CONFIG
+    result = await flow_fixture.async_next(user_input=SUBSCRIBER_CONFIG)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_successful"
+    assert flow_fixture.setup_called
 
+    # Verify existing tokens are replaced
+    entry = get_config_entry(hass)
+    entry.data["token"].pop("expires_at")
+    assert entry.unique_id == DOMAIN
+    assert dict(entry.data) == EXPECTED_CONFIG_ENTRY_DATA
+
+
+async def test_reauth_from_yaml(hass, flow_fixture):
+    """Test Nest reauthentication from configuration.yaml."""
     old_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -132,60 +278,67 @@ async def test_reauth(hass, oauth):
     )
     old_entry.add_to_hass(hass)
 
+    assert await setup.async_setup_component(hass, DOMAIN, CONFIG_FROM_YAML)
+
     entry = get_config_entry(hass)
     assert entry.data["token"] == {
         "access_token": "some-revoked-token",
     }
 
-    await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=old_entry.data
+    # Initiate the reauth flow
+    result = await flow_fixture.async_init(
+        config_entries.SOURCE_REAUTH,
+        data=old_entry.data,
     )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
 
-    # Advance through the reauth flow
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["step_id"] == "reauth_confirm"
+    # Start normal config flow
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "device_access"
+    # Default values populated from existing config entry
+    assert result["data_schema"]({}) == DEVICE_ACCESS_CONFIG
 
-    # Run the oauth flow
-    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
-    await oauth.async_oauth_flow(result)
+    result = await flow_fixture.async_next(user_input=DEVICE_ACCESS_CONFIG)
+    await flow_fixture.async_oauth_flow()
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pubsub"
+    # Verify default values are populated from existing config entry
+    assert result["data_schema"]({}) == SUBSCRIBER_CONFIG
+    result = await flow_fixture.async_next(user_input=SUBSCRIBER_CONFIG)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_successful"
+    assert flow_fixture.setup_called
 
     # Verify existing tokens are replaced
     entry = get_config_entry(hass)
     entry.data["token"].pop("expires_at")
     assert entry.unique_id == DOMAIN
-    assert entry.data["token"] == {
-        "refresh_token": "mock-refresh-token",
-        "access_token": "mock-access-token",
-        "type": "Bearer",
-        "expires_in": 60,
-    }
+    assert dict(entry.data) == EXPECTED_CONFIG_ENTRY_DATA
 
 
-async def test_single_config_entry(hass):
+async def test_single_config_entry_from_yaml(hass, flow_fixture):
     """Test that only a single config entry is allowed."""
     old_entry = MockConfigEntry(
         domain=DOMAIN, data={"auth_implementation": DOMAIN, "sdm": {}}
     )
     old_entry.add_to_hass(hass)
 
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
+    assert await setup.async_setup_component(hass, DOMAIN, CONFIG_FROM_YAML)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    result = await flow_fixture.async_init()
     assert result["type"] == "abort"
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_unexpected_existing_config_entries(hass, oauth):
+async def test_unexpected_existing_config_entries_from_yaml(hass, flow_fixture):
     """Test Nest reauthentication with multiple existing config entries."""
     # Note that this case will not happen in the future since only a single
     # instance is now allowed, but this may have been allowed in the past.
     # On reauth, only one entry is kept and the others are deleted.
 
-    assert await setup.async_setup_component(hass, DOMAIN, CONFIG)
-
     old_entry = MockConfigEntry(
         domain=DOMAIN, data={"auth_implementation": DOMAIN, "sdm": {}}
     )
@@ -195,21 +348,36 @@ async def test_unexpected_existing_config_entries(hass, oauth):
         domain=DOMAIN, data={"auth_implementation": DOMAIN, "sdm": {}}
     )
     old_entry.add_to_hass(hass)
+
+    assert await setup.async_setup_component(hass, DOMAIN, CONFIG_FROM_YAML)
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 2
 
     # Invoke the reauth flow
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=old_entry.data
+    result = await flow_fixture.async_init(
+        config_entries.SOURCE_REAUTH,
+        data=old_entry.data,
     )
-    assert result["type"] == "form"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "reauth_confirm"
 
-    flows = hass.config_entries.flow.async_progress()
-
-    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
-    await oauth.async_oauth_flow(result)
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "device_access"
+    # Verify default values are populated from existing config entry
+    assert result["data_schema"]({}) == DEVICE_ACCESS_CONFIG
+    result = await flow_fixture.async_next(user_input={})
+    await flow_fixture.async_oauth_flow()
+    result = await flow_fixture.async_next(user_input={})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "pubsub"
+    # Verify default values are populated from existing config entry
+    assert result["data_schema"]({}) == SUBSCRIBER_CONFIG
+    result = await flow_fixture.async_next(user_input=SUBSCRIBER_CONFIG)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_successful"
+    assert flow_fixture.setup_called
 
     # Only a single entry now exists, and the other was cleaned up
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -217,9 +385,4 @@ async def test_unexpected_existing_config_entries(hass, oauth):
     entry = entries[0]
     assert entry.unique_id == DOMAIN
     entry.data["token"].pop("expires_at")
-    assert entry.data["token"] == {
-        "refresh_token": "mock-refresh-token",
-        "access_token": "mock-access-token",
-        "type": "Bearer",
-        "expires_in": 60,
-    }
+    assert dict(entry.data) == EXPECTED_CONFIG_ENTRY_DATA


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add step-by-step config flow for `nest` as a step towards making it easier to onboard and troubleshoot.


**Overview**
The SDM API can be configured entirely via this new config flow, but also supports
backwards compatibility with the old approach of using configuration.yaml.

The config flow still inherits from AbstractOAuth2FlowHandler to handle most of the
OAuth functionality, redirects, and token management.  The OAuth redirects
happen in the middle of the flow at the user needs to first provide some
configuration options.  This flow also supports a reauth step that handles
re-running the flow to update existing authentication tokens.

See the [Home Assistant Nest Config Flow](http://bit.ly/3raw7ik) for the original design doc  / overview.

The notable config flow steps are:
- user: To dispatch between API versions and OAuth once configured.
- device_access: Prompt the user for parameters required to talk to the SDM API
- user: Invoked again, this time to run the OAuth flow in the parent class.
- async_oauth_create_entry: Overridden to handle when OAuth is complete.  This
    does not actually create the entry, but holds on to the OAuth token data
    for later
- pubsub: Configure the pubsub subscriber
- finish: Handles creating a new configuration entry or updating the existing
    configuration entry.

**Backwards compatibility**
When reviewing this PR, keep in mind the Nest SDM API now supports 3 different configuration modes for backwards compatibility:
- no `nest:` configuration.yaml entry: SDM API using config flow, no preferred
- `nest:` with `project_id:`: SDM API using `configuration.yaml`
- `nest:` with no `project_id:`: Legacy works with Nest API using `configuration.yaml`

Additionally, for the SDM API, existing `ConfigEntry` objects do not have all required fields, so the integration still needs to check `configuration.yaml` in those cases.


**Testing**
Note that `config_flow.py` retains 97% test coverage with this change, and exercises combinations of the above flows.

Documentation is in progress, and will be ready for review by the time this PR is ready to be merged and submitted.

**Future Improvements Planned**
- Call nest SDM API after OAuth to verify that it works, and link to troubleshooting steps if not
- Break into additional steps, incorporating more text from instructions. (e.g. device access project id on standalone page)
- Explain the correct auth callback url to the user
- Check Pub/Sub subscription interactively to look out for common misconfigurations
- Support reconfiguration on error messages in setup, similar to OAuth flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
