### PR TITLE
Register increment and decrement services for the Number integration

### DIFF
--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -24,6 +24,8 @@ from .const import (
     DEFAULT_MIN_VALUE,
     DEFAULT_STEP,
     DOMAIN,
+    SERVICE_DECREMENT,
+    SERVICE_INCREMENT,
     SERVICE_SET_VALUE,
 )
 
@@ -47,6 +49,18 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         SERVICE_SET_VALUE,
         {vol.Required(ATTR_VALUE): vol.Coerce(float)},
         "async_set_value",
+    )
+
+    component.async_register_entity_service(
+        SERVICE_INCREMENT,
+        {},
+        "async_increment",
+    )
+
+    component.async_register_entity_service(
+        SERVICE_DECREMENT,
+        {},
+        "async_decrement",
     )
 
     return True
@@ -112,3 +126,11 @@ class NumberEntity(Entity):
         """Set new value."""
         assert self.hass is not None
         await self.hass.async_add_executor_job(self.set_value, value)
+
+    async def async_increment(self) -> None:
+        """Increment value."""
+        await self.async_set_value(min(self.value + self.step, self.max_value))
+
+    async def async_decrement(self) -> None:
+        """Decrement value."""
+        await self.async_set_value(max(self.value - self.step, self.min_value))

--- a/homeassistant/components/number/const.py
+++ b/homeassistant/components/number/const.py
@@ -12,3 +12,5 @@ DEFAULT_STEP = 1.0
 DOMAIN = "number"
 
 SERVICE_SET_VALUE = "set_value"
+SERVICE_INCREMENT = "increment"
+SERVICE_DECREMENT = "decrement"

--- a/homeassistant/components/number/services.yaml
+++ b/homeassistant/components/number/services.yaml
@@ -9,3 +9,15 @@ set_value:
     value:
       description: The target value the entity should be set to.
       example: 42
+decrement:
+  description: Decrement the value of a Number entity by its stepping.
+  fields:
+    entity_id:
+      description: Entity id of the Number that should be decremented.
+      example: number.volume
+increment:
+  description: Increment the value of a Number entity by its stepping.
+  fields:
+    entity_id:
+      description: Entity id of the Number that should be incremented.
+      example: number.volume

--- a/tests/components/demo/test_number.py
+++ b/tests/components/demo/test_number.py
@@ -9,6 +9,8 @@ from homeassistant.components.number.const import (
     ATTR_STEP,
     ATTR_VALUE,
     DOMAIN,
+    SERVICE_DECREMENT,
+    SERVICE_INCREMENT,
     SERVICE_SET_VALUE,
 )
 from homeassistant.const import ATTR_ENTITY_ID
@@ -80,7 +82,7 @@ async def test_set_value_bad_range(hass):
     assert state.state == "42.0"
 
 
-async def test_set_set_value(hass):
+async def test_set_value(hass):
     """Test the setting of the value."""
     state = hass.states.get(ENTITY_VOLUME)
     assert state.state == "42.0"
@@ -95,3 +97,33 @@ async def test_set_set_value(hass):
 
     state = hass.states.get(ENTITY_VOLUME)
     assert state.state == "23.0"
+
+
+async def test_decrement_increment(hass):
+    """Test decrementing and incrementing the value."""
+    state = hass.states.get(ENTITY_VOLUME)
+    assert state.state == "42.0"
+
+    # Decrement
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DECREMENT,
+        {ATTR_ENTITY_ID: ENTITY_VOLUME},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_VOLUME)
+    assert state.state == "41.0"
+
+    # Increment
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_INCREMENT,
+        {ATTR_ENTITY_ID: ENTITY_VOLUME},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_VOLUME)
+    assert state.state == "42.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register `number.increment` and `number.decrement` services.  These correspond exactly to the `input_number.increment` and `input_number.decrement` services.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
