### PR TITLE
Cleanup timeouts values for Shelly

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.helpers import (
 )
 
 from .const import (
+    AIOSHELLY_DEVICE_TIMEOUT_SEC,
     BATTERY_DEVICES_WITH_PERMANENT_CONNECTION,
     COAP,
     DATA_CONFIG_ENTRY,
@@ -32,7 +33,6 @@ from .const import (
     POLLING_TIMEOUT_MULTIPLIER,
     REST,
     REST_SENSORS_UPDATE_INTERVAL,
-    SETUP_ENTRY_TIMEOUT_SEC,
     SLEEP_PERIOD_MULTIPLIER,
     UPDATE_PERIOD_MULTIPLIER,
 )
@@ -79,7 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     coap_context = await get_coap_context(hass)
 
     try:
-        async with async_timeout.timeout(SETUP_ENTRY_TIMEOUT_SEC):
+        async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
             device = await aioshelly.Device.create(
                 aiohttp_client.async_get_clientsession(hass),
                 coap_context,
@@ -263,7 +263,7 @@ class ShellyDeviceRestWrapper(update_coordinator.DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch data."""
         try:
-            async with async_timeout.timeout(5):
+            async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
                 _LOGGER.debug("REST update for %s", self.name)
                 return await self.device.update_status()
         except OSError as err:

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -18,7 +18,8 @@ from homeassistant.const import (
 from homeassistant.helpers import aiohttp_client
 
 from . import get_coap_context
-from .const import AIOSHELLY_DEVICE_TIMEOUT_SEC, DOMAIN  # pylint:disable=unused-import
+from .const import AIOSHELLY_DEVICE_TIMEOUT_SEC
+from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.helpers import aiohttp_client
 
 from . import get_coap_context
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import AIOSHELLY_DEVICE_TIMEOUT_SEC, DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ async def validate_input(hass: core.HomeAssistant, host, data):
     )
     coap_context = await get_coap_context(hass)
 
-    async with async_timeout.timeout(5):
+    async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
         device = await aioshelly.Device.create(
             aiohttp_client.async_get_clientsession(hass),
             coap_context,
@@ -187,7 +187,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_get_info(self, host):
         """Get info from shelly device."""
-        async with async_timeout.timeout(5):
+        async with async_timeout.timeout(AIOSHELLY_DEVICE_TIMEOUT_SEC):
             return await aioshelly.get_info(
                 aiohttp_client.async_get_clientsession(self.hass),
                 host,

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -11,8 +11,8 @@ POLLING_TIMEOUT_MULTIPLIER = 1.2
 # Refresh interval for REST sensors
 REST_SENSORS_UPDATE_INTERVAL = 60
 
-# Timeout used for initial entry setup in "async_setup_entry".
-SETUP_ENTRY_TIMEOUT_SEC = 10
+# Timeout used for aioshelly calls
+AIOSHELLY_DEVICE_TIMEOUT_SEC = 10
 
 # Multiplier used to calculate the "update_interval" for sleeping devices.
 SLEEP_PERIOD_MULTIPLIER = 1.2

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -53,7 +53,7 @@ async def test_form(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -68,7 +68,7 @@ async def test_title_without_name(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
 
     settings = MOCK_SETTINGS.copy()
@@ -97,7 +97,7 @@ async def test_title_without_name(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "shelly1pm-12345"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -111,7 +111,7 @@ async def test_form_auth(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
 
     with patch(
@@ -123,7 +123,7 @@ async def test_form_auth(hass):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
 
     with patch(
@@ -145,7 +145,7 @@ async def test_form_auth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == "create_entry"
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result3["title"] == "Test name"
     assert result3["data"] == {
         "host": "1.1.1.1",
@@ -172,7 +172,7 @@ async def test_form_errors_get_info(hass, error):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["errors"] == {"base": base_error}
 
 
@@ -194,7 +194,7 @@ async def test_form_errors_test_connection(hass, error):
             {"host": "1.1.1.1"},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["errors"] == {"base": base_error}
 
 
@@ -219,7 +219,7 @@ async def test_form_already_configured(hass):
             {"host": "1.1.1.1"},
         )
 
-        assert result2["type"] == "abort"
+        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result2["reason"] == "already_configured"
 
     # Test config entry got updated with latest IP
@@ -241,16 +241,28 @@ async def test_user_setup_ignored_device(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
+    settings = MOCK_SETTINGS.copy()
+    settings["device"]["type"] = "SHSW-1"
+    settings["fw"] = "20201124-092534/v1.9.0@57ac4ad8"
+
     with patch(
         "aioshelly.get_info",
         return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
+    ), patch(
+        "aioshelly.Device.create",
+        new=AsyncMock(
+            return_value=Mock(
+                settings=settings,
+            )
+        ),
     ):
+
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1"},
         )
 
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     # Test config entry got updated with latest IP
     assert entry.data["host"] == "1.1.1.1"
@@ -268,7 +280,7 @@ async def test_form_firmware_unsupported(hass):
             {"host": "1.1.1.1"},
         )
 
-        assert result2["type"] == "abort"
+        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result2["reason"] == "unsupported_firmware"
 
 
@@ -302,7 +314,7 @@ async def test_form_auth_errors_test_connection(hass, error):
             result2["flow_id"],
             {"username": "test username", "password": "test password"},
         )
-    assert result3["type"] == "form"
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result3["errors"] == {"base": base_error}
 
 
@@ -319,7 +331,7 @@ async def test_zeroconf(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == "form"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {}
         context = next(
             flow["context"]
@@ -346,7 +358,7 @@ async def test_zeroconf(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "Test name"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -372,7 +384,7 @@ async def test_zeroconf_confirm_error(hass, error):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == "form"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {}
 
     with patch(
@@ -384,7 +396,7 @@ async def test_zeroconf_confirm_error(hass, error):
             {},
         )
 
-    assert result2["type"] == "form"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["errors"] == {"base": base_error}
 
 
@@ -405,7 +417,7 @@ async def test_zeroconf_already_configured(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == "abort"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
 
     # Test config entry got updated with latest IP
@@ -421,7 +433,7 @@ async def test_zeroconf_firmware_unsupported(hass):
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
 
-        assert result["type"] == "abort"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "unsupported_firmware"
 
 
@@ -433,7 +445,7 @@ async def test_zeroconf_cannot_connect(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == "abort"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -450,14 +462,14 @@ async def test_zeroconf_require_auth(hass):
             data=DISCOVERY_INFO,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
-        assert result["type"] == "form"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {},
     )
-    assert result2["type"] == "form"
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["errors"] == {}
 
     with patch(
@@ -479,7 +491,7 @@ async def test_zeroconf_require_auth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == "create_entry"
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result3["title"] == "Test name"
     assert result3["data"] == {
         "host": "1.1.1.1",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Timeouts are in part hardcoded and in part not. Also the value itself is not consistent trough the integration.
This PR will resolve both.

N.B. I though about adding a new timeout variable to differentiate between device create and get info from device, but finally went for a single value as get info needs 10 sec as well in some cases.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
