### PR TITLE
Generate nest images thumbnails from events

### DIFF
--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/nest",
   "requirements": [
       "python-nest==4.1.0",
-      "google-nest-sdm==0.2.5"
+      "google-nest-sdm==0.2.6"
   ],
   "codeowners": [
       "@awarecan",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -681,7 +681,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.5
+google-nest-sdm==0.2.6
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -355,7 +355,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.2.5
+google-nest-sdm==0.2.6
 
 # homeassistant.components.gree
 greeclimate==0.10.3

--- a/tests/components/nest/camera_sdm_test.py
+++ b/tests/components/nest/camera_sdm_test.py
@@ -408,7 +408,7 @@ async def test_camera_image_from_event_not_supported(hass, auth):
 
 
 async def test_generate_event_image_url_failure(hass, auth):
-    """Test fallback stream image fallback on creating an event image url."""
+    """Test fallback to stream on failure to create an image url."""
     subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("camera.my_camera")
@@ -428,7 +428,7 @@ async def test_generate_event_image_url_failure(hass, auth):
 
 
 async def test_fetch_event_image_failure(hass, auth):
-    """Test fallback to a stream still image on image event failure."""
+    """Test fallback to a stream on image download failure."""
     subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("camera.my_camera")
@@ -451,9 +451,6 @@ async def test_fetch_event_image_failure(hass, auth):
 
 async def test_event_image_expired(hass, auth):
     """Test fallback for an event event image that has expired."""
-    # The subscriber receives a message related to an image event.  The camera
-    # holds on to the event message. When the test asks for a capera snapshot
-    # it exchanges the event id for an image url and fetches the image.
     subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("camera.my_camera")

--- a/tests/components/nest/camera_sdm_test.py
+++ b/tests/components/nest/camera_sdm_test.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import aiohttp
 from google_nest_sdm.device import Device
+from google_nest_sdm.event import EventMessage
 import pytest
 
 from homeassistant.components import camera
@@ -36,9 +37,68 @@ DEVICE_TRAITS = {
         "videoCodecs": ["H264"],
         "audioCodecs": ["AAC"],
     },
+    "sdm.devices.traits.CameraEventImage": {},
 }
 DATETIME_FORMAT = "YY-MM-DDTHH:MM:SS"
 DOMAIN = "nest"
+MOTION_EVENT_ID = "FWWVQVUdGNUlTU2V4MGV2aTNXV..."
+
+# Tests can assert that image bytes came from an event or was decoded
+# from the live stream.
+IMAGE_BYTES_FROM_EVENT = b"test url image bytes"
+IMAGE_BYTES_FROM_STREAM = b"test stream image bytes"
+
+TEST_IMAGE_URL = "https://domain/sdm_event_snapshot/dGTZwR3o4Y1..."
+GENERATE_IMAGE_URL_RESPONSE = {
+    "results": {
+        "url": TEST_IMAGE_URL,
+        "token": "g.0.eventToken",
+    },
+}
+IMAGE_AUTHORIZATION_HEADERS = {"Authorization": "Basic g.0.eventToken"}
+
+
+def make_motion_event(timestamp: datetime.datetime = None) -> EventMessage:
+    """Create an EventMessage for a motion event."""
+    if not timestamp:
+        timestamp = utcnow()
+    return EventMessage(
+        {
+            "eventId": "some-event-id",
+            "timestamp": timestamp.isoformat(timespec="seconds"),
+            "resourceUpdate": {
+                "name": DEVICE_ID,
+                "events": {
+                    "sdm.devices.events.CameraMotion.Motion": {
+                        "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
+                        "eventId": MOTION_EVENT_ID,
+                    },
+                },
+            },
+        },
+        auth=None,
+    )
+
+
+def make_stream_url_response(
+    expiration: datetime.datetime = None, token_num: int = 0
+) -> aiohttp.web.Response:
+    """Make response for the API that generates a streaming url."""
+    if not expiration:
+        # Default to an arbitrary time in the future
+        expiration = utcnow() + datetime.timedelta(seconds=100)
+    return aiohttp.web.json_response(
+        {
+            "results": {
+                "streamUrls": {
+                    "rtspUrl": f"rtsp://some/url?auth=g.{token_num}.streamingToken"
+                },
+                "streamExtensionToken": f"g.{token_num}.extensionToken",
+                "streamToken": f"g.{token_num}.streamingToken",
+                "expiresAt": expiration.isoformat(timespec="seconds"),
+            },
+        }
+    )
 
 
 async def async_setup_camera(hass, traits={}, auth=None):
@@ -61,6 +121,19 @@ async def fire_alarm(hass, point_in_time):
     with patch("homeassistant.util.dt.utcnow", return_value=point_in_time):
         async_fire_time_changed(hass, point_in_time)
         await hass.async_block_till_done()
+
+
+async def async_get_image(hass):
+    """Get image from the camera, a wrapper around camera.async_get_image."""
+    # Note: this patches ImageFrame to simulate decoding an image from a live
+    # stream, however the test may not use it.  Tests assert on the image
+    # contents to determine if the image came from the live stream or event.
+    with patch(
+        "homeassistant.components.ffmpeg.ImageFrame.get_image",
+        autopatch=True,
+        return_value=IMAGE_BYTES_FROM_STREAM,
+    ):
+        return await camera.async_get_image(hass, "camera.my_camera")
 
 
 async def test_no_devices(hass):
@@ -106,22 +179,7 @@ async def test_camera_device(hass):
 
 async def test_camera_stream(hass, auth):
     """Test a basic camera and fetch its live stream."""
-    now = utcnow()
-    expiration = now + datetime.timedelta(seconds=100)
-    auth.responses = [
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamUrls": {
-                        "rtspUrl": "rtsp://some/url?auth=g.0.streamingToken"
-                    },
-                    "streamExtensionToken": "g.1.extensionToken",
-                    "streamToken": "g.0.streamingToken",
-                    "expiresAt": expiration.isoformat(timespec="seconds"),
-                },
-            }
-        )
-    ]
+    auth.responses = [make_stream_url_response()]
     await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
 
     assert len(hass.states.async_all()) == 1
@@ -132,14 +190,8 @@ async def test_camera_stream(hass, auth):
     stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
     assert stream_source == "rtsp://some/url?auth=g.0.streamingToken"
 
-    with patch(
-        "homeassistant.components.ffmpeg.ImageFrame.get_image",
-        autopatch=True,
-        return_value=b"image bytes",
-    ):
-        image = await camera.async_get_image(hass, "camera.my_camera")
-
-    assert image.content == b"image bytes"
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_STREAM
 
 
 async def test_camera_stream_missing_trait(hass, auth):
@@ -166,10 +218,9 @@ async def test_camera_stream_missing_trait(hass, auth):
     stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
     assert stream_source is None
 
-    # Currently on support getting the image from a live stream
+    # Unable to get an image from the live stream
     with pytest.raises(HomeAssistantError):
-        image = await camera.async_get_image(hass, "camera.my_camera")
-        assert image is None
+        await async_get_image(hass)
 
 
 async def test_refresh_expired_stream_token(hass, auth):
@@ -180,38 +231,11 @@ async def test_refresh_expired_stream_token(hass, auth):
     stream_3_expiration = now + datetime.timedelta(seconds=360)
     auth.responses = [
         # Stream URL #1
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamUrls": {
-                        "rtspUrl": "rtsp://some/url?auth=g.1.streamingToken"
-                    },
-                    "streamExtensionToken": "g.1.extensionToken",
-                    "streamToken": "g.1.streamingToken",
-                    "expiresAt": stream_1_expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
+        make_stream_url_response(stream_1_expiration, token_num=1),
         # Stream URL #2
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamExtensionToken": "g.2.extensionToken",
-                    "streamToken": "g.2.streamingToken",
-                    "expiresAt": stream_2_expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
+        make_stream_url_response(stream_2_expiration, token_num=2),
         # Stream URL #3
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamExtensionToken": "g.3.extensionToken",
-                    "streamToken": "g.3.streamingToken",
-                    "expiresAt": stream_3_expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
+        make_stream_url_response(stream_3_expiration, token_num=3),
     ]
     await async_setup_camera(
         hass,
@@ -258,36 +282,10 @@ async def test_stream_response_already_expired(hass, auth):
     stream_1_expiration = now + datetime.timedelta(seconds=-90)
     stream_2_expiration = now + datetime.timedelta(seconds=+90)
     auth.responses = [
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamUrls": {
-                        "rtspUrl": "rtsp://some/url?auth=g.1.streamingToken"
-                    },
-                    "streamExtensionToken": "g.1.extensionToken",
-                    "streamToken": "g.1.streamingToken",
-                    "expiresAt": stream_1_expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamUrls": {
-                        "rtspUrl": "rtsp://some/url?auth=g.2.streamingToken"
-                    },
-                    "streamExtensionToken": "g.2.extensionToken",
-                    "streamToken": "g.2.streamingToken",
-                    "expiresAt": stream_2_expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
+        make_stream_url_response(stream_1_expiration, token_num=1),
+        make_stream_url_response(stream_2_expiration, token_num=2),
     ]
-    await async_setup_camera(
-        hass,
-        DEVICE_TRAITS,
-        auth=auth,
-    )
+    await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
 
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
@@ -307,21 +305,8 @@ async def test_stream_response_already_expired(hass, auth):
 
 async def test_camera_removed(hass, auth):
     """Test case where entities are removed and stream tokens expired."""
-    now = utcnow()
-    expiration = now + datetime.timedelta(seconds=100)
     auth.responses = [
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamUrls": {
-                        "rtspUrl": "rtsp://some/url?auth=g.0.streamingToken"
-                    },
-                    "streamExtensionToken": "g.1.extensionToken",
-                    "streamToken": "g.0.streamingToken",
-                    "expiresAt": expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
+        make_stream_url_response(),
         aiohttp.web.json_response({"results": {}}),
     ]
     await async_setup_camera(
@@ -349,39 +334,13 @@ async def test_refresh_expired_stream_failure(hass, auth):
     stream_1_expiration = now + datetime.timedelta(seconds=90)
     stream_2_expiration = now + datetime.timedelta(seconds=180)
     auth.responses = [
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamUrls": {
-                        "rtspUrl": "rtsp://some/url?auth=g.1.streamingToken"
-                    },
-                    "streamExtensionToken": "g.1.extensionToken",
-                    "streamToken": "g.1.streamingToken",
-                    "expiresAt": stream_1_expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
+        make_stream_url_response(expiration=stream_1_expiration, token_num=1),
         # Extending the stream fails with arbitrary error
         aiohttp.web.Response(status=500),
         # Next attempt to get a stream fetches a new url
-        aiohttp.web.json_response(
-            {
-                "results": {
-                    "streamUrls": {
-                        "rtspUrl": "rtsp://some/url?auth=g.2.streamingToken"
-                    },
-                    "streamExtensionToken": "g.2.extensionToken",
-                    "streamToken": "g.2.streamingToken",
-                    "expiresAt": stream_2_expiration.isoformat(timespec="seconds"),
-                },
-            }
-        ),
+        make_stream_url_response(expiration=stream_2_expiration, token_num=2),
     ]
-    await async_setup_camera(
-        hass,
-        DEVICE_TRAITS,
-        auth=auth,
-    )
+    await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
 
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
@@ -399,3 +358,152 @@ async def test_refresh_expired_stream_failure(hass, auth):
     # The stream is entirely refreshed
     stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
     assert stream_source == "rtsp://some/url?auth=g.2.streamingToken"
+
+
+async def test_camera_image_from_last_event(hass, auth):
+    """Test an image generated from an event."""
+    # The subscriber receives a message related to an image event.  The camera
+    # holds on to the event message. When the test asks for a capera snapshot
+    # it exchanges the event id for an image url and fetches the image.
+    subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    # Simulate a pubsub message received by the subscriber with a motion event.
+    await subscriber.async_receive_event(make_motion_event())
+    await hass.async_block_till_done()
+
+    auth.responses = [
+        # Fake response from API that returns url image
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        # Fake response for the image content fetch
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_EVENT
+    # Verify expected image fetch request was captured
+    assert auth.url == TEST_IMAGE_URL
+    assert auth.headers == IMAGE_AUTHORIZATION_HEADERS
+
+
+async def test_camera_image_from_event_not_supported(hass, auth):
+    """Test fallback to stream image when event images are not supported."""
+    # Create a device that does not support the CameraEventImgae trait
+    traits = DEVICE_TRAITS.copy()
+    del traits["sdm.devices.traits.CameraEventImage"]
+    subscriber = await async_setup_camera(hass, traits, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    await subscriber.async_receive_event(make_motion_event())
+    await hass.async_block_till_done()
+
+    # Camera fetches a stream url since CameraEventImage is not supported
+    auth.responses = [make_stream_url_response()]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_STREAM
+
+
+async def test_generate_event_image_url_failure(hass, auth):
+    """Test fallback stream image fallback on creating an event image url."""
+    subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    await subscriber.async_receive_event(make_motion_event())
+    await hass.async_block_till_done()
+
+    auth.responses = [
+        # Fail to generate the image url
+        aiohttp.web.Response(status=500),
+        # Camera fetches a stream url as a fallback
+        make_stream_url_response(),
+    ]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_STREAM
+
+
+async def test_fetch_event_image_failure(hass, auth):
+    """Test fallback to a stream still image on image event failure."""
+    subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    await subscriber.async_receive_event(make_motion_event())
+    await hass.async_block_till_done()
+
+    auth.responses = [
+        # Fake response from API that returns url image
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        # Fail to download the image
+        aiohttp.web.Response(status=500),
+        # Camera fetches a stream url as a fallback
+        make_stream_url_response(),
+    ]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_STREAM
+
+
+async def test_event_image_expired(hass, auth):
+    """Test fallback for an event event image that has expired."""
+    # The subscriber receives a message related to an image event.  The camera
+    # holds on to the event message. When the test asks for a capera snapshot
+    # it exchanges the event id for an image url and fetches the image.
+    subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    # Simulate a pubsub message has already expired
+    event_timestamp = utcnow() - datetime.timedelta(seconds=40)
+    await subscriber.async_receive_event(make_motion_event(event_timestamp))
+    await hass.async_block_till_done()
+
+    # Fallback to a stream url since the event message is expired.
+    auth.responses = [make_stream_url_response()]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_STREAM
+
+
+async def test_event_image_expired_in_cache(hass, auth):
+    """Test fallback for an event image that expired while in cache."""
+    subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    event_timestamp = utcnow()
+    await subscriber.async_receive_event(make_motion_event(event_timestamp))
+    await hass.async_block_till_done()
+
+    # Fallback to a stream url since the event message is expired.
+    auth.responses = [
+        # Fake response from API that returns url image
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        # Fake response for the image content fetch
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+        # Once time advances, fallback to stream url happens
+        make_stream_url_response(),
+    ]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_EVENT
+
+    # Not yet 30 seconds.  Url image is cached and re-used.
+    new_time = event_timestamp + datetime.timedelta(seconds=25)
+    with patch(
+        "homeassistant.components.nest.camera_sdm.utcnow", return_value=new_time
+    ):
+        image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_EVENT
+
+    # Event image is now expired.  Fallback to live stream
+    new_time = event_timestamp + datetime.timedelta(seconds=31)
+    with patch(
+        "homeassistant.components.nest.camera_sdm.utcnow", return_value=new_time
+    ):
+        image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_STREAM

--- a/tests/components/nest/camera_sdm_test.py
+++ b/tests/components/nest/camera_sdm_test.py
@@ -387,6 +387,13 @@ async def test_camera_image_from_last_event(hass, auth):
     assert auth.url == TEST_IMAGE_URL
     assert auth.headers == IMAGE_AUTHORIZATION_HEADERS
 
+    # An additional fetch uses the cache and does not send another RPC
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_EVENT
+    # Verify expected image fetch request was captured
+    assert auth.url == TEST_IMAGE_URL
+    assert auth.headers == IMAGE_AUTHORIZATION_HEADERS
+
 
 async def test_camera_image_from_event_not_supported(hass, auth):
     """Test fallback to stream image when event images are not supported."""

--- a/tests/components/nest/climate_sdm_test.py
+++ b/tests/components/nest/climate_sdm_test.py
@@ -933,14 +933,14 @@ async def test_thermostat_set_hvac_fan_only(hass, auth):
 
     assert len(auth.captured_requests) == 2
 
-    (method, url, json) = auth.captured_requests.pop(0)
+    (method, url, json, headers) = auth.captured_requests.pop(0)
     assert method == "post"
     assert url == "some-device-id:executeCommand"
     assert json == {
         "command": "sdm.devices.commands.Fan.SetTimer",
         "params": {"timerMode": "ON"},
     }
-    (method, url, json) = auth.captured_requests.pop(0)
+    (method, url, json, headers) = auth.captured_requests.pop(0)
     assert method == "post"
     assert url == "some-device-id:executeCommand"
     assert json == {

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -23,6 +23,7 @@ class FakeAuth(AbstractAuth):
         self.method = None
         self.url = None
         self.json = None
+        self.headers = None
         self.captured_requests = []
         # Set up by fixture
         self.client = None
@@ -31,12 +32,13 @@ class FakeAuth(AbstractAuth):
         """Return a valid access token."""
         return ""
 
-    async def request(self, method, url, json):
+    async def request(self, method, url, **kwargs):
         """Capure the request arguments for tests to assert on."""
         self.method = method
         self.url = url
-        self.json = json
-        self.captured_requests.append((method, url, json))
+        self.json = kwargs.get("json")
+        self.headers = kwargs.get("headers")
+        self.captured_requests.append((method, url, self.json, self.headers))
         return await self.client.get("/")
 
     async def response_handler(self, request):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

TL;DR: Use Nest Event Images as the camera still images for 30 seconds after an event.  See http://bit.ly/2WCMTbH for a full design document including discussions of alternative designs considered.

For some background:
- The Home Assistant Nest camera images are made from still frames from the live stream. OK.. that works.
- Device triggers enable automations for Motion/Person/Sound Detection and Doorbell Chime events. Great!
- Home Assistant Nest Device Triggers run in response to Events delivered by Cloud Pub/Sub messages in near real time. Useful!

However, a problem arises when automations fetch a snapshot. A notification message may trigger an image not associated with the event due to latency across the stack in message delivery and stream join latency (though I have a few PRs in flight to improve this, they are still in progress).   See an illustration of the problem from this [Home Assistant Community discussion](https://community.home-assistant.io/t/google-nest-offical-device-access-console-finally-released/229146/924) which represents a typical experience.

The Nest SDM API supports an [EventImage](https://developers.google.com/nest/device-access/traits/device/camera-event-image) trait mean to solve this problem. This exposes an RPC to fetch an image url for a Pub/Sub event, and it can be fetched within the first 30 seconds of the event.

When considering how best to integrate into Home Assistant, we’re balancing across:
- Accuracy: Notifications for events should display what happened at event time.
- Ease of use: We want it to be easy for users to integrate event images into automations.
- Ease of understanding: It should usually behave how users expect
- Simplicity: Want to do this in fewer lines of code if possible, and ideally the solution should place nicely with other parts of Home Assistant. (e.g. not introducing new abstractions)

When it is time to fetch a snapshot, the logic is:
- Check for a recently received event message:
- Determine if the last received event message is still valid, based on the timestamp in the event.
- Send a GenerateImage command for the latest eventId
- Fetch the image using the urland HTTP Authorization header token returned from the API. See Download a camera image.
- Fallback to the existing behavior, of generating a still from the live stream

See https://github.com/allenporter/python-google-nest-sdm/compare/v0.2.5...v0.2.6 for dependency upgrades.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
