### PR TITLE
Add service to lock/unlock Sure Petcare pet flaps 

### DIFF
--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -220,4 +220,4 @@ class SurePetcareAPI:
         elif state.lower() == SureLockStateID.LOCKED_ALL.name.lower():
             await self.surepy.lock(flap_id)
         else:
-            _LOGGER.error(f"Unknown lock state: {state}")
+            _LOGGER.error("Unknown lock state: %s", state)

--- a/homeassistant/components/surepetcare/const.py
+++ b/homeassistant/components/surepetcare/const.py
@@ -31,3 +31,8 @@ BATTERY_ICON = "mdi:battery"
 SURE_BATT_VOLTAGE_FULL = 1.6  # voltage
 SURE_BATT_VOLTAGE_LOW = 1.25  # voltage
 SURE_BATT_VOLTAGE_DIFF = SURE_BATT_VOLTAGE_FULL - SURE_BATT_VOLTAGE_LOW
+
+# lock state service
+SERVICE_SET_LOCK_STATE = "set_lock_state"
+CONF_FLAP_ID = "flap_id"
+CONF_LOCK_STATE = "lock_state"

--- a/homeassistant/components/surepetcare/const.py
+++ b/homeassistant/components/surepetcare/const.py
@@ -34,5 +34,5 @@ SURE_BATT_VOLTAGE_DIFF = SURE_BATT_VOLTAGE_FULL - SURE_BATT_VOLTAGE_LOW
 
 # lock state service
 SERVICE_SET_LOCK_STATE = "set_lock_state"
-CONF_FLAP_ID = "flap_id"
-CONF_LOCK_STATE = "lock_state"
+ATTR_FLAP_ID = "flap_id"
+ATTR_LOCK_STATE = "lock_state"

--- a/homeassistant/components/surepetcare/services.yaml
+++ b/homeassistant/components/surepetcare/services.yaml
@@ -1,0 +1,9 @@
+set_lock_state:
+  description: Sets lock state
+  fields:
+    flap_id:
+      description: Flap ID to lock/unlock
+      example: "123456"
+    lock_state:
+      description: New lock state - unlocked, locked_in, locked_out or locked_all
+      example: "unlocked"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds a new `surepetcare.set_lock_state` service to allow users to change the lock state of Sure Petcare pet flaps. Previously, users could see the state, but needed to use the Sure Petcare app to change the state.

## Docs PR

https://github.com/home-assistant/home-assistant.io/pull/16020

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is dependent on #44556

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
