### PR TITLE
Fix legacy nest api binary_sensor initialization

### DIFF
--- a/homeassistant/components/nest/binary_sensor.py
+++ b/homeassistant/components/nest/binary_sensor.py
@@ -4,7 +4,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import DATA_SDM
-from .legacy.sensor import async_setup_legacy_entry
+from .legacy.binary_sensor import async_setup_legacy_entry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/nest/legacy/binary_sensor.py
+++ b/homeassistant/components/nest/legacy/binary_sensor.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_legacy_entry(hass, entry, async_add_entities):
     """Set up a Nest binary sensor based on a config entry."""
     nest = hass.data[DATA_NEST]
 

--- a/tests/components/nest/test_init_legacy.py
+++ b/tests/components/nest/test_init_legacy.py
@@ -1,0 +1,87 @@
+"""Test basic initialization for the Legacy Nest API using mocks for the Nest python library."""
+
+import time
+
+from homeassistant.setup import async_setup_component
+
+from tests.async_mock import MagicMock, PropertyMock, patch
+from tests.common import MockConfigEntry
+
+DOMAIN = "nest"
+
+CONFIG = {
+    "nest": {
+        "client_id": "some-client-id",
+        "client_secret": "some-client-secret",
+    },
+}
+
+CONFIG_ENTRY_DATA = {
+    "auth_implementation": "local",
+    "tokens": {
+        "expires_at": time.time() + 86400,
+        "access_token": {
+            "token": "some-token",
+        },
+    },
+}
+
+
+def make_thermostat():
+    """Make a mock thermostat with dummy values."""
+    device = MagicMock()
+    type(device).device_id = PropertyMock(return_value="a.b.c.d.e.f.g")
+    type(device).name = PropertyMock(return_value="My Thermostat")
+    type(device).name_long = PropertyMock(return_value="My Thermostat")
+    type(device).serial = PropertyMock(return_value="serial-number")
+    type(device).mode = "off"
+    type(device).hvac_state = "off"
+    type(device).target = PropertyMock(return_value=31.0)
+    type(device).temperature = PropertyMock(return_value=30.1)
+    type(device).min_temperature = PropertyMock(return_value=10.0)
+    type(device).max_temperature = PropertyMock(return_value=50.0)
+    type(device).humidity = PropertyMock(return_value=40.4)
+    type(device).software_version = PropertyMock(return_value="a.b.c")
+    return device
+
+
+async def test_thermostat(hass):
+    """Test simple initialization for thermostat entities."""
+
+    thermostat = make_thermostat()
+
+    structure = MagicMock()
+    type(structure).name = PropertyMock(return_value="My Room")
+    type(structure).thermostats = PropertyMock(return_value=[thermostat])
+    type(structure).eta = PropertyMock(return_value="away")
+
+    nest = MagicMock()
+    type(nest).structures = PropertyMock(return_value=[structure])
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
+    config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.nest.legacy.Nest", return_value=nest), patch(
+        "homeassistant.components.nest.legacy.sensor._VALID_SENSOR_TYPES",
+        ["humidity", "temperature"],
+    ), patch(
+        "homeassistant.components.nest.legacy.binary_sensor._VALID_BINARY_SENSOR_TYPES",
+        {"fan": None},
+    ):
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
+        await hass.async_block_till_done()
+
+    climate = hass.states.get("climate.my_thermostat")
+    assert climate is not None
+    assert climate.state == "off"
+
+    temperature = hass.states.get("sensor.my_thermostat_temperature")
+    assert temperature is not None
+    assert temperature.state == "-1.1"
+
+    humidity = hass.states.get("sensor.my_thermostat_humidity")
+    assert humidity is not None
+    assert humidity.state == "40.4"
+
+    fan = hass.states.get("binary_sensor.my_thermostat_fan")
+    assert fan is not None
+    assert fan.state == "on"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix initialization issue where all sensors were loaded as binary_sensors in https://github.com/home-assistant/core/pull/44368 due to a typo in the package name.

Adds basic tests using mocks to ensure wiring continues to work in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44659
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
