### PR TITLE
Add tado zone binary sensors

### DIFF
--- a/homeassistant/components/tado/binary_sensor.py
+++ b/homeassistant/components/tado/binary_sensor.py
@@ -4,14 +4,25 @@ import logging
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_WINDOW,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DATA, DOMAIN, SIGNAL_TADO_UPDATE_RECEIVED, TYPE_BATTERY, TYPE_POWER
-from .entity import TadoDeviceEntity
+from .const import (
+    DATA,
+    DOMAIN,
+    SIGNAL_TADO_UPDATE_RECEIVED,
+    TYPE_AIR_CONDITIONING,
+    TYPE_BATTERY,
+    TYPE_HEATING,
+    TYPE_HOT_WATER,
+    TYPE_POWER,
+)
+from .entity import TadoDeviceEntity, TadoZoneEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +36,23 @@ DEVICE_SENSORS = {
     ],
 }
 
+ZONE_SENSORS = {
+    TYPE_HEATING: [
+        "power",
+        "link",
+        "overlay",
+        "early start",
+        "open window",
+    ],
+    TYPE_AIR_CONDITIONING: [
+        "power",
+        "link",
+        "overlay",
+        "open window",
+    ],
+    TYPE_HOT_WATER: ["power", "link", "overlay"],
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
@@ -33,6 +61,7 @@ async def async_setup_entry(
 
     tado = hass.data[DOMAIN][entry.entry_id][DATA]
     devices = tado.devices
+    zones = tado.zones
     entities = []
 
     # Create device sensors
@@ -44,8 +73,22 @@ async def async_setup_entry(
 
         entities.extend(
             [
-                TadoDeviceSensor(tado, device, variable)
+                TadoDeviceBinarySensor(tado, device, variable)
                 for variable in DEVICE_SENSORS[device_type]
+            ]
+        )
+
+    # Create zone sensors
+    for zone in zones:
+        zone_type = zone["type"]
+        if zone_type not in ZONE_SENSORS:
+            _LOGGER.warning("Unknown zone type skipped: %s", zone_type)
+            continue
+
+        entities.extend(
+            [
+                TadoZoneBinarySensor(tado, zone["name"], zone["id"], variable)
+                for variable in ZONE_SENSORS[zone_type]
             ]
         )
 
@@ -53,7 +96,7 @@ async def async_setup_entry(
         async_add_entities(entities, True)
 
 
-class TadoDeviceSensor(TadoDeviceEntity, BinarySensorEntity):
+class TadoDeviceBinarySensor(TadoDeviceEntity, BinarySensorEntity):
     """Representation of a tado Sensor."""
 
     def __init__(self, tado, device_info, device_variable):
@@ -124,4 +167,96 @@ class TadoDeviceSensor(TadoDeviceEntity, BinarySensorEntity):
         elif self.device_variable == "connection state":
             self._state = self._device_info.get("connectionState", {}).get(
                 "value", False
+            )
+
+
+class TadoZoneBinarySensor(TadoZoneEntity, BinarySensorEntity):
+    """Representation of a tado Sensor."""
+
+    def __init__(self, tado, zone_name, zone_id, zone_variable):
+        """Initialize of the Tado Sensor."""
+        self._tado = tado
+        super().__init__(zone_name, tado.home_id, zone_id)
+
+        self.zone_variable = zone_variable
+
+        self._unique_id = f"{zone_variable} {zone_id} {tado.home_id}"
+
+        self._state = None
+        self._tado_zone_data = None
+
+    async def async_added_to_hass(self):
+        """Register for sensor updates."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_TADO_UPDATE_RECEIVED.format(
+                    self._tado.home_id, "zone", self.zone_id
+                ),
+                self._async_update_callback,
+            )
+        )
+        self._async_update_zone_data()
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self.zone_name} {self.zone_variable}"
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._state
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor."""
+        if self.zone_variable == "early start":
+            return DEVICE_CLASS_POWER
+        if self.zone_variable == "link":
+            return DEVICE_CLASS_CONNECTIVITY
+        if self.zone_variable == "open window":
+            return DEVICE_CLASS_WINDOW
+        if self.zone_variable == "overlay":
+            return DEVICE_CLASS_POWER
+        if self.zone_variable == "power":
+            return DEVICE_CLASS_POWER
+        return None
+
+    @callback
+    def _async_update_callback(self):
+        """Update and write state."""
+        self._async_update_zone_data()
+        self.async_write_ha_state()
+
+    @callback
+    def _async_update_zone_data(self):
+        """Handle update callbacks."""
+        try:
+            self._tado_zone_data = self._tado.data["zone"][self.zone_id]
+        except KeyError:
+            return
+
+        if self.zone_variable == "power":
+            self._state = self._tado_zone_data.power
+
+        elif self.zone_variable == "link":
+            self._state = self._tado_zone_data.link
+
+        elif self.zone_variable == "overlay":
+            self._state = self._tado_zone_data.overlay_active
+
+        elif self.zone_variable == "early start":
+            self._state = self._tado_zone_data.preparation
+
+        elif self.zone_variable == "open window":
+            self._state = bool(
+                self._tado_zone_data.open_window
+                or self._tado_zone_data.open_window_detected
             )

--- a/homeassistant/components/tado/entity.py
+++ b/homeassistant/components/tado/entity.py
@@ -40,6 +40,7 @@ class TadoZoneEntity(Entity):
         super().__init__()
         self._device_zone_id = f"{home_id}_{zone_id}"
         self.zone_name = zone_name
+        self.zone_id = zone_id
 
     @property
     def device_info(self):

--- a/homeassistant/components/tado/sensor.py
+++ b/homeassistant/components/tado/sensor.py
@@ -23,25 +23,16 @@ ZONE_SENSORS = {
     TYPE_HEATING: [
         "temperature",
         "humidity",
-        "power",
-        "link",
         "heating",
         "tado mode",
-        "overlay",
-        "early start",
-        "open window",
     ],
     TYPE_AIR_CONDITIONING: [
         "temperature",
         "humidity",
-        "power",
-        "link",
         "ac",
         "tado mode",
-        "overlay",
-        "open window",
     ],
-    TYPE_HOT_WATER: ["power", "link", "tado mode", "overlay"],
+    TYPE_HOT_WATER: ["tado mode"],
 }
 
 
@@ -51,10 +42,10 @@ async def async_setup_entry(
     """Set up the Tado sensor platform."""
 
     tado = hass.data[DOMAIN][entry.entry_id][DATA]
-    # Create zone sensors
     zones = tado.zones
     entities = []
 
+    # Create zone sensors
     for zone in zones:
         zone_type = zone["type"]
         if zone_type not in ZONE_SENSORS:
@@ -80,7 +71,6 @@ class TadoZoneSensor(TadoZoneEntity, Entity):
         self._tado = tado
         super().__init__(zone_name, tado.home_id, zone_id)
 
-        self.zone_id = zone_id
         self.zone_variable = zone_variable
 
         self._unique_id = f"{zone_variable} {zone_id} {tado.home_id}"
@@ -172,12 +162,6 @@ class TadoZoneSensor(TadoZoneEntity, Entity):
                 "time": self._tado_zone_data.current_humidity_timestamp
             }
 
-        elif self.zone_variable == "power":
-            self._state = self._tado_zone_data.power
-
-        elif self.zone_variable == "link":
-            self._state = self._tado_zone_data.link
-
         elif self.zone_variable == "heating":
             self._state = self._tado_zone_data.heating_power_percentage
             self._state_attributes = {
@@ -188,26 +172,5 @@ class TadoZoneSensor(TadoZoneEntity, Entity):
             self._state = self._tado_zone_data.ac_power
             self._state_attributes = {"time": self._tado_zone_data.ac_power_timestamp}
 
-        elif self.zone_variable == "tado bridge status":
-            self._state = self._tado_zone_data.connection
-
         elif self.zone_variable == "tado mode":
             self._state = self._tado_zone_data.tado_mode
-
-        elif self.zone_variable == "overlay":
-            self._state = self._tado_zone_data.overlay_active
-            self._state_attributes = (
-                {"termination": self._tado_zone_data.overlay_termination_type}
-                if self._tado_zone_data.overlay_active
-                else {}
-            )
-
-        elif self.zone_variable == "early start":
-            self._state = self._tado_zone_data.preparation
-
-        elif self.zone_variable == "open window":
-            self._state = bool(
-                self._tado_zone_data.open_window
-                or self._tado_zone_data.open_window_detected
-            )
-            self._state_attributes = self._tado_zone_data.open_window_attr

--- a/tests/components/tado/test_binary_sensor.py
+++ b/tests/components/tado/test_binary_sensor.py
@@ -1,8 +1,62 @@
 """The sensor tests for the tado platform."""
 
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 
 from .util import async_init_integration
+
+
+async def test_air_con_create_binary_sensors(hass):
+    """Test creation of aircon sensors."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("binary_sensor.air_conditioning_power")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.air_conditioning_link")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.air_conditioning_overlay")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.air_conditioning_open_window")
+    assert state.state == STATE_OFF
+
+
+async def test_heater_create_binary_sensors(hass):
+    """Test creation of heater sensors."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("binary_sensor.baseboard_heater_power")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.baseboard_heater_link")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.baseboard_heater_early_start")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.baseboard_heater_overlay")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.baseboard_heater_open_window")
+    assert state.state == STATE_OFF
+
+
+async def test_water_heater_create_binary_sensors(hass):
+    """Test creation of water heater sensors."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("binary_sensor.water_heater_link")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.water_heater_overlay")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.water_heater_power")
+    assert state.state == STATE_ON
 
 
 async def test_home_create_binary_sensors(hass):

--- a/tests/components/tado/test_sensor.py
+++ b/tests/components/tado/test_sensor.py
@@ -8,15 +8,6 @@ async def test_air_con_create_sensors(hass):
 
     await async_init_integration(hass)
 
-    state = hass.states.get("sensor.air_conditioning_power")
-    assert state.state == "ON"
-
-    state = hass.states.get("sensor.air_conditioning_link")
-    assert state.state == "ONLINE"
-
-    state = hass.states.get("sensor.air_conditioning_link")
-    assert state.state == "ONLINE"
-
     state = hass.states.get("sensor.air_conditioning_tado_mode")
     assert state.state == "HOME"
 
@@ -26,14 +17,8 @@ async def test_air_con_create_sensors(hass):
     state = hass.states.get("sensor.air_conditioning_ac")
     assert state.state == "ON"
 
-    state = hass.states.get("sensor.air_conditioning_overlay")
-    assert state.state == "True"
-
     state = hass.states.get("sensor.air_conditioning_humidity")
     assert state.state == "60.9"
-
-    state = hass.states.get("sensor.air_conditioning_open_window")
-    assert state.state == "False"
 
 
 async def test_heater_create_sensors(hass):
@@ -41,32 +26,14 @@ async def test_heater_create_sensors(hass):
 
     await async_init_integration(hass)
 
-    state = hass.states.get("sensor.baseboard_heater_power")
-    assert state.state == "ON"
-
-    state = hass.states.get("sensor.baseboard_heater_link")
-    assert state.state == "ONLINE"
-
-    state = hass.states.get("sensor.baseboard_heater_link")
-    assert state.state == "ONLINE"
-
     state = hass.states.get("sensor.baseboard_heater_tado_mode")
     assert state.state == "HOME"
 
     state = hass.states.get("sensor.baseboard_heater_temperature")
     assert state.state == "20.65"
 
-    state = hass.states.get("sensor.baseboard_heater_early_start")
-    assert state.state == "False"
-
-    state = hass.states.get("sensor.baseboard_heater_overlay")
-    assert state.state == "True"
-
     state = hass.states.get("sensor.baseboard_heater_humidity")
     assert state.state == "45.2"
-
-    state = hass.states.get("sensor.baseboard_heater_open_window")
-    assert state.state == "False"
 
 
 async def test_water_heater_create_sensors(hass):
@@ -76,12 +43,3 @@ async def test_water_heater_create_sensors(hass):
 
     state = hass.states.get("sensor.water_heater_tado_mode")
     assert state.state == "HOME"
-
-    state = hass.states.get("sensor.water_heater_link")
-    assert state.state == "ONLINE"
-
-    state = hass.states.get("sensor.water_heater_overlay")
-    assert state.state == "False"
-
-    state = hass.states.get("sensor.water_heater_power")
-    assert state.state == "ON"


### PR DESCRIPTION
## Breaking change
Tado zone sensors will be replaced by their corresponding binary_sensors. Therefore, users will have to update lovelace panels, scripts and automations referring to the following sensors by their corresponding binary sensor (replace **sensor** with **binary_sensor**)
- sensor.%TADO_ZONE%_early_start will be replaced by binary_sensor.%TADO_ZONE%_early_start
- sensor.%TADO_ZONE%_link will be replaced by binary_sensor.%TADO_ZONE%_link
- sensor.%TADO_ZONE%_open_window will be replaced by binary_sensor.%TADO_ZONE%_open_window
- sensor.%TADO_ZONE%_overlay will be replaced by binary_sensor.%TADO_ZONE%_overlay
- sensor.%TADO_ZONE%_power will be replaced by binary_sensor.%TADO_ZONE%_power

The following state attributes have been removed:
- sensor.%TADO_ZONE%_overlay: termination
- sensor.%TADO_ZONE%_open_window: open_window_attr


## Proposed change
Use binary sensors where appropriate (for Tado Zones) instead of normal sensors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
tado:
  username: !secret tado_username
  password: !secret tado_password
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/44571 should be merged first and then rebase this PR
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16076

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
