### PR TITLE
Use zwave js server version check instead of fetching full state

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1093,7 +1093,6 @@ omit =
     homeassistant/components/zoneminder/*
     homeassistant/components/supla/*
     homeassistant/components/zwave/util.py
-    homeassistant/components/zwave_js/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -65,7 +65,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class InvalidInput(exceptions.HomeAssistantError):
-    """Error to indicate url is wrong."""
+    """Error to indicate input data is invalid."""
 
     def __init__(self, error):
         """Initialize error."""

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 
+import aiohttp
 from async_timeout import timeout
 import voluptuous as vol
 from zwave_js_server.version import VersionInfo, get_server_version
@@ -27,7 +28,7 @@ async def validate_input(hass: core.HomeAssistant, user_input: dict) -> VersionI
     async with timeout(10):
         try:
             return await get_server_version(ws_address, async_get_clientsession(hass))
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, aiohttp.ClientError):
             raise InvalidInput("cannot_connect")
 
 

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -1,10 +1,14 @@
 """Config flow for Z-Wave JS integration."""
+import asyncio
 import logging
 
+from async_timeout import timeout
 import voluptuous as vol
+from zwave_js_server.version import VersionInfo, get_server_version
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_URL
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, NAME  # pylint:disable=unused-import
 
@@ -13,18 +17,18 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema({CONF_URL: str})
 
 
-async def validate_input(hass: core.HomeAssistant, user_input: dict) -> bool:
+async def validate_input(hass: core.HomeAssistant, user_input: dict) -> VersionInfo:
     """Validate if the user input allows us to connect."""
     ws_address = user_input[CONF_URL]
 
-    # pylint: disable=fixme
-    # TODO: actually test server connection
-    if not ws_address.startswith("ws://") and not ws_address.startswith("wss://"):
-        raise CannotConnect
-    if not ws_address.endswith("/zjs"):
-        raise CannotConnect
+    if not ws_address.startswith(("ws://", "wss://")):
+        raise InvalidInput("invalid_ws_url")
 
-    return True
+    async with timeout(10):
+        try:
+            return await get_server_version(ws_address, async_get_clientsession(hass))
+        except asyncio.TimeoutError:
+            raise InvalidInput("cannot_connect")
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -43,13 +47,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         try:
-            await validate_input(self.hass, user_input)
-        except CannotConnect:
-            errors["base"] = "cannot_connect"
+            version_info = await validate_input(self.hass, user_input)
+        except InvalidInput as err:
+            errors["base"] = err.error
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
+            await self.async_set_unique_id(version_info.home_id)
+            self._abort_if_unique_id_configured(user_input)
             return self.async_create_entry(title=NAME, data=user_input)
 
         return self.async_show_form(
@@ -57,5 +63,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
+class InvalidInput(exceptions.HomeAssistantError):
+    """Error to indicate url is wrong."""
+
+    def __init__(self, error):
+        """Initialize error."""
+        self.error = error

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -28,8 +28,8 @@ async def validate_input(hass: core.HomeAssistant, user_input: dict) -> VersionI
     async with timeout(10):
         try:
             return await get_server_version(ws_address, async_get_clientsession(hass))
-        except (asyncio.TimeoutError, aiohttp.ClientError):
-            raise InvalidInput("cannot_connect")
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            raise InvalidInput("cannot_connect") from err
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -69,4 +69,5 @@ class InvalidInput(exceptions.HomeAssistantError):
 
     def __init__(self, error):
         """Initialize error."""
+        super().__init__()
         self.error = error

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,6 +3,6 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.2.0"],
+  "requirements": ["zwave-js-server-python==0.3.0"],
   "codeowners": ["@MartinHjelmare"]
 }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -9,6 +9,7 @@
       }
     },
     "error": {
+      "invalid_ws_url": "Invalid websocket URL",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },

--- a/homeassistant/components/zwave_js/translations/en.json
+++ b/homeassistant/components/zwave_js/translations/en.json
@@ -5,6 +5,7 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "invalid_ws_url": "Invalid websocket URL",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2372,4 +2372,4 @@ zigpy==0.29.0
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.2.0
+zwave-js-server-python==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1168,4 +1168,4 @@ zigpy-znp==0.3.0
 zigpy==0.29.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.2.0
+zwave-js-server-python==0.3.0

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1,14 +1,13 @@
 """Test the Z-Wave JS config flow."""
+import asyncio
 from unittest.mock import patch
 
-import pytest
+from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries, setup
-from homeassistant.components.zwave_js.config_flow import CannotConnect, InvalidAuth
 from homeassistant.components.zwave_js.const import DOMAIN
 
 
-@pytest.mark.skip
 async def test_form(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -16,11 +15,14 @@ async def test_form(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == "form"
-    assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.zwave_js.config_flow.PlaceholderHub.authenticate",
-        return_value=True,
+        "homeassistant.components.zwave_js.config_flow.get_server_version",
+        return_value=VersionInfo(
+            driver_version="mock-driver-version",
+            server_version="mock-server-version",
+            home_id=1234,
+        ),
     ), patch(
         "homeassistant.components.zwave_js.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -30,67 +32,47 @@ async def test_form(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+                "url": "ws://localhost:3000",
             },
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "Name of the device"
+    assert result2["title"] == "Z-Wave JS"
     assert result2["data"] == {
-        "host": "1.1.1.1",
-        "username": "test-username",
-        "password": "test-password",
+        "url": "ws://localhost:3000",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
+    assert result2["result"].unique_id == 1234
 
 
-@pytest.mark.skip
-async def test_form_invalid_auth(hass):
+async def test_form_invalid_input(hass):
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-        "homeassistant.components.zwave_js.config_flow.PlaceholderHub.authenticate",
-        side_effect=InvalidAuth,
+        "homeassistant.components.zwave_js.config_flow.get_server_version",
+        side_effect=asyncio.TimeoutError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "invalid_auth"}
-
-
-@pytest.mark.skip
-async def test_form_cannot_connect(hass):
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.zwave_js.config_flow.PlaceholderHub.authenticate",
-        side_effect=CannotConnect,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+                "url": "ws://localhost:3000",
             },
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "url": "not-ws-url",
+        },
+    )
+
+    assert result3["type"] == "form"
+    assert result3["errors"] == {"base": "invalid_ws_url"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use new get_server_version helper to validate the config instead of fetching full state.

Requires https://github.com/home-assistant-libs/zwave-js-server-python/pull/15 + dependency update
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
