### PR TITLE
Remove safe mode from HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -114,6 +114,7 @@ def _has_all_unique_names_and_ports(bridges):
 
 BRIDGE_SCHEMA = vol.All(
     cv.deprecated(CONF_ZEROCONF_DEFAULT_INTERFACE),
+    cv.deprecated(CONF_SAFE_MODE),
     vol.Schema(
         {
             vol.Optional(CONF_HOMEKIT_MODE, default=DEFAULT_HOMEKIT_MODE): vol.In(
@@ -246,7 +247,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     homekit_mode = options.get(CONF_HOMEKIT_MODE, DEFAULT_HOMEKIT_MODE)
     entity_config = options.get(CONF_ENTITY_CONFIG, {}).copy()
     auto_start = options.get(CONF_AUTO_START, DEFAULT_AUTO_START)
-    safe_mode = options.get(CONF_SAFE_MODE, DEFAULT_SAFE_MODE)
     entity_filter = FILTER_SCHEMA(options.get(CONF_FILTER, {}))
 
     homekit = HomeKit(
@@ -256,7 +256,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         ip_address,
         entity_filter,
         entity_config,
-        safe_mode,
         homekit_mode,
         advertise_ip,
         entry.entry_id,
@@ -421,7 +420,6 @@ class HomeKit:
         ip_address,
         entity_filter,
         entity_config,
-        safe_mode,
         homekit_mode,
         advertise_ip=None,
         entry_id=None,
@@ -433,7 +431,6 @@ class HomeKit:
         self._ip_address = ip_address
         self._filter = entity_filter
         self._config = entity_config
-        self._safe_mode = safe_mode
         self._advertise_ip = advertise_ip
         self._entry_id = entry_id
         self._homekit_mode = homekit_mode
@@ -469,10 +466,6 @@ class HomeKit:
             self.driver.load()
         else:
             self.driver.persist()
-
-        if self._safe_mode:
-            _LOGGER.debug("Safe_mode selected for %s", self._name)
-            self.driver.safe_mode = True
 
     def reset_accessories(self, entity_ids):
         """Reset the accessory to load the latest configuration."""

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -21,12 +21,10 @@ from .const import (
     CONF_ENTITY_CONFIG,
     CONF_FILTER,
     CONF_HOMEKIT_MODE,
-    CONF_SAFE_MODE,
     CONF_VIDEO_CODEC,
     DEFAULT_AUTO_START,
     DEFAULT_CONFIG_FLOW_PORT,
     DEFAULT_HOMEKIT_MODE,
-    DEFAULT_SAFE_MODE,
     HOMEKIT_MODE_ACCESSORY,
     HOMEKIT_MODES,
     SHORT_BRIDGE_NAME,
@@ -217,40 +215,32 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_advanced(self, user_input=None):
         """Choose advanced options."""
-        if user_input is not None:
-            self.homekit_options.update(user_input)
-            for key in (CONF_DOMAINS, CONF_ENTITIES):
-                if key in self.homekit_options:
-                    del self.homekit_options[key]
-            return self.async_create_entry(title="", data=self.homekit_options)
+        if not self.show_advanced_options or user_input is not None:
+            if user_input:
+                self.homekit_options.update(user_input)
 
-        schema_base = {}
-
-        if self.show_advanced_options:
-            schema_base[
-                vol.Optional(
-                    CONF_AUTO_START,
-                    default=self.homekit_options.get(
-                        CONF_AUTO_START, DEFAULT_AUTO_START
-                    ),
-                )
-            ] = bool
-        else:
             self.homekit_options[CONF_AUTO_START] = self.homekit_options.get(
                 CONF_AUTO_START, DEFAULT_AUTO_START
             )
 
-        schema_base.update(
-            {
-                vol.Optional(
-                    CONF_SAFE_MODE,
-                    default=self.homekit_options.get(CONF_SAFE_MODE, DEFAULT_SAFE_MODE),
-                ): bool
-            }
-        )
+            for key in (CONF_DOMAINS, CONF_ENTITIES):
+                if key in self.homekit_options:
+                    del self.homekit_options[key]
+
+            return self.async_create_entry(title="", data=self.homekit_options)
 
         return self.async_show_form(
-            step_id="advanced", data_schema=vol.Schema(schema_base)
+            step_id="advanced",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_AUTO_START,
+                        default=self.homekit_options.get(
+                            CONF_AUTO_START, DEFAULT_AUTO_START
+                        ),
+                    ): bool
+                }
+            ),
         )
 
     async def async_step_cameras(self, user_input=None):

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -30,8 +30,7 @@
             },
             "advanced": {
                 "data": {
-                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)",
-                    "safe_mode": "Safe Mode (enable only if pairing fails)"
+                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)"
                 },
                 "description": "These settings only need to be adjusted if HomeKit is not functional.",
                 "title": "Advanced Configuration"

--- a/homeassistant/components/homekit/translations/en.json
+++ b/homeassistant/components/homekit/translations/en.json
@@ -30,8 +30,7 @@
             },
             "advanced": {
                 "data": {
-                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)",
-                    "safe_mode": "Safe Mode (enable only if pairing fails)"
+                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)"
                 },
                 "description": "These settings only need to be adjusted if HomeKit is not functional.",
                 "title": "Advanced Configuration"

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -28,7 +28,6 @@ def _mock_config_entry_with_options_populated():
                 ],
                 "exclude_entities": ["climate.front_gate"],
             },
-            "safe_mode": False,
         },
     )
 
@@ -159,7 +158,7 @@ async def test_options_flow_exclude_mode_advanced(auto_start, hass):
     with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
         result3 = await hass.config_entries.options.async_configure(
             result2["flow_id"],
-            user_input={"auto_start": auto_start, "safe_mode": True},
+            user_input={"auto_start": auto_start},
         )
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -172,7 +171,6 @@ async def test_options_flow_exclude_mode_advanced(auto_start, hass):
             "include_domains": ["fan", "vacuum", "climate", "humidifier"],
             "include_entities": [],
         },
-        "safe_mode": True,
     }
 
 
@@ -204,16 +202,7 @@ async def test_options_flow_exclude_mode_basic(hass):
         result["flow_id"],
         user_input={"entities": ["climate.old"], "include_exclude_mode": "exclude"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["step_id"] == "advanced"
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.options.async_configure(
-            result2["flow_id"],
-            user_input={"safe_mode": True},
-        )
-
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
         "mode": "bridge",
@@ -223,7 +212,6 @@ async def test_options_flow_exclude_mode_basic(hass):
             "include_domains": ["fan", "vacuum", "climate"],
             "include_entities": [],
         },
-        "safe_mode": True,
     }
 
 
@@ -257,16 +245,7 @@ async def test_options_flow_include_mode_basic(hass):
         result["flow_id"],
         user_input={"entities": ["climate.new"], "include_exclude_mode": "include"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["step_id"] == "advanced"
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.options.async_configure(
-            result2["flow_id"],
-            user_input={"safe_mode": True},
-        )
-
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
         "mode": "bridge",
@@ -276,7 +255,6 @@ async def test_options_flow_include_mode_basic(hass):
             "include_domains": ["fan", "vacuum"],
             "include_entities": ["climate.new"],
         },
-        "safe_mode": True,
     }
 
 
@@ -323,16 +301,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
         user_input={"camera_copy": ["camera.native_h264"]},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result3["step_id"] == "advanced"
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result4 = await hass.config_entries.options.async_configure(
-            result3["flow_id"],
-            user_input={"safe_mode": True},
-        )
-
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
         "mode": "bridge",
@@ -343,7 +312,6 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
             "include_entities": [],
         },
         "entity_config": {"camera.native_h264": {"video_codec": "copy"}},
-        "safe_mode": True,
     }
 
     # Now run though again and verify we can turn off copy
@@ -378,16 +346,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
         user_input={"camera_copy": []},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result3["step_id"] == "advanced"
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result4 = await hass.config_entries.options.async_configure(
-            result3["flow_id"],
-            user_input={"safe_mode": True},
-        )
-
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
         "mode": "bridge",
@@ -398,7 +357,6 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
             "include_entities": [],
         },
         "entity_config": {"camera.native_h264": {}},
-        "safe_mode": True,
     }
 
 
@@ -445,16 +403,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
         user_input={"camera_copy": ["camera.native_h264"]},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result3["step_id"] == "advanced"
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result4 = await hass.config_entries.options.async_configure(
-            result3["flow_id"],
-            user_input={"safe_mode": True},
-        )
-
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
         "mode": "bridge",
@@ -465,7 +414,6 @@ async def test_options_flow_include_mode_with_cameras(hass):
             "include_entities": ["camera.native_h264", "camera.transcode_h264"],
         },
         "entity_config": {"camera.native_h264": {"video_codec": "copy"}},
-        "safe_mode": True,
     }
 
     # Now run though again and verify we can turn off copy
@@ -500,16 +448,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
         user_input={"camera_copy": []},
     )
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result3["step_id"] == "advanced"
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result4 = await hass.config_entries.options.async_configure(
-            result3["flow_id"],
-            user_input={"safe_mode": True},
-        )
-
-    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
         "mode": "bridge",
@@ -520,7 +459,6 @@ async def test_options_flow_include_mode_with_cameras(hass):
             "include_entities": [],
         },
         "entity_config": {"camera.native_h264": {}},
-        "safe_mode": True,
     }
 
 
@@ -543,7 +481,6 @@ async def test_options_flow_blocked_when_from_yaml(hass):
                 ],
                 "exclude_entities": ["climate.front_gate"],
             },
-            "safe_mode": False,
         },
         source=SOURCE_IMPORT,
     )
@@ -594,16 +531,7 @@ async def test_options_flow_include_mode_basic_accessory(hass):
         result["flow_id"],
         user_input={"entities": "media_player.tv"},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["step_id"] == "advanced"
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.options.async_configure(
-            result2["flow_id"],
-            user_input={"safe_mode": False},
-        )
-
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
         "mode": "accessory",
@@ -613,5 +541,4 @@ async def test_options_flow_include_mode_basic_accessory(hass):
             "include_domains": [],
             "include_entities": ["media_player.tv"],
         },
-        "safe_mode": False,
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Safe mode was added to work around a race condition where
the mdns announcment was sent too early and would cause
pairing to fail. Since this has been corrected in
HAP-python, there is no longer a need to have
safe mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16149

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
