### PR TITLE
Try to fix flaky Risco test

### DIFF
--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -60,10 +60,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         EVENTS_COORDINATOR: events_coordinator,
     }
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
+    async def start_platforms():
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_setup(entry, component)
+                for component in PLATFORMS
+            ]
         )
+        await events_coordinator.async_refresh()
+
+    hass.async_create_task(start_platforms())
 
     return True
 

--- a/homeassistant/components/risco/sensor.py
+++ b/homeassistant/components/risco/sensor.py
@@ -73,7 +73,6 @@ class RiscoSensor(CoordinatorEntity):
         self.async_on_remove(
             self.coordinator.async_add_listener(self._refresh_from_coordinator)
         )
-        await self.coordinator.async_request_refresh()
 
     def _refresh_from_coordinator(self):
         events = self.coordinator.data

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -167,7 +167,7 @@ async def _check_state(hass, alarm, property, state, entity_id, partition_id):
 
 async def test_states(hass, two_part_alarm):
     """Test the various alarm states."""
-    await setup_risco(hass, CUSTOM_MAPPING_OPTIONS)
+    await setup_risco(hass, [], CUSTOM_MAPPING_OPTIONS)
 
     assert hass.states.get(FIRST_ENTITY_ID).state == STATE_UNKNOWN
     for partition_id, entity_id in {0: FIRST_ENTITY_ID, 1: SECOND_ENTITY_ID}.items():
@@ -249,7 +249,7 @@ async def _call_alarm_service(hass, service, entity_id, **kwargs):
 
 async def test_sets_custom_mapping(hass, two_part_alarm):
     """Test settings the various modes when mapping some states."""
-    await setup_risco(hass, CUSTOM_MAPPING_OPTIONS)
+    await setup_risco(hass, [], CUSTOM_MAPPING_OPTIONS)
 
     registry = await hass.helpers.entity_registry.async_get_registry()
     entity = registry.async_get(FIRST_ENTITY_ID)
@@ -275,7 +275,7 @@ async def test_sets_custom_mapping(hass, two_part_alarm):
 
 async def test_sets_full_custom_mapping(hass, two_part_alarm):
     """Test settings the various modes when mapping all states."""
-    await setup_risco(hass, FULL_CUSTOM_MAPPING)
+    await setup_risco(hass, [], FULL_CUSTOM_MAPPING)
 
     registry = await hass.helpers.entity_registry.async_get_registry()
     entity = registry.async_get(FIRST_ENTITY_ID)
@@ -309,7 +309,7 @@ async def test_sets_full_custom_mapping(hass, two_part_alarm):
 
 async def test_sets_with_correct_code(hass, two_part_alarm):
     """Test settings the various modes when code is required."""
-    await setup_risco(hass, {**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS})
+    await setup_risco(hass, [], {**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS})
 
     code = {"code": 1234}
     await _test_service_call(
@@ -351,7 +351,7 @@ async def test_sets_with_correct_code(hass, two_part_alarm):
 
 async def test_sets_with_incorrect_code(hass, two_part_alarm):
     """Test settings the various modes when code is required and incorrect."""
-    await setup_risco(hass, {**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS})
+    await setup_risco(hass, [], {**CUSTOM_MAPPING_OPTIONS, **CODES_REQUIRED_OPTIONS})
 
     code = {"code": 4321}
     await _test_no_service_call(

--- a/tests/components/risco/test_sensor.py
+++ b/tests/components/risco/test_sensor.py
@@ -172,22 +172,15 @@ async def test_setup(hass, two_zone_alarm):  # noqa: F811
     for id in ENTITY_IDS.values():
         assert not registry.async_is_registered(id)
 
-    await setup_risco(hass)
-    await hass.async_block_till_done()
-    for id in ENTITY_IDS.values():
-        assert registry.async_is_registered(id)
-
     with patch(
-        "homeassistant.components.risco.RiscoAPI.get_events",
-        return_value=TEST_EVENTS,
-    ), patch(
         "homeassistant.components.risco.RiscoAPI.site_uuid",
         new_callable=PropertyMock(return_value=TEST_SITE_UUID),
     ), patch(
         "homeassistant.components.risco.Store.async_save",
     ) as save_mock:
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=65))
-        await hass.async_block_till_done()
+        await setup_risco(hass, TEST_EVENTS)
+        for id in ENTITY_IDS.values():
+            assert registry.async_is_registered(id)
 
         save_mock.assert_awaited_once_with(
             {LAST_EVENT_TIMESTAMP_KEY: TEST_EVENTS[0].time}

--- a/tests/components/risco/util.py
+++ b/tests/components/risco/util.py
@@ -17,7 +17,7 @@ TEST_SITE_UUID = "test-site-uuid"
 TEST_SITE_NAME = "test-site-name"
 
 
-async def setup_risco(hass, options={}):
+async def setup_risco(hass, events=[], options={}):
     """Set up a Risco integration for testing."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=TEST_CONFIG, options=options)
     config_entry.add_to_hass(hass)
@@ -33,6 +33,9 @@ async def setup_risco(hass, options={}):
         new_callable=PropertyMock(return_value=TEST_SITE_NAME),
     ), patch(
         "homeassistant.components.risco.RiscoAPI.close"
+    ), patch(
+        "homeassistant.components.risco.RiscoAPI.get_events",
+        return_value=events,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There's a Risco sensor test that's dependent on the binary sensor platform being loaded. This attempts to always make it pass.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests
## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44784
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
