### PR TITLE
Add discovery to Motion Blinds

### DIFF
--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure Motion Blinds using their WLAN API."""
 import logging
 
+from motionblinds import MotionDiscovery
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -15,7 +16,12 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_HOST): str,
+        vol.Optional(CONF_HOST): str,
+    }
+)
+
+CONFIG_SETTINGS = vol.Schema(
+    {
         vol.Required(CONF_API_KEY): vol.All(str, vol.Length(min=16, max=16)),
     }
 )
@@ -31,33 +37,71 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the Motion Blinds flow."""
         self.host = None
         self.key = None
+        self.ips = []
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:
-            self.host = user_input[CONF_HOST]
-            self.key = user_input[CONF_API_KEY]
-            return await self.async_step_connect()
+            self.host = user_input.get(CONF_HOST)
+
+            if self.host is not None:
+                return await self.async_step_connect()
+
+            # Use MotionGateway discovery
+            discover_class = MotionDiscovery()
+            gateways = await self.hass.async_add_executor_job(discover_class.discover)
+            self.ips = list(gateways.keys())
+
+            if len(self.ips) == 1:
+                self.host = self.ips[0]
+                return await self.async_step_connect()
+
+            if len(self.ips) > 1:
+                return await self.async_step_select()
+
+            errors["base"] = "discovery_error"
 
         return self.async_show_form(
             step_id="user", data_schema=CONFIG_SCHEMA, errors=errors
         )
 
+    async def async_step_select(self, user_input=None):
+        """Handle multiple motion gateways found."""
+        errors = {}
+        if user_input is not None:
+            self.host = user_input["select_ip"]
+            return await self.async_step_connect()
+
+        select_schema = vol.Schema({vol.Required("select_ip"): vol.In(self.ips)})
+
+        return self.async_show_form(
+            step_id="select", data_schema=select_schema, errors=errors
+        )
+
     async def async_step_connect(self, user_input=None):
         """Connect to the Motion Gateway."""
+        errors = {}
+        if user_input is not None:
+            self.key = user_input[CONF_API_KEY]
 
-        connect_gateway_class = ConnectMotionGateway(self.hass, None)
-        if not await connect_gateway_class.async_connect_gateway(self.host, self.key):
-            return self.async_abort(reason="connection_error")
-        motion_gateway = connect_gateway_class.gateway_device
+            connect_gateway_class = ConnectMotionGateway(self.hass, None)
+            if not await connect_gateway_class.async_connect_gateway(
+                self.host, self.key
+            ):
+                return self.async_abort(reason="connection_error")
+            motion_gateway = connect_gateway_class.gateway_device
 
-        mac_address = motion_gateway.mac
+            mac_address = motion_gateway.mac
 
-        await self.async_set_unique_id(mac_address)
-        self._abort_if_unique_id_configured()
+            await self.async_set_unique_id(mac_address)
+            self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(
-            title=DEFAULT_GATEWAY_NAME,
-            data={CONF_HOST: self.host, CONF_API_KEY: self.key},
+            return self.async_create_entry(
+                title=DEFAULT_GATEWAY_NAME,
+                data={CONF_HOST: self.host, CONF_API_KEY: self.key},
+            )
+
+        return self.async_show_form(
+            step_id="connect", data_schema=CONFIG_SETTINGS, errors=errors
         )

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -68,20 +68,16 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_select(self, user_input=None):
         """Handle multiple motion gateways found."""
-        errors = {}
         if user_input is not None:
             self._host = user_input["select_ip"]
             return await self.async_step_connect()
 
         select_schema = vol.Schema({vol.Required("select_ip"): vol.In(self._ips)})
 
-        return self.async_show_form(
-            step_id="select", data_schema=select_schema, errors=errors
-        )
+        return self.async_show_form(step_id="select", data_schema=select_schema)
 
     async def async_step_connect(self, user_input=None):
         """Connect to the Motion Gateway."""
-        errors = {}
         if user_input is not None:
             self._key = user_input[CONF_API_KEY]
 
@@ -102,6 +98,4 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 data={CONF_HOST: self._host, CONF_API_KEY: self._key},
             )
 
-        return self.async_show_form(
-            step_id="connect", data_schema=CONFIG_SETTINGS, errors=errors
-        )
+        return self.async_show_form(step_id="connect", data_schema=CONFIG_SETTINGS)

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -81,7 +81,7 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._key = user_input[CONF_API_KEY]
 
-            connect_gateway_class = ConnectMotionGateway(self.hass, None)
+            connect_gateway_class = ConnectMotionGateway(self.hass, multicast=None)
             if not await connect_gateway_class.async_connect_gateway(
                 self._host, self._key
             ):

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -51,7 +51,7 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # Use MotionGateway discovery
             discover_class = MotionDiscovery()
             gateways = await self.hass.async_add_executor_job(discover_class.discover)
-            self.ips = list(gateways.keys())
+            self.ips = list(gateways)
 
             if len(self.ips) == 1:
                 self.host = self.ips[0]

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -81,9 +81,7 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             key = user_input[CONF_API_KEY]
 
             connect_gateway_class = ConnectMotionGateway(self.hass, multicast=None)
-            if not await connect_gateway_class.async_connect_gateway(
-                self._host, key
-            ):
+            if not await connect_gateway_class.async_connect_gateway(self._host, key):
                 return self.async_abort(reason="connection_error")
             motion_gateway = connect_gateway_class.gateway_device
 

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -36,7 +36,6 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Initialize the Motion Blinds flow."""
         self._host = None
-        self._key = None
         self._ips = []
 
     async def async_step_user(self, user_input=None):
@@ -79,11 +78,11 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_connect(self, user_input=None):
         """Connect to the Motion Gateway."""
         if user_input is not None:
-            self._key = user_input[CONF_API_KEY]
+            key = user_input[CONF_API_KEY]
 
             connect_gateway_class = ConnectMotionGateway(self.hass, multicast=None)
             if not await connect_gateway_class.async_connect_gateway(
-                self._host, self._key
+                self._host, key
             ):
                 return self.async_abort(reason="connection_error")
             motion_gateway = connect_gateway_class.gateway_device
@@ -95,7 +94,7 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             return self.async_create_entry(
                 title=DEFAULT_GATEWAY_NAME,
-                data={CONF_HOST: self._host, CONF_API_KEY: self._key},
+                data={CONF_HOST: self._host, CONF_API_KEY: key},
             )
 
         return self.async_show_form(step_id="connect", data_schema=CONFIG_SETTINGS)

--- a/homeassistant/components/motion_blinds/strings.json
+++ b/homeassistant/components/motion_blinds/strings.json
@@ -4,12 +4,28 @@
     "step": {
       "user": {
         "title": "Motion Blinds",
+        "description": "Connect to your Motion Gateway, if the IP address is not set, auto-discovery is used",
+        "data": {
+          "host": "[%key:common::config_flow::data::ip%]"
+        }
+      },
+      "connect": {
+        "title": "Motion Blinds",
         "description": "You will need the 16 character API Key, see https://www.home-assistant.io/integrations/motion_blinds/#retrieving-the-key for instructions",
         "data": {
-          "host": "[%key:common::config_flow::data::ip%]",
           "api_key": "[%key:common::config_flow::data::api_key%]"
         }
+      },
+      "select": {
+        "title": "Select the Motion Gateway that you wish to connect",
+        "description": "Run the setup again if you want to connect additional Motion Gateways",
+        "data": {
+          "select_ip": "[%key:common::config_flow::data::ip%]"
+        }
       }
+    },
+    "error": {
+      "discovery_error": "Failed to discover a Motion Gateway"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -18,3 +34,6 @@
     }
   }
 }
+
+
+

--- a/homeassistant/components/motion_blinds/translations/en.json
+++ b/homeassistant/components/motion_blinds/translations/en.json
@@ -5,14 +5,30 @@
             "already_in_progress": "Configuration flow is already in progress",
             "connection_error": "Failed to connect"
         },
+        "error": {
+            "discovery_error": "Failed to discover a Motion Gateway"
+        },
         "flow_title": "Motion Blinds",
         "step": {
-            "user": {
+            "connect": {
                 "data": {
-                    "api_key": "API Key",
-                    "host": "IP Address"
+                    "api_key": "API Key"
                 },
                 "description": "You will need the 16 character API Key, see https://www.home-assistant.io/integrations/motion_blinds/#retrieving-the-key for instructions",
+                "title": "Motion Blinds"
+            },
+            "select": {
+                "data": {
+                    "select_ip": "IP Address"
+                },
+                "description": "Run the setup again if you want to connect additional Motion Gateways",
+                "title": "Select the Motion Gateway that you wish to connect"
+            },
+            "user": {
+                "data": {
+                    "host": "IP Address"
+                },
+                "description": "Connect to your Motion Gateway, if the IP address is not set, auto-discovery is used",
                 "title": "Motion Blinds"
             }
         }

--- a/homeassistant/components/motion_blinds/translations/en.json
+++ b/homeassistant/components/motion_blinds/translations/en.json
@@ -5,30 +5,14 @@
             "already_in_progress": "Configuration flow is already in progress",
             "connection_error": "Failed to connect"
         },
-        "error": {
-            "discovery_error": "Failed to discover a Motion Gateway"
-        },
         "flow_title": "Motion Blinds",
         "step": {
-            "connect": {
-                "data": {
-                    "api_key": "API Key"
-                },
-                "description": "You will need the 16 character API Key, see https://www.home-assistant.io/integrations/motion_blinds/#retrieving-the-key for instructions",
-                "title": "Motion Blinds"
-            },
-            "select": {
-                "data": {
-                    "select_ip": "IP Address"
-                },
-                "description": "Run the setup again if you want to connect additional Motion Gateways",
-                "title": "Select the Motion Gateway that you wish to connect"
-            },
             "user": {
                 "data": {
+                    "api_key": "API Key",
                     "host": "IP Address"
                 },
-                "description": "Connect to your Motion Gateway, if the IP address is not set, auto-discovery is used",
+                "description": "You will need the 16 character API Key, see https://www.home-assistant.io/integrations/motion_blinds/#retrieving-the-key for instructions",
                 "title": "Motion Blinds"
             }
         }

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -11,8 +11,51 @@ from homeassistant.const import CONF_API_KEY, CONF_HOST
 from tests.async_mock import Mock, patch
 
 TEST_HOST = "1.2.3.4"
+TEST_HOST2 = "5.6.7.8"
 TEST_API_KEY = "12ab345c-d67e-8f"
-TEST_DEVICE_LIST = {"mac": Mock()}
+TEST_MAC = "ab:cd:ef:gh"
+TEST_MAC2 = "ij:kl:mn:op"
+TEST_DEVICE_LIST = {TEST_MAC: Mock()}
+
+TEST_DISCOVERY_1 = {
+    TEST_HOST: {
+        "msgType": "GetDeviceListAck",
+        "mac": TEST_MAC,
+        "deviceType": "02000002",
+        "ProtocolVersion": "0.9",
+        "token": "12345A678B9CDEFG",
+        "data": [
+            {"mac": "abcdefghujkl", "deviceType": "02000002"},
+            {"mac": "abcdefghujkl0001", "deviceType": "10000000"},
+            {"mac": "abcdefghujkl0002", "deviceType": "10000000"},
+        ],
+    }
+}
+
+TEST_DISCOVERY_2 = {
+    TEST_HOST: {
+        "msgType": "GetDeviceListAck",
+        "mac": TEST_MAC,
+        "deviceType": "02000002",
+        "ProtocolVersion": "0.9",
+        "token": "12345A678B9CDEFG",
+        "data": [
+            {"mac": "abcdefghujkl", "deviceType": "02000002"},
+            {"mac": "abcdefghujkl0001", "deviceType": "10000000"},
+        ],
+    },
+    TEST_HOST2: {
+        "msgType": "GetDeviceListAck",
+        "mac": TEST_MAC2,
+        "deviceType": "02000002",
+        "ProtocolVersion": "0.9",
+        "token": "12345A678B9CDEFG",
+        "data": [
+            {"mac": "abcdefghujkl", "deviceType": "02000002"},
+            {"mac": "abcdefghujkl0001", "deviceType": "10000000"},
+        ],
+    },
+}
 
 
 @pytest.fixture(name="motion_blinds_connect", autouse=True)
@@ -27,6 +70,9 @@ def motion_blinds_connect_fixture():
     ), patch(
         "homeassistant.components.motion_blinds.gateway.MotionGateway.device_list",
         TEST_DEVICE_LIST,
+    ), patch(
+        "homeassistant.components.motion_blinds.config_flow.MotionDiscovery.discover",
+        return_value=TEST_DISCOVERY_1,
     ), patch(
         "homeassistant.components.motion_blinds.async_setup_entry", return_value=True
     ):
@@ -45,13 +91,99 @@ async def test_config_flow_manual_host_success(hass):
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {CONF_HOST: TEST_HOST, CONF_API_KEY: TEST_API_KEY},
+        {CONF_HOST: TEST_HOST},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "connect"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_API_KEY: TEST_API_KEY},
     )
 
     assert result["type"] == "create_entry"
     assert result["title"] == DEFAULT_GATEWAY_NAME
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
+        CONF_API_KEY: TEST_API_KEY,
+    }
+
+
+async def test_config_flow_discovery_1_success(hass):
+    """Successful flow with 1 gateway discovered."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "connect"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_API_KEY: TEST_API_KEY},
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == DEFAULT_GATEWAY_NAME
+    assert result["data"] == {
+        CONF_HOST: TEST_HOST,
+        CONF_API_KEY: TEST_API_KEY,
+    }
+
+
+async def test_config_flow_discovery_2_success(hass):
+    """Successful flow with 2 gateway discovered."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.motion_blinds.config_flow.MotionDiscovery.discover",
+        return_value=TEST_DISCOVERY_2,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "select"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"select_ip": TEST_HOST2},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "connect"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_API_KEY: TEST_API_KEY},
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == DEFAULT_GATEWAY_NAME
+    assert result["data"] == {
+        CONF_HOST: TEST_HOST2,
         CONF_API_KEY: TEST_API_KEY,
     }
 
@@ -66,14 +198,47 @@ async def test_config_flow_connection_error(hass):
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: TEST_HOST},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "connect"
+    assert result["errors"] == {}
+
     with patch(
         "homeassistant.components.motion_blinds.gateway.MotionGateway.GetDeviceList",
         side_effect=socket.timeout,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_HOST: TEST_HOST, CONF_API_KEY: TEST_API_KEY},
+            {CONF_API_KEY: TEST_API_KEY},
         )
 
     assert result["type"] == "abort"
     assert result["reason"] == "connection_error"
+
+
+async def test_config_flow_discovery_fail(hass):
+    """Failed flow with no gateways discovered."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.motion_blinds.config_flow.MotionDiscovery.discover",
+        return_value={},
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "discovery_error"}

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -96,7 +96,7 @@ async def test_config_flow_manual_host_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == None
+    assert result["errors"] is None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -128,7 +128,7 @@ async def test_config_flow_discovery_1_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == None
+    assert result["errors"] is None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -164,8 +164,11 @@ async def test_config_flow_discovery_2_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "select"
-    assert result["data_schema"].schema['select_ip'].container == [TEST_HOST, TEST_HOST2]
-    assert result["errors"] == None
+    assert result["data_schema"].schema["select_ip"].container == [
+        TEST_HOST,
+        TEST_HOST2,
+    ]
+    assert result["errors"] is None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -174,7 +177,7 @@ async def test_config_flow_discovery_2_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == None
+    assert result["errors"] is None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -206,7 +209,7 @@ async def test_config_flow_connection_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == None
+    assert result["errors"] is None
 
     with patch(
         "homeassistant.components.motion_blinds.gateway.MotionGateway.GetDeviceList",

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -96,7 +96,7 @@ async def test_config_flow_manual_host_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == {}
+    assert result["errors"] == None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -128,7 +128,7 @@ async def test_config_flow_discovery_1_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == {}
+    assert result["errors"] == None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -164,7 +164,8 @@ async def test_config_flow_discovery_2_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "select"
-    assert result["errors"] == {}
+    assert result["data_schema"].schema['select_ip'].container == [TEST_HOST, TEST_HOST2]
+    assert result["errors"] == None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -173,7 +174,7 @@ async def test_config_flow_discovery_2_success(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == {}
+    assert result["errors"] == None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -205,7 +206,7 @@ async def test_config_flow_connection_error(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "connect"
-    assert result["errors"] == {}
+    assert result["errors"] == None
 
     with patch(
         "homeassistant.components.motion_blinds.gateway.MotionGateway.GetDeviceList",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add discovery to the config flow so users don't need to know the IP of the Motion Gateway (custom discovery protecol from upstream library, ssdp or mdns/zeroconf discovery is not yet supported by the firmware of the gateway, I am discussing with the manufacturers if ssdp or mdns/zeroconf can be added to the firmware, they are consulting their software developers).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Config Flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
