### PR TITLE
Make DeviceRegistry.async_get_device connections arg optional

### DIFF
--- a/homeassistant/components/acmeda/base.py
+++ b/homeassistant/components/acmeda/base.py
@@ -26,9 +26,7 @@ class AcmedaBase(entity.Entity):
             ent_registry.async_remove(self.entity_id)
 
         dev_registry = await get_dev_reg(self.hass)
-        device = dev_registry.async_get_device(
-            identifiers={(DOMAIN, self.unique_id)}, connections=set()
-        )
+        device = dev_registry.async_get_device(identifiers={(DOMAIN, self.unique_id)})
         if device is not None:
             dev_registry.async_update_device(
                 device.id, remove_config_entry_id=self.registry_entry.config_entry_id

--- a/homeassistant/components/acmeda/helpers.py
+++ b/homeassistant/components/acmeda/helpers.py
@@ -32,9 +32,7 @@ async def update_devices(hass, config_entry, api):
 
     for api_item in api.values():
         # Update Device name
-        device = dev_registry.async_get_device(
-            identifiers={(DOMAIN, api_item.id)}, connections=set()
-        )
+        device = dev_registry.async_get_device(identifiers={(DOMAIN, api_item.id)})
         if device is not None:
             dev_registry.async_update_device(
                 device.id,

--- a/homeassistant/components/broadlink/device.py
+++ b/homeassistant/components/broadlink/device.py
@@ -57,9 +57,7 @@ class BroadlinkDevice:
         Triggered when the device is renamed on the frontend.
         """
         device_registry = await dr.async_get_registry(hass)
-        device_entry = device_registry.async_get_device(
-            {(DOMAIN, entry.unique_id)}, set()
-        )
+        device_entry = device_registry.async_get_device({(DOMAIN, entry.unique_id)})
         device_registry.async_update_device(device_entry.id, name=entry.title)
         await hass.config_entries.async_reload(entry.entry_id)
 

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -196,7 +196,7 @@ class ControllerManager:
         # mapped_ids contains the mapped IDs (new:old)
         for new_id, old_id in mapped_ids.items():
             # update device registry
-            entry = self._device_registry.async_get_device({(DOMAIN, old_id)}, set())
+            entry = self._device_registry.async_get_device({(DOMAIN, old_id)})
             new_identifiers = {(DOMAIN, new_id)}
             if entry:
                 self._device_registry.async_update_device(

--- a/homeassistant/components/hue/helpers.py
+++ b/homeassistant/components/hue/helpers.py
@@ -22,9 +22,7 @@ async def remove_devices(bridge, api_ids, current):
         if entity.entity_id in ent_registry.entities:
             ent_registry.async_remove(entity.entity_id)
         dev_registry = await get_dev_reg(bridge.hass)
-        device = dev_registry.async_get_device(
-            identifiers={(DOMAIN, entity.device_id)}, connections=set()
-        )
+        device = dev_registry.async_get_device(identifiers={(DOMAIN, entity.device_id)})
         if device is not None:
             dev_registry.async_update_device(
                 device.id, remove_config_entry_id=bridge.config_entry.entry_id

--- a/homeassistant/components/insteon/utils.py
+++ b/homeassistant/components/insteon/utils.py
@@ -294,9 +294,7 @@ def async_register_services(hass):
         signal = f"{address.id}_{SIGNAL_REMOVE_ENTITY}"
         async_dispatcher_send(hass, signal)
         dev_registry = await hass.helpers.device_registry.async_get_registry()
-        device = dev_registry.async_get_device(
-            identifiers={(DOMAIN, str(address))}, connections=set()
-        )
+        device = dev_registry.async_get_device(identifiers={(DOMAIN, str(address))})
         if device:
             dev_registry.async_remove_device(device.id)
 

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -398,7 +398,7 @@ class KodiEntity(MediaPlayerEntity):
         version = (await self._kodi.get_application_properties(["version"]))["version"]
         sw_version = f"{version['major']}.{version['minor']}"
         dev_reg = await device_registry.async_get_registry(self.hass)
-        device = dev_reg.async_get_device({(DOMAIN, self.unique_id)}, [])
+        device = dev_reg.async_get_device({(DOMAIN, self.unique_id)})
         dev_reg.async_update_device(device.id, sw_version=sw_version)
 
         self.async_schedule_update_ha_state(True)

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -121,7 +121,7 @@ class SignalUpdateCallback:
             return
         _LOGGER.debug("Event Update %s", events.keys())
         device_registry = await self._hass.helpers.device_registry.async_get_registry()
-        device_entry = device_registry.async_get_device({(DOMAIN, device_id)}, ())
+        device_entry = device_registry.async_get_device({(DOMAIN, device_id)})
         if not device_entry:
             return
         for event in events:

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -230,10 +230,10 @@ class NotionEntity(CoordinatorEntity):
         device_registry = await dr.async_get_registry(self.hass)
         bridge = self.coordinator.data["bridges"][self._bridge_id]
         bridge_device = device_registry.async_get_device(
-            {(DOMAIN, bridge["hardware_id"])}, set()
+            {(DOMAIN, bridge["hardware_id"])}
         )
         this_device = device_registry.async_get_device(
-            {(DOMAIN, sensor["hardware_id"])}, set()
+            {(DOMAIN, sensor["hardware_id"])}
         )
 
         device_registry.async_update_device(

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -348,7 +348,7 @@ async def async_handle_remove_node(hass: HomeAssistant, node: OZWNode):
     dev_registry = await get_dev_reg(hass)
     # grab device in device registry attached to this node
     dev_id = create_device_id(node)
-    device = dev_registry.async_get_device({(DOMAIN, dev_id)}, set())
+    device = dev_registry.async_get_device({(DOMAIN, dev_id)})
     if not device:
         return
     devices_to_remove = [device.id]
@@ -372,7 +372,7 @@ async def async_handle_node_update(hass: HomeAssistant, node: OZWNode):
     dev_registry = await get_dev_reg(hass)
     # grab device in device registry attached to this node
     dev_id = create_device_id(node)
-    device = dev_registry.async_get_device({(DOMAIN, dev_id)}, set())
+    device = dev_registry.async_get_device({(DOMAIN, dev_id)})
     if not device:
         return
     # update device in device registry with (updated) info

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -311,7 +311,6 @@ async def async_setup_internal(hass, entry: config_entries.ConfigEntry):
 
         device_entry = device_registry.async_get_device(
             identifiers={(DOMAIN, *device_id)},
-            connections=set(),
         )
         if device_entry:
             event_data[ATTR_DEVICE_ID] = device_entry.id

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -505,7 +505,7 @@ async def async_setup_entry(hass, config_entry):
     async def _remove_device(node):
         dev_reg = await async_get_device_registry(hass)
         identifier, name = node_device_id_and_name(node)
-        device = dev_reg.async_get_device(identifiers={identifier}, connections=set())
+        device = dev_reg.async_get_device(identifiers={identifier})
         if device is not None:
             _LOGGER.debug("Removing Device - %s - %s", device.id, name)
             dev_reg.async_remove_device(device.id)

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -246,14 +246,12 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         # Set the name in the devices. If they're customised
         # the customisation will not be stored as name and will stick.
         dev_reg = await get_dev_reg(self.hass)
-        device = dev_reg.async_get_device(identifiers={identifier}, connections=set())
+        device = dev_reg.async_get_device(identifiers={identifier})
         dev_reg.async_update_device(device.id, name=self._name)
         # update sub-devices too
         for i in count(2):
             identifier, new_name = node_device_id_and_name(self.node, i)
-            device = dev_reg.async_get_device(
-                identifiers={identifier}, connections=set()
-            )
+            device = dev_reg.async_get_device(identifiers={identifier})
             if not device:
                 break
             dev_reg.async_update_device(device.id, name=new_name)

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -139,7 +139,9 @@ class DeviceRegistry:
 
     @callback
     def async_get_device(
-        self, identifiers: set, connections: set
+        self,
+        identifiers: set,
+        connections: Optional[set] = None,
     ) -> Optional[DeviceEntry]:
         """Check if device is registered."""
         device_id = self._async_get_device_id_from_index(
@@ -150,7 +152,7 @@ class DeviceRegistry:
         return self.devices[device_id]
 
     def _async_get_deleted_device(
-        self, identifiers: set, connections: set
+        self, identifiers: set, connections: Optional[set]
     ) -> Optional[DeletedDeviceEntry]:
         """Check if device is deleted."""
         device_id = self._async_get_device_id_from_index(
@@ -161,7 +163,7 @@ class DeviceRegistry:
         return self.deleted_devices[device_id]
 
     def _async_get_device_id_from_index(
-        self, index: str, identifiers: set, connections: set
+        self, index: str, identifiers: set, connections: Optional[set]
     ) -> Optional[str]:
         """Check if device has previously been registered."""
         devices_index = self._devices_index[index]

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -276,7 +276,7 @@ class DeviceRegistry:
             name = default_name
 
         if via_device is not None:
-            via = self.async_get_device({via_device}, set())
+            via = self.async_get_device({via_device})
             via_device_id: Union[str, UndefinedType] = via.id if via else UNDEFINED
         else:
             via_device_id = UNDEFINED

--- a/tests/components/august/test_binary_sensor.py
+++ b/tests/components/august/test_binary_sensor.py
@@ -121,9 +121,7 @@ async def test_doorbell_device_registry(hass):
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
 
-    reg_device = device_registry.async_get_device(
-        identifiers={("august", "tmt100")}, connections=set()
-    )
+    reg_device = device_registry.async_get_device(identifiers={("august", "tmt100")})
     assert reg_device.model == "hydra1"
     assert reg_device.name == "tmt100 Name"
     assert reg_device.manufacturer == "August Home Inc."

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -26,7 +26,7 @@ async def test_lock_device_registry(hass):
     device_registry = await hass.helpers.device_registry.async_get_registry()
 
     reg_device = device_registry.async_get_device(
-        identifiers={("august", "online_with_doorsense")}, connections=set()
+        identifiers={("august", "online_with_doorsense")}
     )
     assert reg_device.model == "AUG-MD01"
     assert reg_device.sw_version == "undefined-4.3.0-1.8.14"

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -70,9 +70,7 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
 
     # verify hub device is registered correctly
     device_registry = await dr.async_get_registry(hass)
-    hub = device_registry.async_get_device(
-        identifiers={(DOMAIN, "test-bond-id")}, connections=set()
-    )
+    hub = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert hub.name == "test-bond-id"
     assert hub.manufacturer == "Olibra"
     assert hub.model == "test-model"

--- a/tests/components/broadlink/test_device.py
+++ b/tests/components/broadlink/test_device.py
@@ -253,9 +253,7 @@ async def test_device_setup_registry(hass):
 
     assert len(device_registry.devices) == 1
 
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     assert device_entry.identifiers == {(DOMAIN, device.mac)}
     assert device_entry.name == device.name
     assert device_entry.model == device.model
@@ -339,9 +337,7 @@ async def test_device_update_listener(hass):
         hass.config_entries.async_update_entry(mock_entry, title="New Name")
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     assert device_entry.name == "New Name"
     for entry in async_entries_for_device(entity_registry, device_entry.id):
         assert entry.original_name.startswith("New Name")

--- a/tests/components/broadlink/test_remote.py
+++ b/tests/components/broadlink/test_remote.py
@@ -31,7 +31,7 @@ async def test_remote_setup_works(hass):
         mock_api, mock_entry = await device.setup_entry(hass)
 
         device_entry = device_registry.async_get_device(
-            {(DOMAIN, mock_entry.unique_id)}, set()
+            {(DOMAIN, mock_entry.unique_id)}
         )
         entries = async_entries_for_device(entity_registry, device_entry.id)
         remotes = {entry for entry in entries if entry.domain == REMOTE_DOMAIN}
@@ -51,7 +51,7 @@ async def test_remote_send_command(hass):
         mock_api, mock_entry = await device.setup_entry(hass)
 
         device_entry = device_registry.async_get_device(
-            {(DOMAIN, mock_entry.unique_id)}, set()
+            {(DOMAIN, mock_entry.unique_id)}
         )
         entries = async_entries_for_device(entity_registry, device_entry.id)
         remotes = {entry for entry in entries if entry.domain == REMOTE_DOMAIN}
@@ -78,7 +78,7 @@ async def test_remote_turn_off_turn_on(hass):
         mock_api, mock_entry = await device.setup_entry(hass)
 
         device_entry = device_registry.async_get_device(
-            {(DOMAIN, mock_entry.unique_id)}, set()
+            {(DOMAIN, mock_entry.unique_id)}
         )
         entries = async_entries_for_device(entity_registry, device_entry.id)
         remotes = {entry for entry in entries if entry.domain == REMOTE_DOMAIN}

--- a/tests/components/broadlink/test_sensors.py
+++ b/tests/components/broadlink/test_sensors.py
@@ -25,9 +25,7 @@ async def test_a1_sensor_setup(hass):
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors_raw.call_count == 1
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 5
@@ -62,9 +60,7 @@ async def test_a1_sensor_update(hass):
 
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 5
@@ -106,9 +102,7 @@ async def test_rm_pro_sensor_setup(hass):
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count == 1
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 1
@@ -131,9 +125,7 @@ async def test_rm_pro_sensor_update(hass):
 
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 1
@@ -163,9 +155,7 @@ async def test_rm_mini3_no_sensor(hass):
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count <= 1
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 0
@@ -183,9 +173,7 @@ async def test_rm4_pro_hts2_sensor_setup(hass):
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count == 1
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 2
@@ -211,9 +199,7 @@ async def test_rm4_pro_hts2_sensor_update(hass):
 
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 2
@@ -246,9 +232,7 @@ async def test_rm4_pro_no_sensor(hass):
     mock_api, mock_entry = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count <= 1
-    device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_entry.unique_id)}, set()
-    )
+    device_entry = device_registry.async_get_device({(DOMAIN, mock_entry.unique_id)})
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 0

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -88,7 +88,7 @@ async def test_sensors_pro(hass, canary) -> None:
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
 
-    device = device_registry.async_get_device({(DOMAIN, "20")}, set())
+    device = device_registry.async_get_device({(DOMAIN, "20")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "Dining Room"
@@ -206,7 +206,7 @@ async def test_sensors_flex(hass, canary) -> None:
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
 
-    device = device_registry.async_get_device({(DOMAIN, "20")}, set())
+    device = device_registry.async_get_device({(DOMAIN, "20")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "Dining Room"

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -445,7 +445,7 @@ async def test_device_info_ismartgate(ismartgateapi_mock, hass: HomeAssistant) -
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, "xyz")}, set())
+    device = device_registry.async_get_device({(DOMAIN, "xyz")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "mycontroller"
@@ -480,7 +480,7 @@ async def test_device_info_gogogate2(gogogate2api_mock, hass: HomeAssistant) -> 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, "xyz")}, set())
+    device = device_registry.async_get_device({(DOMAIN, "xyz")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "mycontroller"

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -243,7 +243,7 @@ async def test_updates_from_players_changed_new_ids(
     event = asyncio.Event()
 
     # Assert device registry matches current id
-    assert device_registry.async_get_device({(DOMAIN, 1)}, [])
+    assert device_registry.async_get_device({(DOMAIN, 1)})
     # Assert entity registry matches current id
     assert (
         entity_registry.async_get_entity_id(MEDIA_PLAYER_DOMAIN, DOMAIN, "1")
@@ -264,7 +264,7 @@ async def test_updates_from_players_changed_new_ids(
 
     # Assert device registry identifiers were updated
     assert len(device_registry.devices) == 1
-    assert device_registry.async_get_device({(DOMAIN, 101)}, [])
+    assert device_registry.async_get_device({(DOMAIN, 101)})
     # Assert entity registry unique id was updated
     assert len(entity_registry.entities) == 1
     assert (

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -541,7 +541,7 @@ async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
     assert device_reg.async_get(bridge_with_wrong_mac.id) is None
 
     device = device_reg.async_get_device(
-        {(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}, {}
+        {(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
     )
     assert device
     formatted_mac = device_registry.format_mac(homekit.driver.state.mac)
@@ -559,7 +559,7 @@ async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
         await homekit.async_start()
 
     device = device_reg.async_get_device(
-        {(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}, {}
+        {(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
     )
     assert device
     formatted_mac = device_registry.format_mac(homekit.driver.state.mac)

--- a/tests/components/hue/test_device_trigger.py
+++ b/tests/components/hue/test_device_trigger.py
@@ -43,7 +43,7 @@ async def test_get_triggers(hass, mock_bridge, device_reg):
 
     # Get triggers for specific tap switch
     hue_tap_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}, connections={}
+        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
     triggers = await async_get_device_automations(hass, "trigger", hue_tap_device.id)
 
@@ -61,7 +61,7 @@ async def test_get_triggers(hass, mock_bridge, device_reg):
 
     # Get triggers for specific dimmer switch
     hue_dimmer_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}, connections={}
+        {(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
     )
     triggers = await async_get_device_automations(hass, "trigger", hue_dimmer_device.id)
 
@@ -97,7 +97,7 @@ async def test_if_fires_on_state_change(hass, mock_bridge, device_reg, calls):
 
     # Set an automation with a specific tap switch trigger
     hue_tap_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}, connections={}
+        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
     assert await async_setup_component(
         hass,

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -602,7 +602,7 @@ async def help_test_entity_device_info_with_identifier(hass, mqtt_mock, domain, 
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -650,14 +650,14 @@ async def help_test_entity_device_info_remove(hass, mqtt_mock, domain, config):
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = dev_registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = dev_registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique")
 
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", "")
     await hass.async_block_till_done()
 
-    device = dev_registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = dev_registry.async_get_device({("mqtt", "helloworld")})
     assert device is None
     assert not ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique")
 
@@ -678,7 +678,7 @@ async def help_test_entity_device_info_update(hass, mqtt_mock, domain, config):
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -687,7 +687,7 @@ async def help_test_entity_device_info_update(hass, mqtt_mock, domain, config):
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 
@@ -790,7 +790,7 @@ async def help_test_entity_debug_info(hass, mqtt_mock, domain, config):
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -823,7 +823,7 @@ async def help_test_entity_debug_info_max_messages(hass, mqtt_mock, domain, conf
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -885,7 +885,7 @@ async def help_test_entity_debug_info_message(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -931,7 +931,7 @@ async def help_test_entity_debug_info_remove(hass, mqtt_mock, domain, config):
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -975,7 +975,7 @@ async def help_test_entity_debug_info_update_entity_id(hass, mqtt_mock, domain, 
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = dev_registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = dev_registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)

--- a/tests/components/mqtt/test_device_tracker_discovery.py
+++ b/tests/components/mqtt/test_device_tracker_discovery.py
@@ -184,7 +184,7 @@ async def test_cleanup_device_tracker(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
     entity_entry = entity_reg.async_get("device_tracker.mqtt_unique")
     assert entity_entry is not None
@@ -196,7 +196,7 @@ async def test_cleanup_device_tracker(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is None
     entity_entry = entity_reg.async_get("device_tracker.mqtt_unique")
     assert entity_entry is None

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -50,7 +50,7 @@ async def test_get_triggers(hass, device_reg, entity_reg, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     expected_triggers = [
         {
             "platform": "device",
@@ -76,7 +76,7 @@ async def test_get_unknown_triggers(hass, device_reg, entity_reg, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -116,7 +116,7 @@ async def test_get_non_existing_triggers(hass, device_reg, entity_reg, mqtt_mock
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     assert_lists_same(triggers, [])
 
@@ -135,7 +135,7 @@ async def test_discover_bad_triggers(hass, device_reg, entity_reg, mqtt_mock):
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data0)
     await hass.async_block_till_done()
-    assert device_reg.async_get_device({("mqtt", "0AFFD2")}, set()) is None
+    assert device_reg.async_get_device({("mqtt", "0AFFD2")}) is None
 
     # Test sending correct data
     data1 = (
@@ -149,7 +149,7 @@ async def test_discover_bad_triggers(hass, device_reg, entity_reg, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     expected_triggers = [
         {
             "platform": "device",
@@ -185,7 +185,7 @@ async def test_update_remove_triggers(hass, device_reg, entity_reg, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     expected_triggers1 = [
         {
             "platform": "device",
@@ -213,7 +213,7 @@ async def test_update_remove_triggers(hass, device_reg, entity_reg, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", "")
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is None
 
 
@@ -238,7 +238,7 @@ async def test_if_fires_on_mqtt_message(hass, device_reg, calls, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", data2)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -317,7 +317,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -393,7 +393,7 @@ async def test_if_fires_on_mqtt_message_after_update(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -459,7 +459,7 @@ async def test_no_resubscribe_same_topic(hass, device_reg, mqtt_mock):
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -503,7 +503,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -563,7 +563,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -614,7 +614,7 @@ async def test_attach_remove(hass, device_reg, mqtt_mock):
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -668,7 +668,7 @@ async def test_attach_remove_late(hass, device_reg, mqtt_mock):
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -725,7 +725,7 @@ async def test_attach_remove_late2(hass, device_reg, mqtt_mock):
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -812,7 +812,7 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -844,7 +844,7 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -853,7 +853,7 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 
@@ -873,7 +873,7 @@ async def test_cleanup_trigger(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -884,7 +884,7 @@ async def test_cleanup_trigger(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
     # Verify retained discovery topic has been cleared
@@ -908,7 +908,7 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -918,7 +918,7 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -948,7 +948,7 @@ async def test_cleanup_device_several_triggers(hass, device_reg, entity_reg, mqt
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -960,7 +960,7 @@ async def test_cleanup_device_several_triggers(hass, device_reg, entity_reg, mqt
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -971,7 +971,7 @@ async def test_cleanup_device_several_triggers(hass, device_reg, entity_reg, mqt
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -1003,7 +1003,7 @@ async def test_cleanup_device_with_entity1(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -1013,7 +1013,7 @@ async def test_cleanup_device_with_entity1(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -1023,7 +1023,7 @@ async def test_cleanup_device_with_entity1(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -1055,7 +1055,7 @@ async def test_cleanup_device_with_entity2(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -1065,7 +1065,7 @@ async def test_cleanup_device_with_entity2(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -1075,7 +1075,7 @@ async def test_cleanup_device_with_entity2(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -398,7 +398,7 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
     entity_entry = entity_reg.async_get("sensor.mqtt_sensor")
     assert entity_entry is not None
@@ -410,7 +410,7 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is None
     entity_entry = entity_reg.async_get("sensor.mqtt_sensor")
     assert entity_entry is None

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -970,7 +970,7 @@ async def test_mqtt_ws_remove_discovered_device(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -981,7 +981,7 @@ async def test_mqtt_ws_remove_discovered_device(
     assert response["success"]
 
     # Verify device entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is None
 
 
@@ -998,7 +998,7 @@ async def test_mqtt_ws_remove_discovered_device_twice(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -1030,7 +1030,7 @@ async def test_mqtt_ws_remove_discovered_device_same_topic(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -1086,7 +1086,7 @@ async def test_mqtt_ws_get_device_debug_info(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -1168,7 +1168,7 @@ async def test_debug_info_multiple_devices(hass, mqtt_mock):
     for d in devices:
         domain = d["domain"]
         id = d["config"]["device"]["identifiers"][0]
-        device = registry.async_get_device({("mqtt", id)}, set())
+        device = registry.async_get_device({("mqtt", id)})
         assert device is not None
 
         debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -1246,7 +1246,7 @@ async def test_debug_info_multiple_entities_triggers(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     device_id = config[0]["config"]["device"]["identifiers"][0]
-    device = registry.async_get_device({("mqtt", device_id)}, set())
+    device = registry.async_get_device({("mqtt", device_id)})
     assert device is not None
     debug_info_data = await debug_info.info_for_device(hass, device.id)
     assert len(debug_info_data["entities"]) == 2
@@ -1316,7 +1316,7 @@ async def test_debug_info_wildcard(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -1362,7 +1362,7 @@ async def test_debug_info_filter_same(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -1421,7 +1421,7 @@ async def test_debug_info_same_topic(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)
@@ -1472,7 +1472,7 @@ async def test_debug_info_qos_retain(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = await debug_info.info_for_device(hass, device.id)

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -579,7 +579,7 @@ async def test_entity_device_info_with_hub(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.via_device_id == hub.id
 

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -64,13 +64,13 @@ async def test_discover_bad_tag(hass, device_reg, entity_reg, mqtt_mock, tag_moc
     data0 = '{ "device":{"identifiers":["0AFFD2"]}, "topics": "foobar/tag_scanned" }'
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data0)
     await hass.async_block_till_done()
-    assert device_reg.async_get_device({("mqtt", "0AFFD2")}, set()) is None
+    assert device_reg.async_get_device({("mqtt", "0AFFD2")}) is None
 
     # Test sending correct data
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
     await hass.async_block_till_done()
@@ -85,7 +85,7 @@ async def test_if_fires_on_mqtt_message_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -116,7 +116,7 @@ async def test_if_fires_on_mqtt_message_with_template(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN_JSON)
@@ -147,7 +147,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config1))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -235,7 +235,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_template(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config1))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN_JSON)
@@ -275,7 +275,7 @@ async def test_no_resubscribe_same_topic(hass, device_reg, mqtt_mock):
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    assert device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    assert device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     call_count = mqtt_mock.async_subscribe.call_count
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
@@ -291,7 +291,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -359,7 +359,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -423,7 +423,7 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -452,7 +452,7 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -461,7 +461,7 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")}, set())
+    device = registry.async_get_device({("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 
@@ -478,7 +478,7 @@ async def test_cleanup_tag(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     device_reg.async_remove_device(device_entry.id)
@@ -486,7 +486,7 @@ async def test_cleanup_tag(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
     # Verify retained discovery topic has been cleared
@@ -507,14 +507,14 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -538,14 +538,14 @@ async def test_cleanup_device_several_tags(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     # Fake tag scan.
@@ -558,7 +558,7 @@ async def test_cleanup_device_several_tags(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -600,7 +600,7 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -610,7 +610,7 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", "")
@@ -620,7 +620,7 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None
 
 
@@ -660,7 +660,7 @@ async def test_cleanup_device_with_entity2(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
@@ -673,12 +673,12 @@ async def test_cleanup_device_with_entity2(hass, device_reg, entity_reg, mqtt_mo
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_reg.async_get_device({("mqtt", "helloworld")}, set())
+    device_entry = device_reg.async_get_device({("mqtt", "helloworld")})
     assert device_entry is None

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -102,9 +102,7 @@ async def test_get_triggers(hass):
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
-    device_entry = device_registry.async_get_device(
-        {("nest", DEVICE_ID)}, connections={}
-    )
+    device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
 
     expected_triggers = [
         {
@@ -179,9 +177,7 @@ async def test_triggers_for_invalid_device_id(hass):
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
-    device_entry = device_registry.async_get_device(
-        {("nest", DEVICE_ID)}, connections={}
-    )
+    device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
     assert device_entry is not None
 
     # Create an additional device that does not exist.  Fetching supported
@@ -293,9 +289,7 @@ async def test_subscriber_automation(hass, calls):
     subscriber = await async_setup_camera(hass, {DEVICE_ID: camera})
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
-    device_entry = device_registry.async_get_device(
-        {("nest", DEVICE_ID)}, connections={}
-    )
+    device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")
 

--- a/tests/components/onewire/test_entity_owserver.py
+++ b/tests/components/onewire/test_entity_owserver.py
@@ -745,7 +745,7 @@ async def test_owserver_setup_valid_device(owproxy, hass, device_id, platform):
     if len(expected_sensors) > 0:
         device_info = mock_device_sensor["device_info"]
         assert len(device_registry.devices) == 1
-        registry_entry = device_registry.async_get_device({(DOMAIN, device_id)}, set())
+        registry_entry = device_registry.async_get_device({(DOMAIN, device_id)})
         assert registry_entry is not None
         assert registry_entry.identifiers == {(DOMAIN, device_id)}
         assert registry_entry.manufacturer == device_info["manufacturer"]

--- a/tests/components/onewire/test_entity_sysbus.py
+++ b/tests/components/onewire/test_entity_sysbus.py
@@ -157,7 +157,7 @@ async def test_onewiredirect_setup_valid_device(hass, device_id):
     if len(expected_sensors) > 0:
         device_info = mock_device_sensor["device_info"]
         assert len(device_registry.devices) == 1
-        registry_entry = device_registry.async_get_device({(DOMAIN, device_id)}, set())
+        registry_entry = device_registry.async_get_device({(DOMAIN, device_id)})
         assert registry_entry is not None
         assert registry_entry.identifiers == {(DOMAIN, device_id)}
         assert registry_entry.manufacturer == device_info["manufacturer"]

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -40,9 +40,7 @@ async def test_device_registry_insert(hass):
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
 
-    gw_dev = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_GATEWAY_ID)}, connections=set()
-    )
+    gw_dev = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_GATEWAY_ID)})
     assert gw_dev.sw_version == VERSION_OLD
 
 
@@ -67,7 +65,5 @@ async def test_device_registry_update(hass):
         await setup.async_setup_component(hass, DOMAIN, {})
 
     await hass.async_block_till_done()
-    gw_dev = dev_reg.async_get_device(
-        identifiers={(DOMAIN, MOCK_GATEWAY_ID)}, connections=set()
-    )
+    gw_dev = dev_reg.async_get_device(identifiers={(DOMAIN, MOCK_GATEWAY_ID)})
     assert gw_dev.sw_version == VERSION_NEW

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -26,7 +26,6 @@ async def test_sensors(hass):
     device_registry = await hass.helpers.device_registry.async_get_registry()
     reg_device = device_registry.async_get_device(
         identifiers={("powerwall", "TG0123456789AB_TG9876543210BA")},
-        connections=set(),
     )
     assert reg_device.model == "PowerWall 2 (GW1)"
     assert reg_device.sw_version == "1.45.1"

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -304,9 +304,7 @@ async def test_device_info_is_set_from_status_correctly(hass, patch_get_status):
     mock_state = hass.states.get(mock_entity_id).state
 
     mock_d_entries = mock_d_registry.devices
-    mock_entry = mock_d_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_HOST_ID)}, connections=set()
-    )
+    mock_entry = mock_d_registry.async_get_device(identifiers={(DOMAIN, MOCK_HOST_ID)})
     assert mock_state == STATE_STANDBY
 
     assert len(mock_d_entries) == 1

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -95,12 +95,12 @@ async def test_fire_event(hass, rfxtrx):
     await rfxtrx.signal("0716000100900970")
 
     device_id_1 = device_registry.async_get_device(
-        identifiers={("rfxtrx", "11", "0", "213c7f2:16")}, connections=set()
+        identifiers={("rfxtrx", "11", "0", "213c7f2:16")}
     )
     assert device_id_1
 
     device_id_2 = device_registry.async_get_device(
-        identifiers={("rfxtrx", "16", "0", "00:90")}, connections=set()
+        identifiers={("rfxtrx", "16", "0", "00:90")}
     )
     assert device_id_2
 

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -148,11 +148,11 @@ async def test_setup(hass, two_part_alarm):
     assert registry.async_is_registered(SECOND_ENTITY_ID)
 
     registry = await hass.helpers.device_registry.async_get_registry()
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_0")}, {})
+    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_0")})
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_1")}, {})
+    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_1")})
     assert device is not None
     assert device.manufacturer == "Risco"
 

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -60,11 +60,11 @@ async def test_setup(hass, two_zone_alarm):  # noqa: F811
     assert registry.async_is_registered(SECOND_ENTITY_ID)
 
     registry = await hass.helpers.device_registry.async_get_registry()
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_0")}, {})
+    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_0")})
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_1")}, {})
+    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_1")})
     assert device is not None
     assert device.manufacturer == "Risco"
 

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -200,7 +200,7 @@ async def test_device_properties(
 ):
     """Test device properties."""
     registry = await hass.helpers.device_registry.async_get_registry()
-    device = registry.async_get_device({(DOMAIN, "AC000Wxxxxxxxxx")}, [])
+    device = registry.async_get_device({(DOMAIN, "AC000Wxxxxxxxxx")})
     assert getattr(device, device_property) == target_value
 
 

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -57,7 +57,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     entry = entity_registry.async_get("binary_sensor.motion_sensor_1_motion")
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.motion}"
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
     assert entry.model == device.device_type_name

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -576,7 +576,7 @@ async def test_entity_and_device_attributes(hass, thermostat):
     assert entry
     assert entry.unique_id == thermostat.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, thermostat.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, thermostat.device_id)})
     assert entry
     assert entry.name == thermostat.label
     assert entry.model == thermostat.device_type_name

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -40,7 +40,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
     assert entry.model == device.device_type_name

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -62,7 +62,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
     assert entry.model == device.device_type_name

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -115,7 +115,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
     assert entry.model == device.device_type_name

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -27,7 +27,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
     assert entry.model == device.device_type_name

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -85,7 +85,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     entry = entity_registry.async_get("sensor.sensor_1_battery")
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.battery}"
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
     assert entry.model == device.device_type_name

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -30,7 +30,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)}, [])
+    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
     assert entry.model == device.device_type_name

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -114,9 +114,7 @@ async def test_state(hass):
     assert attributes["supported_features"] == SUPPORT_SONGPAL
 
     device_registry = await dr.async_get_registry(hass)
-    device = device_registry.async_get_device(
-        identifiers={(songpal.DOMAIN, MAC)}, connections={}
-    )
+    device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, MAC)}
     assert device.manufacturer == "Sony Corporation"
     assert device.name == FRIENDLY_NAME

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -50,8 +50,7 @@ async def test_device_registry(hass, config_entry, config, soco):
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
     reg_device = device_registry.async_get_device(
-        identifiers={("sonos", "RINCON_test")},
-        connections=set(),
+        identifiers={("sonos", "RINCON_test")}
     )
     assert reg_device.model == "Model Name"
     assert reg_device.sw_version == "49.2-64250"

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -216,7 +216,7 @@ async def _create_entries(
 
     entity_id = entity_registry.async_get_entity_id("light", TWINKLY_DOMAIN, client.id)
     entity = entity_registry.async_get(entity_id)
-    device = device_registry.async_get_device({(TWINKLY_DOMAIN, client.id)}, set())
+    device = device_registry.async_get_device({(TWINKLY_DOMAIN, client.id)})
 
     assert entity is not None
     assert device is not None

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -50,7 +50,7 @@ async def test_get_actions(hass, device_ias):
     ieee_address = str(device_ias[0].ieee)
 
     ha_device_registry = await async_get_registry(hass)
-    reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)}, set())
+    reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)})
 
     actions = await async_get_device_automations(hass, "action", reg_device.id)
 
@@ -73,7 +73,7 @@ async def test_action(hass, device_ias):
     ieee_address = str(zha_device.ieee)
 
     ha_device_registry = await async_get_registry(hass)
-    reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)}, set())
+    reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)})
 
     with patch(
         "zigpy.zcl.Cluster.request",

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -87,7 +87,7 @@ async def test_triggers(hass, mock_devices):
     ieee_address = str(zha_device.ieee)
 
     ha_device_registry = await async_get_registry(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
 
@@ -145,7 +145,7 @@ async def test_no_triggers(hass, mock_devices):
     ieee_address = str(zha_device.ieee)
 
     ha_device_registry = await async_get_registry(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
     assert triggers == [
@@ -174,7 +174,7 @@ async def test_if_fires_on_event(hass, mock_devices, calls):
 
     ieee_address = str(zha_device.ieee)
     ha_device_registry = await async_get_registry(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     assert await async_setup_component(
         hass,
@@ -283,7 +283,7 @@ async def test_exception_no_triggers(hass, mock_devices, calls, caplog):
 
     ieee_address = str(zha_device.ieee)
     ha_device_registry = await async_get_registry(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     await async_setup_component(
         hass,
@@ -325,7 +325,7 @@ async def test_exception_bad_trigger(hass, mock_devices, calls, caplog):
 
     ieee_address = str(zha_device.ieee)
     ha_device_registry = await async_get_registry(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     await async_setup_component(
         hass,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -229,8 +229,8 @@ async def test_removing_config_entries(hass, registry, update_events):
     assert entry2.config_entries == {"123", "456"}
 
     registry.async_clear_config_entry("123")
-    entry = registry.async_get_device({("bridgeid", "0123")}, set())
-    entry3_removed = registry.async_get_device({("bridgeid", "4567")}, set())
+    entry = registry.async_get_device({("bridgeid", "0123")})
+    entry3_removed = registry.async_get_device({("bridgeid", "4567")})
 
     assert entry.config_entries == {"456"}
     assert entry3_removed is None
@@ -336,7 +336,7 @@ async def test_removing_area_id(registry):
     entry_w_area = registry.async_update_device(entry.id, area_id="12345A")
 
     registry.async_clear_area_id("12345A")
-    entry_wo_area = registry.async_get_device({("bridgeid", "0123")}, set())
+    entry_wo_area = registry.async_get_device({("bridgeid", "0123")})
 
     assert not entry_wo_area.area_id
     assert entry_w_area != entry_wo_area
@@ -366,7 +366,7 @@ async def test_deleted_device_removing_area_id(registry):
     )
     assert entry.id == entry2.id
 
-    entry_wo_area = registry.async_get_device({("bridgeid", "0123")}, set())
+    entry_wo_area = registry.async_get_device({("bridgeid", "0123")})
 
     assert not entry_wo_area.area_id
     assert entry_w_area != entry_wo_area
@@ -505,9 +505,9 @@ async def test_loading_saving_data(hass, registry):
     assert list(registry.devices) == list(registry2.devices)
     assert list(registry.deleted_devices) == list(registry2.deleted_devices)
 
-    new_via = registry2.async_get_device({("hue", "0123")}, set())
-    new_light = registry2.async_get_device({("hue", "456")}, set())
-    new_light4 = registry2.async_get_device({("hue", "abc")}, set())
+    new_via = registry2.async_get_device({("hue", "0123")})
+    new_light = registry2.async_get_device({("hue", "456")})
+    new_light4 = registry2.async_get_device({("hue", "abc")})
 
     assert orig_via == new_via
     assert orig_light == new_light
@@ -597,11 +597,11 @@ async def test_update(registry):
     assert updated_entry.via_device_id == "98765B"
     assert updated_entry.disabled_by == "user"
 
-    assert registry.async_get_device({("hue", "456")}, {}) is None
-    assert registry.async_get_device({("bla", "123")}, {}) is None
+    assert registry.async_get_device({("hue", "456")}) is None
+    assert registry.async_get_device({("bla", "123")}) is None
 
-    assert registry.async_get_device({("hue", "654")}, {}) == updated_entry
-    assert registry.async_get_device({("bla", "321")}, {}) == updated_entry
+    assert registry.async_get_device({("hue", "654")}) == updated_entry
+    assert registry.async_get_device({("bla", "321")}) == updated_entry
 
     assert (
         registry.async_get_device(
@@ -652,7 +652,7 @@ async def test_update_remove_config_entries(hass, registry, update_events):
     assert updated_entry.config_entries == {"456"}
     assert removed_entry is None
 
-    removed_entry = registry.async_get_device({("bridgeid", "4567")}, set())
+    removed_entry = registry.async_get_device({("bridgeid", "4567")})
 
     assert removed_entry is None
 
@@ -728,10 +728,10 @@ async def test_cleanup_device_registry(hass, registry):
 
     device_registry.async_cleanup(hass, registry, ent_reg)
 
-    assert registry.async_get_device({("hue", "d1")}, set()) is not None
-    assert registry.async_get_device({("hue", "d2")}, set()) is not None
-    assert registry.async_get_device({("hue", "d3")}, set()) is not None
-    assert registry.async_get_device({("something", "d4")}, set()) is None
+    assert registry.async_get_device({("hue", "d1")}) is not None
+    assert registry.async_get_device({("hue", "d2")}) is not None
+    assert registry.async_get_device({("hue", "d3")}) is not None
+    assert registry.async_get_device({("something", "d4")}) is None
 
 
 async def test_cleanup_startup(hass):

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -747,7 +747,7 @@ async def test_device_info_called(hass):
 
     assert len(hass.states.async_entity_ids()) == 2
 
-    device = registry.async_get_device({("hue", "1234")}, set())
+    device = registry.async_get_device({("hue", "1234")})
     assert device is not None
     assert device.identifiers == {("hue", "1234")}
     assert device.connections == {("mac", "abcd")}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Largish but trivial changeset: makes the `connections` arg to `DeviceRegistry.async_get_device` optional, and cleans up unneeded usages.

The majority of calls to this function do not make use of connections, and a bunch of them passed an incorrect dummy collection type in it (lists, tuples, dicts). Instead of fixing those, I took the above mentioned approach.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
