### PR TITLE
Add stop support to openzwave (mqtt) cover

### DIFF
--- a/homeassistant/components/ozw/cover.py
+++ b/homeassistant/components/ozw/cover.py
@@ -7,8 +7,8 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
-    SUPPORT_STOP,
     SUPPORT_SET_POSITION,
+    SUPPORT_STOP,
     CoverEntity,
 )
 from homeassistant.core import callback
@@ -17,7 +17,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from .const import DATA_UNSUBSCRIBE, DOMAIN
 from .entity import ZWaveDeviceEntity
 
-SUPPORTED_FEATURES_POSITION = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
+SUPPORTED_FEATURES_POSITION = (
+    SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
+)
 SUPPORT_GARAGE = SUPPORT_OPEN | SUPPORT_CLOSE
 VALUE_SELECTED_ID = "Selected_id"
 PRESS_BUTTON = True

--- a/homeassistant/components/ozw/cover.py
+++ b/homeassistant/components/ozw/cover.py
@@ -7,8 +7,6 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
-    SUPPORT_STOP,
     CoverEntity,
 )
 from homeassistant.core import callback
@@ -17,9 +15,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from .const import DATA_UNSUBSCRIBE, DOMAIN
 from .entity import ZWaveDeviceEntity
 
-SUPPORTED_FEATURES_POSITION = (
-    SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
-)
 SUPPORT_GARAGE = SUPPORT_OPEN | SUPPORT_CLOSE
 VALUE_SELECTED_ID = "Selected_id"
 PRESS_BUTTON = True
@@ -62,11 +57,6 @@ class ZWaveCoverEntity(ZWaveDeviceEntity, CoverEntity):
         self._open_button_pressed = False
         self._close_button_pressed = False
         super().__init__(values)
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORTED_FEATURES_POSITION
 
     @property
     def is_closed(self):

--- a/homeassistant/components/ozw/cover.py
+++ b/homeassistant/components/ozw/cover.py
@@ -78,7 +78,8 @@ class ZWaveCoverEntity(ZWaveDeviceEntity, CoverEntity):
         """Stop cover."""
         # Need to issue both buttons release since qt-openzwave implements idempotency
         # keeping internal state of model to trigger actual updates. We could also keep
-        # another state in Hass.io to know which button to release, but this implementation is simpler.
+        # another state in Home Assistant to know which button to release,
+        # but this implementation is simpler.
         self.values.open.send_value(RELEASE_BUTTON)
         self.values.close.send_value(RELEASE_BUTTON)
 

--- a/tests/components/ozw/test_cover.py
+++ b/tests/components/ozw/test_cover.py
@@ -16,6 +16,25 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
     assert state.state == "closed"
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
+    # Test setting position
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": "cover.roller_shutter_3_instance_1_level", "position": 50},
+        blocking=True,
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": 50, "ValueIDKey": 625573905}
+
+    # Feedback on state
+    cover_msg.decode()
+    cover_msg.payload["Value"] = 50
+    cover_msg.encode()
+    receive_message(cover_msg)
+    await hass.async_block_till_done()
+
     # Test opening
     await hass.services.async_call(
         "cover",
@@ -23,22 +42,22 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level"},
         blocking=True,
     )
-    assert len(sent_messages) == 1
-    msg = sent_messages[0]
+    assert len(sent_messages) == 2
+    msg = sent_messages[1]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": 99, "ValueIDKey": 625573905}
+    assert msg["payload"] == {"Value": True, "ValueIDKey": 281475602284568}
 
-    # Feedback on state
-    cover_msg.decode()
-    cover_msg.payload["Value"] = 99
-    cover_msg.encode()
-    receive_message(cover_msg)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("cover.roller_shutter_3_instance_1_level")
-    assert state is not None
-    assert state.state == "open"
-    assert state.attributes[ATTR_CURRENT_POSITION] == 100
+    # Test stopping after opening
+    await hass.services.async_call(
+        "cover",
+        "stop_cover",
+        {"entity_id": "cover.roller_shutter_3_instance_1_level"},
+        blocking=True,
+    )
+    assert len(sent_messages) == 3
+    msg = sent_messages[2]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": False, "ValueIDKey": 281475602284568}
 
     # Test closing
     await hass.services.async_call(
@@ -47,22 +66,32 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level"},
         blocking=True,
     )
-    assert len(sent_messages) == 2
-    msg = sent_messages[1]
+    assert len(sent_messages) == 4
+    msg = sent_messages[3]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": 0, "ValueIDKey": 625573905}
+    assert msg["payload"] == {"Value": True, "ValueIDKey": 562950578995224}
 
-    # Test setting position
+    # Test stopping after closing
     await hass.services.async_call(
         "cover",
-        "set_cover_position",
-        {"entity_id": "cover.roller_shutter_3_instance_1_level", "position": 50},
+        "stop_cover",
+        {"entity_id": "cover.roller_shutter_3_instance_1_level"},
         blocking=True,
     )
-    assert len(sent_messages) == 3
-    msg = sent_messages[2]
+    assert len(sent_messages) == 5
+    msg = sent_messages[4]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": 50, "ValueIDKey": 625573905}
+    assert msg["payload"] == {"Value": False, "ValueIDKey": 562950578995224}
+
+    # Test stopping after no open/close
+    await hass.services.async_call(
+        "cover",
+        "stop_cover",
+        {"entity_id": "cover.roller_shutter_3_instance_1_level"},
+        blocking=True,
+    )
+    # no message sent
+    assert len(sent_messages) == 5
 
     # Test converting position to zwave range for position > 0
     await hass.services.async_call(
@@ -71,8 +100,8 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level", "position": 100},
         blocking=True,
     )
-    assert len(sent_messages) == 4
-    msg = sent_messages[3]
+    assert len(sent_messages) == 6
+    msg = sent_messages[5]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": 99, "ValueIDKey": 625573905}
 
@@ -83,8 +112,8 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level", "position": 0},
         blocking=True,
     )
-    assert len(sent_messages) == 5
-    msg = sent_messages[4]
+    assert len(sent_messages) == 7
+    msg = sent_messages[6]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": 0, "ValueIDKey": 625573905}
 

--- a/tests/components/ozw/test_cover.py
+++ b/tests/components/ozw/test_cover.py
@@ -108,7 +108,6 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": False, "ValueIDKey": 562950578995224}
 
-
     # Test converting position to zwave range for position > 0
     await hass.services.async_call(
         "cover",

--- a/tests/components/ozw/test_cover.py
+++ b/tests/components/ozw/test_cover.py
@@ -54,10 +54,14 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level"},
         blocking=True,
     )
-    assert len(sent_messages) == 3
+    assert len(sent_messages) == 4
     msg = sent_messages[2]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": False, "ValueIDKey": 281475602284568}
+
+    msg = sent_messages[3]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": False, "ValueIDKey": 562950578995224}
 
     # Test closing
     await hass.services.async_call(
@@ -66,8 +70,8 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level"},
         blocking=True,
     )
-    assert len(sent_messages) == 4
-    msg = sent_messages[3]
+    assert len(sent_messages) == 5
+    msg = sent_messages[4]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": True, "ValueIDKey": 562950578995224}
 
@@ -78,8 +82,12 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level"},
         blocking=True,
     )
-    assert len(sent_messages) == 5
-    msg = sent_messages[4]
+    assert len(sent_messages) == 7
+    msg = sent_messages[5]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": False, "ValueIDKey": 281475602284568}
+
+    msg = sent_messages[6]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": False, "ValueIDKey": 562950578995224}
 
@@ -90,8 +98,16 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level"},
         blocking=True,
     )
-    # no message sent
-    assert len(sent_messages) == 5
+    # both stop open/close messages sent
+    assert len(sent_messages) == 9
+    msg = sent_messages[7]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": False, "ValueIDKey": 281475602284568}
+
+    msg = sent_messages[8]
+    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+    assert msg["payload"] == {"Value": False, "ValueIDKey": 562950578995224}
+
 
     # Test converting position to zwave range for position > 0
     await hass.services.async_call(
@@ -100,8 +116,8 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level", "position": 100},
         blocking=True,
     )
-    assert len(sent_messages) == 6
-    msg = sent_messages[5]
+    assert len(sent_messages) == 10
+    msg = sent_messages[9]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": 99, "ValueIDKey": 625573905}
 
@@ -112,8 +128,8 @@ async def test_cover(hass, cover_data, sent_messages, cover_msg):
         {"entity_id": "cover.roller_shutter_3_instance_1_level", "position": 0},
         blocking=True,
     )
-    assert len(sent_messages) == 7
-    msg = sent_messages[6]
+    assert len(sent_messages) == 11
+    msg = sent_messages[10]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     assert msg["payload"] == {"Value": 0, "ValueIDKey": 625573905}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not sure how how it may have a negative impact / breaking change over the current implementation.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add stop support to openzwave (mqtt) cover
Attempts to solve https://github.com/home-assistant/core/issues/38018


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38018
- This PR is related to issue: 
- Link to documentation pull request: 

Button press and release are not implemented in python openzwave mqtt, so boolean constants have been used instead. Not sure about the location of these constants as button press and release implementation should be the business of openzwave mqtt library anyway.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
