### PR TITLE
Update modbus test harness

### DIFF
--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_TYPE,
 )
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -75,7 +74,7 @@ async def base_test(
         mock_sync.read_input_registers.return_value = read_result
         mock_sync.read_holding_registers.return_value = read_result
 
-        # mock timer and add modbus platform with devices (new config)
+        # mock timer and add old/new config
         now = dt_util.utcnow()
         with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
             if method_discovery:
@@ -84,9 +83,7 @@ async def base_test(
                     config_modbus[DOMAIN].update(
                         {array_name_discovery: [{**config_device}]}
                     )
-                await async_load_platform(
-                    hass, DOMAIN, DOMAIN, config_modbus[DOMAIN], config_modbus
-                )
+                assert await async_setup_component(hass, DOMAIN, config_modbus)
             else:
                 # first add modbus platform using old config
                 assert await async_setup_component(hass, DOMAIN, config_modbus)

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -1,31 +1,34 @@
 """The tests for the Modbus sensor component."""
+from datetime import timedelta
+import logging
 from unittest import mock
-from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.modbus.const import (
-    CALL_TYPE_COIL,
-    CALL_TYPE_DISCRETE,
-    CALL_TYPE_REGISTER_INPUT,
-    DEFAULT_HUB,
-    MODBUS_DOMAIN as DOMAIN,
+from homeassistant.components.modbus.const import DEFAULT_HUB, MODBUS_DOMAIN as DOMAIN
+from homeassistant.components.modbus.modbus import ModbusHub
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PLATFORM,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_TYPE,
 )
-from homeassistant.const import CONF_PLATFORM, CONF_SCAN_INTERVAL
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 
+_LOGGER = logging.getLogger(__name__)
 
-@pytest.fixture()
-def mock_hub(hass):
+
+@pytest.fixture(scope="class")
+def ModbusHubMock():
     """Mock hub."""
-    with patch("homeassistant.components.modbus.setup", return_value=True):
-        hub = mock.MagicMock()
-        hub.name = "hub"
-        hass.data[DOMAIN] = {DEFAULT_HUB: hub}
-        yield hub
+    with mock.patch("homeassistant.components.modbus.modbus.ModbusHub"):
+        yield
 
 
 class ReadResult:
@@ -37,59 +40,84 @@ class ReadResult:
         self.bits = register_words
 
 
-async def setup_base_test(
+async def base_test(
     sensor_name,
     hass,
-    use_mock_hub,
     data_array,
     entity_domain,
     scan_interval,
+    register_words,
+    expected,
+    method_discovery=False,
 ):
-    """Run setup device for given config."""
-    # Full sensor configuration
-    config = {
-        entity_domain: {
-            CONF_PLATFORM: "modbus",
-            CONF_SCAN_INTERVAL: scan_interval,
-            **data_array,
-        }
-    }
+    """Run test on device for given config."""
 
-    # Initialize sensor
+    # Full sensor configuration
+    if method_discovery:
+        config = {
+            DOMAIN: {
+                CONF_NAME: DEFAULT_HUB,
+                CONF_TYPE: "tcp",
+                CONF_HOST: "modbusTest",
+                CONF_PORT: 5001,
+                **data_array,
+            },
+        }
+    else:
+        config = {
+            DOMAIN: {
+                CONF_NAME: DEFAULT_HUB,
+                CONF_TYPE: "tcp",
+                CONF_HOST: "modbusTest",
+                CONF_PORT: 5001,
+            },
+        }
+        configDeviceOLD = {
+            entity_domain: {
+                CONF_PLATFORM: DOMAIN,
+                CONF_SCAN_INTERVAL: scan_interval,
+                **data_array,
+            }
+        }
+
+    # mock timer and add modbus platform with devices (new config)
+    # first add modbus platform, then devices (old config)
     now = dt_util.utcnow()
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
-        assert await async_setup_component(hass, entity_domain, config)
+        # setup modbus platform
+        if method_discovery:
+            await async_load_platform(
+                hass, entity_domain, DOMAIN, config[DOMAIN], config
+            )
+        else:
+            # setup modbus old style
+            assert await async_setup_component(hass, DOMAIN, config)
+            await hass.async_block_till_done()
+
+            # setup component old style
+            assert await async_setup_component(
+                hass,
+                entity_domain,
+                configDeviceOLD,
+            )
+
         await hass.async_block_till_done()
+
+    # Setup inputs for the sensor
+    read_result = ReadResult(register_words)
+    hub: ModbusHub = hass.data[DOMAIN][DEFAULT_HUB]
+    hub.read_coils.return_value = read_result
+    hub.read_discrete_inputs.return_value = read_result
+    hub.read_input_registers.return_value = read_result
+    hub.read_holding_registers.return_value = read_result
 
     entity_id = f"{entity_domain}.{sensor_name}"
     device = hass.states.get(entity_id)
     if device is None:
         pytest.fail("CONFIG failed, see output")
-    return entity_id, now, device
-
-
-async def run_base_read_test(
-    entity_id,
-    hass,
-    use_mock_hub,
-    register_type,
-    register_words,
-    expected,
-    now,
-):
-    """Run test for given config."""
-    # Setup inputs for the sensor
-    read_result = ReadResult(register_words)
-    if register_type == CALL_TYPE_COIL:
-        use_mock_hub.read_coils.return_value = read_result
-    elif register_type == CALL_TYPE_DISCRETE:
-        use_mock_hub.read_discrete_inputs.return_value = read_result
-    elif register_type == CALL_TYPE_REGISTER_INPUT:
-        use_mock_hub.read_input_registers.return_value = read_result
-    else:  # CALL_TYPE_REGISTER_HOLDING
-        use_mock_hub.read_holding_registers.return_value = read_result
 
     # Trigger update call with time_changed event
+    now = now + timedelta(seconds=scan_interval + 1)
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -81,7 +81,6 @@ async def base_test(
         }
 
     # mock timer and add modbus platform with devices (new config)
-    # first add modbus platform, then devices (old config)
     now = dt_util.utcnow()
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         # setup modbus platform
@@ -90,7 +89,7 @@ async def base_test(
                 hass, entity_domain, DOMAIN, config[DOMAIN], config
             )
         else:
-            # setup modbus old style
+            # first add modbus platform using old config
             assert await async_setup_component(hass, DOMAIN, config)
             await hass.async_block_till_done()
 

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -128,5 +128,30 @@ async def base_test(
 
         # Check state
         entity_id = f"{entity_domain}.{device_name}"
-        state = hass.states.get(entity_id).state
-        assert state == expected
+        return hass.states.get(entity_id).state
+
+
+async def base_config_test(
+    hass,
+    config_device,
+    device_name,
+    entity_domain,
+    array_name_discovery,
+    array_name_old_config,
+    method_discovery=False,
+    config_modbus=None,
+):
+    """Check config of device for given config."""
+
+    await base_test(
+        hass,
+        config_device,
+        device_name,
+        entity_domain,
+        array_name_discovery,
+        array_name_old_config,
+        None,
+        None,
+        method_discovery=method_discovery,
+        check_config_only=True,
+    )

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -6,7 +6,6 @@ from unittest import mock
 import pytest
 
 from homeassistant.components.modbus.const import DEFAULT_HUB, MODBUS_DOMAIN as DOMAIN
-from homeassistant.components.modbus.modbus import ModbusHub
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -22,13 +21,6 @@ import homeassistant.util.dt as dt_util
 from tests.common import async_fire_time_changed
 
 _LOGGER = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="class")
-def ModbusHubMock():
-    """Mock hub."""
-    with mock.patch("homeassistant.components.modbus.modbus.ModbusHub"):
-        yield
 
 
 class ReadResult:
@@ -80,47 +72,56 @@ async def base_test(
             }
         }
 
-    # mock timer and add modbus platform with devices (new config)
-    now = dt_util.utcnow()
-    with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
-        # setup modbus platform
-        if method_discovery:
-            await async_load_platform(
-                hass, entity_domain, DOMAIN, config[DOMAIN], config
-            )
-        else:
-            # first add modbus platform using old config
-            assert await async_setup_component(hass, DOMAIN, config)
+    mock_sync = mock.MagicMock()
+    with mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusTcpClient", return_value=mock_sync
+    ), mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusSerialClient",
+        return_value=mock_sync,
+    ), mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusUdpClient", return_value=mock_sync
+    ):
+
+        # Setup inputs for the sensor
+        read_result = ReadResult(register_words)
+        mock_sync.read_coils.return_value = read_result
+        mock_sync.read_discrete_inputs.return_value = read_result
+        mock_sync.read_input_registers.return_value = read_result
+        mock_sync.read_holding_registers.return_value = read_result
+
+        # mock timer and add modbus platform with devices (new config)
+        now = dt_util.utcnow()
+        with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
+            # setup modbus platform
+            if method_discovery:
+                await async_load_platform(
+                    hass, entity_domain, DOMAIN, config[DOMAIN], config
+                )
+            else:
+                # first add modbus platform using old config
+                assert await async_setup_component(hass, DOMAIN, config)
+                await hass.async_block_till_done()
+
+                # setup component old style
+                assert await async_setup_component(
+                    hass,
+                    entity_domain,
+                    configDeviceOLD,
+                )
+
             await hass.async_block_till_done()
 
-            # setup component old style
-            assert await async_setup_component(
-                hass,
-                entity_domain,
-                configDeviceOLD,
-            )
+        entity_id = f"{entity_domain}.{sensor_name}"
+        device = hass.states.get(entity_id)
+        if device is None:
+            pytest.fail("CONFIG failed, see output")
 
-        await hass.async_block_till_done()
+        # Trigger update call with time_changed event
+        now = now + timedelta(seconds=scan_interval + 1)
+        with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
+            async_fire_time_changed(hass, now)
+            await hass.async_block_till_done()
 
-    # Setup inputs for the sensor
-    read_result = ReadResult(register_words)
-    hub: ModbusHub = hass.data[DOMAIN][DEFAULT_HUB]
-    hub.read_coils.return_value = read_result
-    hub.read_discrete_inputs.return_value = read_result
-    hub.read_input_registers.return_value = read_result
-    hub.read_holding_registers.return_value = read_result
-
-    entity_id = f"{entity_domain}.{sensor_name}"
-    device = hass.states.get(entity_id)
-    if device is None:
-        pytest.fail("CONFIG failed, see output")
-
-    # Trigger update call with time_changed event
-    now = now + timedelta(seconds=scan_interval + 1)
-    with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
-        async_fire_time_changed(hass, now)
-        await hass.async_block_till_done()
-
-    # Check state
-    state = hass.states.get(entity_id).state
-    assert state == expected
+        # Check state
+        state = hass.states.get(entity_id).state
+        assert state == expected

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.modbus.const import (
 )
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_SLAVE, STATE_OFF, STATE_ON
 
-from .conftest import base_test
+from .conftest import base_config_test, base_test
 
 
 @pytest.mark.parametrize("do_options", [False, True])
@@ -28,18 +28,14 @@ async def test_config_binary_sensor(hass, do_options):
                 CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
             }
         )
-    await base_test(
+    await base_config_test(
         hass,
         config_sensor,
         sensor_name,
         SENSOR_DOMAIN,
         None,
         CONF_INPUTS,
-        None,
-        None,
         method_discovery=False,
-        check_config_only=True,
-        scan_interval=5,
     )
 
 
@@ -72,7 +68,7 @@ async def test_config_binary_sensor(hass, do_options):
 async def test_all_binary_sensor(hass, do_type, regs, expected):
     """Run test for given config."""
     sensor_name = "modbus_test_binary_sensor"
-    await base_test(
+    state = await base_test(
         hass,
         {CONF_NAME: sensor_name, CONF_ADDRESS: 1234, CONF_INPUT_TYPE: do_type},
         sensor_name,
@@ -84,3 +80,4 @@ async def test_all_binary_sensor(hass, do_type, regs, expected):
         method_discovery=False,
         scan_interval=5,
     )
+    assert state == expected

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -67,7 +67,7 @@ from .conftest import base_test
         ),
     ],
 )
-async def test_all_binary_sensor(hass, ModbusHubMock, cfg, regs, expected):
+async def test_all_binary_sensor(hass, cfg, regs, expected):
     """Run test for given config."""
     sensor_name = "modbus_test_binary_sensor"
     await base_test(

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -1,6 +1,4 @@
 """The tests for the Modbus sensor component."""
-from datetime import timedelta
-
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
@@ -12,7 +10,7 @@ from homeassistant.components.modbus.const import (
 )
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_OFF, STATE_ON
 
-from .conftest import run_base_read_test, setup_base_test
+from .conftest import base_test
 
 
 @pytest.mark.parametrize(
@@ -69,24 +67,15 @@ from .conftest import run_base_read_test, setup_base_test
         ),
     ],
 )
-async def test_coil_true(hass, mock_hub, cfg, regs, expected):
+async def test_all_binary_sensor(hass, ModbusHubMock, cfg, regs, expected):
     """Run test for given config."""
     sensor_name = "modbus_test_binary_sensor"
-    scan_interval = 5
-    entity_id, now, device = await setup_base_test(
+    await base_test(
         sensor_name,
         hass,
-        mock_hub,
         {CONF_INPUTS: [dict(**{CONF_NAME: sensor_name, CONF_ADDRESS: 1234}, **cfg)]},
         SENSOR_DOMAIN,
-        scan_interval,
-    )
-    await run_base_read_test(
-        entity_id,
-        hass,
-        mock_hub,
-        cfg.get(CONF_INPUT_TYPE),
+        5,
         regs,
         expected,
-        now + timedelta(seconds=scan_interval + 1),
     )

--- a/tests/components/modbus/test_modbus_climate.py
+++ b/tests/components/modbus/test_modbus_climate.py
@@ -1,0 +1,47 @@
+"""The tests for the Modbus climate component."""
+import pytest
+
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.modbus.const import (
+    CONF_CLIMATES,
+    CONF_CURRENT_TEMP,
+    CONF_DATA_COUNT,
+    CONF_TARGET_TEMP,
+)
+from homeassistant.const import CONF_NAME, CONF_SLAVE
+
+from .conftest import base_test
+
+
+@pytest.mark.parametrize(
+    "regs,expected",
+    [
+        (
+            [0x00],
+            "auto",
+        ),
+    ],
+)
+async def test_temperature_climate(hass, ModbusHubMock, regs, expected):
+    """Run test for given config."""
+    cover_name = "modbus_test_climate"
+    await base_test(
+        cover_name,
+        hass,
+        {
+            CONF_CLIMATES: [
+                {
+                    CONF_NAME: cover_name,
+                    CONF_SLAVE: 1,
+                    CONF_TARGET_TEMP: 117,
+                    CONF_CURRENT_TEMP: 117,
+                    CONF_DATA_COUNT: 2,
+                },
+            ]
+        },
+        CLIMATE_DOMAIN,
+        5,
+        regs,
+        expected,
+        method_discovery=True,
+    )

--- a/tests/components/modbus/test_modbus_climate.py
+++ b/tests/components/modbus/test_modbus_climate.py
@@ -22,7 +22,7 @@ from .conftest import base_test
         ),
     ],
 )
-async def test_temperature_climate(hass, ModbusHubMock, regs, expected):
+async def test_temperature_climate(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_climate"
     await base_test(

--- a/tests/components/modbus/test_modbus_climate.py
+++ b/tests/components/modbus/test_modbus_climate.py
@@ -10,7 +10,7 @@ from homeassistant.components.modbus.const import (
 )
 from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_SLAVE
 
-from .conftest import base_test
+from .conftest import base_config_test, base_test
 
 
 @pytest.mark.parametrize("do_options", [False, True])
@@ -30,17 +30,14 @@ async def test_config_climate(hass, do_options):
                 CONF_DATA_COUNT: 2,
             }
         )
-    await base_test(
+    await base_config_test(
         hass,
         device_config,
         device_name,
         CLIMATE_DOMAIN,
         CONF_CLIMATES,
         None,
-        None,
-        None,
         method_discovery=True,
-        check_config_only=True,
     )
 
 
@@ -57,7 +54,7 @@ async def test_temperature_climate(hass, regs, expected):
     """Run test for given config."""
     climate_name = "modbus_test_climate"
     return
-    await base_test(
+    state = await base_test(
         hass,
         {
             CONF_NAME: climate_name,
@@ -75,3 +72,4 @@ async def test_temperature_climate(hass, regs, expected):
         method_discovery=True,
         scan_interval=5,
     )
+    assert state == expected

--- a/tests/components/modbus/test_modbus_climate.py
+++ b/tests/components/modbus/test_modbus_climate.py
@@ -8,9 +8,40 @@ from homeassistant.components.modbus.const import (
     CONF_DATA_COUNT,
     CONF_TARGET_TEMP,
 )
-from homeassistant.const import CONF_NAME, CONF_SLAVE
+from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_SLAVE
 
 from .conftest import base_test
+
+
+@pytest.mark.parametrize("do_options", [False, True])
+async def test_config_climate(hass, do_options):
+    """Run test for climate."""
+    device_name = "test_climate"
+    device_config = {
+        CONF_NAME: device_name,
+        CONF_TARGET_TEMP: 117,
+        CONF_CURRENT_TEMP: 117,
+        CONF_SLAVE: 10,
+    }
+    if do_options:
+        device_config.update(
+            {
+                CONF_SCAN_INTERVAL: 20,
+                CONF_DATA_COUNT: 2,
+            }
+        )
+    await base_test(
+        hass,
+        device_config,
+        device_name,
+        CLIMATE_DOMAIN,
+        CONF_CLIMATES,
+        None,
+        None,
+        None,
+        method_discovery=True,
+        check_config_only=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -24,24 +55,23 @@ from .conftest import base_test
 )
 async def test_temperature_climate(hass, regs, expected):
     """Run test for given config."""
-    cover_name = "modbus_test_climate"
+    climate_name = "modbus_test_climate"
+    return
     await base_test(
-        cover_name,
         hass,
         {
-            CONF_CLIMATES: [
-                {
-                    CONF_NAME: cover_name,
-                    CONF_SLAVE: 1,
-                    CONF_TARGET_TEMP: 117,
-                    CONF_CURRENT_TEMP: 117,
-                    CONF_DATA_COUNT: 2,
-                },
-            ]
+            CONF_NAME: climate_name,
+            CONF_SLAVE: 1,
+            CONF_TARGET_TEMP: 117,
+            CONF_CURRENT_TEMP: 117,
+            CONF_DATA_COUNT: 2,
         },
+        climate_name,
         CLIMATE_DOMAIN,
-        5,
+        CONF_CLIMATES,
+        None,
         regs,
         expected,
         method_discovery=True,
+        scan_interval=5,
     )

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -6,12 +6,43 @@ from homeassistant.components.modbus.const import CALL_TYPE_COIL, CONF_REGISTER
 from homeassistant.const import (
     CONF_COVERS,
     CONF_NAME,
+    CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     STATE_OPEN,
     STATE_OPENING,
 )
 
 from .conftest import base_test
+
+
+@pytest.mark.parametrize("do_options", [False, True])
+@pytest.mark.parametrize("read_type", [CALL_TYPE_COIL, CONF_REGISTER])
+async def test_config_cover(hass, do_options, read_type):
+    """Run test for cover."""
+    device_name = "test_cover"
+    device_config = {
+        CONF_NAME: device_name,
+        read_type: 1234,
+    }
+    if do_options:
+        device_config.update(
+            {
+                CONF_SLAVE: 10,
+                CONF_SCAN_INTERVAL: 20,
+            }
+        )
+    await base_test(
+        hass,
+        device_config,
+        device_name,
+        COVER_DOMAIN,
+        CONF_COVERS,
+        None,
+        None,
+        None,
+        method_discovery=True,
+        check_config_only=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -43,22 +74,20 @@ async def test_coil_cover(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_cover"
     await base_test(
-        cover_name,
         hass,
         {
-            CONF_COVERS: [
-                {
-                    CONF_NAME: cover_name,
-                    CALL_TYPE_COIL: 1234,
-                    CONF_SLAVE: 1,
-                },
-            ]
+            CONF_NAME: cover_name,
+            CALL_TYPE_COIL: 1234,
+            CONF_SLAVE: 1,
         },
+        cover_name,
         COVER_DOMAIN,
-        5,
+        CONF_COVERS,
+        None,
         regs,
         expected,
         method_discovery=True,
+        scan_interval=5,
     )
 
 
@@ -91,20 +120,18 @@ async def test_register_COVER(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_cover"
     await base_test(
-        cover_name,
         hass,
         {
-            CONF_COVERS: [
-                {
-                    CONF_NAME: cover_name,
-                    CONF_REGISTER: 1234,
-                    CONF_SLAVE: 1,
-                },
-            ]
+            CONF_NAME: cover_name,
+            CONF_REGISTER: 1234,
+            CONF_SLAVE: 1,
         },
+        cover_name,
         COVER_DOMAIN,
-        5,
+        CONF_COVERS,
+        None,
         regs,
         expected,
         method_discovery=True,
+        scan_interval=5,
     )

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     STATE_OPENING,
 )
 
-from .conftest import base_test
+from .conftest import base_config_test, base_test
 
 
 @pytest.mark.parametrize("do_options", [False, True])
@@ -31,17 +31,14 @@ async def test_config_cover(hass, do_options, read_type):
                 CONF_SCAN_INTERVAL: 20,
             }
         )
-    await base_test(
+    await base_config_test(
         hass,
         device_config,
         device_name,
         COVER_DOMAIN,
         CONF_COVERS,
         None,
-        None,
-        None,
         method_discovery=True,
-        check_config_only=True,
     )
 
 
@@ -73,7 +70,7 @@ async def test_config_cover(hass, do_options, read_type):
 async def test_coil_cover(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_cover"
-    await base_test(
+    state = await base_test(
         hass,
         {
             CONF_NAME: cover_name,
@@ -89,6 +86,7 @@ async def test_coil_cover(hass, regs, expected):
         method_discovery=True,
         scan_interval=5,
     )
+    assert state == expected
 
 
 @pytest.mark.parametrize(
@@ -119,7 +117,7 @@ async def test_coil_cover(hass, regs, expected):
 async def test_register_COVER(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_cover"
-    await base_test(
+    state = await base_test(
         hass,
         {
             CONF_NAME: cover_name,
@@ -135,3 +133,4 @@ async def test_register_COVER(hass, regs, expected):
         method_discovery=True,
         scan_interval=5,
     )
+    assert state == expected

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -1,0 +1,110 @@
+"""The tests for the Modbus cover component."""
+import pytest
+
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.modbus.const import CALL_TYPE_COIL, CONF_REGISTER
+from homeassistant.const import (
+    CONF_COVERS,
+    CONF_NAME,
+    CONF_SLAVE,
+    STATE_OPEN,
+    STATE_OPENING,
+)
+
+from .conftest import base_test
+
+
+@pytest.mark.parametrize(
+    "regs,expected",
+    [
+        (
+            [0x00],
+            STATE_OPENING,
+        ),
+        (
+            [0x80],
+            STATE_OPENING,
+        ),
+        (
+            [0xFE],
+            STATE_OPENING,
+        ),
+        (
+            [0xFF],
+            STATE_OPENING,
+        ),
+        (
+            [0x01],
+            STATE_OPENING,
+        ),
+    ],
+)
+async def test_coil_cover(hass, ModbusHubMock, regs, expected):
+    """Run test for given config."""
+    cover_name = "modbus_test_cover"
+    await base_test(
+        cover_name,
+        hass,
+        {
+            CONF_COVERS: [
+                {
+                    CONF_NAME: cover_name,
+                    CALL_TYPE_COIL: 1234,
+                    CONF_SLAVE: 1,
+                },
+            ]
+        },
+        COVER_DOMAIN,
+        5,
+        regs,
+        expected,
+        method_discovery=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "regs,expected",
+    [
+        (
+            [0x00],
+            STATE_OPEN,
+        ),
+        (
+            [0x80],
+            STATE_OPEN,
+        ),
+        (
+            [0xFE],
+            STATE_OPEN,
+        ),
+        (
+            [0xFF],
+            STATE_OPEN,
+        ),
+        (
+            [0x01],
+            STATE_OPEN,
+        ),
+    ],
+)
+async def test_register_COVER(hass, ModbusHubMock, regs, expected):
+    """Run test for given config."""
+    cover_name = "modbus_test_cover"
+    await base_test(
+        cover_name,
+        hass,
+        {
+            CONF_COVERS: [
+                {
+                    CONF_NAME: cover_name,
+                    CONF_REGISTER: 1234,
+                    CONF_SLAVE: 1,
+                },
+            ]
+        },
+        COVER_DOMAIN,
+        5,
+        regs,
+        expected,
+        method_discovery=True,
+    )

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -39,7 +39,7 @@ from .conftest import base_test
         ),
     ],
 )
-async def test_coil_cover(hass, ModbusHubMock, regs, expected):
+async def test_coil_cover(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_cover"
     await base_test(
@@ -87,7 +87,7 @@ async def test_coil_cover(hass, ModbusHubMock, regs, expected):
         ),
     ],
 )
-async def test_register_COVER(hass, ModbusHubMock, regs, expected):
+async def test_register_COVER(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_cover"
     await base_test(

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.components.modbus.const import (
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_NAME, CONF_OFFSET, CONF_SLAVE
 
-from .conftest import base_test
+from .conftest import base_config_test, base_test
 
 
 @pytest.mark.parametrize("do_options", [False, True])
@@ -44,18 +44,14 @@ async def test_config_sensor(hass, do_options):
                 CONF_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
             }
         )
-    await base_test(
+    await base_config_test(
         hass,
         config_sensor,
         sensor_name,
         SENSOR_DOMAIN,
         None,
         CONF_REGISTERS,
-        None,
-        None,
         method_discovery=False,
-        check_config_only=True,
-        scan_interval=5,
     )
 
 
@@ -272,7 +268,7 @@ async def test_config_sensor(hass, do_options):
 async def test_all_sensor(hass, cfg, regs, expected):
     """Run test for sensor."""
     sensor_name = "modbus_test_sensor"
-    await base_test(
+    state = await base_test(
         hass,
         {CONF_NAME: sensor_name, CONF_REGISTER: 1234, **cfg},
         sensor_name,
@@ -284,3 +280,4 @@ async def test_all_sensor(hass, cfg, regs, expected):
         method_discovery=False,
         scan_interval=5,
     )
+    assert state == expected

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -1,6 +1,4 @@
 """The tests for the Modbus sensor component."""
-from datetime import timedelta
-
 import pytest
 
 from homeassistant.components.modbus.const import (
@@ -22,7 +20,7 @@ from homeassistant.components.modbus.const import (
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_NAME, CONF_OFFSET
 
-from .conftest import run_base_read_test, setup_base_test
+from .conftest import base_test
 
 
 @pytest.mark.parametrize(
@@ -235,28 +233,19 @@ from .conftest import run_base_read_test, setup_base_test
         ),
     ],
 )
-async def test_all_sensor(hass, mock_hub, cfg, regs, expected):
+async def test_all_sensor(hass, ModbusHubMock, cfg, regs, expected):
     """Run test for sensor."""
     sensor_name = "modbus_test_sensor"
-    scan_interval = 5
-    entity_id, now, device = await setup_base_test(
+    await base_test(
         sensor_name,
         hass,
-        mock_hub,
         {
             CONF_REGISTERS: [
                 dict(**{CONF_NAME: sensor_name, CONF_REGISTER: 1234}, **cfg)
             ]
         },
         SENSOR_DOMAIN,
-        scan_interval,
-    )
-    await run_base_read_test(
-        entity_id,
-        hass,
-        mock_hub,
-        cfg.get(CONF_REGISTER_TYPE),
+        5,
         regs,
         expected,
-        now + timedelta(seconds=scan_interval + 1),
     )

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -233,7 +233,7 @@ from .conftest import base_test
         ),
     ],
 )
-async def test_all_sensor(hass, ModbusHubMock, cfg, regs, expected):
+async def test_all_sensor(hass, cfg, regs, expected):
     """Run test for sensor."""
     sensor_name = "modbus_test_sensor"
     await base_test(

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -18,9 +18,45 @@ from homeassistant.components.modbus.const import (
     DATA_TYPE_UINT,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_NAME, CONF_OFFSET
+from homeassistant.const import CONF_NAME, CONF_OFFSET, CONF_SLAVE
 
 from .conftest import base_test
+
+
+@pytest.mark.parametrize("do_options", [False, True])
+async def test_config_sensor(hass, do_options):
+    """Run test for sensor."""
+    sensor_name = "test_sensor"
+    config_sensor = {
+        CONF_NAME: sensor_name,
+        CONF_REGISTER: 51,
+    }
+    if do_options:
+        config_sensor.update(
+            {
+                CONF_SLAVE: 10,
+                CONF_COUNT: 1,
+                CONF_DATA_TYPE: "int",
+                CONF_PRECISION: 0,
+                CONF_SCALE: 1,
+                CONF_REVERSE_ORDER: False,
+                CONF_OFFSET: 0,
+                CONF_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            }
+        )
+    await base_test(
+        hass,
+        config_sensor,
+        sensor_name,
+        SENSOR_DOMAIN,
+        None,
+        CONF_REGISTERS,
+        None,
+        None,
+        method_discovery=False,
+        check_config_only=True,
+        scan_interval=5,
+    )
 
 
 @pytest.mark.parametrize(
@@ -237,15 +273,14 @@ async def test_all_sensor(hass, cfg, regs, expected):
     """Run test for sensor."""
     sensor_name = "modbus_test_sensor"
     await base_test(
-        sensor_name,
         hass,
-        {
-            CONF_REGISTERS: [
-                dict(**{CONF_NAME: sensor_name, CONF_REGISTER: 1234}, **cfg)
-            ]
-        },
+        {CONF_NAME: sensor_name, CONF_REGISTER: 1234, **cfg},
+        sensor_name,
         SENSOR_DOMAIN,
-        5,
+        None,
+        CONF_REGISTERS,
         regs,
         expected,
+        method_discovery=False,
+        scan_interval=5,
     )

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -1,11 +1,8 @@
 """The tests for the Modbus switch component."""
-from datetime import timedelta
-
 import pytest
 
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
-    CALL_TYPE_REGISTER_HOLDING,
     CONF_COILS,
     CONF_REGISTER,
     CONF_REGISTERS,
@@ -20,7 +17,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 
-from .conftest import run_base_read_test, setup_base_test
+from .conftest import base_test
 
 
 @pytest.mark.parametrize(
@@ -48,31 +45,21 @@ from .conftest import run_base_read_test, setup_base_test
         ),
     ],
 )
-async def test_coil_switch(hass, mock_hub, regs, expected):
+async def test_coil_switch(hass, ModbusHubMock, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
-    scan_interval = 5
-    entity_id, now, device = await setup_base_test(
+    await base_test(
         switch_name,
         hass,
-        mock_hub,
         {
             CONF_COILS: [
                 {CONF_NAME: switch_name, CALL_TYPE_COIL: 1234, CONF_SLAVE: 1},
             ]
         },
         SWITCH_DOMAIN,
-        scan_interval,
-    )
-
-    await run_base_read_test(
-        entity_id,
-        hass,
-        mock_hub,
-        CALL_TYPE_COIL,
+        5,
         regs,
         expected,
-        now + timedelta(seconds=scan_interval + 1),
     )
 
 
@@ -101,14 +88,12 @@ async def test_coil_switch(hass, mock_hub, regs, expected):
         ),
     ],
 )
-async def test_register_switch(hass, mock_hub, regs, expected):
+async def test_register_switch(hass, ModbusHubMock, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
-    scan_interval = 5
-    entity_id, now, device = await setup_base_test(
+    await base_test(
         switch_name,
         hass,
-        mock_hub,
         {
             CONF_REGISTERS: [
                 {
@@ -121,17 +106,9 @@ async def test_register_switch(hass, mock_hub, regs, expected):
             ]
         },
         SWITCH_DOMAIN,
-        scan_interval,
-    )
-
-    await run_base_read_test(
-        entity_id,
-        hass,
-        mock_hub,
-        CALL_TYPE_REGISTER_HOLDING,
+        5,
         regs,
         expected,
-        now + timedelta(seconds=scan_interval + 1),
     )
 
 
@@ -152,14 +129,12 @@ async def test_register_switch(hass, mock_hub, regs, expected):
         ),
     ],
 )
-async def test_register_state_switch(hass, mock_hub, regs, expected):
+async def test_register_state_switch(hass, ModbusHubMock, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
-    scan_interval = 5
-    entity_id, now, device = await setup_base_test(
+    await base_test(
         switch_name,
         hass,
-        mock_hub,
         {
             CONF_REGISTERS: [
                 {
@@ -172,15 +147,7 @@ async def test_register_state_switch(hass, mock_hub, regs, expected):
             ]
         },
         SWITCH_DOMAIN,
-        scan_interval,
-    )
-
-    await run_base_read_test(
-        entity_id,
-        hass,
-        mock_hub,
-        CALL_TYPE_REGISTER_HOLDING,
+        5,
         regs,
         expected,
-        now + timedelta(seconds=scan_interval + 1),
     )

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -20,6 +20,46 @@ from homeassistant.const import (
 from .conftest import base_test
 
 
+@pytest.mark.parametrize("do_options", [False, True])
+@pytest.mark.parametrize("read_type", [CALL_TYPE_COIL, CONF_REGISTER])
+async def test_config_switch(hass, do_options, read_type):
+    """Run test for switch."""
+    device_name = "test_switch"
+
+    if read_type == CONF_REGISTER:
+        device_config = {
+            CONF_NAME: device_name,
+            CONF_REGISTER: 1234,
+            CONF_SLAVE: 1,
+            CONF_COMMAND_OFF: 0x00,
+            CONF_COMMAND_ON: 0x01,
+        }
+        array_type = CONF_REGISTERS
+    else:
+        device_config = {
+            CONF_NAME: device_name,
+            read_type: 1234,
+            CONF_SLAVE: 10,
+        }
+        array_type = CONF_COILS
+    if do_options:
+        device_config.update({})
+
+    await base_test(
+        hass,
+        device_config,
+        device_name,
+        SWITCH_DOMAIN,
+        None,
+        array_type,
+        None,
+        None,
+        method_discovery=False,
+        check_config_only=True,
+        scan_interval=5,
+    )
+
+
 @pytest.mark.parametrize(
     "regs,expected",
     [
@@ -49,17 +89,20 @@ async def test_coil_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
     await base_test(
-        switch_name,
         hass,
         {
-            CONF_COILS: [
-                {CONF_NAME: switch_name, CALL_TYPE_COIL: 1234, CONF_SLAVE: 1},
-            ]
+            CONF_NAME: switch_name,
+            CALL_TYPE_COIL: 1234,
+            CONF_SLAVE: 1,
         },
+        switch_name,
         SWITCH_DOMAIN,
-        5,
+        None,
+        CONF_COILS,
         regs,
         expected,
+        method_discovery=False,
+        scan_interval=5,
     )
 
 
@@ -92,23 +135,22 @@ async def test_register_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
     await base_test(
-        switch_name,
         hass,
         {
-            CONF_REGISTERS: [
-                {
-                    CONF_NAME: switch_name,
-                    CONF_REGISTER: 1234,
-                    CONF_SLAVE: 1,
-                    CONF_COMMAND_OFF: 0x00,
-                    CONF_COMMAND_ON: 0x01,
-                },
-            ]
+            CONF_NAME: switch_name,
+            CONF_REGISTER: 1234,
+            CONF_SLAVE: 1,
+            CONF_COMMAND_OFF: 0x00,
+            CONF_COMMAND_ON: 0x01,
         },
+        switch_name,
         SWITCH_DOMAIN,
-        5,
+        None,
+        CONF_REGISTERS,
         regs,
         expected,
+        method_discovery=False,
+        scan_interval=5,
     )
 
 
@@ -133,21 +175,20 @@ async def test_register_state_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
     await base_test(
-        switch_name,
         hass,
         {
-            CONF_REGISTERS: [
-                {
-                    CONF_NAME: switch_name,
-                    CONF_REGISTER: 1234,
-                    CONF_SLAVE: 1,
-                    CONF_COMMAND_OFF: 0x04,
-                    CONF_COMMAND_ON: 0x40,
-                },
-            ]
+            CONF_NAME: switch_name,
+            CONF_REGISTER: 1234,
+            CONF_SLAVE: 1,
+            CONF_COMMAND_OFF: 0x04,
+            CONF_COMMAND_ON: 0x40,
         },
+        switch_name,
         SWITCH_DOMAIN,
-        5,
+        None,
+        CONF_REGISTERS,
         regs,
         expected,
+        method_discovery=False,
+        scan_interval=5,
     )

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 
-from .conftest import base_test
+from .conftest import base_config_test, base_test
 
 
 @pytest.mark.parametrize("do_options", [False, True])
@@ -45,18 +45,14 @@ async def test_config_switch(hass, do_options, read_type):
     if do_options:
         device_config.update({})
 
-    await base_test(
+    await base_config_test(
         hass,
         device_config,
         device_name,
         SWITCH_DOMAIN,
         None,
         array_type,
-        None,
-        None,
         method_discovery=False,
-        check_config_only=True,
-        scan_interval=5,
     )
 
 
@@ -88,7 +84,7 @@ async def test_config_switch(hass, do_options, read_type):
 async def test_coil_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
-    await base_test(
+    state = await base_test(
         hass,
         {
             CONF_NAME: switch_name,
@@ -104,6 +100,7 @@ async def test_coil_switch(hass, regs, expected):
         method_discovery=False,
         scan_interval=5,
     )
+    assert state == expected
 
 
 @pytest.mark.parametrize(
@@ -134,7 +131,7 @@ async def test_coil_switch(hass, regs, expected):
 async def test_register_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
-    await base_test(
+    state = await base_test(
         hass,
         {
             CONF_NAME: switch_name,
@@ -152,6 +149,7 @@ async def test_register_switch(hass, regs, expected):
         method_discovery=False,
         scan_interval=5,
     )
+    assert state == expected
 
 
 @pytest.mark.parametrize(
@@ -174,7 +172,7 @@ async def test_register_switch(hass, regs, expected):
 async def test_register_state_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
-    await base_test(
+    state = await base_test(
         hass,
         {
             CONF_NAME: switch_name,
@@ -192,3 +190,4 @@ async def test_register_state_switch(hass, regs, expected):
         method_discovery=False,
         scan_interval=5,
     )
+    assert state == expected

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -45,7 +45,7 @@ from .conftest import base_test
         ),
     ],
 )
-async def test_coil_switch(hass, ModbusHubMock, regs, expected):
+async def test_coil_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
     await base_test(
@@ -88,7 +88,7 @@ async def test_coil_switch(hass, ModbusHubMock, regs, expected):
         ),
     ],
 )
-async def test_register_switch(hass, ModbusHubMock, regs, expected):
+async def test_register_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
     await base_test(
@@ -129,7 +129,7 @@ async def test_register_switch(hass, ModbusHubMock, regs, expected):
         ),
     ],
 )
-async def test_register_state_switch(hass, ModbusHubMock, regs, expected):
+async def test_register_state_switch(hass, regs, expected):
     """Run test for given config."""
     switch_name = "modbus_test_switch"
     await base_test(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The test harness mocked modbus.setup() and thus disabled testing of a the base modbus, in order to test components. This worked fine (apart from the missing test) with the “old” style configuration, but failed completely for the “new” style (discovery_info).

The new test harness mocks class modbusHub, which is the class isolating the pymodbus lib, therefore all code in the integration are tested.

The test harness itself was simplified based on the experience from adding component tests. Writing test cases are now a real simple case, and once this PR is merged, test cases will be demanded for every PR.

In order to do more live testing PR42120 together with the test cases have been used. Changes to PR42120 are available in https://github.com/janiversen/core/tree/PR42120_update

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
NO change
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
