### PR TITLE
Change rest sensors update interval for Shelly Motion

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.helpers import (
 )
 
 from .const import (
-    BATTERY_DEVICES_WITH_PERNAMENT_CONNECTION,
+    BATTERY_DEVICES_WITH_PERMANENT_CONNECTION,
     COAP,
     DATA_CONFIG_ENTRY,
     DOMAIN,
@@ -244,7 +244,7 @@ class ShellyDeviceRestWrapper(update_coordinator.DataUpdateCoordinator):
         """Initialize the Shelly device wrapper."""
         if (
             device.settings["device"]["type"]
-            in BATTERY_DEVICES_WITH_PERNAMENT_CONNECTION
+            in BATTERY_DEVICES_WITH_PERMANENT_CONNECTION
         ):
             update_interval = (
                 SLEEP_PERIOD_MULTIPLIER * device.settings["coiot"]["update_period"]

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -256,7 +256,7 @@ class ShellyDeviceRestWrapper(update_coordinator.DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=get_device_name(device),
-            update_interval=timedelta(seconds=(update_interval)),
+            update_interval=timedelta(seconds=update_interval),
         )
         self.device = device
 

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -246,19 +246,17 @@ class ShellyDeviceRestWrapper(update_coordinator.DataUpdateCoordinator):
             device.settings["device"]["type"]
             in BATTERY_DEVICES_WITH_PERNAMENT_CONNECTION
         ):
-            update_interval = timedelta(
-                seconds=(
-                    SLEEP_PERIOD_MULTIPLIER * device.settings["coiot"]["update_period"]
-                )
+            update_interval = (
+                SLEEP_PERIOD_MULTIPLIER * device.settings["coiot"]["update_period"]
             )
         else:
-            update_interval = timedelta(seconds=REST_SENSORS_UPDATE_INTERVAL)
+            update_interval = REST_SENSORS_UPDATE_INTERVAL
 
         super().__init__(
             hass,
             _LOGGER,
             name=get_device_name(device),
-            update_interval=update_interval,
+            update_interval=timedelta(seconds=(update_interval)),
         )
         self.device = device
 

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.helpers import (
 )
 
 from .const import (
+    BATTERY_DEVICES_WITH_PERNAMENT_CONNECTION,
     COAP,
     DATA_CONFIG_ENTRY,
     DOMAIN,
@@ -241,12 +242,23 @@ class ShellyDeviceRestWrapper(update_coordinator.DataUpdateCoordinator):
 
     def __init__(self, hass, device: aioshelly.Device):
         """Initialize the Shelly device wrapper."""
+        if (
+            device.settings["device"]["type"]
+            in BATTERY_DEVICES_WITH_PERNAMENT_CONNECTION
+        ):
+            update_interval = timedelta(
+                seconds=(
+                    SLEEP_PERIOD_MULTIPLIER * device.settings["coiot"]["update_period"]
+                )
+            )
+        else:
+            update_interval = timedelta(seconds=REST_SENSORS_UPDATE_INTERVAL)
 
         super().__init__(
             hass,
             _LOGGER,
             name=get_device_name(device),
-            update_interval=timedelta(seconds=REST_SENSORS_UPDATE_INTERVAL),
+            update_interval=update_interval,
         )
         self.device = device
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -32,3 +32,6 @@ INPUTS_EVENTS_DICT = {
     "SL": "single_long",
     "LS": "long_single",
 }
+
+# List of battery devices that maintain a permanent WiFi connection
+BATTERY_DEVICES_WITH_PERNAMENT_CONNECTION = ["SHMOS-01"]

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -34,4 +34,4 @@ INPUTS_EVENTS_DICT = {
 }
 
 # List of battery devices that maintain a permanent WiFi connection
-BATTERY_DEVICES_WITH_PERNAMENT_CONNECTION = ["SHMOS-01"]
+BATTERY_DEVICES_WITH_PERMANENT_CONNECTION = ["SHMOS-01"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly Motion is a battery powered device with a permanent WiFi connection. Frequent polling of the device will drain the battery. This PR changes the `update_interval` of the rest sensors to prevent this. The value of CoAP update period (it's 3600 seconds for Shelly Motion) is used to compute the `update_interval`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
