### PR TITLE
Support for the INHIBIT parameter within supported HomeMatic actors

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -58,6 +58,7 @@ from .const import (
     DISCOVER_BINARY_SENSORS,
     DISCOVER_CLIMATE,
     DISCOVER_COVER,
+    DISCOVER_INHIBIT,
     DISCOVER_LIGHTS,
     DISCOVER_LOCKS,
     DISCOVER_SENSORS,
@@ -454,6 +455,7 @@ def _system_callback_handler(hass, config, src, *args):
                 ("climate", DISCOVER_CLIMATE),
                 ("lock", DISCOVER_LOCKS),
                 ("binary_sensor", DISCOVER_BATTERY),
+                ("switch", DISCOVER_INHIBIT),
             ):
                 # Get all devices of a specific type
                 found_devices = _get_devices(hass, discovery_type, addresses, interface)
@@ -491,6 +493,7 @@ def _get_devices(hass, discovery_type, keys, interface):
         # Class not supported by discovery type
         if (
             discovery_type != DISCOVER_BATTERY
+            and discovery_type != DISCOVER_INHIBIT
             and class_name not in HM_DEVICE_TYPES[discovery_type]
         ):
             continue
@@ -507,6 +510,9 @@ def _get_devices(hass, discovery_type, keys, interface):
                 metadata.update({ATTR_LOW_BAT: device.ATTRIBUTENODE[ATTR_LOW_BAT]})
             else:
                 continue
+        elif discovery_type == DISCOVER_INHIBIT:
+            if "INHIBIT" in device.WRITENODE:
+                metadata.update({"INHIBIT": device.WRITENODE["INHIBIT"]})
         else:
             metadata.update({None: device.ELEMENT})
 

--- a/homeassistant/components/homematic/const.py
+++ b/homeassistant/components/homematic/const.py
@@ -10,6 +10,7 @@ DISCOVER_COVER = "homematic.cover"
 DISCOVER_CLIMATE = "homematic.climate"
 DISCOVER_LOCKS = "homematic.locks"
 DISCOVER_BATTERY = "homematic.battery"
+DISCOVER_INHIBIT = "homematic.inhibit"
 
 ATTR_DISCOVER_DEVICES = "devices"
 ATTR_PARAM = "param"
@@ -210,6 +211,7 @@ HM_ATTRIBUTE_SUPPORT = {
     "VOLTAGE": ["voltage", {}],
     "OPERATING_VOLTAGE": ["voltage", {}],
     "WORKING": ["working", {0: "No", 1: "Yes"}],
+    "INHIBIT": ["inhibit", {0: "Unlocked", 1: "Locked"}],
     "STATE_UNCERTAIN": ["state_uncertain", {}],
 }
 

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -80,12 +80,13 @@ class HMDevice(Entity):
             "interface": self._interface,
         }
 
-        # Generate a dictionary with attributes
-        for node, data in HM_ATTRIBUTE_SUPPORT.items():
-            # Is an attribute and exists for this object
-            if node in self._data:
-                value = data[1].get(self._data[node], self._data[node])
-                attr[data[0]] = value
+        if self._state != "INHIBIT":
+            # Generate a dictionary with attributes
+            for node, data in HM_ATTRIBUTE_SUPPORT.items():
+                # Is an attribute and exists for this object
+                if node in self._data:
+                    value = data[1].get(self._data[node], self._data[node])
+                    attr[data[0]] = value
 
         return attr
 
@@ -186,6 +187,9 @@ class HMDevice(Entity):
         # Add all attributes to data dictionary
         for data_note in self._hmdevice.ATTRIBUTENODE:
             self._data.update({data_note: None})
+
+        if "INHIBIT" in self._hmdevice.WRITENODE:
+            self._data.update({"INHIBIT": None})
 
         # Initialize device specific data
         self._init_data_struct()

--- a/homeassistant/components/homematic/switch.py
+++ b/homeassistant/components/homematic/switch.py
@@ -46,8 +46,7 @@ class HMSwitch(HMDevice, SwitchEntity):
         if self._state == "INHIBIT":
             if self.is_on:
                 return "mdi:lock"
-            else:
-                return "mdi:lock-open"
+            return "mdi:lock-open"
         return super().icon
 
     def turn_on(self, **kwargs):

--- a/homeassistant/components/homematic/switch.py
+++ b/homeassistant/components/homematic/switch.py
@@ -40,19 +40,37 @@ class HMSwitch(HMDevice, SwitchEntity):
 
         return None
 
+    @property
+    def icon(self):
+        """Set lock icon for INHIBIT switches."""
+        if self._state == "INHIBIT":
+            if self.is_on:
+                return "mdi:lock"
+            else:
+                return "mdi:lock-open"
+        return super().icon
+
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        self._hmdevice.on(self._channel)
+        if self._state == "INHIBIT":
+            self._hmdevice.set_inhibit(True, self._channel)
+        else:
+            self._hmdevice.on(self._channel)
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
-        self._hmdevice.off(self._channel)
+        if self._state == "INHIBIT":
+            self._hmdevice.set_inhibit(False, self._channel)
+        else:
+            self._hmdevice.off(self._channel)
 
     def _init_data_struct(self):
         """Generate the data dictionary (self._data) from metadata."""
-        self._state = "STATE"
+        if self._state is None:
+            self._state = "STATE"
         self._data.update({self._state: None})
 
         # Need sensor values for SwitchPowermeter
-        for node in self._hmdevice.SENSORNODE:
-            self._data.update({node: None})
+        if self._state != "INHIBIT":
+            for node in self._hmdevice.SENSORNODE:
+                self._data.update({node: None})


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR propose to support for the INHIBIT parameter within supported HomeMatic actors. In HomeMatic platform almost all actors can be set into INHIBIT mode (INHIBIT-Parameter). If an actor has INHIBIT mode active, its state can't be changed by directly paired devices or buttons on the actor itself. However actors can still be changed over XML-API of the CCU, which means changes over HomeAssistent is still possible. 
One main advantage of this feature is, that buttons on switches for light or windows covers can be locked out. This can be useful as a child protection feature or for preventing external located switches to be switched.

Following changes are included:

- The `Inhibit` parameter will be added in the entity attributes (Value can be: Locked or Unlocked), can be used in automations or entities.
- During entity discovery for every found Inhibit parameter a switch entity `<entity_name> INHIBIT` will be created

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR requires that the changes on PR [364](https://github.com/danielperna84/pyhomematic/pull/364) on pyhomatic project to be merged. (@danielperna84)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
