### PR TITLE
Shutdown asyncio http server within 10 seconds

### DIFF
--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -28,7 +28,7 @@ class HomeAssistantTCPSite(web.BaseSite):
         host: Union[None, str, List[str]],
         port: int,
         *,
-        shutdown_timeout: float = 60.0,
+        shutdown_timeout: float = 10.0,
         ssl_context: Optional[SSLContext] = None,
         backlog: int = 128,
         reuse_address: Optional[bool] = None,


### PR DESCRIPTION
If there are open requests, the http server waits up to 60 seconds.
However, some requests (such as the Reboot button in the
Supervisor menu) seems to keep a connection open and needlessly
slow down the reboot process:

```
Jan 11 00:52:54 homeassistant eb034fca9c7d[404]: 2021-01-11 00:52:54 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event homeassistant_stop[L]>
Jan 11 00:52:54 homeassistant eb034fca9c7d[404]: 2021-01-11 00:52:54 DEBUG (MainThread) [homeassistant.helpers.restore_state] Dumping states 111
Jan 11 00:52:54 homeassistant eb034fca9c7d[404]: 2021-01-11 00:52:54 DEBUG (MainThread) [homeassistant.helpers.restore_state] Dumping states
Jan 11 00:52:54 homeassistant eb034fca9c7d[404]: 2021-01-11 00:52:54 INFO (MainThread) [homeassistant.components.websocket_api.http.connection] [281473359593728] Connection closed by client
Jan 11 00:52:56 homeassistant eb034fca9c7d[404]: 2021-01-11 00:52:56 DEBUG (MainThread) [homeassistant.components.websocket_api.http.connection] [281473359593728] Disconnected
Jan 11 00:53:54 homeassistant eb034fca9c7d[404]: 2021-01-11 00:53:54 DEBUG (MainThread) [homeassistant.core] Waited 60 seconds for task: <Task pending name='Task-585' coro=<async_setup.<locals>.stop_server() running at /usr/src/homeassistant/homeassistant/components/http/__init__.py:228> wait_for=<_GatheringFuture pending cb=[<TaskWakeupMethWrapper object at 0xffff9f112f70>()]> cb=[_wait.<locals>._on_completion() at /usr/local/lib/python3.8/asyncio/tasks.py:518]>
...
```

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
