### PR TITLE
Better general/fallback error message and traceback for unknown config errors

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -434,7 +434,7 @@ def _format_config_error(
         else:
             message += f"{humanize_error(config, ex)}."
     else:
-        message += str(ex)
+        message += str(ex) or repr(ex)
 
     try:
         domain_config = config.get(domain, config)

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -412,17 +412,19 @@ def async_log_exception(
     """
     if hass is not None:
         async_notify_setup_error(hass, domain, link)
-    _LOGGER.error(_format_config_error(ex, domain, config, link))
+    message, is_friendly = _format_config_error(ex, domain, config, link)
+    _LOGGER.error(message, exc_info=not is_friendly and ex)
 
 
 @callback
 def _format_config_error(
     ex: Exception, domain: str, config: Dict, link: Optional[str] = None
-) -> str:
+) -> Tuple[str, bool]:
     """Generate log exception for configuration validation.
 
     This method must be run in the event loop.
     """
+    is_friendly = False
     message = f"Invalid config for [{domain}]: "
     if isinstance(ex, vol.Invalid):
         if "extra keys not allowed" in ex.error_message:
@@ -433,6 +435,7 @@ def _format_config_error(
             )
         else:
             message += f"{humanize_error(config, ex)}."
+        is_friendly = True
     else:
         message += str(ex) or repr(ex)
 
@@ -449,7 +452,7 @@ def _format_config_error(
     if domain != CONF_CORE and link:
         message += f"Please check the docs at {link}"
 
-    return message
+    return message, is_friendly
 
 
 async def async_process_ha_core_config(hass: HomeAssistant, config: Dict) -> None:

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -78,7 +78,7 @@ async def async_check_ha_config_file(hass: HomeAssistant) -> HomeAssistantConfig
 
     def _comp_error(ex: Exception, domain: str, config: ConfigType) -> None:
         """Handle errors from components: async_log_exception."""
-        result.add_error(_format_config_error(ex, domain, config), domain, config)
+        result.add_error(_format_config_error(ex, domain, config)[0], domain, config)
 
     # Load configuration.yaml
     config_path = hass.config.path(YAML_CONFIG_FILE)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If `str(ex)` outputs an empty string, we display nothing useful in the config error log entry. Here's something I started seeing a while back:
```
ERROR (MainThread) [homeassistant.config] Invalid config for [automation]:  (See /home/scop/Documents/code/home-assistant/config/configuration.yaml, line 9). 
```
I first added a fallback to `repr(ex)` to get at least something, which is... in this case something slightly more useful:
```
ERROR (MainThread) [homeassistant.config] Invalid config for [automation]: InvalidDeviceAutomationConfig() (See/home/scop/Documents/code/home-assistant/config/configuration.yaml, line 9). 
```

But I think it would be good to log a traceback unless there error was something we are sure to have formatted in a friendly way, so I added that, and now I get:
```
ERROR (MainThread) [homeassistant.config] Invalid config for [automation]: InvalidDeviceAutomationConfig() (See /home/scop/Documents/code/home-assistant/config/configuration.yaml, line 9). 
Traceback (most recent call last):
  File "/home/scop/Documents/code/home-assistant/homeassistant/components/automation/config.py", line 84, in _try_async_validate_config_item
    config = await async_validate_config_item(hass, config, full_config)
  File "/home/scop/Documents/code/home-assistant/homeassistant/components/automation/config.py", line 62, in async_validate_config_item
    config[CONF_TRIGGER] = await async_validate_trigger_config(
  File "/home/scop/Documents/code/home-assistant/homeassistant/helpers/trigger.py", line 48, in async_validate_trigger_config
    conf = await platform.async_validate_trigger_config(hass, conf)
  File "/home/scop/Documents/code/home-assistant/homeassistant/components/device_automation/trigger.py", line 21, in async_validate_trigger_config
    return await getattr(platform, "async_validate_trigger_config")(hass, config)
  File "/home/scop/Documents/code/home-assistant/homeassistant/components/deconz/device_trigger.py", line 420, in async_validate_trigger_config
    raise InvalidDeviceAutomationConfig
homeassistant.components.device_automation.exceptions.InvalidDeviceAutomationConfig
```

Now that's something I can use in order to start figuring out what's wrong with the config (= a deconz device trigger config issue somewhere).

Submitting as two commits in case the traceback is frowned upon; at least the repr part should be uncontroversial I believe.

(I'll file separate PR's for improving the deCONZ errors.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!Include error repr in config error message is str(error) yields nothing
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #44654
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
