### PR TITLE
Propose an integration quality for nest SDM integration

### DIFF
--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -12,5 +12,5 @@
       "@awarecan",
       "@allenporter"
   ],
-  "quality_scale": "silver"
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -11,5 +11,6 @@
   "codeowners": [
       "@awarecan",
       "@allenporter"
-  ]
+  ],
+  "quality_scale": "silver"
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Would like an audit of the appropriate integration quality scale for Nest SDM integration, or identify gaps and potential improvements.  This PR proposes `silver` however meets nearly all of the criteria of higher levels.

See http://bit.ly/2LD9eDO for the "roadmap" for this integration.

**Silver**

- Connection/configuration is handled via a component.
  - :heavy_check_mark:
- Set an appropriate `SCAN_INTERVAL` (if a polling integration)
  - :heavy_check_mark: Integration uses a Pub/sub subscriber to receive updates
- Raise `PlatformNotReady` if unable to connect during platform setup (if appropriate)
  -  :heavy_check_mark: https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/sensor_sdm.py#L41-L45
  - :heavy_check_mark: https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/climate_sdm.py#L84-L87
  - :heavy_check_mark: https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/camera_sdm.py#L35-L38
- Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.  ([docs](config_entries_config_flow_handler.md#reauthentication))
    - :heavy_check_mark: https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/api.py#L35
    - :heavy_check_mark:  Triggers Reauth flow  if tokens are unable to be refreshed: https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/__init__.py#L166-L176
- Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
    - Uses a pub/sub subscriber which queues update messages until the are ACK'd, then redelivers once connected.
    -  :heavy_check_mark: Logs an error once on startup when subscriber or device API is unavailable https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/__init__.py#L184 
- Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
    -  Does not do anything special if issuing commands to the cloud service fails, and may end up with a stack trace in logs.
- Set `available` property to `False` if appropriate ([docs](core/entity.md#generic-properties))
  - :information_source: N/A
- Entities have unique ID (if available) ([docs](entity_registry_index.md#unique-id-requirements))
  - :information_source: N/A


**Gold**

- Configurable via config entries.
  - Don't allow configuring already configured device/service (example: no 2 entries for same hub)
      - :heavy_check_mark:  https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/config_flow.py#L155
  - Tests for the config flow
    -  :heavy_check_mark: Entire integration has >96% test coverage
  - Discoverable (if available)
      -  :information_source: N/A
  - Set unique ID in config flow (if available)
    - ✔️ [config_flow](https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/config_flow.py#L114)
- Entities have device info (if available) ([docs](device_registry_index.md#defining-devices))
  - ✔️ All entities use [device_info](https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/device_info.py#L26) to populate their `device_info`
- Tests for fetching data from the integration and controlling it ([docs](development_testing.md))
  -  :heavy_check_mark: Entire integration has >96% test coverage [coveragerc](https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/.coveragerc#L583)
- Has a code owner ([docs](creating_integration_manifest.md#code-owners))
  - :heavy_check_mark: 
- Entities only subscribe to updates inside `async_added_to_hass` and unsubscribe inside `async_will_remove_from_hass` ([docs](core/entity.md#lifecycle-hooks))
  - :heavy_check_mark:  And entities use `async_on_remove` to unsubscribe
- Entities have correct device classes where appropriate ([docs](core/entity.md#generic-properties))
    - :heavy_check_mark: [temperature](https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/sensor_sdm.py#L109)
    - :heavy_check_mark: [humidity](https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/sensor_sdm.py#L140)
    - :heavy_check_mark: [camera](https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/camera_sdm.py#L52) and [climate](https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/climate_sdm.py#L96) inherit from the appropriate entity which handles this
- Supports entities being disabled and leverages `Entity.entity_registry_enabled_default` to disable less popular entities ([docs](core/entity.md#advanced-properties))
  - :question: Not doing anything special here.  Seems to support disabling in the UI, but unclear.  All entities registered by default.
- If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.
    -  :information_source: N/A

Caveats: UI based config flow needs an architecture issue to discuss.  Existing config flow was rejected https://github.com/home-assistant/core/pull/44529 due to lack of account linking support, which isn't compatible with Nest Device Access Program

**Platinum**

- Set appropriate `PARALLEL_UPDATES` constant
    -  :question: Haven't looked into PARALLEL_UPDATES yet
- Support config entry unloading (called when config entry is removed)
    - :heavy_check_mark: https://github.com/home-assistant/core/blob/a6e474c7c9027568ab21d0b82bfbc0b964efd69e/homeassistant/components/nest/__init__.py#L209
- Integration + dependency are async
  -  :heavy_check_mark: All google-nest-sdm is fully async
- Uses aiohttp and allows passing in websession (if making HTTP requests)
  -  :heavy_check_mark: [RPCs to SDM API](https://github.com/allenporter/python-google-nest-sdm/blob/349619450e1fa4ac2de8ae0be282b0778e8365b0/google_nest_sdm/auth.py#L51) are done using aiohttp 
  - ❓ : Google Pub/sub subscriber streaming RPCs are not using aiohttp / websession (yet) however they have a streaming API in progress.  All work happens in a background thread and communication in/out is async.


**Other Caveats**

- Stream urls expire, which is [not really supported very well]https://github.com/home-assistant/core/issues/42793 (pending Architecture Issue that I need to file to discuss)
- [Integration setup is a huge pain](https://www.home-assistant.io/integrations/nest/#device-access-registration) requiring literally over 40 steps

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
