### PR TITLE
Clear cached nest event images after expiration

### DIFF
--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -227,5 +227,4 @@ class NestCamera(Camera):
         """Clear images cached from events and scheduled callback."""
         self._event_id = None
         self._event_image_bytes = None
-        if self._event_image_cleanup_unsub is not None:
-            self._event_image_cleanup_unsub()
+        self._event_image_cleanup_unsub = None

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -155,7 +155,10 @@ class NestCamera(Camera):
             await self._stream.stop_rtsp_stream()
         if self._stream_refresh_unsub:
             self._stream_refresh_unsub()
-        self._handle_event_image_cleanup()
+        self._event_id = None
+        self._event_image_bytes = None
+        if self._event_image_cleanup_unsub is not None:
+            self._event_image_cleanup_unsub()
 
     async def async_added_to_hass(self):
         """Run when entity is added to register update signal handler."""

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -66,6 +66,7 @@ class NestCamera(Camera):
         # Cache of most recent event image
         self._event_id = None
         self._event_image_bytes = None
+        self._event_image_cleanup_unsub = None
 
     @property
     def should_poll(self) -> bool:
@@ -154,6 +155,7 @@ class NestCamera(Camera):
             await self._stream.stop_rtsp_stream()
         if self._stream_refresh_unsub:
             self._stream_refresh_unsub()
+        self._handle_event_image_cleanup()
 
     async def async_added_to_hass(self):
         """Run when entity is added to register update signal handler."""
@@ -181,10 +183,20 @@ class NestCamera(Camera):
         if not trait:
             return None
         # Reuse image bytes if they have already been fetched
-        event_id = trait.last_event.event_id
-        if self._event_id is not None and self._event_id == event_id:
+        event = trait.last_event
+        if self._event_id is not None and self._event_id == event.event_id:
             return self._event_image_bytes
-        _LOGGER.info("Fetching URL for event_id %s", event_id)
+        _LOGGER.debug("Generating event image URL for event_id %s", event.event_id)
+        image_bytes = await self._async_fetch_active_event_image(trait)
+        if image_bytes is None:
+            return None
+        self._event_id = event.event_id
+        self._event_image_bytes = image_bytes
+        self._schedule_event_image_cleanup(event.expires_at)
+        return image_bytes
+
+    async def _async_fetch_active_event_image(self, trait):
+        """Return image bytes for an active event."""
         try:
             event_image = await trait.generate_active_event_image()
         except GoogleNestException as err:
@@ -193,10 +205,24 @@ class NestCamera(Camera):
         if not event_image:
             return None
         try:
-            image_bytes = await event_image.contents()
+            return await event_image.contents()
         except GoogleNestException as err:
             _LOGGER.debug("Unable to fetch event image: %s", err)
             return None
-        self._event_id = event_id
-        self._event_image_bytes = image_bytes
-        return image_bytes
+
+    def _schedule_event_image_cleanup(self, point_in_time):
+        """Schedules an alarm to remove the image bytes from memory, honoring expiration."""
+        if self._event_image_cleanup_unsub is not None:
+            self._event_image_cleanup_unsub()
+        self._event_image_cleanup_unsub = async_track_point_in_utc_time(
+            self.hass,
+            self._handle_event_image_cleanup,
+            point_in_time,
+        )
+
+    def _handle_event_image_cleanup(self, now):
+        """Clear images cached from events and scheduled callback."""
+        self._event_id = None
+        self._event_image_bytes = None
+        if self._event_image_cleanup_unsub is not None:
+            self._event_image_cleanup_unsub()

--- a/tests/components/nest/camera_sdm_test.py
+++ b/tests/components/nest/camera_sdm_test.py
@@ -59,20 +59,22 @@ GENERATE_IMAGE_URL_RESPONSE = {
 IMAGE_AUTHORIZATION_HEADERS = {"Authorization": "Basic g.0.eventToken"}
 
 
-def make_motion_event(timestamp: datetime.datetime = None) -> EventMessage:
+def make_motion_event(
+    event_id: str = MOTION_EVENT_ID, timestamp: datetime.datetime = None
+) -> EventMessage:
     """Create an EventMessage for a motion event."""
     if not timestamp:
         timestamp = utcnow()
     return EventMessage(
         {
-            "eventId": "some-event-id",
+            "eventId": "some-event-id",  # Ignored; we use the resource updated event id below
             "timestamp": timestamp.isoformat(timespec="seconds"),
             "resourceUpdate": {
                 "name": DEVICE_ID,
                 "events": {
                     "sdm.devices.events.CameraMotion.Motion": {
                         "eventSessionId": "CjY5Y3VKaTZwR3o4Y19YbTVfMF...",
-                        "eventId": MOTION_EVENT_ID,
+                        "eventId": event_id,
                     },
                 },
             },
@@ -127,7 +129,7 @@ async def fire_alarm(hass, point_in_time):
 async def async_get_image(hass):
     """Get image from the camera, a wrapper around camera.async_get_image."""
     # Note: this patches ImageFrame to simulate decoding an image from a live
-    # stream, however the test may not use it.  Tests assert on the image
+    # stream, however the test may not use it. Tests assert on the image
     # contents to determine if the image came from the live stream or event.
     with patch(
         "homeassistant.components.ffmpeg.ImageFrame.get_image",
@@ -363,7 +365,7 @@ async def test_refresh_expired_stream_failure(hass, auth):
 
 async def test_camera_image_from_last_event(hass, auth):
     """Test an image generated from an event."""
-    # The subscriber receives a message related to an image event.  The camera
+    # The subscriber receives a message related to an image event. The camera
     # holds on to the event message. When the test asks for a capera snapshot
     # it exchanges the event id for an image url and fetches the image.
     subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
@@ -464,7 +466,7 @@ async def test_event_image_expired(hass, auth):
 
     # Simulate a pubsub message has already expired
     event_timestamp = utcnow() - datetime.timedelta(seconds=40)
-    await subscriber.async_receive_event(make_motion_event(event_timestamp))
+    await subscriber.async_receive_event(make_motion_event(timestamp=event_timestamp))
     await hass.async_block_till_done()
 
     # Fallback to a stream url since the event message is expired.
@@ -472,3 +474,78 @@ async def test_event_image_expired(hass, auth):
 
     image = await async_get_image(hass)
     assert image.content == IMAGE_BYTES_FROM_STREAM
+
+
+async def test_event_image_becomes_expired(hass, auth):
+    """Test fallback for an event event image that has been cleaned up on expiration."""
+    subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    event_timestamp = utcnow()
+    await subscriber.async_receive_event(make_motion_event(timestamp=event_timestamp))
+    await hass.async_block_till_done()
+
+    auth.responses = [
+        # Fake response from API that returns url image
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        # Fake response for the image content fetch
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+        # Image is refetched after being cleared by expiration alarm
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        aiohttp.web.Response(body=b"updated image bytes"),
+    ]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_EVENT
+
+    # Event image is still valid before expiration
+    next_update = event_timestamp + datetime.timedelta(seconds=25)
+    await fire_alarm(hass, next_update)
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_EVENT
+
+    # Fire an alarm well after expiration, removing image from cache
+    # Note: This test does not override the "now" logic within the underlying
+    # python library that tracks active events. Instead, it exercises the
+    # alarm behavior only. That is, the library may still think the event is
+    # active even though Home Assistant does not due to patching time.
+    next_update = event_timestamp + datetime.timedelta(seconds=180)
+    await fire_alarm(hass, next_update)
+
+    image = await async_get_image(hass)
+    assert image.content == b"updated image bytes"
+
+
+async def test_multiple_event_images(hass, auth):
+    """Test fallback for an event event image that has been cleaned up on expiration."""
+    subscriber = await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    event_timestamp = utcnow()
+    await subscriber.async_receive_event(make_motion_event(timestamp=event_timestamp))
+    await hass.async_block_till_done()
+
+    auth.responses = [
+        # Fake response from API that returns url image
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        # Fake response for the image content fetch
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+        # Image is refetched after being cleared by expiration alarm
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        aiohttp.web.Response(body=b"updated image bytes"),
+    ]
+
+    image = await async_get_image(hass)
+    assert image.content == IMAGE_BYTES_FROM_EVENT
+
+    next_event_timestamp = event_timestamp + datetime.timedelta(seconds=25)
+    await subscriber.async_receive_event(
+        make_motion_event(event_id="updated-event-id", timestamp=next_event_timestamp)
+    )
+    await hass.async_block_till_done()
+
+    image = await async_get_image(hass)
+    assert image.content == b"updated image bytes"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Clear any cached nest event images using an alarm.  This addresses some discussion in https://github.com/home-assistant/core/pull/44638 

The code for fetching the event image was pulled into a helper as a readability improvement.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
