### PR TITLE
Roon media player: Add discovery - and improve play_media

### DIFF
--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 
-from roonapi import RoonApi
+from roonapi import RoonApi, RoonDiscovery
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
@@ -10,6 +10,7 @@ from homeassistant.const import CONF_API_KEY, CONF_HOST
 
 from .const import (  # pylint: disable=unused-import
     AUTHENTICATE_TIMEOUT,
+    CONF_ROON_ID,
     DEFAULT_NAME,
     DOMAIN,
     ROON_APPINFO,
@@ -25,36 +26,64 @@ TIMEOUT = 120
 class RoonHub:
     """Interact with roon during config flow."""
 
-    def __init__(self, host):
-        """Initialize."""
-        self._host = host
+    def discover(self):
+        """Try and discover roon servers."""
+        discovery = RoonDiscovery(None)
+        servers = discovery.all()
+        _LOGGER.debug("Servers = %s", servers)
+        discovery.stop()
+        return servers
 
-    async def authenticate(self, hass) -> bool:
-        """Test if we can authenticate with the host."""
+    async def authenticate(self, hass, host, servers):
+        """Authenticate with one or more roon servers."""
         token = None
+        core_id = None
         secs = 0
-        roonapi = RoonApi(ROON_APPINFO, None, self._host, blocking_init=False)
+        if host is None:
+            apis = [
+                RoonApi(ROON_APPINFO, None, server[0], server[1], blocking_init=False)
+                for server in servers
+            ]
+        else:
+            apis = [RoonApi(ROON_APPINFO, None, host, blocking_init=False)]
+
         while secs < TIMEOUT:
-            token = roonapi.token
+            # Roon can discover multiple devices - not all of which are proper servers, so try and authenticate with them all.
+            # The user will only enable one - so look for a valid token
+            auth_api = [api for api in apis if api.token is not None]
+
             secs += AUTHENTICATE_TIMEOUT
-            if token:
+            if len(auth_api) > 0:
+                core_id = auth_api[0].core_id
+                token = auth_api[0].token
                 break
+
             await asyncio.sleep(AUTHENTICATE_TIMEOUT)
 
-        token = roonapi.token
-        roonapi.stop()
-        return token
+        for api in apis:
+            api.stop()
+
+        return (token, core_id)
 
 
-async def authenticate(hass: core.HomeAssistant, host):
+async def discover():
     """Connect and authenticate home assistant."""
 
-    hub = RoonHub(host)
-    token = await hub.authenticate(hass)
+    hub = RoonHub()
+    servers = hub.discover()
+
+    return servers
+
+
+async def authenticate(hass: core.HomeAssistant, host, servers):
+    """Connect and authenticate home assistant."""
+
+    hub = RoonHub()
+    (token, core_id) = await hub.authenticate(hass, host, servers)
     if token is None:
         raise InvalidAuth
 
-    return {CONF_HOST: host, CONF_API_KEY: token}
+    return {CONF_HOST: host, CONF_ROON_ID: core_id, CONF_API_KEY: token}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -66,11 +95,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Initialize the Roon flow."""
         self._host = None
+        self._servers = []
 
     async def async_step_user(self, user_input=None):
         """Handle getting host details from the user."""
 
         errors = {}
+        self._servers = await discover()
+
+        # We discovered one or more  roon - so skip to authentication
+        if len(self._servers) > 0:
+            return await self.async_step_link()
+
         if user_input is not None:
             self._host = user_input["host"]
             existing = {
@@ -92,7 +128,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             try:
-                info = await authenticate(self.hass, self._host)
+                info = await authenticate(self.hass, self._host, self._servers)
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except

--- a/homeassistant/components/roon/const.py
+++ b/homeassistant/components/roon/const.py
@@ -4,6 +4,8 @@ AUTHENTICATE_TIMEOUT = 5
 
 DOMAIN = "roon"
 
+CONF_ROON_ID = "roon_server_id"
+
 DATA_CONFIGS = "roon_configs"
 
 DEFAULT_NAME = "Roon Labs Music Player"

--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
   "requirements": [
-    "roonapi==0.0.29"
+    "roonapi==0.0.30"
   ],
   "codeowners": [
     "@pavoni"

--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
   "requirements": [
-    "roonapi==0.0.28"
+    "roonapi==0.0.29"
   ],
   "codeowners": [
     "@pavoni"

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -175,7 +175,7 @@ class RoonDevice(MediaPlayerEntity):
             "name": self.name,
             "manufacturer": "RoonLabs",
             "model": dev_model,
-            "via_hub": (DOMAIN, self._server.host),
+            "via_hub": (DOMAIN, self._server.roon_id),
         }
 
     def update_data(self, player_data=None):

--- a/homeassistant/components/roon/server.py
+++ b/homeassistant/components/roon/server.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util.dt import utcnow
 
-from .const import ROON_APPINFO
+from .const import CONF_ROON_ID, ROON_APPINFO
 
 _LOGGER = logging.getLogger(__name__)
 FULL_SYNC_INTERVAL = 30
@@ -28,21 +28,25 @@ class RoonServer:
         self._exit = False
         self._roon_name_by_id = {}
 
-    @property
-    def host(self):
-        """Return the host of this server."""
-        return self.config_entry.data[CONF_HOST]
-
     async def async_setup(self, tries=0):
-        """Set up a roon server based on host parameter."""
-        host = self.host
+        """Set up a roon server based on config parameters."""
         hass = self.hass
+        # Host will be None for configs using discovery
+        host = self.config_entry.data[CONF_HOST]
         token = self.config_entry.data[CONF_API_KEY]
-        _LOGGER.debug("async_setup: %s %s", token, host)
-        self.roonapi = RoonApi(ROON_APPINFO, token, host, blocking_init=False)
+        # Default to None for compatibility with older configs
+        core_id = self.config_entry.data.get(CONF_ROON_ID, None)
+        _LOGGER.debug("async_setup: host=%s core_id=%s token=%s", host, core_id, token)
+
+        self.roonapi = RoonApi(
+            ROON_APPINFO, token, host, blocking_init=False, core_id=core_id
+        )
         self.roonapi.register_state_callback(
             self.roonapi_state_callback, event_filter=["zones_changed"]
         )
+
+        # Default to 'host' for compatibility with older configs without core_id
+        self.roon_id = core_id if core_id is not None else host
 
         # initialize media_player platform
         hass.async_create_task(
@@ -152,11 +156,11 @@ class RoonServer:
         new_dict = zone.copy()
         new_dict.update(output)
         new_dict.pop("outputs")
-        new_dict["host"] = self.host
+        new_dict["roon_id"] = self.roon_id
         new_dict["is_synced"] = len(zone["outputs"]) > 1
         new_dict["zone_name"] = zone["display_name"]
         new_dict["display_name"] = output["display_name"]
         new_dict["last_changed"] = utcnow()
         # we don't use the zone_id or output_id for now as unique id as I've seen cases were it changes for some reason
-        new_dict["dev_id"] = f"roon_{self.host}_{output['display_name']}"
+        new_dict["dev_id"] = f"roon_{self.roon_id}_{output['display_name']}"
         return new_dict

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1952,7 +1952,7 @@ rokuecp==0.6.0
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.28
+roonapi==0.0.29
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1952,7 +1952,7 @@ rokuecp==0.6.0
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.29
+roonapi==0.0.30
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -960,7 +960,7 @@ rokuecp==0.6.0
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.28
+roonapi==0.0.29
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -960,7 +960,7 @@ rokuecp==0.6.0
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.29
+roonapi==0.0.30
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -3,49 +3,88 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, setup
 from homeassistant.components.roon.const import DOMAIN
-from homeassistant.const import CONF_HOST
-
-from tests.common import MockConfigEntry
 
 
-class RoonApiMock:
-    """Mock to handle returning tokens for testing the RoonApi."""
+class RoonHubMock:
+    """Class to mock the Roon API for testing."""
 
-    def __init__(self, token):
+    def __init__(self, token, servers):
         """Initialize."""
         self._token = token
+        self._servers = servers
 
-    @property
-    def token(self):
-        """Return the auth token from the api."""
-        return self._token
+    def discover(self):
+        """Return discovered roon servers."""
+        return self._servers
 
-    def stop(self):  # pylint: disable=no-self-use
-        """Close down the api."""
-        return
+    async def authenticate(self, hass, host, servers):
+        """Authenticate against roon."""
+        return (self._token, "core_id")
 
 
-async def test_form_and_auth(hass):
-    """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == "form"
-    assert result["errors"] == {}
+class RoonHubMockException(RoonHubMock):
+    """Class to mock the Roon API for testing that throws an unexpected exception."""
 
-    with patch("homeassistant.components.roon.config_flow.TIMEOUT", 0,), patch(
-        "homeassistant.components.roon.const.AUTHENTICATE_TIMEOUT",
-        0,
-    ), patch(
-        "homeassistant.components.roon.config_flow.RoonApi",
-        return_value=RoonApiMock("good_token"),
-    ), patch(
-        "homeassistant.components.roon.async_setup", return_value=True
-    ) as mock_setup, patch(
+    async def authenticate(self, hass, host, servers):
+        """Throw exception when authenticating."""
+        raise Exception
+
+
+async def test_successful_discovery_and_auth(hass):
+    """Test when discovery and auth both work ok."""
+    with patch(
+        "homeassistant.components.roon.config_flow.RoonHub",
+        return_value=RoonHubMock("good_token", ["2.2.2.2"]),
+    ), patch("homeassistant.components.roon.async_setup", return_value=True), patch(
         "homeassistant.components.roon.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
+    ):
+
+        await setup.async_setup_component(hass, "persistent_notification", {})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+        # Should go straight to link if server was discovered
+        assert result["type"] == "form"
+        assert result["step_id"] == "link"
+        assert result["errors"] == {}
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
+
+    assert result2["title"] == "Roon Labs Music Player"
+    assert result2["data"] == {
+        "host": None,
+        "api_key": "good_token",
+        "roon_server_id": "core_id",
+    }
+
+
+async def test_unsuccessful_discovery_user_form_and_auth(hass):
+    """Test unsuccessful discover, user adding the host via the form and then successful auth."""
+    with patch(
+        "homeassistant.components.roon.config_flow.RoonHub",
+        return_value=RoonHubMock("good_token", []),
+    ), patch("homeassistant.components.roon.async_setup", return_value=True), patch(
+        "homeassistant.components.roon.async_setup_entry",
+        return_value=True,
+    ):
+
+        await setup.async_setup_component(hass, "persistent_notification", {})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+        # Should show the form if server was not discovered
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert result["errors"] == {}
+
         await hass.config_entries.flow.async_configure(
             result["flow_id"], {"host": "1.1.1.1"}
         )
@@ -54,113 +93,67 @@ async def test_form_and_auth(hass):
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
     assert result2["title"] == "Roon Labs Music Player"
-    assert result2["data"] == {"host": "1.1.1.1", "api_key": "good_token"}
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "api_key": "good_token",
+        "roon_server_id": "core_id",
+    }
 
 
-async def test_form_no_token(hass):
-    """Test we handle no token being returned (timeout or not authorized)."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    with patch("homeassistant.components.roon.config_flow.TIMEOUT", 0,), patch(
-        "homeassistant.components.roon.const.AUTHENTICATE_TIMEOUT",
-        0,
-    ), patch(
-        "homeassistant.components.roon.config_flow.RoonApi",
-        return_value=RoonApiMock(None),
+async def test_successful_discovery_no_auth(hass):
+    """Test successful discover, but failed auth."""
+    with patch(
+        "homeassistant.components.roon.config_flow.RoonHub",
+        return_value=RoonHubMock(None, ["2.2.2.2"]),
+    ), patch("homeassistant.components.roon.async_setup", return_value=True), patch(
+        "homeassistant.components.roon.async_setup_entry",
+        return_value=True,
     ):
-        await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"host": "1.1.1.1"}
+
+        await setup.async_setup_component(hass, "persistent_notification", {})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        await hass.async_block_till_done()
+
+        # Should go straight to link if server was discovered
+        assert result["type"] == "form"
+        assert result["step_id"] == "link"
+        assert result["errors"] == {}
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
-    assert result2["type"] == "form"
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_unknown_exception(hass):
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
+async def test_unexpected_exception(hass):
+    """Test successful discover, but failed auth."""
     with patch(
-        "homeassistant.components.roon.config_flow.RoonApi",
-        side_effect=Exception,
-    ):
-        await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"host": "1.1.1.1"}
-        )
-
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "unknown"}
-
-
-async def test_form_host_already_exists(hass):
-    """Test we add the host if the config exists and it isn't a duplicate."""
-
-    MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "existing_host"}).add_to_hass(hass)
-
-    await setup.async_setup_component(hass, "persistent_notification", {})
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == "form"
-    assert result["errors"] == {}
-
-    with patch("homeassistant.components.roon.config_flow.TIMEOUT", 0,), patch(
-        "homeassistant.components.roon.const.AUTHENTICATE_TIMEOUT",
-        0,
-    ), patch(
-        "homeassistant.components.roon.config_flow.RoonApi",
-        return_value=RoonApiMock("good_token"),
-    ), patch(
-        "homeassistant.components.roon.async_setup", return_value=True
-    ) as mock_setup, patch(
+        "homeassistant.components.roon.config_flow.RoonHub",
+        return_value=RoonHubMockException(None, ["2.2.2.2"]),
+    ), patch("homeassistant.components.roon.async_setup", return_value=True), patch(
         "homeassistant.components.roon.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
-        await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"host": "1.1.1.1"}
+    ):
+
+        await setup.async_setup_component(hass, "persistent_notification", {})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        await hass.async_block_till_done()
+
+        # Should go straight to link if server was discovered
+        assert result["type"] == "form"
+        assert result["step_id"] == "link"
+        assert result["errors"] == {}
+
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == "Roon Labs Music Player"
-    assert result2["data"] == {"host": "1.1.1.1", "api_key": "good_token"}
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 2
-
-
-async def test_form_duplicate_host(hass):
-    """Test we don't add the host if it's a duplicate."""
-
-    MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "existing_host"}).add_to_hass(hass)
-
-    await setup.async_setup_component(hass, "persistent_notification", {})
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == "form"
-    assert result["errors"] == {}
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"host": "existing_host"}
-    )
-
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "duplicate_entry"}
+    assert result2["errors"] == {"base": "unknown"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This PR changes how the `play_media` call works for roon players. 

The previous implementation was very limited  - but anyone using it in automations will need to change their calls to the new structure.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are four changes in this PR.

1. A bump to the pyroon library version. The changes are small - mainly an improved error message when `play_media` can't follow the path specified. The new error message lists the path options at the point the error occurred - which should help people navigate their roon library structure.
https://github.com/pavoni/pyroon/compare/0.0.29a...0.0.30

1. A rewrite of the `play_media` call. Previously this couldn't navigate the roon library properly - and so limited users to playing top level items. The previous code also hard coded roon API strings. A recent roon software release require a HA patch to resolve - this code removes that dependency. 
The new code allow `media_id` to be path, so that a `media_id` of `Library/Artists/Neil Young/Harvest` will play an album and `My Live Radio/BBC Radio 4` will play a radio station. Some helpful error messages have been added to the roon library - to assist people in navigating their library. I will also update the HA documentation.

1. Addition of roon discovery. There were previously issues with discovery in the roon library - which stopped it working effectively. These have now been resolved - and so this PR switches to use discovery. If discovery fails to find any servers the code still allows users to specify a host. 

1. Lastly in working on the library I found a unique ID for each roon core server - and so this PR also now uses this in place of the IP address that was used previous. This was suggested by @MartinHjelmare when he reviewed the initial PR - but at the time the library didn't have a suitable id available. Using a unique id allows some simplification of the `config_flow` - since it is no longer possible to specify duplicate addresses. There is a little code to main backwards compatibility of player names - so HA users do not need to re-create their integrations - and players are not renamed. 

Given that this contains a change initially suggested by @MartinHjelmare - he may want to review. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Please note that roon discovery is slightly odd in that it also returns some clients as well as servers - the `config_flow` codes handles this by asking all the discovered servers for authorisation, the `id` of whichever server the user authorises is then stored to use to scope future discovery calls.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
