### PR TITLE
Revert "Bump pypck to 0.7.8"

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -139,8 +139,7 @@ class LcnEntity(Entity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
-        if not self.device_connection.is_group:
-            self.device_connection.register_for_inputs(self.input_received)
+        self.device_connection.register_for_inputs(self.input_received)
 
     @property
     def name(self):

--- a/homeassistant/components/lcn/binary_sensor.py
+++ b/homeassistant/components/lcn/binary_sensor.py
@@ -50,10 +50,9 @@ class LcnRegulatorLockSensor(LcnEntity, BinarySensorEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(
-                self.setpoint_variable
-            )
+        await self.device_connection.activate_status_request_handler(
+            self.setpoint_variable
+        )
 
     @property
     def is_on(self):
@@ -86,10 +85,9 @@ class LcnBinarySensor(LcnEntity, BinarySensorEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(
-                self.bin_sensor_port
-            )
+        await self.device_connection.activate_status_request_handler(
+            self.bin_sensor_port
+        )
 
     @property
     def is_on(self):
@@ -118,8 +116,7 @@ class LcnLockKeysSensor(LcnEntity, BinarySensorEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.source)
+        await self.device_connection.activate_status_request_handler(self.source)
 
     @property
     def is_on(self):

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -63,9 +63,8 @@ class LcnClimate(LcnEntity, ClimateEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.variable)
-            await self.device_connection.activate_status_request_handler(self.setpoint)
+        await self.device_connection.activate_status_request_handler(self.variable)
+        await self.device_connection.activate_status_request_handler(self.setpoint)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -161,8 +161,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.motor)
+        await self.device_connection.activate_status_request_handler(self.motor)
 
     @property
     def is_closed(self):

--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -68,8 +68,7 @@ class LcnOutputLight(LcnEntity, LightEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.output)
+        await self.device_connection.activate_status_request_handler(self.output)
 
     @property
     def supported_features(self):
@@ -156,8 +155,7 @@ class LcnRelayLight(LcnEntity, LightEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.output)
+        await self.device_connection.activate_status_request_handler(self.output)
 
     @property
     def is_on(self):

--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -2,10 +2,6 @@
   "domain": "lcn",
   "name": "LCN",
   "documentation": "https://www.home-assistant.io/integrations/lcn",
-  "requirements": [
-    "pypck==0.7.8"
-  ],
-  "codeowners": [
-    "@alengwenus"
-  ]
+  "requirements": ["pypck==0.7.7"],
+  "codeowners": ["@alengwenus"]
 }

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -57,8 +57,7 @@ class LcnVariableSensor(LcnEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.variable)
+        await self.device_connection.activate_status_request_handler(self.variable)
 
     @property
     def state(self):
@@ -99,8 +98,7 @@ class LcnLedLogicSensor(LcnEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.source)
+        await self.device_connection.activate_status_request_handler(self.source)
 
     @property
     def state(self):

--- a/homeassistant/components/lcn/switch.py
+++ b/homeassistant/components/lcn/switch.py
@@ -50,8 +50,7 @@ class LcnOutputSwitch(LcnEntity, SwitchEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.output)
+        await self.device_connection.activate_status_request_handler(self.output)
 
     @property
     def is_on(self):
@@ -98,8 +97,7 @@ class LcnRelaySwitch(LcnEntity, SwitchEntity):
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        if not self.device_connection.is_group:
-            await self.device_connection.activate_status_request_handler(self.output)
+        await self.device_connection.activate_status_request_handler(self.output)
 
     @property
     def is_on(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1607,7 +1607,7 @@ pyownet==0.10.0.post1
 pypca==0.0.7
 
 # homeassistant.components.lcn
-pypck==0.7.8
+pypck==0.7.7
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.1


### PR DESCRIPTION
Reverts home-assistant/core#44834

Temporarily creates a revert to get this bump out of the 2021.1.0 release. 

It was cherry-picked, however, the upstream library dropped Python 3.7 support (which isn't dropped in this release yet).

I'm reverting this revert after the release.
