### PR TITLE
Add additional supported feature support to universal media player

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -33,8 +33,13 @@ from homeassistant.components.media_player.const import (
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     SUPPORT_CLEAR_PLAYLIST,
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_SHUFFLE_SET,
+    SUPPORT_STOP,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
@@ -406,6 +411,22 @@ class UniversalMediaPlayer(MediaPlayerEntity):
             flags |= SUPPORT_TURN_ON
         if SERVICE_TURN_OFF in self._cmds:
             flags |= SUPPORT_TURN_OFF
+
+        if SERVICE_MEDIA_PLAY_PAUSE in self._cmds:
+            flags |= SUPPORT_PLAY | SUPPORT_PAUSE
+        else:
+            if SERVICE_MEDIA_PLAY in self._cmds:
+                flags |= SUPPORT_PLAY
+            if SERVICE_MEDIA_PAUSE in self._cmds:
+                flags |= SUPPORT_PAUSE
+
+        if SERVICE_MEDIA_STOP in self._cmds:
+            flags |= SUPPORT_STOP
+
+        if SERVICE_MEDIA_NEXT_TRACK in self._cmds:
+            flags |= SUPPORT_NEXT_TRACK
+        if SERVICE_MEDIA_PREVIOUS_TRACK in self._cmds:
+            flags |= SUPPORT_PREVIOUS_TRACK
 
         if any([cmd in self._cmds for cmd in [SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN]]):
             flags |= SUPPORT_VOLUME_STEP

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -20,6 +20,7 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_PLAYLIST,
     ATTR_MEDIA_POSITION,
     ATTR_MEDIA_POSITION_UPDATED_AT,
+    ATTR_MEDIA_REPEAT,
     ATTR_MEDIA_SEASON,
     ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SERIES_TITLE,
@@ -28,15 +29,20 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_TRACK,
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
+    ATTR_SOUND_MODE,
+    ATTR_SOUND_MODE_LIST,
     DOMAIN,
     SERVICE_CLEAR_PLAYLIST,
     SERVICE_PLAY_MEDIA,
+    SERVICE_SELECT_SOUND_MODE,
     SERVICE_SELECT_SOURCE,
     SUPPORT_CLEAR_PLAYLIST,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
     SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_REPEAT_SET,
+    SUPPORT_SELECT_SOUND_MODE,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_SHUFFLE_SET,
     SUPPORT_STOP,
@@ -60,7 +66,9 @@ from homeassistant.const import (
     SERVICE_MEDIA_PREVIOUS_TRACK,
     SERVICE_MEDIA_SEEK,
     SERVICE_MEDIA_STOP,
+    SERVICE_REPEAT_SET,
     SERVICE_SHUFFLE_SET,
+    SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     SERVICE_VOLUME_DOWN,
@@ -388,6 +396,16 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         return self._child_attr(ATTR_APP_NAME)
 
     @property
+    def sound_mode(self):
+        """Return the current sound mode of the device."""
+        return self._override_or_child_attr(ATTR_SOUND_MODE)
+
+    @property
+    def sound_mode_list(self):
+        """List of available sound modes."""
+        return self._override_or_child_attr(ATTR_SOUND_MODE_LIST)
+
+    @property
     def source(self):
         """Return the current input source of the device."""
         return self._override_or_child_attr(ATTR_INPUT_SOURCE)
@@ -396,6 +414,11 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     def source_list(self):
         """List of available input sources."""
         return self._override_or_child_attr(ATTR_INPUT_SOURCE_LIST)
+
+    @property
+    def repeat(self):
+        """Boolean if repeating is enabled."""
+        return self._override_or_child_attr(ATTR_MEDIA_REPEAT)
 
     @property
     def shuffle(self):
@@ -436,7 +459,10 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         if SERVICE_VOLUME_MUTE in self._cmds and ATTR_MEDIA_VOLUME_MUTED in self._attrs:
             flags |= SUPPORT_VOLUME_MUTE
 
-        if SERVICE_SELECT_SOURCE in self._cmds:
+        if (
+            SERVICE_SELECT_SOURCE in self._cmds
+            and ATTR_INPUT_SOURCE_LIST in self._attrs
+        ):
             flags |= SUPPORT_SELECT_SOURCE
 
         if SERVICE_CLEAR_PLAYLIST in self._cmds:
@@ -444,6 +470,15 @@ class UniversalMediaPlayer(MediaPlayerEntity):
 
         if SERVICE_SHUFFLE_SET in self._cmds and ATTR_MEDIA_SHUFFLE in self._attrs:
             flags |= SUPPORT_SHUFFLE_SET
+
+        if SERVICE_REPEAT_SET in self._cmds and ATTR_MEDIA_REPEAT in self._attrs:
+            flags |= SUPPORT_REPEAT_SET
+
+        if (
+            SERVICE_SELECT_SOUND_MODE in self._cmds
+            and ATTR_SOUND_MODE_LIST in self._attrs
+        ):
+            flags |= SUPPORT_SELECT_SOUND_MODE
 
         return flags
 
@@ -523,6 +558,13 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         """Play or pause the media player."""
         await self._async_call_service(SERVICE_MEDIA_PLAY_PAUSE)
 
+    async def async_select_sound_mode(self, sound_mode):
+        """Select sound mode."""
+        data = {ATTR_SOUND_MODE: sound_mode}
+        await self._async_call_service(
+            SERVICE_SELECT_SOUND_MODE, data, allow_override=True
+        )
+
     async def async_select_source(self, source):
         """Set the input source."""
         data = {ATTR_INPUT_SOURCE: source}
@@ -536,6 +578,15 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         """Enable/disable shuffling."""
         data = {ATTR_MEDIA_SHUFFLE: shuffle}
         await self._async_call_service(SERVICE_SHUFFLE_SET, data, allow_override=True)
+
+    async def async_set_repeat(self, repeat):
+        """Set repeat mode."""
+        data = {ATTR_MEDIA_REPEAT: repeat}
+        await self._async_call_service(SERVICE_REPEAT_SET, data, allow_override=True)
+
+    async def async_toggle(self):
+        """Toggle the power on the media player."""
+        await self._async_call_service(SERVICE_TOGGLE)
 
     async def async_update(self):
         """Update state in HA."""


### PR DESCRIPTION
## Proposed change
1. `universal` media player already had support for the following services, but didn't advertise them as supported features. This PR advertises them as supported features so that the frontend knows what features to expose:
  - `media_play_pause`
  - `media_play`
  - `media_pause`
  - `media_stop`
  - `media_next_track`
  - `media_previous_track`

2. I added the following new services, adding supported_features logic for the two marked with an x:
  - `repeat_set` x
  - `select_sound_mode` x
  - `toggle`

3. `universal` was advertising support for selecting an input source if the `select_source` service was available, but IMO it should also be based on whether the input source list property is available since the UI won't make sense without a list to choose from, so I updated that accordingly.

4. I added test coverage for the `clear_playlist` supported feature because that appeared to be missing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16056

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
