### PR TITLE
Fix broken test test_auto_purge in recorder 

### DIFF
--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the Recorder component."""
 # pylint: disable=protected-access
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from sqlalchemy.exc import OperationalError
 
@@ -23,7 +23,7 @@ from homeassistant.util import dt as dt_util
 from .common import wait_recording_done
 
 from tests.async_mock import patch
-from tests.common import async_fire_time_changed, get_test_home_assistant
+from tests.common import fire_time_changed, get_test_home_assistant
 
 
 def test_saving_state(hass, hass_recorder):
@@ -351,8 +351,15 @@ async def test_defaults_set(hass):
     assert recorder_config["purge_keep_days"] == 10
 
 
+def run_tasks_at_time(hass, test_time):
+    """Advance the clock and wait for any callbacks to finish."""
+    fire_time_changed(hass, test_time)
+    hass.block_till_done()
+    hass.data[DATA_INSTANCE].block_till_done()
+
+
 def test_auto_purge(hass_recorder):
-    """Test saving and restoring a state."""
+    """Test periodic purge alarm scheduling."""
     hass = hass_recorder()
 
     original_tz = dt_util.DEFAULT_TIME_ZONE
@@ -360,18 +367,40 @@ def test_auto_purge(hass_recorder):
     tz = dt_util.get_time_zone("Europe/Copenhagen")
     dt_util.set_default_time_zone(tz)
 
+    # Purging is schedule to happen at 4:12am every day. Exercise this behavior
+    # by firing alarms and advancing the clock around this time. Pick an arbitrary
+    # year in the future to avoid boundary conditions relative to the current date.
+    #
+    # The clock is started at 4:15am then advanced forward below
     now = dt_util.utcnow()
-    test_time = now + timedelta(days=365)
-    async_fire_time_changed(hass, test_time)
+    test_time = tz.localize(datetime(now.year + 2, 1, 1, 4, 15, 0))
+    run_tasks_at_time(hass, test_time)
 
     with patch(
         "homeassistant.components.recorder.purge.purge_old_data", return_value=True
     ) as purge_old_data:
-        for delta in (-1, 0, 1):
-            async_fire_time_changed(hass, test_time + timedelta(seconds=delta))
-            hass.block_till_done()
-            hass.data[DATA_INSTANCE].block_till_done()
+        # Advance one day, and the purge task should run
+        test_time = test_time + timedelta(days=1)
+        run_tasks_at_time(hass, test_time)
+        assert len(purge_old_data.mock_calls) == 1
 
+        purge_old_data.reset_mock()
+
+        # Advance one day, and the purge task should run again
+        test_time = test_time + timedelta(days=1)
+        run_tasks_at_time(hass, test_time)
+        assert len(purge_old_data.mock_calls) == 1
+
+        purge_old_data.reset_mock()
+
+        # Advance less than one full day.  The alarm should not yet fire.
+        test_time = test_time + timedelta(hours=23)
+        run_tasks_at_time(hass, test_time)
+        assert len(purge_old_data.mock_calls) == 0
+
+        # Advance to the next day and fire the alarm again
+        test_time = test_time + timedelta(hours=1)
+        run_tasks_at_time(hass, test_time)
         assert len(purge_old_data.mock_calls) == 1
 
     dt_util.set_default_time_zone(original_tz)

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1,6 +1,6 @@
 """The tests for the Recorder component."""
 # pylint: disable=protected-access
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from sqlalchemy.exc import OperationalError
 
@@ -361,7 +361,7 @@ def test_auto_purge(hass_recorder):
     dt_util.set_default_time_zone(tz)
 
     now = dt_util.utcnow()
-    test_time = tz.localize(datetime(now.year + 1, 1, 1, 4, 12, 0))
+    test_time = now + timedelta(days=365)
     async_fire_time_changed(hass, test_time)
 
     with patch(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix test that is currently failing all PR test jobs. It seems to be failing because it is near the end of the year, so the assumptions about date math are not matching the expected behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
