### PR TITLE
Skip yeelight turn on when in music mode

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -713,10 +713,11 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         if ATTR_TRANSITION in kwargs:  # passed kwarg overrides config
             duration = int(kwargs.get(ATTR_TRANSITION) * 1000)  # kwarg in s
 
-        # When in music mode, skip turn_on if there is no change, to speed up color
+        # When in music mode, skip turn_on if there is no change, except brightness, to
+        # speed up color changes.
         # changes
         if self._bulb.music_mode:
-            if brightness or colortemp or rgb or flash or effect:
+            if colortemp or rgb or flash or effect:
                 turn_on_before_change = False
         else:
             if self.config[CONF_MODE_MUSIC]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

I think it might be breaking change. If someone uses turn_on in music_mode, via script / automation, now light wont turn on, on each call. Its needed to turn on light in separate call. When turning on via UI, it works without any changes, because there is only possible to turn on, or change brightness. In both cases it will turn on light, even when in music_mode, as before.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Skip turn_on, when in music mode, and we are changing something else than brightness. It allow to faster color changes, useful in fast color sync, like when using https://github.com/diyhue/diyHue. Currently each color change also send turn on, which slow downs color sync.

Before:

```
2020-12-26 08:40:33 DEBUG (SyncWorker_0) [yeelight.main] Bulb<10.0.7.184:55443, type=BulbType.Color> > {'id': 157, 'method': 'set_power', 'params': ['on', 'smooth', 350]}
2020-12-26 08:40:33 DEBUG (SyncWorker_0) [yeelight.main] Music mode cache update: {'rgb': 14942097}
2020-12-26 08:40:33 DEBUG (SyncWorker_0) [yeelight.main] Bulb<10.0.7.184:55443, type=BulbType.Color> > {'id': 158, 'method': 'set_rgb', 'params': [14942097, 'smooth', 350]}
2020-12-26 08:40:34 DEBUG (SyncWorker_2) [yeelight.main] Music mode cache update: {'power': 'on'}
2020-12-26 08:40:34 DEBUG (SyncWorker_2) [yeelight.main] Bulb<10.0.7.184:55443, type=BulbType.Color> > {'id': 159, 'method': 'set_power', 'params': ['on', 'smooth', 350]}
2020-12-26 08:40:34 DEBUG (SyncWorker_2) [yeelight.main] Music mode cache update: {'rgb': 16112383}
2020-12-26 08:40:34 DEBUG (SyncWorker_2) [yeelight.main] Bulb<10.0.7.184:55443, type=BulbType.Color> > {'id': 160, 'method': 'set_rgb', 'params': [16112383, 'smooth', 350]}
2020-12-26 08:40:34 DEBUG (SyncWorker_0) [yeelight.main] Music mode cache update: {'power': 'on'}
2020-12-26 08:40:34 DEBUG (SyncWorker_0) [yeelight.main] Bulb<10.0.7.184:55443, type=BulbType.Color> > {'id': 161, 'method': 'set_power', 'params': ['on', 'smooth', 350]}
2020-12-26 08:40:34 DEBUG (SyncWorker_0) [yeelight.main] Music mode cache update: {'rgb': 49151}
2020-12-26 08:40:34 DEBUG (SyncWorker_0) [yeelight.main] Bulb<10.0.7.184:55443, type=BulbType.Color> > {'id': 162, 'method': 'set_rgb', 'params': [49151, 'smooth', 350]}
```

After:

```
2020-12-26 09:25:39 DEBUG (SyncWorker_5) [yeelight.main] Bulb<10.0.7.185:55443, type=BulbType.Color> > {'id': 5, 'method': 'set_rgb', 'params': [14315007, 'smooth', 350]}
2020-12-26 09:25:40 DEBUG (SyncWorker_0) [yeelight.main] Music mode cache update: {'rgb': 14315007}
2020-12-26 09:25:40 DEBUG (SyncWorker_0) [yeelight.main] Bulb<10.0.7.185:55443, type=BulbType.Color> > {'id': 6, 'method': 'set_rgb', 'params': [14315007, 'smooth', 350]}
2020-12-26 09:25:40 DEBUG (SyncWorker_5) [yeelight.main] Music mode cache update: {'rgb': 7199487}
2020-12-26 09:25:40 DEBUG (SyncWorker_5) [yeelight.main] Bulb<10.0.7.185:55443, type=BulbType.Color> > {'id': 7, 'method': 'set_rgb', 'params': [7199487, 'smooth', 350]}
2020-12-26 09:25:40 DEBUG (SyncWorker_3) [yeelight.main] Music mode cache update: {'rgb': 7199487}
2020-12-26 09:25:40 DEBUG (SyncWorker_3) [yeelight.main] Bulb<10.0.7.185:55443, type=BulbType.Color> > {'id': 8, 'method': 'set_rgb', 'params': [7199487, 'smooth', 350]}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
