### PR TITLE
Bump mychevy version to 2.1.0

### DIFF
--- a/homeassistant/components/mychevy/manifest.json
+++ b/homeassistant/components/mychevy/manifest.json
@@ -2,6 +2,6 @@
   "domain": "mychevy",
   "name": "myChevrolet",
   "documentation": "https://www.home-assistant.io/integrations/mychevy",
-  "requirements": ["mychevy==2.0.1"],
+  "requirements": ["mychevy==2.1.0"],
   "codeowners": []
 }

--- a/homeassistant/components/mychevy/manifest.json
+++ b/homeassistant/components/mychevy/manifest.json
@@ -2,6 +2,6 @@
   "domain": "mychevy",
   "name": "myChevrolet",
   "documentation": "https://www.home-assistant.io/integrations/mychevy",
-  "requirements": ["mychevy==2.1.0"],
+  "requirements": ["mychevy==2.1.1"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -955,7 +955,7 @@ mitemp_bt==0.0.3
 mutagen==1.45.1
 
 # homeassistant.components.mychevy
-mychevy==2.0.1
+mychevy==2.1.0
 
 # homeassistant.components.mycroft
 mycroftapi==2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -955,7 +955,7 @@ mitemp_bt==0.0.3
 mutagen==1.45.1
 
 # homeassistant.components.mychevy
-mychevy==2.1.0
+mychevy==2.1.1
 
 # homeassistant.components.mycroft
 mycroftapi==2.0


### PR DESCRIPTION
This fixes login and adds additional attributes fetched for cars

Changelog: <https://github.com/sdague/mychevy/blob/master/HISTORY.rst>
Git diff compare view: <https://github.com/sdague/mychevy/compare/v2.0.1...v2.1.1>

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
