### PR TITLE
Upgrade pubnubsub-handler to 1.0.9 for wink component

### DIFF
--- a/homeassistant/components/wink/manifest.json
+++ b/homeassistant/components/wink/manifest.json
@@ -2,7 +2,7 @@
   "domain": "wink",
   "name": "Wink",
   "documentation": "https://www.home-assistant.io/integrations/wink",
-  "requirements": ["pubnubsub-handler==1.0.8", "python-wink==1.10.5"],
+  "requirements": ["pubnubsub-handler==1.0.9", "python-wink==1.10.5"],
   "dependencies": ["configurator", "http"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1177,7 +1177,7 @@ psutil==5.7.2
 ptvsd==4.3.2
 
 # homeassistant.components.wink
-pubnubsub-handler==1.0.8
+pubnubsub-handler==1.0.9
 
 # homeassistant.components.pulseaudio_loopback
 pulsectl==20.2.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

This upgrades the version of pubnubsub-handler to 1.0.9 to fix an `AttributeError` thrown on shutdown of the wink component. It pulls in the fix merged in https://github.com/w1ll1am23/pubnubsub-handler/pull/3.

This should fix the behavior seen in #37165.

https://github.com/w1ll1am23/pubnubsub-handler/blob/master/CHANGELOG.md

https://github.com/w1ll1am23/pubnubsub-handler/compare/0ea6a6f46bef365aabf75787cf15a49eb231700b...38446c19642c9e4661f9ebda951d6912d346c994

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
# Standard wink configuration
wink:
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37165

https://github.com/w1ll1am23/pubnubsub-handler/compare/0ea6a6f46bef365aabf75787cf15a49eb231700b...38446c19642c9e4661f9ebda951d6912d346c994

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
