### PR TITLE
Publish timestamps in nest events

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -138,6 +138,7 @@ class SignalUpdateCallback:
             message = {
                 "device_id": device_entry.id,
                 "type": event_type,
+                "timestamp": event_message.timestamp,
             }
             self._hass.bus.async_fire(NEST_EVENT, message)
 

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -10,6 +10,7 @@ from homeassistant.components.device_automation.exceptions import (
 from homeassistant.components.nest import DOMAIN
 from homeassistant.components.nest.events import NEST_EVENT
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
 
 from .common import async_setup_sdm_platform
 
@@ -213,7 +214,7 @@ async def test_fires_on_camera_motion(hass, calls):
     """Test camera_motion triggers firing."""
     assert await setup_automation(hass, DEVICE_ID, "camera_motion")
 
-    message = {"device_id": DEVICE_ID, "type": "camera_motion"}
+    message = {"device_id": DEVICE_ID, "type": "camera_motion", "timestamp": utcnow()}
     hass.bus.async_fire(NEST_EVENT, message)
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -224,7 +225,7 @@ async def test_fires_on_camera_person(hass, calls):
     """Test camera_person triggers firing."""
     assert await setup_automation(hass, DEVICE_ID, "camera_person")
 
-    message = {"device_id": DEVICE_ID, "type": "camera_person"}
+    message = {"device_id": DEVICE_ID, "type": "camera_person", "timestamp": utcnow()}
     hass.bus.async_fire(NEST_EVENT, message)
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -235,7 +236,7 @@ async def test_fires_on_camera_sound(hass, calls):
     """Test camera_person triggers firing."""
     assert await setup_automation(hass, DEVICE_ID, "camera_sound")
 
-    message = {"device_id": DEVICE_ID, "type": "camera_sound"}
+    message = {"device_id": DEVICE_ID, "type": "camera_sound", "timestamp": utcnow()}
     hass.bus.async_fire(NEST_EVENT, message)
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -246,7 +247,7 @@ async def test_fires_on_doorbell_chime(hass, calls):
     """Test doorbell_chime triggers firing."""
     assert await setup_automation(hass, DEVICE_ID, "doorbell_chime")
 
-    message = {"device_id": DEVICE_ID, "type": "doorbell_chime"}
+    message = {"device_id": DEVICE_ID, "type": "doorbell_chime", "timestamp": utcnow()}
     hass.bus.async_fire(NEST_EVENT, message)
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -257,7 +258,11 @@ async def test_trigger_for_wrong_device_id(hass, calls):
     """Test for turn_on and turn_off triggers firing."""
     assert await setup_automation(hass, DEVICE_ID, "camera_motion")
 
-    message = {"device_id": "wrong-device-id", "type": "camera_motion"}
+    message = {
+        "device_id": "wrong-device-id",
+        "type": "camera_motion",
+        "timestamp": utcnow(),
+    }
     hass.bus.async_fire(NEST_EVENT, message)
     await hass.async_block_till_done()
     assert len(calls) == 0
@@ -267,7 +272,11 @@ async def test_trigger_for_wrong_event_type(hass, calls):
     """Test for turn_on and turn_off triggers firing."""
     assert await setup_automation(hass, DEVICE_ID, "camera_motion")
 
-    message = {"device_id": DEVICE_ID, "type": "wrong-event-type"}
+    message = {
+        "device_id": DEVICE_ID,
+        "type": "wrong-event-type",
+        "timestamp": utcnow(),
+    }
     hass.bus.async_fire(NEST_EVENT, message)
     await hass.async_block_till_done()
     assert len(calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Publish timestamps in nest events to give advanced users additional control on how to handle events.  Events may be published at a later time than "now", or may be kept in a backlog while home assistant is down.  This adds the timestamp of from the pub/sub message to the nest event payload.

See https://developers.google.com/nest/device-access/api/events#resource-events for details on events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #44589
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
