### PR TITLE
Feature/caldav default offset

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -52,7 +52,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                         vol.Required(CONF_CALENDAR): cv.string,
                         vol.Required(CONF_NAME): cv.string,
                         vol.Required(CONF_SEARCH): cv.string,
-                        vol.Optional(CONF_DEFAULTOFFSET, default="00:00"): cv.time_period_str,
+                        vol.Optional(
+                            CONF_DEFAULTOFFSET, default="00:00"
+                        ): cv.time_period_str,
                     }
                 )
             ],
@@ -99,8 +101,13 @@ def setup_platform(hass, config, add_entities, disc_info=None):
             default_offset = cust_calendar[CONF_DEFAULTOFFSET]
             calendar_devices.append(
                 WebDavCalendarEventDevice(
-                    name, calendar, entity_id, days, True, cust_calendar[CONF_SEARCH],
-                    default_offset
+                    name,
+                    calendar,
+                    entity_id,
+                    days,
+                    True,
+                    cust_calendar[CONF_SEARCH],
+                    default_offset,
                 )
             )
 
@@ -119,8 +126,16 @@ def setup_platform(hass, config, add_entities, disc_info=None):
 class WebDavCalendarEventDevice(CalendarEventDevice):
     """A device for getting the next Task from a WebDav Calendar."""
 
-    def __init__(self, name, calendar, entity_id, days, all_day=False, search=None,
-            default_offset=None):
+    def __init__(
+        self,
+        name,
+        calendar,
+        entity_id,
+        days,
+        all_day=False,
+        search=None,
+        default_offset=None,
+    ):
         """Create the WebDav Calendar Event Device."""
         self.data = WebDavCalendarData(calendar, days, all_day, search)
         self.entity_id = entity_id

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -89,7 +89,7 @@ def normalize_event(event):
     return normalized_event
 
 
-def calculate_offset(event, offset):
+def calculate_offset(event, offset, default_offset=None):
     """Calculate event offset.
 
     Return the updated event with the offset_time included.
@@ -110,6 +110,8 @@ def calculate_offset(event, offset):
         offset_time = time_period_str(time)
         summary = (summary[: search.start()] + summary[search.end() :]).strip()
         event["summary"] = summary
+    elif default_offset:
+        offset_time = default_offset
     else:
         offset_time = dt.dt.timedelta()  # default it
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add the possibility to use a default offset when using custom calenders. This is useful, if you can't change the description to contain a offset.

Example: You have a calendar provided by your garbage collector company which contains the dates when the collection starts. You should be notified hours before the event in the calendar is entered.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
calendar:
 - platform: caldav
   url: https://nextcloud.com/remote.php/dav
   username: 'caluser'
   password: !secret calpasswd
   custom_calendars:
     - name: Garbage Bins
       calendar: "Home"
       search: '.*Garbagebin'
       default_offset: '-6:00'
```

## Additional information


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
