### PR TITLE
Add index to old_state_id column for postgres and older databases

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -313,6 +313,9 @@ def _apply_update(engine, new_version, old_version):
         _drop_index(engine, "events", "ix_events_event_type")
     elif new_version == 10:
         _update_states_table_with_foreign_key_options(engine)
+    elif new_version == 11:
+        _create_index(engine, "states", "ix_states_old_state_id")
+
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -211,7 +211,13 @@ def _update_states_table_with_foreign_key_options(engine):
     inspector = reflection.Inspector.from_engine(engine)
     alters = []
     for foreign_key in inspector.get_foreign_keys(TABLE_STATES):
-        if foreign_key["name"] and not foreign_key["options"]:
+        if foreign_key["name"] and (
+            # MySQL/MariaDB will have empty options
+            not foreign_key["options"]
+            or
+            # Postgres will have ondelete set to None
+            foreign_key["options"].get("ondelete") is None
+        ):
             alters.append(
                 {
                     "old_fk": ForeignKeyConstraint((), (), name=foreign_key["name"]),
@@ -312,8 +318,10 @@ def _apply_update(engine, new_version, old_version):
         _create_index(engine, "events", "ix_events_event_type_time_fired")
         _drop_index(engine, "events", "ix_events_event_type")
     elif new_version == 10:
-        _update_states_table_with_foreign_key_options(engine)
+        # Now done in step 11
+        pass
     elif new_version == 11:
+        _update_states_table_with_foreign_key_options(engine)
         _create_index(engine, "states", "ix_states_old_state_id")
 
     else:

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -321,9 +321,8 @@ def _apply_update(engine, new_version, old_version):
         # Now done in step 11
         pass
     elif new_version == 11:
-        _update_states_table_with_foreign_key_options(engine)
         _create_index(engine, "states", "ix_states_old_state_id")
-
+        _update_states_table_with_foreign_key_options(engine)
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -25,7 +25,7 @@ import homeassistant.util.dt as dt_util
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The schema was updated in #43610 but the index for
`old_state_id` was not added on migration.

sqlalchemy's abstraction is a bit different for
postgres and mysql:

postgres reports a `dict` of keys set to `None` when
there are no actions for the FK.  mysql reports an empty
`dict`.  This change accommodates postgres to ensure
it gets the `ondelete` actions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44736
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
