### PR TITLE
Fix template triggers from time events

### DIFF
--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -67,7 +67,7 @@ async def async_attach_trigger(
                 "entity_id": entity_id,
                 "from_state": from_s,
                 "to_state": to_s,
-                "for": time_delta,
+                "for": None,
                 "description": description,
             }
         }

--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -52,25 +52,32 @@ async def async_attach_trigger(
         if not result_as_boolean(result):
             return
 
-        entity_id = event.data.get("entity_id")
-        from_s = event.data.get("old_state")
-        to_s = event.data.get("new_state")
+        entity_id = event and event.data.get("entity_id")
+        from_s = event and event.data.get("old_state")
+        to_s = event and event.data.get("new_state")
+
+        if entity_id is not None:
+            description = f"{entity_id} via template"
+        else:
+            description = "time change or manual update via template"
+
+        trigger_variables = {
+            "trigger": {
+                "platform": platform_type,
+                "entity_id": entity_id,
+                "from_state": from_s,
+                "to_state": to_s,
+                "for": time_delta,
+                "description": description,
+            }
+        }
 
         @callback
         def call_action(*_):
             """Call action with right context."""
             hass.async_run_hass_job(
                 job,
-                {
-                    "trigger": {
-                        "platform": "template",
-                        "entity_id": entity_id,
-                        "from_state": from_s,
-                        "to_state": to_s,
-                        "for": time_delta if not time_delta else period,
-                        "description": f"{entity_id} via template",
-                    }
-                },
+                trigger_variables,
                 (to_s.context if to_s else None),
             )
 
@@ -78,24 +85,17 @@ async def async_attach_trigger(
             call_action()
             return
 
-        variables = {
-            "trigger": {
-                "platform": platform_type,
-                "entity_id": entity_id,
-                "from_state": from_s,
-                "to_state": to_s,
-            }
-        }
-
         try:
             period = cv.positive_time_period(
-                template.render_complex(time_delta, variables)
+                template.render_complex(time_delta, trigger_variables)
             )
         except (exceptions.TemplateError, vol.Invalid) as ex:
             _LOGGER.error(
                 "Error rendering '%s' for template: %s", automation_info["name"], ex
             )
             return
+
+        trigger_variables["trigger"]["for"] = period
 
         delay_cancel = async_call_later(hass, period.seconds, call_action)
 

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -11,6 +11,7 @@ from homeassistant.core import Context, callback
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from tests.async_mock import patch
 from tests.common import (
     assert_setup_component,
     async_fire_time_changed,
@@ -811,3 +812,58 @@ async def test_invalid_for_template_1(hass, calls):
         hass.states.async_set("test.entity", "world")
         await hass.async_block_till_done()
         assert mock_logger.error.called
+
+
+async def test_if_fires_on_time_change(hass, calls):
+    """Test for firing on time changes."""
+    start_time = dt_util.utcnow() + timedelta(hours=24)
+    time_that_will_not_match_right_away = start_time.replace(minute=1, second=0)
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ utcnow().minute % 2 == 0 }}",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+        )
+        await hass.async_block_till_done()
+        assert len(calls) == 0
+
+    # Trigger once (match template)
+    first_time = start_time.replace(minute=2, second=0)
+    with patch("homeassistant.util.dt.utcnow", return_value=first_time):
+        async_fire_time_changed(hass, first_time)
+        await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Trigger again (match template)
+    second_time = start_time.replace(minute=4, second=0)
+    with patch("homeassistant.util.dt.utcnow", return_value=second_time):
+        async_fire_time_changed(hass, second_time)
+        await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Trigger again (do not match template)
+    third_time = start_time.replace(minute=5, second=0)
+    with patch("homeassistant.util.dt.utcnow", return_value=third_time):
+        async_fire_time_changed(hass, third_time)
+        await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Trigger again (match template)
+    forth_time = start_time.replace(minute=8, second=0)
+    with patch("homeassistant.util.dt.utcnow", return_value=forth_time):
+        async_fire_time_changed(hass, forth_time)
+        await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert len(calls) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix template triggers from time

If the template was triggered by a time change it would
not have an entity_id


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44063
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
