### PR TITLE
Do not restore unavailable state for august locks

### DIFF
--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -11,7 +11,7 @@ from .subscriber import AugustSubscriberMixin
 _LOGGER = logging.getLogger(__name__)
 
 ACTIVITY_STREAM_FETCH_LIMIT = 10
-ACTIVITY_CATCH_UP_FETCH_LIMIT = 1000
+ACTIVITY_CATCH_UP_FETCH_LIMIT = 2500
 
 
 class ActivityStream(AugustSubscriberMixin):
@@ -102,11 +102,14 @@ class ActivityStream(AugustSubscriberMixin):
     def _process_newer_device_activities(self, activities):
         updated_device_ids = set()
         for activity in activities:
-            self._latest_activities_by_id_type.setdefault(activity.device_id, {})
+            device_id = activity.device_id
+            activity_type = activity.activity_type
 
-            lastest_activity = self._latest_activities_by_id_type[
-                activity.device_id
-            ].get(activity.activity_type)
+            self._latest_activities_by_id_type.setdefault(device_id, {})
+
+            lastest_activity = self._latest_activities_by_id_type[device_id].get(
+                activity_type
+            )
 
             # Ignore activities that are older than the latest one
             if (
@@ -115,10 +118,8 @@ class ActivityStream(AugustSubscriberMixin):
             ):
                 continue
 
-            self._latest_activities_by_id_type[activity.device_id][
-                activity.activity_type
-            ] = activity
+            self._latest_activities_by_id_type[device_id][activity_type] = activity
 
-            updated_device_ids.add(activity.device_id)
+            updated_device_ids.add(device_id)
 
         return updated_device_ids

--- a/homeassistant/components/august/sensor.py
+++ b/homeassistant/components/august/sensor.py
@@ -4,7 +4,7 @@ import logging
 from august.activity import ActivityType
 
 from homeassistant.components.sensor import DEVICE_CLASS_BATTERY
-from homeassistant.const import ATTR_ENTITY_PICTURE, PERCENTAGE
+from homeassistant.const import ATTR_ENTITY_PICTURE, PERCENTAGE, STATE_UNAVAILABLE
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_registry import async_get_registry
@@ -157,8 +157,8 @@ class AugustOperatorSensor(AugustEntityMixin, RestoreEntity, Entity):
             self._device_id, [ActivityType.LOCK_OPERATION]
         )
 
+        self._available = True
         if lock_activity is not None:
-            self._available = True
             self._state = lock_activity.operated_by
             self._operated_remote = lock_activity.operated_remote
             self._operated_keypad = lock_activity.operated_keypad
@@ -193,7 +193,7 @@ class AugustOperatorSensor(AugustEntityMixin, RestoreEntity, Entity):
         await super().async_added_to_hass()
 
         last_state = await self.async_get_last_state()
-        if not last_state:
+        if not last_state or last_state.state == STATE_UNAVAILABLE:
             return
 
         self._state = last_state.state

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -6,7 +6,6 @@ from homeassistant.const import (
     SERVICE_LOCK,
     SERVICE_UNLOCK,
     STATE_LOCKED,
-    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
@@ -98,7 +97,7 @@ async def test_one_lock_operation(hass):
     assert lock_operator_sensor
     assert (
         hass.states.get("sensor.online_with_doorsense_name_operator").state
-        == STATE_UNAVAILABLE
+        == STATE_UNKNOWN
     )
 
 

--- a/tests/components/august/test_sensor.py
+++ b/tests/components/august/test_sensor.py
@@ -1,6 +1,6 @@
 """The sensor tests for the august platform."""
 
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, STATE_UNKNOWN
 
 from tests.components.august.mocks import (
     _create_august_with_devices,
@@ -120,7 +120,7 @@ async def test_create_lock_with_low_battery_linked_keypad(hass):
     )
     assert (
         hass.states.get("sensor.a6697750d607098bae8d6baa11ef8063_name_operator").state
-        == STATE_UNAVAILABLE
+        == STATE_UNKNOWN
     )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not restore unavailable state for august locks

The state should be unknown if we do not have data, not unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
