### PR TITLE
Repair flaky and broken stream tests in test_hls.py, and turn back on

### DIFF
--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -117,9 +117,13 @@ class StreamOutput:
         self._cursor = segment.sequence
         return segment
 
-    @callback
     def put(self, segment: Segment) -> None:
         """Store output."""
+        self._stream.hass.loop.call_soon_threadsafe(self._async_put, segment)
+
+    @callback
+    def _async_put(self, segment: Segment) -> None:
+        """Store output from event loop."""
         # Start idle timeout when we start receiving data
         if self._unsub is None:
             self._unsub = async_call_later(

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -52,7 +52,8 @@ class HlsMasterPlaylistView(StreamView):
         stream.start()
         # Wait for a segment to be ready
         if not track.segments:
-            await track.recv()
+            if not await track.recv():
+                return web.HTTPNotFound()
         headers = {"Content-Type": FORMAT_CONTENT_TYPE["hls"]}
         return web.Response(body=self.render(track).encode("utf-8"), headers=headers)
 
@@ -105,7 +106,8 @@ class HlsPlaylistView(StreamView):
         stream.start()
         # Wait for a segment to be ready
         if not track.segments:
-            await track.recv()
+            if not await track.recv():
+                return web.HTTPNotFound()
         headers = {"Content-Type": FORMAT_CONTENT_TYPE["hls"]}
         return web.Response(body=self.render(track).encode("utf-8"), headers=headers)
 

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -224,7 +224,7 @@ def _stream_worker_internal(hass, stream, quit_event):
         if not stream.keepalive:
             # End of stream, clear listeners and stop thread
             for fmt in stream.outputs:
-                hass.loop.call_soon_threadsafe(stream.outputs[fmt].put, None)
+                stream.outputs[fmt].put(None)
 
     if not peek_first_pts():
         container.close()
@@ -275,8 +275,7 @@ def _stream_worker_internal(hass, stream, quit_event):
                 for fmt, (buffer, _) in outputs.items():
                     buffer.output.close()
                     if stream.outputs.get(fmt):
-                        hass.loop.call_soon_threadsafe(
-                            stream.outputs[fmt].put,
+                        stream.outputs[fmt].put(
                             Segment(
                                 sequence,
                                 buffer.segment,

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -1,11 +1,24 @@
-"""The tests for hls streams."""
+"""The tests for hls streams.
+
+The tests encode stream (as an h264 video), then load the stream and verify
+that it is decoded properly. The background worker thread responsible for
+decoding will decode the stream as fast as possible, and when completed
+clears all output buffers. This can be a problem for the test that wishes
+to retrieve and verify decoded segments. If the worker finishes first, there is
+nothing for the test to verify. The solution is the WorkerSync class that
+allows the tests to pause the worker thread before finalizing the stream
+so that it can inspect the output.
+"""
 from datetime import timedelta
+import threading
 from unittest.mock import patch
 from urllib.parse import urlparse
 
 import av
+import pytest
 
 from homeassistant.components.stream import request_stream
+from homeassistant.components.stream.core import Segment, StreamOutput
 from homeassistant.const import HTTP_NOT_FOUND
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -14,7 +27,47 @@ from tests.common import async_fire_time_changed
 from tests.components.stream.common import generate_h264_video, preload_stream
 
 
-async def test_hls_stream(hass, hass_client):
+class WorkerSync:
+    """Test fixture that intercepts stream worker calls to StreamOutput."""
+
+    def __init__(self):
+        """Initialize WorkerSync."""
+        self._event = None
+        self._put_original = StreamOutput.put
+
+    def pause(self):
+        """Pause the worker before it finalizes the stream."""
+        self._event = threading.Event()
+
+    def resume(self):
+        """Allow the worker thread to finalize the stream."""
+        self._event.set()
+
+    def blocking_put(self, stream_output: StreamOutput, segment: Segment):
+        """Proxy StreamOutput.put, intercepted for test to pause worker."""
+        if segment is None and self._event:
+            # Worker is ending the stream, which clears all output buffers.
+            # Block the worker thread until the test has a chance to verify
+            # the segments under test.
+            self._event.wait()
+
+        # Forward to actual StreamOutput.put
+        self._put_original(stream_output, segment)
+
+
+@pytest.fixture()
+def worker_sync(hass):
+    """Patch StreamOutput to allow test to synchronize worker stream end."""
+    sync = WorkerSync()
+    with patch(
+        "homeassistant.components.stream.core.StreamOutput.put",
+        side_effect=sync.blocking_put,
+        autospec=True,
+    ):
+        yield sync
+
+
+async def test_hls_stream(hass, hass_client, worker_sync):
     """
     Test hls stream.
 
@@ -22,6 +75,8 @@ async def test_hls_stream(hass, hass_client):
     integration with the stream component.
     """
     await async_setup_component(hass, "stream", {"stream": {}})
+
+    worker_sync.pause()
 
     # Setup demo HLS track
     source = generate_h264_video()
@@ -52,6 +107,8 @@ async def test_hls_stream(hass, hass_client):
     segment_response = await http_client.get(segment_url)
     assert segment_response.status == 200
 
+    worker_sync.resume()
+
     # Stop stream, if it hasn't quit already
     stream.stop()
 
@@ -60,9 +117,11 @@ async def test_hls_stream(hass, hass_client):
     assert fail_response.status == HTTP_NOT_FOUND
 
 
-async def test_stream_timeout(hass, hass_client):
+async def test_stream_timeout(hass, hass_client, worker_sync):
     """Test hls stream timeout."""
     await async_setup_component(hass, "stream", {"stream": {}})
+
+    worker_sync.pause()
 
     # Setup demo HLS track
     source = generate_h264_video()
@@ -87,6 +146,8 @@ async def test_stream_timeout(hass, hass_client):
     playlist_response = await http_client.get(parsed_url.path)
     assert playlist_response.status == 200
 
+    worker_sync.resume()
+
     # Wait 5 minutes
     future = dt_util.utcnow() + timedelta(minutes=5)
     async_fire_time_changed(hass, future)
@@ -96,9 +157,11 @@ async def test_stream_timeout(hass, hass_client):
     assert fail_response.status == HTTP_NOT_FOUND
 
 
-async def test_stream_ended(hass):
+async def test_stream_ended(hass, worker_sync):
     """Test hls stream packets ended."""
     await async_setup_component(hass, "stream", {"stream": {}})
+
+    worker_sync.pause()
 
     # Setup demo HLS track
     source = generate_h264_video()
@@ -114,6 +177,9 @@ async def test_stream_ended(hass):
         if segment is None:
             break
         segments = segment.sequence
+        # Allow worker to finalize once enough of the stream is been consumed
+        if segments > 1:
+            worker_sync.resume()
 
     assert segments > 1
     assert not track.get_segment()

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from urllib.parse import urlparse
 
 import av
-import pytest
 
 from homeassistant.components.stream import request_stream
 from homeassistant.const import HTTP_NOT_FOUND
@@ -15,7 +14,6 @@ from tests.common import async_fire_time_changed
 from tests.components.stream.common import generate_h264_video, preload_stream
 
 
-@pytest.mark.skip("Flaky in CI")
 async def test_hls_stream(hass, hass_client):
     """
     Test hls stream.
@@ -62,7 +60,6 @@ async def test_hls_stream(hass, hass_client):
     assert fail_response.status == HTTP_NOT_FOUND
 
 
-@pytest.mark.skip("Flaky in CI")
 async def test_stream_timeout(hass, hass_client):
     """Test hls stream timeout."""
     await async_setup_component(hass, "stream", {"stream": {}})
@@ -99,7 +96,6 @@ async def test_stream_timeout(hass, hass_client):
     assert fail_response.status == HTTP_NOT_FOUND
 
 
-@pytest.mark.skip("Flaky in CI")
 async def test_stream_ended(hass):
     """Test hls stream packets ended."""
     await async_setup_component(hass, "stream", {"stream": {}})

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -48,7 +48,7 @@ async def test_hls_stream(hass, hass_client):
     # Fetch segment
     playlist = await playlist_response.text()
     playlist_url = "/".join(parsed_url.path.split("/")[:-1])
-    segment_url = playlist_url + playlist.splitlines()[-1][1:]
+    segment_url = playlist_url + "/" + playlist.splitlines()[-1]
     segment_response = await http_client.get(segment_url)
     assert segment_response.status == 200
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Background: Tests encode a fake video them start a stream to be decoded. Tests
assert on the decoded segments, however there is a race with the stream worker
which can finish decoding first, and end the stream which erases all buffers.  These
tests were previously disabled in https://github.com/home-assistant/core/pull/23493

Breadown of fixes:
- Fix the race conditions by adding synchronization points right before the
  stream is finalized.
- Refactor `StreamOutput.put` so that a `patch()` can block the worker
  thread.  . This is a bit of a hack, but it is the simplist possible
  code change to add this synchronization and maybe provides OK separation of
  responsibilities from the worker anyway.  Previously, the `put` call would happen
  in the event loop which was not safe to block.
- Fix a big in parsing the path that caused the test to fail, likely due to a change introduced while the tests were disabled.
- Handle race where the HLS stream view `recv()` call returns `None`, indicating
  the worker finished while the request was waiting.

The tests were previously failing anywhere from 2-5% of the time on a lightly
loaded machine doing 1k iterations.  Now, have 0% flake rate.  Tested with:
```
$ py.test --count=1000 tests/components/strema/test_hls.py
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/issues/482
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
