### PR TITLE
2021.1.1

### DIFF
--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -82,7 +82,7 @@ class HassIOAuth(HassIOBaseAuth):
                 data[ATTR_USERNAME], data[ATTR_PASSWORD]
             )
         except auth_ha.InvalidAuth:
-            raise HTTPUnauthorized() from None
+            raise HTTPNotFound() from None
 
         return web.Response(status=HTTP_OK)
 

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -79,6 +79,9 @@ class KNXCover(KnxEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
+        # state shall be "unknown" when xknx travelcalculator is not initialized
+        if self._device.current_position() is None:
+            return None
         return self._device.is_closed()
 
     @property

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -232,7 +232,7 @@ async def async_setup(hass, config):
     async def async_handle_toggle_service(light, call):
         """Handle toggling a light."""
         if light.is_on:
-            off_params = filter_turn_off_params(call.data)
+            off_params = filter_turn_off_params(call.data["params"])
             await light.async_turn_off(**off_params)
         else:
             await async_handle_light_on_service(light, call)

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["pymyq==2.0.12"],
+  "requirements": ["pymyq==2.0.13"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 2021
 MINOR_VERSION = 1
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1536,7 +1536,7 @@ pymsteams==0.1.12
 pymusiccast==0.1.6
 
 # homeassistant.components.myq
-pymyq==2.0.12
+pymyq==2.0.13
 
 # homeassistant.components.mysensors
 pymysensors==0.18.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -779,7 +779,7 @@ pymodbus==2.3.0
 pymonoprice==0.3
 
 # homeassistant.components.myq
-pymyq==2.0.12
+pymyq==2.0.13
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -66,7 +66,7 @@ async def test_login_error(hass, hassio_client_supervisor):
         )
 
         # Check we got right response
-        assert resp.status == 401
+        assert resp.status == 404
         mock_login.assert_called_with("test", "123456")
 
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -336,6 +336,21 @@ async def test_services(hass, mock_light_profiles):
         light.ATTR_TRANSITION: prof_t,
     }
 
+    await hass.services.async_call(
+        light.DOMAIN,
+        SERVICE_TOGGLE,
+        {
+            ATTR_ENTITY_ID: ent3.entity_id,
+            light.ATTR_TRANSITION: 4,
+        },
+        blocking=True,
+    )
+
+    _, data = ent3.last_call("turn_off")
+    assert data == {
+        light.ATTR_TRANSITION: 4,
+    }
+
     # Test bad data
     await hass.services.async_call(
         light.DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_MATCH_ALL}, blocking=True

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -7,6 +7,7 @@ import logging
 from types import MappingProxyType
 from unittest import mock
 
+from async_timeout import timeout
 import pytest
 import voluptuous as vol
 
@@ -545,6 +546,41 @@ async def test_wait_basic(hass, action_type):
 
 
 @pytest.mark.parametrize("action_type", ["template", "trigger"])
+async def test_wait_basic_times_out(hass, action_type):
+    """Test wait actions times out when the action does not happen."""
+    wait_alias = "wait step"
+    action = {"alias": wait_alias}
+    if action_type == "template":
+        action["wait_template"] = "{{ states.switch.test.state == 'off' }}"
+    else:
+        action["wait_for_trigger"] = {
+            "platform": "state",
+            "entity_id": "switch.test",
+            "to": "off",
+        }
+    sequence = cv.SCRIPT_SCHEMA(action)
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+    wait_started_flag = async_watch_for_action(script_obj, wait_alias)
+    timed_out = False
+
+    try:
+        hass.states.async_set("switch.test", "on")
+        hass.async_create_task(script_obj.async_run(context=Context()))
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+        assert script_obj.is_running
+        assert script_obj.last_action == wait_alias
+        hass.states.async_set("switch.test", "not_on")
+
+        with timeout(0.1):
+            await hass.async_block_till_done()
+    except asyncio.TimeoutError:
+        timed_out = True
+        await script_obj.async_stop()
+
+    assert timed_out
+
+
+@pytest.mark.parametrize("action_type", ["template", "trigger"])
 async def test_multiple_runs_wait(hass, action_type):
     """Test multiple runs with wait in script."""
     event = "test_event"
@@ -782,28 +818,51 @@ async def test_wait_template_variables_in(hass):
 
 async def test_wait_template_with_utcnow(hass):
     """Test the wait template with utcnow."""
-    sequence = cv.SCRIPT_SCHEMA({"wait_template": "{{ utcnow().hours == 12 }}"})
+    sequence = cv.SCRIPT_SCHEMA({"wait_template": "{{ utcnow().hour == 12 }}"})
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
     wait_started_flag = async_watch_for_action(script_obj, "wait")
-    start_time = dt_util.utcnow() + timedelta(hours=24)
+    start_time = dt_util.utcnow().replace(minute=1) + timedelta(hours=48)
 
     try:
         hass.async_create_task(script_obj.async_run(context=Context()))
-        async_fire_time_changed(hass, start_time.replace(hour=5))
-        assert not script_obj.is_running
-        async_fire_time_changed(hass, start_time.replace(hour=12))
-
         await asyncio.wait_for(wait_started_flag.wait(), 1)
-
         assert script_obj.is_running
+
+        match_time = start_time.replace(hour=12)
+        with patch("homeassistant.util.dt.utcnow", return_value=match_time):
+            async_fire_time_changed(hass, match_time)
     except (AssertionError, asyncio.TimeoutError):
         await script_obj.async_stop()
         raise
     else:
-        async_fire_time_changed(hass, start_time.replace(hour=3))
         await hass.async_block_till_done()
-
         assert not script_obj.is_running
+
+
+async def test_wait_template_with_utcnow_no_match(hass):
+    """Test the wait template with utcnow that does not match."""
+    sequence = cv.SCRIPT_SCHEMA({"wait_template": "{{ utcnow().hour == 12 }}"})
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+    wait_started_flag = async_watch_for_action(script_obj, "wait")
+    start_time = dt_util.utcnow().replace(minute=1) + timedelta(hours=48)
+    timed_out = False
+
+    try:
+        hass.async_create_task(script_obj.async_run(context=Context()))
+        await asyncio.wait_for(wait_started_flag.wait(), 1)
+        assert script_obj.is_running
+
+        non_maching_time = start_time.replace(hour=3)
+        with patch("homeassistant.util.dt.utcnow", return_value=non_maching_time):
+            async_fire_time_changed(hass, non_maching_time)
+
+        with timeout(0.1):
+            await hass.async_block_till_done()
+    except asyncio.TimeoutError:
+        timed_out = True
+        await script_obj.async_stop()
+
+    assert timed_out
 
 
 @pytest.mark.parametrize("mode", ["no_timeout", "timeout_finish", "timeout_not_finish"])


### PR DESCRIPTION
- Fix KNX cover state return open when unknown ([@farmio] - [#44926]) ([knx docs])
- Fix wait_template incorrectly matching falsey values ([@bdraco] - [#44938])
- Disambiguate Supervisor HTTPUnauthorized on user/password validation ([@zeehio] - [#44940]) ([hassio docs])
- Fix parameters when toggling light ([@emontnemery] - [#44950]) ([light docs])
- Bump pymyq to 2.0.13 ([@ehendrix23] - [#44961]) ([myq docs])

[#44926]: https://github.com/home-assistant/core/pull/44926
[#44938]: https://github.com/home-assistant/core/pull/44938
[#44940]: https://github.com/home-assistant/core/pull/44940
[#44950]: https://github.com/home-assistant/core/pull/44950
[#44961]: https://github.com/home-assistant/core/pull/44961
[@bdraco]: https://github.com/bdraco
[@ehendrix23]: https://github.com/ehendrix23
[@emontnemery]: https://github.com/emontnemery
[@farmio]: https://github.com/farmio
[@zeehio]: https://github.com/zeehio
[hassio docs]: https://www.home-assistant.io/integrations/hassio/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[light docs]: https://www.home-assistant.io/integrations/light/
[myq docs]: https://www.home-assistant.io/integrations/myq/