### PR TITLE
Add debug logging to command line notify

### DIFF
--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -26,17 +26,19 @@ def get_service(hass, config, discovery_info=None):
     """Get the Command Line notification service."""
     command = config[CONF_COMMAND]
     timeout = config[CONF_COMMAND_TIMEOUT]
+    name = config[CONF_NAME]
 
-    return CommandLineNotificationService(command, timeout)
+    return CommandLineNotificationService(command, timeout, name)
 
 
 class CommandLineNotificationService(BaseNotificationService):
     """Implement the notification service for the Command Line service."""
 
-    def __init__(self, command, timeout):
+    def __init__(self, command, timeout, name):
         """Initialize the service."""
         self.command = command
         self._timeout = timeout
+        self.name = name
 
     def send_message(self, message="", **kwargs):
         """Send a message to a command line."""
@@ -50,9 +52,6 @@ class CommandLineNotificationService(BaseNotificationService):
                 shell=True,  # nosec # shell by design
             )
 
-            _LOGGER.debug(
-                "Running command: `%s`, with input: %s", self.command, message
-            )
             stdout_data, stderr_data = proc.communicate(
                 input=message, timeout=self._timeout
             )
@@ -61,15 +60,15 @@ class CommandLineNotificationService(BaseNotificationService):
 
             if stdout_data:
                 _LOGGER.debug(
-                    "Stdout of command: `%s`, return code: %s:\n%s",
-                    self.command,
+                    "Stdout of command_line notify '%s': return code: %s\n%s",
+                    self.name,
                     proc.returncode,
                     stdout_data,
                 )
             if stderr_data:
                 _LOGGER.debug(
-                    "Stderr of command: `%s`, return code: %s:\n%s",
-                    self.command,
+                    "Stderr of command_line notify '%s': return code: %s\n%s",
+                    self.name,
                     proc.returncode,
                     stderr_data,
                 )

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -21,6 +21,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
+# pylint: disable=unused-argument
 def get_service(hass, config, discovery_info=None):
     """Get the Command Line notification service."""
     command = config[CONF_COMMAND]
@@ -44,26 +45,22 @@ class CommandLineNotificationService(BaseNotificationService):
                 self.command,
                 universal_newlines=True,
                 stdin=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 shell=True,  # nosec # shell by design
             )
-            
-            _LOGGER.debug("Running command: `%s`, with input: %s", self.command, message) 
-            stdout_data, stderr_data = proc.communicate(input=message, timeout=self._timeout)
+
+            _LOGGER.debug(
+                "Running command: `%s`, with input: %s", self.command, message
+            )
+            _, stderr_data = proc.communicate(input=message, timeout=self._timeout)
             if proc.returncode != 0:
                 _LOGGER.error("Command failed: %s", self.command)
-            
-            if stdout_data:
-                _LOGGER.debug(
-                    "Stdout of command: `%s`, return code: %s:\n%s",
-                    self.command,
-                    process.returncode,
-                    stdout_data,
-                )
+
             if stderr_data:
                 _LOGGER.debug(
                     "Stderr of command: `%s`, return code: %s:\n%s",
                     self.command,
-                    process.returncode,
+                    proc.returncode,
                     stderr_data,
                 )
         except subprocess.TimeoutExpired:

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -45,6 +45,7 @@ class CommandLineNotificationService(BaseNotificationService):
                 self.command,
                 universal_newlines=True,
                 stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=True,  # nosec # shell by design
             )
@@ -52,10 +53,19 @@ class CommandLineNotificationService(BaseNotificationService):
             _LOGGER.debug(
                 "Running command: `%s`, with input: %s", self.command, message
             )
-            _, stderr_data = proc.communicate(input=message, timeout=self._timeout)
+            stdout_data, stderr_data = proc.communicate(
+                input=message, timeout=self._timeout
+            )
             if proc.returncode != 0:
                 _LOGGER.error("Command failed: %s", self.command)
 
+            if stdout_data:
+                _LOGGER.debug(
+                    "Stdout of command: `%s`, return code: %s:\n%s",
+                    self.command,
+                    proc.returncode,
+                    stdout_data,
+                )
             if stderr_data:
                 _LOGGER.debug(
                     "Stderr of command: `%s`, return code: %s:\n%s",

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -46,9 +46,26 @@ class CommandLineNotificationService(BaseNotificationService):
                 stdin=subprocess.PIPE,
                 shell=True,  # nosec # shell by design
             )
-            proc.communicate(input=message, timeout=self._timeout)
+            
+            _LOGGER.debug("Running command: `%s`, with input: %s", self.command, message) 
+            stdout_data, stderr_data = proc.communicate(input=message, timeout=self._timeout)
             if proc.returncode != 0:
                 _LOGGER.error("Command failed: %s", self.command)
+            
+            if stdout_data:
+                _LOGGER.debug(
+                    "Stdout of command: `%s`, return code: %s:\n%s",
+                    self.command,
+                    process.returncode,
+                    stdout_data,
+                )
+            if stderr_data:
+                _LOGGER.debug(
+                    "Stderr of command: `%s`, return code: %s:\n%s",
+                    self.command,
+                    process.returncode,
+                    stderr_data,
+                )
         except subprocess.TimeoutExpired:
             _LOGGER.error("Timeout for command: %s", self.command)
         except subprocess.SubprocessError:

--- a/tests/components/command_line/test_notify.py
+++ b/tests/components/command_line/test_notify.py
@@ -137,7 +137,6 @@ async def test_debug_logging_error(hass, caplog):
             "notify", "test", {"message": "error"}, blocking=True
         )
         await hass.async_block_till_done()
-        assert "Running command" in caplog.text
         assert "Stderr" in caplog.text
         assert "Stdout" not in caplog.text
 
@@ -155,6 +154,5 @@ async def test_debug_logging_success(hass, caplog):
             "notify", "test", {"message": "success"}, blocking=True
         )
         await hass.async_block_till_done()
-        assert "Running command" in caplog.text
         assert "Stdout" in caplog.text
         assert "Stderr" not in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Command line notify does not log the command it is going to run when debug logging is turned on for it whereas the other command line options do. This makes it difficult to debug an issue.  Added debug logging before that logs out the command and input about to be run (similar to the other options in the command line platform) as well as stderr debug logging afterwards.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
notify:
  - name: Test notifier
    platform: command_line
    command: "espeak -vmb/mb-us1"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
