### PR TITLE
Add support for VeSync dimmer switches

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -994,6 +994,7 @@ omit =
     homeassistant/components/vesync/common.py
     homeassistant/components/vesync/const.py
     homeassistant/components/vesync/fan.py
+    homeassistant/components/vesync/light.py
     homeassistant/components/vesync/switch.py
     homeassistant/components/viaggiatreno/sensor.py
     homeassistant/components/vicare/*

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -18,9 +18,9 @@ from .const import (
     VS_DISCOVERY,
     VS_DISPATCHERS,
     VS_FANS,
+    VS_LIGHTS,
     VS_MANAGER,
     VS_SWITCHES,
-    VS_LIGHTS,
 )
 
 PLATFORMS = ["switch", "fan", "light"]

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -20,9 +20,10 @@ from .const import (
     VS_FANS,
     VS_MANAGER,
     VS_SWITCHES,
+    VS_LIGHTS,
 )
 
-PLATFORMS = ["switch", "fan"]
+PLATFORMS = ["switch", "fan", "light"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,6 +86,7 @@ async def async_setup_entry(hass, config_entry):
 
     switches = hass.data[DOMAIN][VS_SWITCHES] = []
     fans = hass.data[DOMAIN][VS_FANS] = []
+    lights = hass.data[DOMAIN][VS_LIGHTS] = []
 
     hass.data[DOMAIN][VS_DISPATCHERS] = []
 
@@ -96,15 +98,21 @@ async def async_setup_entry(hass, config_entry):
         fans.extend(device_dict[VS_FANS])
         hass.async_create_task(forward_setup(config_entry, "fan"))
 
+    if device_dict[VS_LIGHTS]:
+        lights.extend(device_dict[VS_LIGHTS])
+        hass.async_create_task(forward_setup(config_entry, "light"))
+
     async def async_new_device_discovery(service):
         """Discover if new devices should be added."""
         manager = hass.data[DOMAIN][VS_MANAGER]
         switches = hass.data[DOMAIN][VS_SWITCHES]
         fans = hass.data[DOMAIN][VS_FANS]
+        lights = hass.data[DOMAIN][VS_LIGHTS]
 
         dev_dict = await async_process_devices(hass, manager)
         switch_devs = dev_dict.get(VS_SWITCHES, [])
         fan_devs = dev_dict.get(VS_FANS, [])
+        light_devs = dev_dict.get(VS_LIGHTS, [])
 
         switch_set = set(switch_devs)
         new_switches = list(switch_set.difference(switches))
@@ -125,6 +133,16 @@ async def async_setup_entry(hass, config_entry):
         if new_fans and not fans:
             fans.extend(new_fans)
             hass.async_create_task(forward_setup(config_entry, "fan"))
+
+        light_set = set(light_devs)
+        new_lights = list(light_set.difference(lights))
+        if new_lights and lights:
+            lights.extend(new_lights)
+            async_dispatcher_send(hass, VS_DISCOVERY.format(VS_LIGHTS), new_lights)
+            return
+        if new_lights and not lights:
+            lights.extend(new_lights)
+            hass.async_create_task(forward_setup(config_entry, "light"))
 
     hass.services.async_register(
         DOMAIN, SERVICE_UPDATE_DEVS, async_new_device_discovery

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.helpers.entity import ToggleEntity
 
-from .const import VS_FANS, VS_SWITCHES
+from .const import VS_FANS, VS_SWITCHES, VS_LIGHTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,6 +13,7 @@ async def async_process_devices(hass, manager):
     devices = {}
     devices[VS_SWITCHES] = []
     devices[VS_FANS] = []
+    devices[VS_LIGHTS] = []
 
     await hass.async_add_executor_job(manager.update)
 
@@ -28,7 +29,9 @@ async def async_process_devices(hass, manager):
         for switch in manager.switches:
             if not switch.is_dimmable():
                 devices[VS_SWITCHES].append(switch)
-        _LOGGER.info("%d VeSync standard switches found", len(manager.switches))
+            else:
+                devices[VS_LIGHTS].append(switch)
+        _LOGGER.info("%d VeSync switches found", len(manager.switches))
 
     return devices
 

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.helpers.entity import ToggleEntity
 
-from .const import VS_FANS, VS_SWITCHES, VS_LIGHTS
+from .const import VS_FANS, VS_LIGHTS, VS_SWITCHES
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -7,4 +7,5 @@ SERVICE_UPDATE_DEVS = "update_devices"
 
 VS_SWITCHES = "switches"
 VS_FANS = "fans"
+VS_LIGHTS = "lights"
 VS_MANAGER = "manager"

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -78,6 +78,7 @@ class VeSyncDimmerHA(VeSyncDevice, LightEntity):
 
     @property
     def supported_features(self):
+        """Get supported features for this entity."""
         return SUPPORT_BRIGHTNESS
 
     @property

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -4,8 +4,8 @@ import math
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    LightEntity,
     SUPPORT_BRIGHTNESS,
+    LightEntity,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -1,0 +1,86 @@
+"""Support for VeSync dimmers."""
+import logging
+import math
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    LightEntity,
+    SUPPORT_BRIGHTNESS,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .common import VeSyncDevice
+from .const import DOMAIN, VS_DISCOVERY, VS_DISPATCHERS, VS_LIGHTS
+
+_LOGGER = logging.getLogger(__name__)
+
+DEV_TYPE_TO_HA = {
+    "ESD16": "light",
+    "ESWD16": "light",
+}
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up lights."""
+
+    async def async_discover(devices):
+        """Add new devices to platform."""
+        _async_setup_entities(devices, async_add_entities)
+
+    disp = async_dispatcher_connect(
+        hass, VS_DISCOVERY.format(VS_LIGHTS), async_discover
+    )
+    hass.data[DOMAIN][VS_DISPATCHERS].append(disp)
+
+    _async_setup_entities(hass.data[DOMAIN][VS_LIGHTS], async_add_entities)
+    return True
+
+
+@callback
+def _async_setup_entities(devices, async_add_entities):
+    """Check if device is online and add entity."""
+    dev_list = []
+    for dev in devices:
+        if DEV_TYPE_TO_HA.get(dev.device_type) == "light":
+            dev_list.append(VeSyncDimmerHA(dev))
+        else:
+            _LOGGER.warning(
+                "%s - Unknown device type - %s", dev.device_name, dev.device_type
+            )
+            continue
+
+    async_add_entities(dev_list, update_before_add=True)
+
+
+class VeSyncDimmerHA(VeSyncDevice, LightEntity):
+    """Representation of a VeSync dimmer."""
+
+    def __init__(self, dimmer):
+        """Initialize the VeSync dimmer device."""
+        super().__init__(dimmer)
+        self.dimmer = dimmer
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = int(kwargs[ATTR_BRIGHTNESS])
+            if brightness < 1:
+                brightness = 1
+            elif brightness > 255:
+                brightness = 100
+            else:
+                brightness = math.ceil((brightness / 255) * 100)
+            self.dimmer.set_brightness(brightness)
+        # Avoid turning device back on if this is just a brightness adjustment
+        if not self.is_on:
+            self.device.turn_on()
+
+    @property
+    def supported_features(self):
+        return SUPPORT_BRIGHTNESS
+
+    @property
+    def brightness(self):
+        """Get dimmer brightness."""
+        return math.ceil(int(self.dimmer.brightness) / 100) * 255

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -84,4 +84,4 @@ class VeSyncDimmerHA(VeSyncDevice, LightEntity):
     @property
     def brightness(self):
         """Get dimmer brightness."""
-        return math.ceil(int(self.dimmer.brightness) / 100) * 255
+        return math.round((int(self.dimmer.brightness) / 100) * 255)

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -64,13 +64,12 @@ class VeSyncDimmerHA(VeSyncDevice, LightEntity):
     def turn_on(self, **kwargs):
         """Turn the device on."""
         if ATTR_BRIGHTNESS in kwargs:
+            # get brightness from HA data
             brightness = int(kwargs[ATTR_BRIGHTNESS])
-            if brightness < 1:
-                brightness = 1
-            elif brightness > 255:
-                brightness = 100
-            else:
-                brightness = math.ceil((brightness / 255) * 100)
+            # clamp to 1-255
+            brightness = max(1, min(brightness, 255))
+            # convert to 1-100 range that vesync api expects
+            brightness = math.ceil((brightness / 255) * 100)
             self.dimmer.set_brightness(brightness)
         # Avoid turning device back on if this is just a brightness adjustment
         if not self.is_on:

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -1,6 +1,5 @@
 """Support for VeSync dimmers."""
 import logging
-import math
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -67,7 +67,7 @@ class VeSyncDimmerHA(VeSyncDevice, LightEntity):
             # get brightness from HA data
             brightness = int(kwargs[ATTR_BRIGHTNESS])
             # convert to percent that vesync api expects
-            brightness = math.round((brightness / 255) * 100)
+            brightness = round((brightness / 255) * 100)
             # clamp to 1-100
             brightness = max(1, min(brightness, 100))
             self.dimmer.set_brightness(brightness)
@@ -83,4 +83,4 @@ class VeSyncDimmerHA(VeSyncDevice, LightEntity):
     @property
     def brightness(self):
         """Get dimmer brightness."""
-        return math.round((int(self.dimmer.brightness) / 100) * 255)
+        return round((int(self.dimmer.brightness) / 100) * 255)

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -66,10 +66,10 @@ class VeSyncDimmerHA(VeSyncDevice, LightEntity):
         if ATTR_BRIGHTNESS in kwargs:
             # get brightness from HA data
             brightness = int(kwargs[ATTR_BRIGHTNESS])
-            # clamp to 1-255
-            brightness = max(1, min(brightness, 255))
-            # convert to 1-100 range that vesync api expects
-            brightness = math.ceil((brightness / 255) * 100)
+            # convert to percent that vesync api expects
+            brightness = math.round((brightness / 255) * 100)
+            # clamp to 1-100
+            brightness = max(1, min(brightness, 100))
             self.dimmer.set_brightness(brightness)
         # Avoid turning device back on if this is just a brightness adjustment
         if not self.is_on:

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -44,7 +44,7 @@ def _async_setup_entities(devices, async_add_entities):
         if DEV_TYPE_TO_HA.get(dev.device_type) == "light":
             dev_list.append(VeSyncDimmerHA(dev))
         else:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "%s - Unknown device type - %s", dev.device_name, dev.device_type
             )
             continue


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for VeSync dimmer switches as Light entities. The prior code discarded dimmers when creating Switch entities. This PR consumes those dimmers to create Light entities that properly support the brightness setting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #43716 -- it is a more complete fix for the same issue.
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16686

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
