### PR TITLE
Add option to extract single bit from a registry of modbus sensor

### DIFF
--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -60,6 +60,7 @@ DEFAULT_STRUCT_FORMAT = {
     DATA_TYPE_UINT: {1: "H", 2: "I", 4: "Q"},
     DATA_TYPE_FLOAT: {1: "e", 2: "f", 4: "d"},
 }
+CONF_BIT = "bit"
 
 # switch.py
 CONF_STATE_OFF = "state_off"

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -39,6 +39,7 @@ from .const import (
     DEFAULT_HUB,
     DEFAULT_STRUCT_FORMAT,
     MODBUS_DOMAIN,
+    CONF_BIT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,7 +63,6 @@ def number(value: Any) -> Union[int, float]:
     except (TypeError, ValueError) as err:
         raise vol.Invalid(f"invalid number {value}") from err
 
-CONF_BIT = "bit"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -180,7 +180,7 @@ class ModbusRegisterSensor(RestoreEntity):
         precision,
         data_type,
         device_class,
-        bit,        
+        bit,
     ):
         """Initialize the modbus register sensor."""
         self._hub = hub
@@ -260,13 +260,13 @@ class ModbusRegisterSensor(RestoreEntity):
 
         if self._bit:
             bytes_as_bits = ''.join(format(byte, '08b') for byte in byte_string)
-            #Position is between 0 and len -1
-            position = len(bytes_as_bits) -1 -self._bit
+            # Position is between 0 and len -1
+            position = len(bytes_as_bits) - 1 - self._bit
             val = bytes_as_bits[position]
-            _LOGGER.error("Bit at position %s is: %s", self._bit,val)
+            _LOGGER.error("Bit at position %s is: %s", self._bit, val)
             self._value = str(val)
 
-        else:        
+        else:
             if self._data_type == DATA_TYPE_STRING:
                 self._value = byte_string.decode()
             else:

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -199,7 +199,7 @@ class ModbusRegisterSensor(RestoreEntity):
         self._device_class = device_class
         self._value = None
         self._available = True
-        self._bit = bit        
+        self._bit = bit
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -259,7 +259,7 @@ class ModbusRegisterSensor(RestoreEntity):
         byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
 
         if self._bit:
-            bytes_as_bits = ''.join(format(byte, '08b') for byte in byte_string)
+            bytes_as_bits = "".join(format(byte, '08b') for byte in byte_string)
             # Position is between 0 and len -1
             position = len(bytes_as_bits) - 1 - self._bit
             val = bytes_as_bits[position]

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -62,8 +62,6 @@ def number(value: Any) -> Union[int, float]:
     except (TypeError, ValueError) as err:
         raise vol.Invalid(f"invalid number {value}") from err
 
-
-""" Add bit option for single bit extraction from registry """
 CONF_BIT = "bit"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -64,7 +64,7 @@ def number(value: Any) -> Union[int, float]:
 
 
 """ Add bit option for single bit extraction from registry """
-CONF_BIT = 'bit'
+CONF_BIT = "bit"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .const import (
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_REGISTER_INPUT,
+    CONF_BIT,
     CONF_COUNT,
     CONF_DATA_TYPE,
     CONF_HUB,
@@ -39,7 +40,6 @@ from .const import (
     DEFAULT_HUB,
     DEFAULT_STRUCT_FORMAT,
     MODBUS_DOMAIN,
-    CONF_BIT,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -62,6 +62,7 @@ def number(value: Any) -> Union[int, float]:
     except (TypeError, ValueError) as err:
         raise vol.Invalid(f"invalid number {value}") from err
 
+
 """ Add bit option for single bit extraction from registry """
 CONF_BIT = 'bit'
 
@@ -98,8 +99,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         ]
     }
 )
-
-
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -181,7 +180,7 @@ class ModbusRegisterSensor(RestoreEntity):
         precision,
         data_type,
         device_class,
-        bit,
+        bit,        
     ):
         """Initialize the modbus register sensor."""
         self._hub = hub
@@ -200,7 +199,7 @@ class ModbusRegisterSensor(RestoreEntity):
         self._device_class = device_class
         self._value = None
         self._available = True
-        self._bit = bit
+        self._bit = bit        
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -258,8 +257,7 @@ class ModbusRegisterSensor(RestoreEntity):
             registers.reverse()
 
         byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
-        
-        
+
         if self._bit:
             bytes_as_bits = ''.join(format(byte, '08b') for byte in byte_string)
             #Position is between 0 and len -1
@@ -268,7 +266,7 @@ class ModbusRegisterSensor(RestoreEntity):
             _LOGGER.error("Bit at position %s is: %s", self._bit,val)
             self._value = str(val)
 
-        else:
+        else:        
             if self._data_type == DATA_TYPE_STRING:
                 self._value = byte_string.decode()
             else:

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -259,7 +259,7 @@ class ModbusRegisterSensor(RestoreEntity):
         byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
 
         if self._bit:
-            bytes_as_bits = "".join(format(byte, '08b') for byte in byte_string)
+            bytes_as_bits = "".join(format(byte, "08b") for byte in byte_string)
             # Position is between 0 and len -1
             position = len(bytes_as_bits) - 1 - self._bit
             val = bytes_as_bits[position]

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -262,17 +262,6 @@ class ModbusRegisterSwitch(ModbusBaseSwitch, SwitchEntity):
 
         return int(result.registers[0])
 
-    # def _write_register(self, value):
-        # """Write holding register using the Modbus hub slave."""
-        # try:
-            # self._hub.write_registers(self._slave, self._register, value)
-        # except ConnectionException:
-            # self._available = False
-            # return
-
-        # self._available = True
-
-
     def _write_register(self, value):
         """Write holding register using the Modbus hub slave."""
         try:
@@ -281,7 +270,7 @@ class ModbusRegisterSwitch(ModbusBaseSwitch, SwitchEntity):
                     self._slave, self._register, [int(float(i)) for i in value]
                 )
             else:          
-                self._hub.write_register(self._slave, self._register, value)                   
+                self._hub.write_register(self._slave, self._register, value)
         except ConnectionException:
             self._available = False
             return

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -269,7 +269,7 @@ class ModbusRegisterSwitch(ModbusBaseSwitch, SwitchEntity):
                 self._hub.write_registers(
                     self._slave, self._register, [int(float(i)) for i in value]
                 )
-            else:          
+            else:
                 self._hub.write_register(self._slave, self._register, value)
         except ConnectionException:
             self._available = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
-->
This PR improves parsing of input data in Modbus Sensor adding the possibility to extract a single bit from modbus register adding a bit option on configuration.yaml
See bellow an example to extract bit 1 from register 12
![image](https://user-images.githubusercontent.com/7046065/103440926-15163580-4c4a-11eb-872c-c8f220963db5.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: modbus
    - name: Modbus Registry Bit 1 Extraction
      slave: 11
      register: 12
      bit: 1
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: It will be necessary to update the documentation

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
