### PR TITLE
Add support for SwitchBot Curtains

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -861,6 +861,7 @@ omit =
     homeassistant/components/swiss_public_transport/sensor.py
     homeassistant/components/swisscom/device_tracker.py
     homeassistant/components/switchbot/switch.py
+    homeassistant/components/switchbot/cover.py
     homeassistant/components/switcher_kis/switch.py
     homeassistant/components/switchmate/switch.py
     homeassistant/components/syncthru/sensor.py

--- a/homeassistant/components/switchbot/cover.py
+++ b/homeassistant/components/switchbot/cover.py
@@ -3,7 +3,6 @@ from typing import Any, Dict
 
 # pylint: disable=import-error, no-member
 import switchbot
-
 import voluptuous as vol
 
 from homeassistant.components.cover import (
@@ -44,7 +43,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class SwitchBotCurtain(CoverEntity, RestoreEntity):
-    """Representation of a Switchbot Curtain"""
+    """Representation of a Switchbot Curtain."""
 
     def __init__(self, mac, name, password) -> None:
         """Initialize the Switchbot Curtain."""

--- a/homeassistant/components/switchbot/cover.py
+++ b/homeassistant/components/switchbot/cover.py
@@ -1,0 +1,142 @@
+"""Support for SwitchBot curtains."""
+from typing import Any, Dict
+
+# pylint: disable=import-error, no-member
+import switchbot
+
+import voluptuous as vol
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DEVICE_CLASS_CURTAIN,
+    PLATFORM_SCHEMA,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    CoverEntity,
+)
+from homeassistant.const import CONF_MAC, CONF_NAME, CONF_PASSWORD
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.restore_state import RestoreEntity
+
+COVER_FEATURES = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+
+CLOSED_POSITION = 0
+OPEN_POSITION = 100
+
+DEFAULT_NAME = "Switchbot Curtain"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_MAC): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Perform the setup for Switchbot devices."""
+    name = config.get(CONF_NAME)
+    mac_addr = config[CONF_MAC]
+    password = config.get(CONF_PASSWORD)
+    add_entities([SwitchBotCurtain(mac_addr, name, password)])
+
+
+class SwitchBotCurtain(CoverEntity, RestoreEntity):
+    """Representation of a Switchbot Curtain"""
+
+    def __init__(self, mac, name, password) -> None:
+        """Initialize the Switchbot Curtain."""
+
+        self._state = None
+        self._last_run_success = None
+        self._position = None
+        self._name = name
+        self._mac = mac
+        self._device = switchbot.SwitchbotCurtain(mac=mac, password=password)
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state:
+            self._state = state.state
+            self._position = state.attributes.get("current_cover_position")
+        else:
+            self._state = "unknown"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, Home Assistant friendly identifier for this entity."""
+        return self._mac.replace(":", "")
+
+    @property
+    def name(self):
+        """Return the name of the device as reported by tellcore."""
+        return self._name
+
+    @property
+    def current_cover_position(self):
+        """
+        Return current position of cover.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        return self._position
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_CURTAIN
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return COVER_FEATURES
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return true if unable to access real state of entity."""
+        return True
+
+    @property
+    def is_closed(self):
+        """Return true if cover is closed, else False."""
+        return self.current_cover_position == CLOSED_POSITION
+
+    def open_cover(self, **kwargs):
+        """Set the cover to the open position."""
+        if self._device.open():
+            self._state = "open"
+            self._position = OPEN_POSITION
+            self._last_run_success = True
+        else:
+            self._last_run_success = False
+
+    def close_cover(self, **kwargs):
+        """Set the cover to the closed position."""
+        if self._device.close():
+            self._state = "closed"
+            self._position = CLOSED_POSITION
+            self._last_run_success = True
+        else:
+            self._last_run_success = False
+
+    def set_cover_position(self, **kwargs):
+        """Set the cover to a specific position."""
+        position = kwargs[ATTR_POSITION]
+        if self._device.set_position(position):
+            self._state = "open"
+            self._position = position
+            self._last_run_success = True
+        else:
+            self._last_run_success = False
+
+    @property
+    def device_state_attributes(self) -> Dict[str, Any]:
+        """Return the state attributes."""
+        return {
+            "last_run_success": self._last_run_success,
+            "current_cover_position": self._position,
+        }

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,6 +2,6 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.8.0"],
+  "requirements": ["PySwitchbot==0.9.1"],
   "codeowners": ["@danielhiversen"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -55,7 +55,7 @@ PyRMVtransport==0.2.9
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-# PySwitchbot==0.8.0
+# PySwitchbot==0.9.1
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extend support for SwitchBot devices to include the Curtain robot.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
cover:
- platform: switchbot
  mac: 'eb:aa:aa:aa:aa:aa'
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
