### PR TITLE
Add Chinese (Hong Kong) to Google Cloud TTS

### DIFF
--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -25,6 +25,7 @@ CONF_TEXT_TYPE = "text_type"
 SUPPORTED_LANGUAGES = [
     "ar-XA",
     "bn-IN",
+    "yue-HK",
     "cmn-CN",
     "cmn-TW",
     "cs-CZ",


### PR DESCRIPTION
Add Chinese (Hong Kong) to Google Cloud TTS

add yue-HK

reference
Supported voices and languages
https://cloud.google.com/text-to-speech/docs/voices