### PR TITLE
Correct Dyson climate fan auto mode

### DIFF
--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -333,6 +333,8 @@ class DysonPureHotCoolEntity(ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
+        if self._device.state.speed == FanMode.AUTO.value:
+			return FAN_AUTO
         if self._device.state.fan_state == FanState.FAN_OFF.value:
             return FAN_OFF
 
@@ -368,7 +370,7 @@ class DysonPureHotCoolEntity(ClimateEntity):
         elif fan_mode == FAN_HIGH:
             self._device.set_fan_speed(FanSpeed.FAN_SPEED_10)
         elif fan_mode == FAN_AUTO:
-            self._device.set_fan_speed(FanSpeed.FAN_SPEED_AUTO)
+            self._device.enable_auto_mode()
 
     def set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""

--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -5,6 +5,7 @@ from libpurecool.const import (
     FanPower,
     FanSpeed,
     FanState,
+    FanMode,
     FocusMode,
     HeatMode,
     HeatState,

--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -334,8 +334,8 @@ class DysonPureHotCoolEntity(ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
-        if self._device.state.auto_mode != AutoMode.AUTO_ON.value:
-            if self._device.state.fan_state == FanState.FAN_OFF.value:
+        if self._device.state.auto_mode != AutoMode.AUTO_ON.value and \
+            self._device.state.fan_state == FanState.FAN_OFF.value:
                 return FAN_OFF
 
         return SPEED_MAP[self._device.state.speed]

--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -2,10 +2,10 @@
 import logging
 
 from libpurecool.const import (
+    FanMode,
     FanPower,
     FanSpeed,
     FanState,
-    FanMode,
     FocusMode,
     HeatMode,
     HeatState,

--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -371,6 +371,7 @@ class DysonPureHotCoolEntity(ClimateEntity):
         elif fan_mode == FAN_HIGH:
             self._device.set_fan_speed(FanSpeed.FAN_SPEED_10)
         elif fan_mode == FAN_AUTO:
+            self._device.set_fan_speed(FanSpeed.FAN_SPEED_AUTO)
             self._device.enable_auto_mode()
 
     def set_hvac_mode(self, hvac_mode):

--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -334,9 +334,11 @@ class DysonPureHotCoolEntity(ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
-        if self._device.state.auto_mode != AutoMode.AUTO_ON.value and \
-            self._device.state.fan_state == FanState.FAN_OFF.value:
-                return FAN_OFF
+        if (
+            self._device.state.auto_mode != AutoMode.AUTO_ON.value
+            and self._device.state.fan_state == FanState.FAN_OFF.value
+        ):
+            return FAN_OFF
 
         return SPEED_MAP[self._device.state.speed]
 

--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -334,7 +334,7 @@ class DysonPureHotCoolEntity(ClimateEntity):
     def fan_mode(self):
         """Return the fan setting."""
         if self._device.state.speed == FanMode.AUTO.value:
-			return FAN_AUTO
+            return FAN_AUTO
         if self._device.state.fan_state == FanState.FAN_OFF.value:
             return FAN_OFF
 

--- a/homeassistant/components/dyson/climate.py
+++ b/homeassistant/components/dyson/climate.py
@@ -2,7 +2,7 @@
 import logging
 
 from libpurecool.const import (
-    FanMode,
+    AutoMode,
     FanPower,
     FanSpeed,
     FanState,
@@ -334,10 +334,9 @@ class DysonPureHotCoolEntity(ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
-        if self._device.state.speed == FanMode.AUTO.value:
-            return FAN_AUTO
-        if self._device.state.fan_state == FanState.FAN_OFF.value:
-            return FAN_OFF
+        if self._device.state.auto_mode != AutoMode.AUTO_ON.value:
+            if self._device.state.fan_state == FanState.FAN_OFF.value:
+                return FAN_OFF
 
         return SPEED_MAP[self._device.state.speed]
 
@@ -371,7 +370,6 @@ class DysonPureHotCoolEntity(ClimateEntity):
         elif fan_mode == FAN_HIGH:
             self._device.set_fan_speed(FanSpeed.FAN_SPEED_10)
         elif fan_mode == FAN_AUTO:
-            self._device.set_fan_speed(FanSpeed.FAN_SPEED_AUTO)
             self._device.enable_auto_mode()
 
     def set_hvac_mode(self, hvac_mode):

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -678,7 +678,6 @@ async def test_purehotcool_set_fan_mode(devices, login, hass):
         True,
     )
     assert device.enable_auto_mode.call_count == 1
-    device.set_fan_speed.assert_called_with(FanSpeed.FAN_SPEED_AUTO)
 
 
 @patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -516,24 +516,6 @@ async def test_purehotcool_empty_env_attributes(devices, login, hass):
     "homeassistant.components.dyson.DysonAccount.devices",
     return_value=[_get_dyson_purehotcool_device()],
 )
-async def test_purehotcool_fan_state_auto(devices, login, hass):
-    """Test device fan state auto."""
-    device = devices.return_value[0]
-    device.state.fan_state = FanState.FAN_AUTO.value
-    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
-    await hass.async_block_till_done()
-
-    state = hass.states.get("climate.living_room")
-    attributes = state.attributes
-
-    assert attributes[ATTR_FAN_MODE] == FAN_AUTO
-
-
-@patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
-@patch(
-    "homeassistant.components.dyson.DysonAccount.devices",
-    return_value=[_get_dyson_purehotcool_device()],
-)
 async def test_purehotcool_fan_state_off(devices, login, hass):
     """Test device fan state off."""
     device = devices.return_value[0]
@@ -695,7 +677,7 @@ async def test_purehotcool_set_fan_mode(devices, login, hass):
         {ATTR_ENTITY_ID: "climate.living_room", ATTR_FAN_MODE: FAN_AUTO},
         True,
     )
-    assert device.set_fan_speed.call_count == 4
+    assert device.enable_auto_mode.call_count == 1
     device.set_fan_speed.assert_called_with(FanSpeed.FAN_SPEED_AUTO)
 
 

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -516,6 +516,24 @@ async def test_purehotcool_empty_env_attributes(devices, login, hass):
     "homeassistant.components.dyson.DysonAccount.devices",
     return_value=[_get_dyson_purehotcool_device()],
 )
+async def test_purehotcool_fan_state_auto(devices, login, hass):
+    """Test device fan state auto."""
+    device = devices.return_value[0]
+    device.state.fan_state = FanState.FAN_AUTO.value
+    await async_setup_component(hass, DYSON_DOMAIN, _get_config())
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.living_room")
+    attributes = state.attributes
+
+    assert attributes[ATTR_FAN_MODE] == FAN_AUTO
+
+
+@patch("homeassistant.components.dyson.DysonAccount.login", return_value=True)
+@patch(
+    "homeassistant.components.dyson.DysonAccount.devices",
+    return_value=[_get_dyson_purehotcool_device()],
+)
 async def test_purehotcool_fan_state_off(devices, login, hass):
     """Test device fan state off."""
     device = devices.return_value[0]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Climate would incorrectly report dyson climate fan mode as off when infact it was set to Auto. Will also use the correct method for enabling auto mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44470
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
