### PR TITLE
Update the Utility Meter sensor status on HA start

### DIFF
--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -169,7 +169,11 @@ class UtilityMeterSensor(RestoreEntity):
         new_state = event.data.get("new_state")
         if new_state is None:
             return
-        if self._tariff == new_state.state:
+
+        self._change_status(new_state.state)
+
+    def _change_status(self, tariff):
+        if self._tariff == tariff:
             self._collecting = async_track_state_change_event(
                 self.hass, [self._sensor_source_id], self.async_reading
             )
@@ -271,24 +275,26 @@ class UtilityMeterSensor(RestoreEntity):
             self._last_reset = dt_util.parse_datetime(
                 state.attributes.get(ATTR_LAST_RESET)
             )
-            if state.attributes.get(ATTR_STATUS) == PAUSED:
-                # Fake cancellation function to init the meter paused
+            if state.attributes.get(ATTR_STATUS) == COLLECTING:
+                # Fake cancellation function to init the meter in similar state
                 self._collecting = lambda: None
 
         @callback
         def async_source_tracking(event):
             """Wait for source to be ready, then start meter."""
             if self._tariff_entity is not None:
-                _LOGGER.debug("Track %s", self._tariff_entity)
+                _LOGGER.debug(
+                    "<%s> tracks utility meter %s", self.name, self._tariff_entity
+                )
                 async_track_state_change_event(
                     self.hass, [self._tariff_entity], self.async_tariff_change
                 )
 
                 tariff_entity_state = self.hass.states.get(self._tariff_entity)
-                if self._tariff != tariff_entity_state.state:
-                    return
+                self._change_status(tariff_entity_state.state)
+                return
 
-            _LOGGER.debug("tracking source: %s", self._sensor_source_id)
+            _LOGGER.debug("<%s> collecting from %s", self.name, self._sensor_source_id)
             self._collecting = async_track_state_change_event(
                 self.hass, [self._sensor_source_id], self.async_reading
             )

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -298,7 +298,6 @@ class UtilityMeterSensor(RestoreEntity):
             self._collecting = async_track_state_change_event(
                 self.hass, [self._sensor_source_id], self.async_reading
             )
-            self.async_write_ha_state()
 
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_START, async_source_tracking

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -271,7 +271,6 @@ class UtilityMeterSensor(RestoreEntity):
             self._last_reset = dt_util.parse_datetime(
                 state.attributes.get(ATTR_LAST_RESET)
             )
-            self.async_write_ha_state()
             if state.attributes.get(ATTR_STATUS) == PAUSED:
                 # Fake cancellation function to init the meter paused
                 self._collecting = lambda: None
@@ -293,6 +292,7 @@ class UtilityMeterSensor(RestoreEntity):
             self._collecting = async_track_state_change_event(
                 self.hass, [self._sensor_source_id], self.async_reading
             )
+            self.async_write_ha_state()
 
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_START, async_source_tracking

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -27,7 +27,6 @@ from homeassistant.core import State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.async_mock import patch
 from tests.common import async_fire_time_changed, mock_restore_cache
 
 

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -55,6 +55,21 @@ async def test_state(hass):
     )
     await hass.async_block_till_done()
 
+    state = hass.states.get("sensor.energy_bill_onpeak")
+    assert state is not None
+    assert state.state == "0"
+    assert state.attributes.get("status") == "collecting"
+
+    state = hass.states.get("sensor.energy_bill_midpeak")
+    assert state is not None
+    assert state.state == "0"
+    assert state.attributes.get("status") == "paused"
+
+    state = hass.states.get("sensor.energy_bill_offpeak")
+    assert state is not None
+    assert state.state == "0"
+    assert state.attributes.get("status") == "paused"
+
     now = dt_util.utcnow() + timedelta(seconds=10)
     with patch("homeassistant.util.dt.utcnow", return_value=now):
         hass.states.async_set(
@@ -68,14 +83,17 @@ async def test_state(hass):
     state = hass.states.get("sensor.energy_bill_onpeak")
     assert state is not None
     assert state.state == "1"
+    assert state.attributes.get("status") == "collecting"
 
     state = hass.states.get("sensor.energy_bill_midpeak")
     assert state is not None
     assert state.state == "0"
+    assert state.attributes.get("status") == "paused"
 
     state = hass.states.get("sensor.energy_bill_offpeak")
     assert state is not None
     assert state.state == "0"
+    assert state.attributes.get("status") == "paused"
 
     await hass.services.async_call(
         DOMAIN,
@@ -99,14 +117,17 @@ async def test_state(hass):
     state = hass.states.get("sensor.energy_bill_onpeak")
     assert state is not None
     assert state.state == "1"
+    assert state.attributes.get("status") == "paused"
 
     state = hass.states.get("sensor.energy_bill_midpeak")
     assert state is not None
     assert state.state == "0"
+    assert state.attributes.get("status") == "paused"
 
     state = hass.states.get("sensor.energy_bill_offpeak")
     assert state is not None
     assert state.state == "3"
+    assert state.attributes.get("status") == "collecting"
 
     await hass.services.async_call(
         DOMAIN,

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -11,16 +11,24 @@ from homeassistant.components.utility_meter.const import (
     SERVICE_CALIBRATE_METER,
     SERVICE_SELECT_TARIFF,
 )
+from homeassistant.components.utility_meter.sensor import (
+    ATTR_LAST_RESET,
+    ATTR_STATUS,
+    COLLECTING,
+    PAUSED,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
     ENERGY_KILO_WATT_HOUR,
     EVENT_HOMEASSISTANT_START,
 )
+from homeassistant.core import State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.async_mock import patch
+from tests.common import async_fire_time_changed, mock_restore_cache
 
 
 @contextmanager
@@ -58,17 +66,17 @@ async def test_state(hass):
     state = hass.states.get("sensor.energy_bill_onpeak")
     assert state is not None
     assert state.state == "0"
-    assert state.attributes.get("status") == "collecting"
+    assert state.attributes.get("status") == COLLECTING
 
     state = hass.states.get("sensor.energy_bill_midpeak")
     assert state is not None
     assert state.state == "0"
-    assert state.attributes.get("status") == "paused"
+    assert state.attributes.get("status") == PAUSED
 
     state = hass.states.get("sensor.energy_bill_offpeak")
     assert state is not None
     assert state.state == "0"
-    assert state.attributes.get("status") == "paused"
+    assert state.attributes.get("status") == PAUSED
 
     now = dt_util.utcnow() + timedelta(seconds=10)
     with patch("homeassistant.util.dt.utcnow", return_value=now):
@@ -83,17 +91,17 @@ async def test_state(hass):
     state = hass.states.get("sensor.energy_bill_onpeak")
     assert state is not None
     assert state.state == "1"
-    assert state.attributes.get("status") == "collecting"
+    assert state.attributes.get("status") == COLLECTING
 
     state = hass.states.get("sensor.energy_bill_midpeak")
     assert state is not None
     assert state.state == "0"
-    assert state.attributes.get("status") == "paused"
+    assert state.attributes.get("status") == PAUSED
 
     state = hass.states.get("sensor.energy_bill_offpeak")
     assert state is not None
     assert state.state == "0"
-    assert state.attributes.get("status") == "paused"
+    assert state.attributes.get("status") == PAUSED
 
     await hass.services.async_call(
         DOMAIN,
@@ -117,17 +125,17 @@ async def test_state(hass):
     state = hass.states.get("sensor.energy_bill_onpeak")
     assert state is not None
     assert state.state == "1"
-    assert state.attributes.get("status") == "paused"
+    assert state.attributes.get("status") == PAUSED
 
     state = hass.states.get("sensor.energy_bill_midpeak")
     assert state is not None
     assert state.state == "0"
-    assert state.attributes.get("status") == "paused"
+    assert state.attributes.get("status") == PAUSED
 
     state = hass.states.get("sensor.energy_bill_offpeak")
     assert state is not None
     assert state.state == "3"
-    assert state.attributes.get("status") == "collecting"
+    assert state.attributes.get("status") == COLLECTING
 
     await hass.services.async_call(
         DOMAIN,
@@ -150,6 +158,65 @@ async def test_state(hass):
     state = hass.states.get("sensor.energy_bill_midpeak")
     assert state is not None
     assert state.state == "0.123"
+
+
+async def test_restore_state(hass):
+    """Test utility sensor restore state."""
+    config = {
+        "utility_meter": {
+            "energy_bill": {
+                "source": "sensor.energy",
+                "tariffs": ["onpeak", "midpeak", "offpeak"],
+            }
+        }
+    }
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                "sensor.energy_bill_onpeak",
+                "3",
+                attributes={
+                    ATTR_STATUS: PAUSED,
+                    ATTR_LAST_RESET: "2020-12-21T00:00:00.013073+00:00",
+                },
+            ),
+            State(
+                "sensor.energy_bill_offpeak",
+                "6",
+                attributes={
+                    ATTR_STATUS: COLLECTING,
+                    ATTR_LAST_RESET: "2020-12-21T00:00:00.013073+00:00",
+                },
+            ),
+        ],
+    )
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, SENSOR_DOMAIN, config)
+    await hass.async_block_till_done()
+
+    # restore from cache
+    state = hass.states.get("sensor.energy_bill_onpeak")
+    assert state.state == "3"
+    assert state.attributes.get("status") == PAUSED
+
+    state = hass.states.get("sensor.energy_bill_offpeak")
+    assert state.state == "6"
+    assert state.attributes.get("status") == COLLECTING
+
+    # utility_meter is loaded, now set sensors according to utility_meter:
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("utility_meter.energy_bill")
+    assert state.state == "onpeak"
+
+    state = hass.states.get("sensor.energy_bill_onpeak")
+    assert state.attributes.get("status") == COLLECTING
+
+    state = hass.states.get("sensor.energy_bill_offpeak")
+    assert state.attributes.get("status") == PAUSED
 
 
 async def test_net_consumption(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
On HA start all utility meters would show `status == "paused"` until first tariff change. This fixes that issue
Furthermore it increases test coverage and better debug information

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
