### PR TITLE
Move HomeKit autostart to advanced options flow

### DIFF
--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -128,7 +128,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         default_domains = [] if self._async_current_names() else DEFAULT_DOMAINS
         setup_schema = vol.Schema(
             {
-                vol.Optional(CONF_AUTO_START, default=DEFAULT_AUTO_START): bool,
                 vol.Required(
                     CONF_INCLUDE_DOMAINS, default=default_domains
                 ): cv.multi_select(SUPPORTED_DOMAINS),

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -30,7 +30,7 @@
             },
             "advanced": {
                 "data": {
-                    "auto_start": "[%key:component::homekit::config::step::user::data::auto_start%]",
+                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)",
                     "safe_mode": "Safe Mode (enable only if pairing fails)"
                 },
                 "description": "These settings only need to be adjusted if HomeKit is not functional.",
@@ -42,7 +42,6 @@
         "step": {
             "user": {
                 "data": {
-                    "auto_start": "Autostart (disable if using Z-Wave or other delayed start system)",
                     "include_domains": "Domains to include"
                 },
                 "description": "The HomeKit integration will allow you to access your Home Assistant entities in HomeKit. In bridge mode, HomeKit Bridges are limited to 150 accessories per instance including the bridge itself. If you wish to bridge more than the maximum number of accessories, it is recommended that you use multiple HomeKit bridges for different domains. Detailed entity configuration is only available via YAML for the primary bridge.",

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1,4 +1,6 @@
 """Test the HomeKit config flow."""
+import pytest
+
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.homekit.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT
@@ -25,7 +27,6 @@ def _mock_config_entry_with_options_populated():
                 ],
                 "exclude_entities": ["climate.front_gate"],
             },
-            "auto_start": False,
             "safe_mode": False,
         },
     )
@@ -46,7 +47,7 @@ async def test_user_form(hass):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"auto_start": True, "include_domains": ["light"]},
+            {"include_domains": ["light"]},
         )
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -68,7 +69,6 @@ async def test_user_form(hass):
     assert result3["title"][:11] == "HASS Bridge"
     bridge_name = (result3["title"].split(":"))[0]
     assert result3["data"] == {
-        "auto_start": True,
         "filter": {
             "exclude_domains": [],
             "exclude_entities": [],
@@ -123,7 +123,8 @@ async def test_import(hass):
     assert len(mock_setup_entry.mock_calls) == 2
 
 
-async def test_options_flow_exclude_mode_advanced(hass):
+@pytest.mark.parametrize("auto_start", [True, False])
+async def test_options_flow_exclude_mode_advanced(auto_start, hass):
     """Test config flow options in exclude mode with advanced options."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -157,12 +158,12 @@ async def test_options_flow_exclude_mode_advanced(hass):
     with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
         result3 = await hass.config_entries.options.async_configure(
             result2["flow_id"],
-            user_input={"auto_start": True, "safe_mode": True},
+            user_input={"auto_start": auto_start, "safe_mode": True},
         )
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": True,
+        "auto_start": auto_start,
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -213,7 +214,7 @@ async def test_options_flow_exclude_mode_basic(hass):
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": False,
+        "auto_start": True,
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -266,7 +267,7 @@ async def test_options_flow_include_mode_basic(hass):
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": False,
+        "auto_start": True,
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -332,7 +333,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": False,
+        "auto_start": True,
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -387,7 +388,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": False,
+        "auto_start": True,
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -454,7 +455,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": False,
+        "auto_start": True,
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -509,7 +510,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": False,
+        "auto_start": True,
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -603,7 +604,7 @@ async def test_options_flow_include_mode_basic_accessory(hass):
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
-        "auto_start": False,
+        "auto_start": True,
         "mode": "accessory",
         "filter": {
             "exclude_domains": [],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Users were disabling autostart because they saw the word z-wave
and wondering why homekit was not working. Newer z-wave restores
entities so it is no longer necessary to disable auto-start and
should only be used in advanced cases.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
