### PR TITLE
Improve device registry type hints

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -237,7 +237,7 @@ class DeviceRegistry:
         default_name: Union[str, None, UndefinedType] = UNDEFINED,
         sw_version: Union[str, None, UndefinedType] = UNDEFINED,
         entry_type: Union[str, None, UndefinedType] = UNDEFINED,
-        via_device: Optional[str] = None,
+        via_device: Optional[Tuple[str, str]] = None,
         # To disable a device if it gets created
         disabled_by: Union[str, None, UndefinedType] = UNDEFINED,
     ) -> Optional[DeviceEntry]:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -13,6 +13,8 @@ from .debounce import Debouncer
 from .singleton import singleton
 from .typing import UNDEFINED, HomeAssistantType, UndefinedType
 
+# mypy: disallow_any_generics
+
 if TYPE_CHECKING:
     from . import entity_registry
 
@@ -124,7 +126,7 @@ class DeviceRegistry:
 
     devices: Dict[str, DeviceEntry]
     deleted_devices: Dict[str, DeletedDeviceEntry]
-    _devices_index: Dict[str, Dict[str, Dict[str, str]]]
+    _devices_index: Dict[str, Dict[str, Dict[Tuple[str, str], str]]]
 
     def __init__(self, hass: HomeAssistantType) -> None:
         """Initialize the device registry."""
@@ -140,8 +142,8 @@ class DeviceRegistry:
     @callback
     def async_get_device(
         self,
-        identifiers: set,
-        connections: Optional[set] = None,
+        identifiers: Set[Tuple[str, str]],
+        connections: Optional[Set[Tuple[str, str]]] = None,
     ) -> Optional[DeviceEntry]:
         """Check if device is registered."""
         device_id = self._async_get_device_id_from_index(
@@ -152,7 +154,9 @@ class DeviceRegistry:
         return self.devices[device_id]
 
     def _async_get_deleted_device(
-        self, identifiers: set, connections: Optional[set]
+        self,
+        identifiers: Set[Tuple[str, str]],
+        connections: Optional[Set[Tuple[str, str]]],
     ) -> Optional[DeletedDeviceEntry]:
         """Check if device is deleted."""
         device_id = self._async_get_device_id_from_index(
@@ -163,7 +167,10 @@ class DeviceRegistry:
         return self.deleted_devices[device_id]
 
     def _async_get_device_id_from_index(
-        self, index: str, identifiers: set, connections: Optional[set]
+        self,
+        index: str,
+        identifiers: Set[Tuple[str, str]],
+        connections: Optional[Set[Tuple[str, str]]],
     ) -> Optional[str]:
         """Check if device has previously been registered."""
         devices_index = self._devices_index[index]
@@ -227,8 +234,8 @@ class DeviceRegistry:
         self,
         *,
         config_entry_id: str,
-        connections: Optional[set] = None,
-        identifiers: Optional[set] = None,
+        connections: Optional[Set[Tuple[str, str]]] = None,
+        identifiers: Optional[Set[Tuple[str, str]]] = None,
         manufacturer: Union[str, None, UndefinedType] = UNDEFINED,
         model: Union[str, None, UndefinedType] = UNDEFINED,
         name: Union[str, None, UndefinedType] = UNDEFINED,
@@ -305,7 +312,7 @@ class DeviceRegistry:
         model: Union[str, None, UndefinedType] = UNDEFINED,
         name: Union[str, None, UndefinedType] = UNDEFINED,
         name_by_user: Union[str, None, UndefinedType] = UNDEFINED,
-        new_identifiers: Union[set, UndefinedType] = UNDEFINED,
+        new_identifiers: Union[Set[Tuple[str, str]], UndefinedType] = UNDEFINED,
         sw_version: Union[str, None, UndefinedType] = UNDEFINED,
         via_device_id: Union[str, None, UndefinedType] = UNDEFINED,
         remove_config_entry_id: Union[str, UndefinedType] = UNDEFINED,
@@ -333,9 +340,9 @@ class DeviceRegistry:
         *,
         add_config_entry_id: Union[str, UndefinedType] = UNDEFINED,
         remove_config_entry_id: Union[str, UndefinedType] = UNDEFINED,
-        merge_connections: Union[set, UndefinedType] = UNDEFINED,
-        merge_identifiers: Union[set, UndefinedType] = UNDEFINED,
-        new_identifiers: Union[set, UndefinedType] = UNDEFINED,
+        merge_connections: Union[Set[Tuple[str, str]], UndefinedType] = UNDEFINED,
+        merge_identifiers: Union[Set[Tuple[str, str]], UndefinedType] = UNDEFINED,
+        new_identifiers: Union[Set[Tuple[str, str]], UndefinedType] = UNDEFINED,
         manufacturer: Union[str, None, UndefinedType] = UNDEFINED,
         model: Union[str, None, UndefinedType] = UNDEFINED,
         name: Union[str, None, UndefinedType] = UNDEFINED,
@@ -657,7 +664,7 @@ def async_setup_cleanup(hass: HomeAssistantType, dev_reg: DeviceRegistry) -> Non
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, startup_clean)
 
 
-def _normalize_connections(connections: set) -> set:
+def _normalize_connections(connections: Set[Tuple[str, str]]) -> Set[Tuple[str, str]]:
     """Normalize connections to ensure we can match mac addresses."""
     return {
         (key, format_mac(value)) if key == CONNECTION_NETWORK_MAC else (key, value)
@@ -666,7 +673,8 @@ def _normalize_connections(connections: set) -> set:
 
 
 def _add_device_to_index(
-    devices_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+    devices_index: Dict[str, Dict[Tuple[str, str], str]],
+    device: Union[DeviceEntry, DeletedDeviceEntry],
 ) -> None:
     """Add a device to the index."""
     for identifier in device.identifiers:
@@ -676,7 +684,8 @@ def _add_device_to_index(
 
 
 def _remove_device_from_index(
-    devices_index: dict, device: Union[DeviceEntry, DeletedDeviceEntry]
+    devices_index: Dict[str, Dict[Tuple[str, str], str]],
+    device: Union[DeviceEntry, DeletedDeviceEntry],
 ) -> None:
     """Remove a device from the index."""
     for identifier in device.identifiers:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This improves device registry type hints as discussed in https://github.com/home-assistant/core/pull/44406#discussion_r551100084

We could use TypedDicts in the index or even better change it to a NamedTuple, ditto its elements without affecting the module API to clean things up. But this one does nothing to that, just adds appropriate type hints for the current implementation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #44406
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
