### PR TITLE
Reload pkg_resources after adding the deps folder to the Python path

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -2,6 +2,7 @@
 import asyncio
 import contextlib
 from datetime import datetime
+import importlib
 import logging
 import logging.handlers
 import os
@@ -360,6 +361,10 @@ async def async_mount_local_lib_path(config_dir: str) -> str:
     lib_dir = await async_get_user_site(deps_dir)
     if lib_dir not in sys.path:
         sys.path.insert(0, lib_dir)
+        try:
+            importlib.reload(sys.modules["pkg_resources"])
+        except KeyError:
+            pass
     return deps_dir
 
 


### PR DESCRIPTION
The pkg_resources module internally caches its working set of discovered
Python packages. After "deps" has been added to the path, the cached
information no longer reflects reality, which can cause an error if
another package later tries to query it. Reloading pkg_resources fixes
this.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I am using Home Assistant on ArchLinux as installed via the instructions on https://wiki.archlinux.org/index.php/Home_Assistant . This was previously working well. More recently, the Nest integration started crashing with this error:

```
Traceback (most recent call last):
  File "/home/dphoyes/devel/home-assistant-core/homeassistant/setup.py", line 166, in _async_setup_component
    component = integration.get_component()
  File "/home/dphoyes/devel/home-assistant-core/homeassistant/loader.py", line 416, in get_component
    cache[self.domain] = importlib.import_module(self.pkg_path)
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/dphoyes/devel/home-assistant-core/homeassistant/components/nest/__init__.py", line 12, in <module>
    from google_nest_sdm.google_nest_subscriber import GoogleNestSubscriber
  File "/home/dphoyes/devel/home-assistant-core/config/deps/lib/python3.9/site-packages/google_nest_sdm/google_nest_subscriber.py", line 12, in <module>
    from google.cloud import pubsub_v1
  File "/home/dphoyes/devel/home-assistant-core/config/deps/lib/python3.9/site-packages/google/cloud/pubsub_v1/__init__.py", line 18, in <module>
    from google.cloud.pubsub_v1 import publisher
  File "/home/dphoyes/devel/home-assistant-core/config/deps/lib/python3.9/site-packages/google/cloud/pubsub_v1/publisher/__init__.py", line 17, in <module>
    from google.cloud.pubsub_v1.publisher.client import Client
  File "/home/dphoyes/devel/home-assistant-core/config/deps/lib/python3.9/site-packages/google/cloud/pubsub_v1/publisher/client.py", line 45, in <module>
    __version__ = pkg_resources.get_distribution("google-cloud-pubsub").version
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 465, in get_distribution
    dist = get_provider(dist)
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 341, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 884, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 770, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'google-cloud-pubsub' distribution was not found and is required by the application
```

I believe it is caused by the fact the ArchLinux install relies on the "deps" folder to provide the home-assistant's dependencies - ie. there's no virtualenv. This folder isn't added to the Python path until after `pkg_resources` has done its package discovery and cached the results, and therefore `pkg_resources` cannot see the `google-cloud-pubsub` installation that the "deps" folder provides. When `google/cloud/pubsub_v1/publisher/client.py` tries to query `pkg_resources` for its version number, we get the error. This patch fixes the problem for me, though I'm open to alternative ideas.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
