### PR TITLE
Add MQTT Number (non optimistic)

### DIFF
--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -178,7 +178,8 @@ class MqttNumber(
         if self._optimistic:
             last_state = await self.async_get_last_state()
             if last_state:
-                self._state = last_state.state
+                print(last_state)
+                self._current_number = last_state.state
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -178,7 +178,6 @@ class MqttNumber(
         if self._optimistic:
             last_state = await self.async_get_last_state()
             if last_state:
-                print(last_state)
                 self._current_number = last_state.state
 
     async def async_will_remove_from_hass(self):

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -111,7 +111,6 @@ class MqttNumber(
     def __init__(self, config, config_entry, discovery_data):
         """Initialize the MQTT Number."""
         self._config = config
-        self._unique_id = config.get(CONF_UNIQUE_ID)
         self._sub_state = None
 
         self._current_number = None

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -5,7 +5,13 @@ import voluptuous as vol
 
 from homeassistant.components import number
 from homeassistant.components.number import NumberEntity
-from homeassistant.const import CONF_DEVICE, CONF_NAME, CONF_UNIQUE_ID
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_ICON,
+    CONF_NAME,
+    CONF_OPTIMISTIC,
+    CONF_UNIQUE_ID,
+)
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import (
@@ -13,11 +19,14 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.reload import async_setup_reload_service
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import (
     ATTR_DISCOVERY_HASH,
+    CONF_COMMAND_TOPIC,
     CONF_QOS,
+    CONF_STATE_TOPIC,
     DOMAIN,
     PLATFORMS,
     MqttAttributes,
@@ -32,15 +41,16 @@ from .discovery import MQTT_DISCOVERY_DONE, MQTT_DISCOVERY_NEW, clear_discovery_
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_TOPIC = "topic"
 DEFAULT_NAME = "MQTT Number"
+DEFAULT_OPTIMISTIC = False
 
 PLATFORM_SCHEMA = (
-    mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend(
+    mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
         {
             vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
+            vol.Optional(CONF_ICON): cv.icon,
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-            vol.Required(CONF_TOPIC): mqtt.valid_subscribe_topic,
+            vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
         }
     )
@@ -94,6 +104,7 @@ class MqttNumber(
     MqttDiscoveryUpdate,
     MqttEntityDeviceInfo,
     NumberEntity,
+    RestoreEntity,
 ):
     """representation of an MQTT number."""
 
@@ -104,6 +115,8 @@ class MqttNumber(
         self._sub_state = None
 
         self._current_number = None
+        self._optimistic = config.get(CONF_OPTIMISTIC)
+        self._unique_id = config.get(CONF_UNIQUE_ID)
 
         device_config = config.get(CONF_DEVICE)
 
@@ -145,18 +158,27 @@ class MqttNumber(
             except ValueError:
                 _LOGGER.warning("We received <%s> which is not a Number", msg.payload)
 
-        self._sub_state = await subscription.async_subscribe_topics(
-            self.hass,
-            self._sub_state,
-            {
-                "state_topic": {
-                    "topic": self._config[CONF_TOPIC],
-                    "msg_callback": message_received,
-                    "qos": self._config[CONF_QOS],
-                    "encoding": None,
-                }
-            },
-        )
+        if self._config.get(CONF_STATE_TOPIC) is None:
+            # Force into optimistic mode.
+            self._optimistic = True
+        else:
+            self._sub_state = await subscription.async_subscribe_topics(
+                self.hass,
+                self._sub_state,
+                {
+                    "state_topic": {
+                        "topic": self._config.get(CONF_STATE_TOPIC),
+                        "msg_callback": message_received,
+                        "qos": self._config[CONF_QOS],
+                        "encoding": None,
+                    }
+                },
+            )
+
+        if self._optimistic:
+            last_state = await self.async_get_last_state()
+            if last_state:
+                self._state = last_state.state
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""
@@ -174,19 +196,22 @@ class MqttNumber(
 
     async def async_set_value(self, value: float) -> None:
         """Update the current value."""
+
+        current_number = value
+
         if value.is_integer():
-            self._current_number = int(value)
-        else:
-            self._current_number = value
+            current_number = int(value)
+
+        if self._optimistic:
+            self._current_number = current_number
+            self.async_write_ha_state()
 
         mqtt.async_publish(
             self.hass,
-            self._config[CONF_TOPIC],
-            self._current_number,
+            self._config[CONF_COMMAND_TOPIC],
+            current_number,
             self._config[CONF_QOS],
         )
-
-        self.async_write_ha_state()
 
     @property
     def name(self):
@@ -202,3 +227,13 @@ class MqttNumber(
     def should_poll(self):
         """Return the polling state."""
         return False
+
+    @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return self._optimistic
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._config.get(CONF_ICON)

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -174,6 +174,8 @@ async def test_run_number_service(hass, mqtt_mock):
         blocking=True,
     )
     mqtt_mock.async_publish.assert_called_once_with(cmd_topic, "30", 0, False)
+    state = hass.states.get("number.test_number")
+    assert state.state == "32"
 
 
 async def test_availability_when_connection_lost(hass, mqtt_mock):

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -40,7 +40,7 @@ from .test_common import (
 from tests.common import async_fire_mqtt_message
 
 DEFAULT_CONFIG = {
-    number.DOMAIN: {"platform": "mqtt", "name": "test", "topic": "test_topic"}
+    number.DOMAIN: {"platform": "mqtt", "name": "test", "command_topic": "test-topic"}
 }
 
 
@@ -50,7 +50,14 @@ async def test_run_number_setup(hass, mqtt_mock):
     await async_setup_component(
         hass,
         "number",
-        {"number": {"platform": "mqtt", "topic": topic, "name": "Test Number"}},
+        {
+            "number": {
+                "platform": "mqtt",
+                "state_topic": topic,
+                "command_topic": topic,
+                "name": "Test Number",
+            }
+        },
     )
     await hass.async_block_till_done()
 
@@ -75,7 +82,14 @@ async def test_run_number_service_optimistic(hass, mqtt_mock):
     await async_setup_component(
         hass,
         "number",
-        {"number": {"platform": "mqtt", "topic": topic, "name": "Test Number"}},
+        {
+            "number": {
+                "platform": "mqtt",
+                "state_topic": topic,
+                "command_topic": topic,
+                "name": "Test Number",
+            }
+        },
     )
     await hass.async_block_till_done()
 
@@ -189,13 +203,15 @@ async def test_unique_id(hass, mqtt_mock):
             {
                 "platform": "mqtt",
                 "name": "Test 1",
-                "topic": "test-topic",
+                "state_topic": "test-topic",
+                "command_topic": "test-topic",
                 "unique_id": "TOTALLY_UNIQUE",
             },
             {
                 "platform": "mqtt",
                 "name": "Test 2",
-                "topic": "test-topic",
+                "state_topic": "test-topic",
+                "command_topic": "test-topic",
                 "unique_id": "TOTALLY_UNIQUE",
             },
         ]
@@ -211,8 +227,12 @@ async def test_discovery_removal_number(hass, mqtt_mock, caplog):
 
 async def test_discovery_update_number(hass, mqtt_mock, caplog):
     """Test update of discovered number."""
-    data1 = '{ "name": "Beer", "topic": "test_topic"}'
-    data2 = '{ "name": "Milk", "topic": "test_topic"}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "test-topic", "command_topic": "test-topic"}'
+    )
+    data2 = (
+        '{ "name": "Milk", "state_topic": "test-topic", "command_topic": "test-topic"}'
+    )
 
     await help_test_discovery_update(
         hass, mqtt_mock, caplog, number.DOMAIN, data1, data2
@@ -221,7 +241,9 @@ async def test_discovery_update_number(hass, mqtt_mock, caplog):
 
 async def test_discovery_update_unchanged_number(hass, mqtt_mock, caplog):
     """Test update of discovered number."""
-    data1 = '{ "name": "Beer", "topic": "test_topic"}'
+    data1 = (
+        '{ "name": "Beer", "state_topic": "test-topic", "command_topic": "test-topic"}'
+    )
     with patch(
         "homeassistant.components.mqtt.number.MqttNumber.discovery_update"
     ) as discovery_update:
@@ -234,7 +256,9 @@ async def test_discovery_update_unchanged_number(hass, mqtt_mock, caplog):
 async def test_discovery_broken(hass, mqtt_mock, caplog):
     """Test handling of bad discovery message."""
     data1 = '{ "name": "Beer" }'
-    data2 = '{ "name": "Milk", "topic": "test_topic"}'
+    data2 = (
+        '{ "name": "Milk", "state_topic": "test-topic", "command_topic": "test-topic"}'
+    )
 
     await help_test_discovery_broken(
         hass, mqtt_mock, caplog, number.DOMAIN, data1, data2
@@ -272,7 +296,7 @@ async def test_entity_device_info_remove(hass, mqtt_mock):
 async def test_entity_id_update_subscriptions(hass, mqtt_mock):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock, number.DOMAIN, DEFAULT_CONFIG, ["test_topic"]
+        hass, mqtt_mock, number.DOMAIN, DEFAULT_CONFIG
     )
 
 
@@ -286,5 +310,5 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock):
 async def test_entity_debug_info_message(hass, mqtt_mock):
     """Test MQTT debug info."""
     await help_test_entity_debug_info_message(
-        hass, mqtt_mock, number.DOMAIN, DEFAULT_CONFIG, "test_topic", b"ON"
+        hass, mqtt_mock, number.DOMAIN, DEFAULT_CONFIG, payload=b"1"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previous PR #44739 covered only optimistic case, this PR is a follow up to cover both cases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
number:
  - platform: mqtt
    state_topic: mydevice/parameter
    command_topic: mydevice/parameter/set
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16115

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
