### PR TITLE
Zeroconf lowercase

### DIFF
--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
   "requirements": ["brother==0.1.20"],
-  "zeroconf": [{"type": "_printer._tcp.local.", "name":"Brother*"}],
+  "zeroconf": [{ "type": "_printer._tcp.local.", "name": "brother*" }],
   "config_flow": true,
   "quality_scale": "platinum"
 }

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -290,16 +290,16 @@ async def _async_start_zeroconf_browser(hass, zeroconf):
             lowercase_name = None
 
         if "macaddress" in info.get("properties", {}):
-            lowercase_mac = info["properties"]["macaddress"].lower()
+            uppercase_mac = info["properties"]["macaddress"].upper()
         else:
-            lowercase_mac = None
+            uppercase_mac = None
 
         for entry in zeroconf_types[service_type]:
             if len(entry) > 1:
                 if (
-                    lowercase_mac is not None
+                    uppercase_mac is not None
                     and "macaddress" in entry
-                    and not fnmatch.fnmatch(lowercase_mac, entry["macaddress"])
+                    and not fnmatch.fnmatch(uppercase_mac, entry["macaddress"])
                 ):
                     continue
                 if (

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -284,22 +284,30 @@ async def _async_start_zeroconf_browser(hass, zeroconf):
                     # likely bad homekit data
                     return
 
+        if "name" in info:
+            lowercase_name = info["name"].lower()
+        else:
+            lowercase_name = None
+
+        if "macaddress" in info.get("properties", {}):
+            lowercase_mac = info["properties"]["macaddress"].lower()
+        else:
+            lowercase_mac = None
+
         for entry in zeroconf_types[service_type]:
             if len(entry) > 1:
-                if "macaddress" in entry:
-                    if "properties" not in info:
-                        continue
-                    if "macaddress" not in info["properties"]:
-                        continue
-                    if not fnmatch.fnmatch(
-                        info["properties"]["macaddress"], entry["macaddress"]
-                    ):
-                        continue
-                if "name" in entry:
-                    if "name" not in info:
-                        continue
-                    if not fnmatch.fnmatch(info["name"], entry["name"]):
-                        continue
+                if (
+                    lowercase_mac is not None
+                    and "macaddress" in entry
+                    and not fnmatch.fnmatch(lowercase_mac, entry["macaddress"])
+                ):
+                    continue
+                if (
+                    lowercase_name is not None
+                    and "name" in entry
+                    and not fnmatch.fnmatch(lowercase_name, entry["name"])
+                ):
+                    continue
 
             hass.add_job(
                 hass.config_entries.flow.async_init(

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -116,7 +116,7 @@ ZEROCONF = {
     "_printer._tcp.local.": [
         {
             "domain": "brother",
-            "name": "Brother*"
+            "name": "brother*"
         }
     ],
     "_spotify-connect._tcp.local.": [

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -33,6 +33,14 @@ def documentation_url(value: str) -> str:
     return value
 
 
+def verify_lowercase(value: str):
+    """Verify a value is lowercase."""
+    if value.lower() != value:
+        raise vol.Invalid("Value needs to be lowercase")
+
+    return value
+
+
 MANIFEST_SCHEMA = vol.Schema(
     {
         vol.Required("domain"): str,
@@ -45,8 +53,8 @@ MANIFEST_SCHEMA = vol.Schema(
                 vol.Schema(
                     {
                         vol.Required("type"): str,
-                        vol.Optional("macaddress"): str,
-                        vol.Optional("name"): str,
+                        vol.Optional("macaddress"): vol.All(str, verify_lowercase),
+                        vol.Optional("name"): vol.All(str, verify_lowercase),
                     }
                 ),
             )

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -41,6 +41,14 @@ def verify_lowercase(value: str):
     return value
 
 
+def verify_uppercase(value: str):
+    """Verify a value is uppercase."""
+    if value.upper() != value:
+        raise vol.Invalid("Value needs to be uppercase")
+
+    return value
+
+
 MANIFEST_SCHEMA = vol.Schema(
     {
         vol.Required("domain"): str,
@@ -53,7 +61,7 @@ MANIFEST_SCHEMA = vol.Schema(
                 vol.Schema(
                     {
                         vol.Required("type"): str,
-                        vol.Optional("macaddress"): vol.All(str, verify_lowercase),
+                        vol.Optional("macaddress"): vol.All(str, verify_uppercase),
                         vol.Optional("name"): vol.All(str, verify_lowercase),
                     }
                 ),

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -248,7 +248,11 @@ async def test_zeroconf_match(hass, mock_zeroconf):
 
     with patch.dict(
         zc_gen.ZEROCONF,
-        {"_http._tcp.local.": [{"domain": "shelly", "name": "shelly*"}]},
+        {
+            "_http._tcp.local.": [
+                {"domain": "shelly", "name": "shelly*", "macaddress": "FFAADD*"}
+            ]
+        },
         clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -242,7 +242,7 @@ async def test_zeroconf_match(hass, mock_zeroconf):
         handlers[0](
             zeroconf,
             "_http._tcp.local.",
-            "shelly108._http._tcp.local.",
+            "Shelly108._http._tcp.local.",
             ServiceStateChange.Added,
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Zeroconf will now match zeroconf names on lowercase and MAC addresses on uppercase. Manifests are required to make sure their types match.

Complements #44672

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
