### PR TITLE
Increase update interval in AccuWeather integration

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -100,13 +100,13 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator):
         self.accuweather = AccuWeather(api_key, session, location_key=self.location_key)
 
         # Enabling the forecast download increases the number of requests per data
-        # update, we use 32 minutes for current condition only and 64 minutes for
+        # update, we use 40 minutes for current condition only and 80 minutes for
         # current condition and forecast as update interval to not exceed allowed number
-        # of requests. We have 50 requests allowed per day, so we use 45 and leave 5 as
+        # of requests. We have 50 requests allowed per day, so we use 36 and leave 14 as
         # a reserve for restarting HA.
-        update_interval = (
-            timedelta(minutes=64) if self.forecast else timedelta(minutes=32)
-        )
+        update_interval = timedelta(minutes=32)
+        if self.forecast:
+            update_interval *= 2
         _LOGGER.debug("Data will be update every %s", update_interval)
 
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)

--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -104,7 +104,7 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator):
         # current condition and forecast as update interval to not exceed allowed number
         # of requests. We have 50 requests allowed per day, so we use 36 and leave 14 as
         # a reserve for restarting HA.
-        update_interval = timedelta(minutes=32)
+        update_interval = timedelta(minutes=40)
         if self.forecast:
             update_interval *= 2
         _LOGGER.debug("Data will be update every %s", update_interval)

--- a/homeassistant/components/accuweather/strings.json
+++ b/homeassistant/components/accuweather/strings.json
@@ -25,7 +25,7 @@
     "step": {
       "user": {
         "title": "AccuWeather Options",
-        "description": "Due to the limitations of the free version of the AccuWeather API key, when you enable weather forecast, data updates will be performed every 64 minutes instead of every 32 minutes.",
+        "description": "Due to the limitations of the free version of the AccuWeather API key, when you enable weather forecast, data updates will be performed every 80 minutes instead of every 40 minutes.",
         "data": {
           "forecast": "Weather forecast"
         }

--- a/tests/components/accuweather/test_init.py
+++ b/tests/components/accuweather/test_init.py
@@ -1,7 +1,8 @@
 """Test init of AccuWeather integration."""
+from datetime import timedelta
 from unittest.mock import patch
 
-from homeassistant.components.accuweather.const import DOMAIN
+from homeassistant.components.accuweather.const import COORDINATOR, DOMAIN
 from homeassistant.config_entries import (
     ENTRY_STATE_LOADED,
     ENTRY_STATE_NOT_LOADED,
@@ -58,3 +59,23 @@ async def test_unload_entry(hass):
 
     assert entry.state == ENTRY_STATE_NOT_LOADED
     assert not hass.data.get(DOMAIN)
+
+
+async def test_update_interval(hass):
+    """Test correct update interval."""
+    entry = await init_integration(hass)
+
+    assert entry.state == ENTRY_STATE_LOADED
+    assert hass.data[DOMAIN][entry.entry_id][COORDINATOR].update_interval == timedelta(
+        minutes=40
+    )
+
+
+async def test_update_interval_forecast(hass):
+    """Test correct update interval when forecast is True."""
+    entry = await init_integration(hass, forecast=True)
+
+    assert entry.state == ENTRY_STATE_LOADED
+    assert hass.data[DOMAIN][entry.entry_id][COORDINATOR].update_interval == timedelta(
+        minutes=80
+    )

--- a/tests/components/accuweather/test_init.py
+++ b/tests/components/accuweather/test_init.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from accuweather import ApiError
+
 from homeassistant.components.accuweather.const import COORDINATOR, DOMAIN
 from homeassistant.config_entries import (
     ENTRY_STATE_LOADED,
@@ -40,7 +42,7 @@ async def test_config_not_ready(hass):
 
     with patch(
         "homeassistant.components.accuweather.AccuWeather._async_get_data",
-        side_effect=ConnectionError(),
+        side_effect=ApiError("API Error"),
     ):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
AccuWeather allows 50 requests a day so users who frequently restart HA receive the error `The allowed number of requests has been exceeded`. Unfortunately, the moment of resetting the number of allowed requests is variable and we cannot calculate the dynamic update interval.
This PR increase `update_interval` for 40 minutes and 80 minutes if forecast is enabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42166 #39314
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
