### PR TITLE
Bump caldav version to 0.7.1

### DIFF
--- a/homeassistant/components/caldav/manifest.json
+++ b/homeassistant/components/caldav/manifest.json
@@ -2,6 +2,6 @@
   "domain": "caldav",
   "name": "CalDAV",
   "documentation": "https://www.home-assistant.io/integrations/caldav",
-  "requirements": ["caldav==0.6.1"],
+  "requirements": ["caldav==0.7.1"],
   "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -405,7 +405,7 @@ btsmarthub_devicelist==0.2.0
 buienradar==1.0.4
 
 # homeassistant.components.caldav
-caldav==0.6.1
+caldav==0.7.1
 
 # homeassistant.components.circuit
 circuit-webhook==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -211,7 +211,7 @@ bsblan==0.3.7
 buienradar==1.0.4
 
 # homeassistant.components.caldav
-caldav==0.6.1
+caldav==0.7.1
 
 # homeassistant.components.coinmarketcap
 coinmarketcap==5.0.3


### PR DESCRIPTION
## Breaking change


## Proposed change
This PR bumps the version of caldav : 

Details below: (https://github.com/python-caldav/caldav/compare/v0.6.2...v0.7.1)



## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone
