### PR TITLE
Change how WLED entity names and IDs are chosen

### DIFF
--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -111,6 +111,7 @@ def wled_exception_handler(func):
 
 
 async def wled_get_title_base_for_config_entry(entry: ConfigEntry, hass: HomeAssistant):
+    """Decides what the entity names (and IDs) are based on."""
     title_base = entry.title
     device_registry = await hass.helpers.device_registry.async_get_registry()
     device = device_registry.async_get_device({(DOMAIN, entry.data.get("mac"))}, set())

--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -110,6 +110,18 @@ def wled_exception_handler(func):
     return handler
 
 
+async def wled_get_title_base_for_config_entry(entry: ConfigEntry, hass: HomeAssistant):
+    title_base = entry.title
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_device({(DOMAIN, entry.data.get("mac"))}, set())
+    if device is not None:
+        title_base = device.name
+        if device.name_by_user is not None:
+            title_base = device.name_by_user
+
+    return title_base
+
+
 class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
     """Class to manage fetching WLED data from single endpoint."""
 

--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -76,6 +76,11 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
             user_input[CONF_HOST] = self.context.get(CONF_HOST)
             user_input[CONF_MAC] = self.context.get(CONF_MAC)
 
+        title = user_input[CONF_HOST]
+        if source == SOURCE_ZEROCONF:
+            # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
+            title = self.context.get(CONF_NAME)
+
         if user_input.get(CONF_MAC) is None or not prepare:
             session = async_get_clientsession(self.hass)
             wled = WLED(user_input[CONF_HOST], session=session)
@@ -86,15 +91,11 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
                     return self.async_abort(reason="cannot_connect")
                 return self._show_setup_form({"base": "cannot_connect"})
             user_input[CONF_MAC] = device.info.mac_address
+            title = device.info.name
 
         # Check if already configured
         await self.async_set_unique_id(user_input[CONF_MAC])
         self._abort_if_unique_id_configured(updates={CONF_HOST: user_input[CONF_HOST]})
-
-        title = user_input[CONF_HOST]
-        if source == SOURCE_ZEROCONF:
-            # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
-            title = self.context.get(CONF_NAME)
 
         if prepare:
             return await self.async_step_zeroconf_confirm()

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -105,10 +105,10 @@ class WLEDMasterLight(LightEntity, WLEDDeviceEntity):
     def __init__(
         self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
     ):
+        """Initialize WLED master light."""
         if title_base is None:
             title_base = coordinator.data.info.name
 
-        """Initialize WLED master light."""
         super().__init__(
             entry_id=entry_id,
             coordinator=coordinator,
@@ -172,10 +172,10 @@ class WLEDSegmentLight(LightEntity, WLEDDeviceEntity):
         segment: int,
         title_base=None,
     ):
+        """Initialize WLED segment light."""
         if title_base is None:
             title_base = coordinator.data.info.name
 
-        """Initialize WLED segment light."""
         self._rgbw = coordinator.data.info.leds.rgbw
         self._segment = segment
 

--- a/homeassistant/components/wled/sensor.py
+++ b/homeassistant/components/wled/sensor.py
@@ -15,7 +15,11 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.dt import utcnow
 
-from . import WLEDDataUpdateCoordinator, WLEDDeviceEntity
+from . import (
+    WLEDDataUpdateCoordinator,
+    WLEDDeviceEntity,
+    wled_get_title_base_for_config_entry,
+)
 from .const import ATTR_LED_COUNT, ATTR_MAX_POWER, CURRENT_MA, DOMAIN
 
 
@@ -27,14 +31,16 @@ async def async_setup_entry(
     """Set up WLED sensor based on a config entry."""
     coordinator: WLEDDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
+    title_base = await wled_get_title_base_for_config_entry(entry, coordinator.hass)
+
     sensors = [
-        WLEDEstimatedCurrentSensor(entry.entry_id, coordinator),
-        WLEDUptimeSensor(entry.entry_id, coordinator),
-        WLEDFreeHeapSensor(entry.entry_id, coordinator),
-        WLEDWifiBSSIDSensor(entry.entry_id, coordinator),
-        WLEDWifiChannelSensor(entry.entry_id, coordinator),
-        WLEDWifiRSSISensor(entry.entry_id, coordinator),
-        WLEDWifiSignalSensor(entry.entry_id, coordinator),
+        WLEDEstimatedCurrentSensor(entry.entry_id, coordinator, title_base),
+        WLEDUptimeSensor(entry.entry_id, coordinator, title_base),
+        WLEDFreeHeapSensor(entry.entry_id, coordinator, title_base),
+        WLEDWifiBSSIDSensor(entry.entry_id, coordinator, title_base),
+        WLEDWifiChannelSensor(entry.entry_id, coordinator, title_base),
+        WLEDWifiRSSISensor(entry.entry_id, coordinator, title_base),
+        WLEDWifiSignalSensor(entry.entry_id, coordinator, title_base),
     ]
 
     async_add_entities(sensors, True)
@@ -80,14 +86,19 @@ class WLEDSensor(WLEDDeviceEntity):
 class WLEDEstimatedCurrentSensor(WLEDSensor):
     """Defines a WLED estimated current sensor."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED estimated current sensor."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             entry_id=entry_id,
             icon="mdi:power",
             key="estimated_current",
-            name=f"{coordinator.data.info.name} Estimated Current",
+            name=f"{title_base} Estimated Current",
             unit_of_measurement=CURRENT_MA,
         )
 
@@ -113,15 +124,20 @@ class WLEDEstimatedCurrentSensor(WLEDSensor):
 class WLEDUptimeSensor(WLEDSensor):
     """Defines a WLED uptime sensor."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED uptime sensor."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             enabled_default=False,
             entry_id=entry_id,
             icon="mdi:clock-outline",
             key="uptime",
-            name=f"{coordinator.data.info.name} Uptime",
+            name=f"{title_base} Uptime",
         )
 
     @property
@@ -139,15 +155,20 @@ class WLEDUptimeSensor(WLEDSensor):
 class WLEDFreeHeapSensor(WLEDSensor):
     """Defines a WLED free heap sensor."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED free heap sensor."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             enabled_default=False,
             entry_id=entry_id,
             icon="mdi:memory",
             key="free_heap",
-            name=f"{coordinator.data.info.name} Free Memory",
+            name=f"{title_base} Free Memory",
             unit_of_measurement=DATA_BYTES,
         )
 
@@ -160,15 +181,20 @@ class WLEDFreeHeapSensor(WLEDSensor):
 class WLEDWifiSignalSensor(WLEDSensor):
     """Defines a WLED Wi-Fi signal sensor."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED Wi-Fi signal sensor."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             enabled_default=False,
             entry_id=entry_id,
             icon="mdi:wifi",
             key="wifi_signal",
-            name=f"{coordinator.data.info.name} Wi-Fi Signal",
+            name=f"{title_base} Wi-Fi Signal",
             unit_of_measurement=PERCENTAGE,
         )
 
@@ -181,15 +207,20 @@ class WLEDWifiSignalSensor(WLEDSensor):
 class WLEDWifiRSSISensor(WLEDSensor):
     """Defines a WLED Wi-Fi RSSI sensor."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED Wi-Fi RSSI sensor."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             enabled_default=False,
             entry_id=entry_id,
             icon="mdi:wifi",
             key="wifi_rssi",
-            name=f"{coordinator.data.info.name} Wi-Fi RSSI",
+            name=f"{title_base} Wi-Fi RSSI",
             unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         )
 
@@ -207,15 +238,20 @@ class WLEDWifiRSSISensor(WLEDSensor):
 class WLEDWifiChannelSensor(WLEDSensor):
     """Defines a WLED Wi-Fi Channel sensor."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED Wi-Fi Channel sensor."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             enabled_default=False,
             entry_id=entry_id,
             icon="mdi:wifi",
             key="wifi_channel",
-            name=f"{coordinator.data.info.name} Wi-Fi Channel",
+            name=f"{title_base} Wi-Fi Channel",
         )
 
     @property
@@ -227,15 +263,20 @@ class WLEDWifiChannelSensor(WLEDSensor):
 class WLEDWifiBSSIDSensor(WLEDSensor):
     """Defines a WLED Wi-Fi BSSID sensor."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED Wi-Fi BSSID sensor."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             enabled_default=False,
             entry_id=entry_id,
             icon="mdi:wifi",
             key="wifi_bssid",
-            name=f"{coordinator.data.info.name} Wi-Fi BSSID",
+            name=f"{title_base} Wi-Fi BSSID",
         )
 
     @property

--- a/homeassistant/components/wled/switch.py
+++ b/homeassistant/components/wled/switch.py
@@ -6,7 +6,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import WLEDDataUpdateCoordinator, WLEDDeviceEntity, wled_exception_handler
+from . import (
+    WLEDDataUpdateCoordinator,
+    WLEDDeviceEntity,
+    wled_exception_handler,
+    wled_get_title_base_for_config_entry,
+)
 from .const import (
     ATTR_DURATION,
     ATTR_FADE,
@@ -26,10 +31,12 @@ async def async_setup_entry(
     """Set up WLED switch based on a config entry."""
     coordinator: WLEDDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
+    title_base = await wled_get_title_base_for_config_entry(entry, coordinator.hass)
+
     switches = [
-        WLEDNightlightSwitch(entry.entry_id, coordinator),
-        WLEDSyncSendSwitch(entry.entry_id, coordinator),
-        WLEDSyncReceiveSwitch(entry.entry_id, coordinator),
+        WLEDNightlightSwitch(entry.entry_id, coordinator, title_base),
+        WLEDSyncSendSwitch(entry.entry_id, coordinator, title_base),
+        WLEDSyncReceiveSwitch(entry.entry_id, coordinator, title_base),
     ]
     async_add_entities(switches, True)
 
@@ -61,14 +68,19 @@ class WLEDSwitch(WLEDDeviceEntity, SwitchEntity):
 class WLEDNightlightSwitch(WLEDSwitch):
     """Defines a WLED nightlight switch."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED nightlight switch."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             entry_id=entry_id,
             icon="mdi:weather-night",
             key="nightlight",
-            name=f"{coordinator.data.info.name} Nightlight",
+            name=f"{title_base} Nightlight",
         )
 
     @property
@@ -99,14 +111,19 @@ class WLEDNightlightSwitch(WLEDSwitch):
 class WLEDSyncSendSwitch(WLEDSwitch):
     """Defines a WLED sync send switch."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator) -> None:
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ) -> None:
         """Initialize WLED sync send switch."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             entry_id=entry_id,
             icon="mdi:upload-network-outline",
             key="sync_send",
-            name=f"{coordinator.data.info.name} Sync Send",
+            name=f"{title_base} Sync Send",
         )
 
     @property
@@ -133,14 +150,19 @@ class WLEDSyncSendSwitch(WLEDSwitch):
 class WLEDSyncReceiveSwitch(WLEDSwitch):
     """Defines a WLED sync receive switch."""
 
-    def __init__(self, entry_id: str, coordinator: WLEDDataUpdateCoordinator):
+    def __init__(
+        self, entry_id: str, coordinator: WLEDDataUpdateCoordinator, title_base=None
+    ):
         """Initialize WLED sync receive switch."""
+        if title_base is None:
+            title_base = coordinator.data.info.name
+
         super().__init__(
             coordinator=coordinator,
             entry_id=entry_id,
             icon="mdi:download-network-outline",
             key="sync_receive",
-            name=f"{coordinator.data.info.name} Sync Receive",
+            name=f"{title_base} Sync Receive",
         )
 
     @property

--- a/tests/components/wled/__init__.py
+++ b/tests/components/wled/__init__.py
@@ -5,6 +5,7 @@ import json
 from homeassistant.components.wled.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_MAC, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceRegistry
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -15,6 +16,7 @@ async def init_integration(
     aioclient_mock: AiohttpClientMocker,
     rgbw: bool = False,
     skip_setup: bool = False,
+    device_registry: DeviceRegistry = None,
 ) -> MockConfigEntry:
     """Set up the WLED integration in Home Assistant."""
 
@@ -46,10 +48,19 @@ async def init_integration(
     )
 
     entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "192.168.1.123", CONF_MAC: "aabbccddeeff"}
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.123", CONF_MAC: data["info"]["mac"]},
+        title="WLED Mock Config Entry",
     )
 
     entry.add_to_hass(hass)
+
+    if device_registry is not None:
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, entry.data.get("mac"))},
+            name=data["info"]["name"],
+        )
 
     if not skip_setup:
         await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,2 +1,11 @@
 """wled conftest."""
+import pytest
+
 from tests.components.light.conftest import mock_light_profiles  # noqa
+from tests.common import mock_device_registry
+
+
+@pytest.fixture
+def device_registry(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,8 +1,8 @@
 """wled conftest."""
 import pytest
 
-from tests.components.light.conftest import mock_light_profiles  # noqa
 from tests.common import mock_device_registry
+from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
 @pytest.fixture

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -207,7 +207,7 @@ async def test_full_user_flow_implementation(
 
     assert result["data"][CONF_HOST] == "192.168.1.123"
     assert result["data"][CONF_MAC] == "aabbccddeeff"
-    assert result["title"] == "192.168.1.123"
+    assert result["title"] == "WLED RGB Light"
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
 
@@ -237,5 +237,5 @@ async def test_full_zeroconf_flow_implementation(
     result = await flow.async_step_zeroconf_confirm(user_input={})
     assert result["data"][CONF_HOST] == "192.168.1.123"
     assert result["data"][CONF_MAC] == "aabbccddeeff"
-    assert result["title"] == "example"
+    assert result["title"] == "WLED RGB Light"
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/wled/test_init.py
+++ b/tests/components/wled/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the WLED integration."""
 from wled import WLEDConnectionError
 
+from homeassistant.components.wled import wled_get_title_base_for_config_entry
 from homeassistant.components.wled.const import DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 from homeassistant.core import HomeAssistant
@@ -37,3 +38,42 @@ async def test_setting_unique_id(hass, aioclient_mock):
 
     assert hass.data[DOMAIN]
     assert entry.unique_id == "aabbccddeeff"
+
+
+async def test_base_title_no_device(hass, aioclient_mock) -> None:
+    """Test if the base title will be based on the config entry if no device exists."""
+    # Do not pass the DeviceRegistry, so no device is created
+    entry = await init_integration(hass, aioclient_mock, skip_setup=True)
+
+    base_title = await wled_get_title_base_for_config_entry(entry, hass)
+
+    assert base_title == "WLED Mock Config Entry"
+
+
+async def test_base_title_with_device(hass, aioclient_mock, device_registry) -> None:
+    """Test if the base title will be based on the device name with both ConfigEntry and Device existing."""
+    entry = await init_integration(
+        hass, aioclient_mock, skip_setup=True, device_registry=device_registry
+    )
+
+    base_title = await wled_get_title_base_for_config_entry(entry, hass)
+
+    assert base_title == "WLED RGB Light"
+
+
+async def test_base_title_with_device_and_name_by_user(
+    hass, aioclient_mock, device_registry
+) -> None:
+    """Test if the base title will be based on the user defined device name with both ConfigEntry and Device existing."""
+    entry = await init_integration(
+        hass, aioclient_mock, skip_setup=True, device_registry=device_registry
+    )
+
+    device = device_registry.async_get_device({(DOMAIN, entry.data.get("mac"))}, set())
+    device = device_registry.async_update_device(
+        device.id, name_by_user="WLED RGB Light User Name"
+    )
+
+    base_title = await wled_get_title_base_for_config_entry(entry, hass)
+
+    assert base_title == "WLED RGB Light User Name"

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -44,10 +44,10 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_rgb_light_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test the creation and values of the WLED lights."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
@@ -101,10 +101,10 @@ async def test_rgb_light_state(
 
 
 async def test_segment_change_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog, device_registry
 ) -> None:
     """Test the change of state of the WLED segments."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
@@ -159,10 +159,10 @@ async def test_segment_change_state(
 
 
 async def test_master_change_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog, device_registry
 ) -> None:
     """Test the change of state of the WLED master light control."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("wled.WLED.master") as light_mock:
         await hass.services.async_call(
@@ -228,10 +228,10 @@ async def test_master_change_state(
 
 
 async def test_dynamically_handle_segments(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test if a new/deleted segment is dynamically added/removed."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     assert hass.states.get("light.wled_rgb_light_master")
     assert hass.states.get("light.wled_rgb_light_segment_0")
@@ -261,10 +261,10 @@ async def test_dynamically_handle_segments(
 
 
 async def test_single_segment_behavior(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog, device_registry
 ) -> None:
     """Test the behavior of the integration with a single segment."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     data = json.loads(load_fixture("wled/rgb_single_segment.json"))
     device = WLEDDevice(data)
@@ -344,11 +344,11 @@ async def test_single_segment_behavior(
 
 
 async def test_light_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog, device_registry
 ) -> None:
     """Test error handling of the WLED lights."""
     aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("homeassistant.components.wled.WLED.update"):
         await hass.services.async_call(
@@ -365,10 +365,10 @@ async def test_light_error(
 
 
 async def test_light_connection_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test error handling of the WLED switches."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("homeassistant.components.wled.WLED.update"), patch(
         "homeassistant.components.wled.WLED.segment", side_effect=WLEDConnectionError
@@ -386,10 +386,12 @@ async def test_light_connection_error(
 
 
 async def test_rgbw_light(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test RGBW support for WLED."""
-    await init_integration(hass, aioclient_mock, rgbw=True)
+    await init_integration(
+        hass, aioclient_mock, rgbw=True, device_registry=device_registry
+    )
 
     state = hass.states.get("light.wled_rgbw_light")
     assert state.state == STATE_ON
@@ -444,10 +446,10 @@ async def test_rgbw_light(
 
 
 async def test_effect_service(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test the effect service of a WLED light."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
@@ -570,11 +572,11 @@ async def test_effect_service(
 
 
 async def test_effect_service_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog, device_registry
 ) -> None:
     """Test error handling of the WLED effect service."""
     aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("homeassistant.components.wled.WLED.update"):
         await hass.services.async_call(
@@ -591,10 +593,10 @@ async def test_effect_service_error(
 
 
 async def test_preset_service(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test the preset service of a WLED light."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("wled.WLED.preset") as light_mock:
         await hass.services.async_call(
@@ -613,11 +615,11 @@ async def test_preset_service(
 
 
 async def test_preset_service_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog, device_registry
 ) -> None:
     """Test error handling of the WLED preset service."""
     aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("homeassistant.components.wled.WLED.update"):
         await hass.services.async_call(

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -30,11 +30,13 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_sensors(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test the creation and values of the WLED sensors."""
 
-    entry = await init_integration(hass, aioclient_mock, skip_setup=True)
+    entry = await init_integration(
+        hass, aioclient_mock, skip_setup=True, device_registry=device_registry
+    )
     registry = await hass.helpers.entity_registry.async_get_registry()
 
     # Pre-create registry entries for disabled by default sensors
@@ -181,10 +183,13 @@ async def test_sensors(
     ),
 )
 async def test_disabled_by_default_sensors(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, entity_id: str
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    entity_id: str,
+    device_registry,
 ) -> None:
     """Test the disabled by default WLED sensors."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
     registry = await hass.helpers.entity_registry.async_get_registry()
 
     state = hass.states.get(entity_id)

--- a/tests/components/wled/test_switch.py
+++ b/tests/components/wled/test_switch.py
@@ -25,10 +25,10 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_switch_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test the creation and values of the WLED switches."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
@@ -66,10 +66,10 @@ async def test_switch_state(
 
 
 async def test_switch_change_state(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test the change of state of the WLED switches."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     # Nightlight
     with patch("wled.WLED.nightlight") as nightlight_mock:
@@ -136,11 +136,11 @@ async def test_switch_change_state(
 
 
 async def test_switch_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog, device_registry
 ) -> None:
     """Test error handling of the WLED switches."""
     aioclient_mock.post("http://192.168.1.123:80/json/state", text="", status=400)
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("homeassistant.components.wled.WLED.update"):
         await hass.services.async_call(
@@ -157,10 +157,10 @@ async def test_switch_error(
 
 
 async def test_switch_connection_error(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, device_registry
 ) -> None:
     """Test error handling of the WLED switches."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, device_registry=device_registry)
 
     with patch("homeassistant.components.wled.WLED.update"), patch(
         "homeassistant.components.wled.WLED.nightlight", side_effect=WLEDConnectionError


### PR DESCRIPTION
## Proposed change
Before this change, these two behaviors were true:
1. When creating entities, the WLED component used the actual name / title of the WLED device itself, so whatever is configured in its settings on the controller / what's coming from the API call that the component does.
2. When choosing the name of the config entry, the component used the value of the hostname of the WLED device.

_Note: I did not mark this as breaking change. Technically, it changes the way how entities are named, but it will not affect people that never touch what the WLED Config Flow does. It will only fix a behavior with entities named wrongly after you touched the HA device. Pls read below and decide for yourself :)_

### 1.: Entity Names
This becomes an issue if you renamed the entities created by the component. Renaming can easiliy happen by renaming the HA device, as HA asks you if you also want to rename the entities belonging to it. Because:
The issue with this behavior is that for advanced WLED setups where you make use of different presets with different amounts of segments, the WLED component will delete or create entities "on the fly", strictly speaking: At the next scan interval after you loaded a preset that changed the number of segments. So when adding these new entities, it will again use the WLED name configured on the controller itself and not the HA device name, which would make more sense, as HA asked me to rename the entities based on the HA device. And then, the entities will have the wrong name again,
A usecase where I faced this issue is looked like this:
1. Assumption: I have renamed the entities when renaming the HA device and a preset is loaded with eight segments
2. An automation triggers and loads a preset with fewer segments: Entities for these segments get deleted
3. Another automation that loads the preset from before again with eight segments: These entities now have different names (and IDs) than before: They don't inherit from the HA device, but from the WLED name coming over the API.

My change will use the HA device name, therefore properly restoring these entity names and IDs.

For users who never renamed the HA device, this won't make any change, as the HA device is equal to the WLED name. But if you change this name configured on the WLED device itself, or if you rename the HA device, the entities will have "wrong" / unwanted namings.
I felt it's a better way to always use the HA device name as a base for the entity names (and therefore) and entity IDs. As the entity names should not be dependent on the WLED name, but on something HA, and the HA device makes the most sense here,

### 2.: Name of the config entry
As a plus, I also changed the name of the Config Entry that's creating using Config Flow, away from the WLED host name (so e.g. `wled-33135b`) to the name configured on WLED. With this change, the Config Entry and the HA device will both have the same name.
Strictly speaking, this PR then has two changes and should be split. But it's so small and was such a low hanging fruit, I just added it :)

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:

_I never created an issue for it, as I wanted to fix it directly on my own as my first (of hopefully many to come) contribution :)_

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- ~[ ] Documentation added/updated for [www.home-assistant.io][docs-repository]~

If the code communicates with devices, web services, or third-party tools:

- ~[ ] The [manifest file][manifest-docs] has all fields filled out correctly.~
      ~Updated and included derived files by running: `python3 -m script.hassfest`.~
- ~[ ] New or updated dependencies have been added to `requirements_all.txt`.~
      ~Updated by running `python3 -m script.gen_requirements_all`.~
- ~[ ] Untested files have been added to `.coveragerc`.~

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone