### PR TITLE
Camera Status and Motion record status

### DIFF
--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -1,4 +1,5 @@
 """Support for Ubiquiti's UVC cameras."""
+from datetime import datetime
 import logging
 import re
 
@@ -108,6 +109,16 @@ class UnifiVideoCamera(Camera):
                 return SUPPORT_STREAM
 
         return 0
+
+    @property
+    def state_attributes(self):
+        """Return the camera state attributes."""
+        attr = super().state_attributes
+        if self.motion_detection_enabled:
+            attr["last_recording_start_time"] = timestamp_ms_to_date(
+                self._caminfo["lastRecordingStartTime"]
+            )
+        return attr
 
     @property
     def is_recording(self):
@@ -235,3 +246,9 @@ class UnifiVideoCamera(Camera):
     def update(self):
         """Update the info."""
         self._caminfo = self._nvr.get_camera(self._uuid)
+
+
+def timestamp_ms_to_date(epoch_ms) -> datetime or None:
+    """Convert millisecond timestamp to datetime."""
+    if epoch_ms:
+        return datetime.fromtimestamp(epoch_ms / 1000)

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -123,7 +123,15 @@ class UnifiVideoCamera(Camera):
     @property
     def is_recording(self):
         """Return true if the camera is recording."""
-        return self._caminfo["recordingSettings"]["fullTimeRecordEnabled"]
+        recording_state = "DISABLED"
+        if "recordingIndicator" in self._caminfo.keys():
+            recording_state = self._caminfo["recordingIndicator"]
+
+        return (
+            self._caminfo["recordingSettings"]["fullTimeRecordEnabled"]
+            or recording_state == "MOTION_INPROGRESS"
+            or recording_state == "MOTION_FINISHED"
+        )
 
     @property
     def motion_detection_enabled(self):

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -260,6 +260,15 @@ class TestUVC(unittest.TestCase):
             == self.uvc.state_attributes["last_recording_start_time"]
         )
 
+        self.nvr.get_camera.return_value["recordingIndicator"] = "DISABLED"
+        assert not self.uvc.is_recording
+
+        self.nvr.get_camera.return_value["recordingIndicator"] = "MOTION_INPROGRESS"
+        assert self.uvc.is_recording
+
+        self.nvr.get_camera.return_value["recordingIndicator"] = "MOTION_FINISHED"
+        assert self.uvc.is_recording
+
     def test_stream(self):
         """Test the RTSP stream URI."""
         stream_source = yield from self.uvc.stream_source()

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -1,4 +1,5 @@
 """The tests for UVC camera module."""
+from datetime import datetime
 import socket
 import unittest
 from unittest import mock
@@ -198,10 +199,14 @@ class TestUVC(unittest.TestCase):
         self.nvr.get_camera.return_value = {
             "model": "UVC Fake",
             "uuid": "06e3ff29-8048-31c2-8574-0852d1bd0e03",
-            "recordingSettings": {"fullTimeRecordEnabled": True},
+            "recordingSettings": {
+                "fullTimeRecordEnabled": True,
+                "motionRecordEnabled": False,
+            },
             "host": "host-a",
             "internalHost": "host-b",
             "username": "admin",
+            "lastRecordingStartTime": 1610070992367,
             "channels": [
                 {
                     "id": "0",
@@ -240,6 +245,20 @@ class TestUVC(unittest.TestCase):
         assert "UVC Fake" == self.uvc.model
         assert SUPPORT_STREAM == self.uvc.supported_features
         assert "uuid" == self.uvc.unique_id
+
+    def test_motion_recording_mode_properties(self):
+        """Test the properties."""
+        self.nvr.get_camera.return_value["recordingSettings"][
+            "fullTimeRecordEnabled"
+        ] = False
+        self.nvr.get_camera.return_value["recordingSettings"][
+            "motionRecordEnabled"
+        ] = True
+        assert not self.uvc.is_recording
+        assert (
+            datetime(2021, 1, 8, 1, 56, 32, 367000)
+            == self.uvc.state_attributes["last_recording_start_time"]
+        )
 
     def test_stream(self):
         """Test the RTSP stream URI."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Couple of changes for the unifi video component
- Add the last recording time and camera connection status to the attributes
- Newer cameras can report the recording status, updating to reflect this in the entity state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
