### PR TITLE
Fix script wait templates with now/utcnow

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -715,9 +715,9 @@ def async_track_template(
 
         hass.async_run_hass_job(
             job,
-            event.data.get("entity_id"),
-            event.data.get("old_state"),
-            event.data.get("new_state"),
+            event and event.data.get("entity_id"),
+            event and event.data.get("old_state"),
+            event and event.data.get("new_state"),
         )
 
     info = async_track_template_result(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -62,7 +62,11 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.helpers import condition, config_validation as cv, service, template
-from homeassistant.helpers.event import async_call_later, async_track_template
+from homeassistant.helpers.event import (
+    TrackTemplate,
+    async_call_later,
+    async_track_template_result,
+)
 from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.trigger import (
     async_initialize_triggers,
@@ -355,7 +359,7 @@ class _ScriptRun:
             return
 
         @callback
-        def async_script_wait(entity_id, from_s, to_s):
+        def _async_script_wait(event, updates):
             """Handle script after template condition is true."""
             self._variables["wait"] = {
                 "remaining": to_context.remaining if to_context else delay,
@@ -364,9 +368,12 @@ class _ScriptRun:
             done.set()
 
         to_context = None
-        unsub = async_track_template(
-            self._hass, wait_template, async_script_wait, self._variables
+        info = async_track_template_result(
+            self._hass,
+            [TrackTemplate(wait_template, self._variables)],
+            _async_script_wait,
         )
+        unsub = info.async_remove
 
         self._changed()
         done = asyncio.Event()

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -908,6 +908,33 @@ async def test_track_template_error_can_recover(hass, caplog):
     assert "UndefinedError" not in caplog.text
 
 
+async def test_track_template_time_change(hass, caplog):
+    """Test tracking template with time change."""
+    template_error = Template("{{ utcnow().minute % 2 == 0 }}", hass)
+    calls = []
+
+    @ha.callback
+    def error_callback(entity_id, old_state, new_state):
+        calls.append((entity_id, old_state, new_state))
+
+    start_time = dt_util.utcnow() + timedelta(hours=24)
+    time_that_will_not_match_right_away = start_time.replace(minute=1, second=0)
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        async_track_template(hass, template_error, error_callback)
+        await hass.async_block_till_done()
+        assert not calls
+
+    first_time = start_time.replace(minute=2, second=0)
+    with patch("homeassistant.util.dt.utcnow", return_value=first_time):
+        async_fire_time_changed(hass, first_time)
+        await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0] == (None, None, None)
+
+
 async def test_track_template_result(hass):
     """Test tracking template."""
     specific_runs = []

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -788,7 +788,6 @@ async def test_wait_template_with_utcnow(hass):
     start_time = dt_util.utcnow() + timedelta(hours=24)
 
     try:
-        hass.states.async_set("switch.test", "on")
         hass.async_create_task(script_obj.async_run(context=Context()))
         async_fire_time_changed(hass, start_time.replace(hour=5))
         assert not script_obj.is_running

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -780,6 +780,33 @@ async def test_wait_template_variables_in(hass):
         assert not script_obj.is_running
 
 
+async def test_wait_template_with_utcnow(hass):
+    """Test the wait template with utcnow."""
+    sequence = cv.SCRIPT_SCHEMA({"wait_template": "{{ utcnow().hours == 12 }}"})
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
+    start_time = dt_util.utcnow() + timedelta(hours=24)
+
+    try:
+        hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run(context=Context()))
+        async_fire_time_changed(hass, start_time.replace(hour=5))
+        assert not script_obj.is_running
+        async_fire_time_changed(hass, start_time.replace(hour=12))
+
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+
+        assert script_obj.is_running
+    except (AssertionError, asyncio.TimeoutError):
+        await script_obj.async_stop()
+        raise
+    else:
+        async_fire_time_changed(hass, start_time.replace(hour=3))
+        await hass.async_block_till_done()
+
+        assert not script_obj.is_running
+
+
 @pytest.mark.parametrize("mode", ["no_timeout", "timeout_finish", "timeout_not_finish"])
 @pytest.mark.parametrize("action_type", ["template", "trigger"])
 async def test_wait_variables_out(hass, mode, action_type):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Script wait templates would throw an exception if they changed because of `utcnow()` or `now()`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44699
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
