### PR TITLE
Tado: use proper variable name to avoid confusion

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -168,7 +168,7 @@ class TadoConnector:
         self._password = password
         self._fallback = fallback
 
-        self.device_id = None
+        self.home_id = None
         self.tado = None
         self.zones = None
         self.devices = None
@@ -188,7 +188,7 @@ class TadoConnector:
         # Load zones and devices
         self.zones = self.tado.getZones()
         self.devices = self.tado.getDevices()
-        self.device_id = self.tado.getMe()["homes"][0]["id"]
+        self.home_id = self.tado.getMe()["homes"][0]["id"]
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -218,14 +218,14 @@ class TadoConnector:
 
         _LOGGER.debug(
             "Dispatching update to %s %s %s: %s",
-            self.device_id,
+            self.home_id,
             sensor_type,
             sensor,
             data,
         )
         dispatcher_send(
             self.hass,
-            SIGNAL_TADO_UPDATE_RECEIVED.format(self.device_id, sensor_type, sensor),
+            SIGNAL_TADO_UPDATE_RECEIVED.format(self.home_id, sensor_type, sensor),
         )
 
     def get_capabilities(self, zone_id):

--- a/homeassistant/components/tado/binary_sensor.py
+++ b/homeassistant/components/tado/binary_sensor.py
@@ -63,7 +63,7 @@ class TadoDeviceSensor(TadoDeviceEntity, BinarySensorEntity):
 
         self.device_variable = device_variable
 
-        self._unique_id = f"{device_variable} {self.device_id} {tado.device_id}"
+        self._unique_id = f"{device_variable} {self.device_id} {tado.home_id}"
 
         self._state = None
 
@@ -74,7 +74,7 @@ class TadoDeviceSensor(TadoDeviceEntity, BinarySensorEntity):
             async_dispatcher_connect(
                 self.hass,
                 SIGNAL_TADO_UPDATE_RECEIVED.format(
-                    self._tado.device_id, "device", self.device_id
+                    self._tado.home_id, "device", self.device_id
                 ),
                 self._async_update_callback,
             )

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -203,11 +203,11 @@ class TadoClimate(TadoZoneEntity, ClimateEntity):
     ):
         """Initialize of Tado climate entity."""
         self._tado = tado
-        super().__init__(zone_name, tado.device_id, zone_id)
+        super().__init__(zone_name, tado.home_id, zone_id)
 
         self.zone_id = zone_id
         self.zone_type = zone_type
-        self._unique_id = f"{zone_type} {zone_id} {tado.device_id}"
+        self._unique_id = f"{zone_type} {zone_id} {tado.home_id}"
 
         self._ac_device = zone_type == TYPE_AIR_CONDITIONING
         self._supported_hvac_modes = supported_hvac_modes
@@ -245,7 +245,7 @@ class TadoClimate(TadoZoneEntity, ClimateEntity):
             async_dispatcher_connect(
                 self.hass,
                 SIGNAL_TADO_UPDATE_RECEIVED.format(
-                    self._tado.device_id, "zone", self.zone_id
+                    self._tado.home_id, "zone", self.zone_id
                 ),
                 self._async_update_callback,
             )

--- a/homeassistant/components/tado/entity.py
+++ b/homeassistant/components/tado/entity.py
@@ -35,10 +35,10 @@ class TadoDeviceEntity(Entity):
 class TadoZoneEntity(Entity):
     """Base implementation for Tado zone."""
 
-    def __init__(self, zone_name, device_id, zone_id):
+    def __init__(self, zone_name, home_id, zone_id):
         """Initialize a Tado zone."""
         super().__init__()
-        self._device_zone_id = f"{device_id}_{zone_id}"
+        self._device_zone_id = f"{home_id}_{zone_id}"
         self.zone_name = zone_name
 
     @property

--- a/homeassistant/components/tado/sensor.py
+++ b/homeassistant/components/tado/sensor.py
@@ -78,12 +78,12 @@ class TadoZoneSensor(TadoZoneEntity, Entity):
     def __init__(self, tado, zone_name, zone_id, zone_variable):
         """Initialize of the Tado Sensor."""
         self._tado = tado
-        super().__init__(zone_name, tado.device_id, zone_id)
+        super().__init__(zone_name, tado.home_id, zone_id)
 
         self.zone_id = zone_id
         self.zone_variable = zone_variable
 
-        self._unique_id = f"{zone_variable} {zone_id} {tado.device_id}"
+        self._unique_id = f"{zone_variable} {zone_id} {tado.home_id}"
 
         self._state = None
         self._state_attributes = None
@@ -96,7 +96,7 @@ class TadoZoneSensor(TadoZoneEntity, Entity):
             async_dispatcher_connect(
                 self.hass,
                 SIGNAL_TADO_UPDATE_RECEIVED.format(
-                    self._tado.device_id, "zone", self.zone_id
+                    self._tado.home_id, "zone", self.zone_id
                 ),
                 self._async_update_callback,
             )

--- a/homeassistant/components/tado/water_heater.py
+++ b/homeassistant/components/tado/water_heater.py
@@ -133,10 +133,10 @@ class TadoWaterHeater(TadoZoneEntity, WaterHeaterEntity):
         """Initialize of Tado water heater entity."""
 
         self._tado = tado
-        super().__init__(zone_name, tado.device_id, zone_id)
+        super().__init__(zone_name, tado.home_id, zone_id)
 
         self.zone_id = zone_id
-        self._unique_id = f"{zone_id} {tado.device_id}"
+        self._unique_id = f"{zone_id} {tado.home_id}"
 
         self._device_is_active = False
 
@@ -161,7 +161,7 @@ class TadoWaterHeater(TadoZoneEntity, WaterHeaterEntity):
             async_dispatcher_connect(
                 self.hass,
                 SIGNAL_TADO_UPDATE_RECEIVED.format(
-                    self._tado.device_id, "zone", self.zone_id
+                    self._tado.home_id, "zone", self.zone_id
                 ),
                 self._async_update_callback,
             )


### PR DESCRIPTION
## Proposed change
Current device_id variable refers to the Home ID obtained from the Tado API.
Let's use home_id in order to avoid confusion with Tado devices (https://github.com/home-assistant/core/pull/44475#discussion_r549016244).


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
tado:
  username: !secret tado_username
  password: !secret tado_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
