### PR TITLE
Update roomba config flow to walk users through pairing

### DIFF
--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -1,5 +1,8 @@
 """Config flow to configure roomba component."""
+
 from roombapy import Roomba
+from roombapy.discovery import RoombaDiscovery
+from roombapy.getpassword import RoombaPassword
 import voluptuous as vol
 
 from homeassistant import config_entries, core
@@ -18,15 +21,9 @@ from .const import (
 )
 from .const import DOMAIN  # pylint:disable=unused-import
 
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): str,
-        vol.Required(CONF_BLID): str,
-        vol.Required(CONF_PASSWORD): str,
-        vol.Optional(CONF_CONTINUOUS, default=DEFAULT_CONTINUOUS): bool,
-        vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): int,
-    }
-)
+DEFAULT_OPTIONS = {CONF_CONTINUOUS: DEFAULT_CONTINUOUS, CONF_DELAY: DEFAULT_DELAY}
+
+MAX_NUM_DEVICES_TO_DISCOVER = 25
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -57,11 +54,25 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
+    def __init__(self):
+        """Initialize the roomba flow."""
+        self.discovered_robots = {}
+        self.name = None
+        self.blid = None
+        self.host = None
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
+
+    @callback
+    def _async_get_roomba_discovery(self):
+        """Create a discovery object."""
+        discovery = RoombaDiscovery()
+        discovery.amount_of_broadcasted_messages = MAX_NUM_DEVICES_TO_DISCOVER
+        return discovery
 
     async def async_step_import(self, import_info):
         """Set the config entry up from yaml."""
@@ -69,22 +80,141 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
+        # This is for backwards compatibility.
+        return await self.async_step_init(user_input)
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow start."""
+        # Check if user chooses manual entry
+        if user_input is not None and not user_input.get(CONF_HOST):
+            return await self.async_step_manual()
+
+        if (
+            user_input is not None
+            and self.discovered_robots is not None
+            and user_input[CONF_HOST] in self.discovered_robots
+        ):
+            self.host = user_input[CONF_HOST]
+            device = self.discovered_robots[self.host]
+            self.blid = device.blid
+            self.name = device.robot_name
+            await self.async_set_unique_id(self.blid, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            return await self.async_step_link()
+
+        already_configured = self._async_current_ids(False)
+        discovery = self._async_get_roomba_discovery()
+        devices = await self.hass.async_add_executor_job(discovery.get_all)
+
+        if devices:
+            # Find already configured hosts
+            self.discovered_robots = {
+                device.ip: device
+                for device in devices
+                if device.blid not in already_configured
+            }
+
+        if not self.discovered_robots:
+            return await self.async_step_manual()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional("host"): vol.In(
+                        {
+                            **{
+                                device.ip: f"{device.robot_name} ({device.ip})"
+                                for device in devices
+                                if device.blid not in already_configured
+                            },
+                            None: "Manually add a Roomba or Braava",
+                        }
+                    )
+                }
+            ),
+        )
+
+    async def async_step_manual(self, user_input=None):
+        """Handle manual device setup."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="manual",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_HOST): str, vol.Required(CONF_BLID): str}
+                ),
+            )
+
+        if any(
+            user_input["host"] == entry.data.get("host")
+            for entry in self._async_current_entries()
+        ):
+            return self.async_abort(reason="already_configured")
+
+        self.host = user_input[CONF_HOST]
+        self.blid = user_input[CONF_BLID]
+        await self.async_set_unique_id(self.blid, raise_on_progress=False)
+        self._abort_if_unique_id_configured()
+        return await self.async_step_link()
+
+    async def async_step_link(self, user_input=None):
+        """Attempt to link with the Roomba.
+
+        Given a configured host, will ask the user to press the home and target buttons
+        to connect to the device.
+        """
+        if user_input is None:
+            return self.async_show_form(step_id="link")
+
+        password = await self.hass.async_add_executor_job(
+            RoombaPassword(self.host).get_password
+        )
+
+        if not password:
+            return await self.async_step_link_manual()
+
+        config = {
+            CONF_HOST: self.host,
+            CONF_BLID: self.blid,
+            CONF_PASSWORD: password,
+            **DEFAULT_OPTIONS,
+        }
+
+        if not self.name:
+            try:
+                info = await validate_input(self.hass, config)
+            except CannotConnect:
+                return self.async_abort(reason="cannot_connect")
+
+            await async_disconnect_or_timeout(self.hass, info[ROOMBA_SESSION])
+            self.name = info[CONF_NAME]
+
+        return self.async_create_entry(title=self.name, data=config)
+
+    async def async_step_link_manual(self, user_input=None):
+        """Handle manual linking."""
         errors = {}
 
         if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_BLID])
-            self._abort_if_unique_id_configured()
+            config = {
+                CONF_HOST: self.host,
+                CONF_BLID: self.blid,
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                **DEFAULT_OPTIONS,
+            }
             try:
-                info = await validate_input(self.hass, user_input)
+                info = await validate_input(self.hass, config)
             except CannotConnect:
                 errors = {"base": "cannot_connect"}
 
-            if "base" not in errors:
+            if not errors:
                 await async_disconnect_or_timeout(self.hass, info[ROOMBA_SESSION])
-                return self.async_create_entry(title=info[CONF_NAME], data=user_input)
+                return self.async_create_entry(title=info[CONF_NAME], data=config)
 
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+            step_id="link_manual",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            errors=errors,
         )
 
 

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -241,7 +241,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
 
 @callback
-def _async_get_roomba_discovery(self):
+def _async_get_roomba_discovery():
     """Create a discovery object."""
     discovery = RoombaDiscovery()
     discovery.amount_of_broadcasted_messages = MAX_NUM_DEVICES_TO_DISCOVER

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -74,10 +74,6 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         discovery.amount_of_broadcasted_messages = MAX_NUM_DEVICES_TO_DISCOVER
         return discovery
 
-    async def async_step_import(self, import_info):
-        """Set the config entry up from yaml."""
-        return await self.async_step_user(import_info)
-
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         # This is for backwards compatibility.

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -67,13 +67,6 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
-    @callback
-    def _async_get_roomba_discovery(self):
-        """Create a discovery object."""
-        discovery = RoombaDiscovery()
-        discovery.amount_of_broadcasted_messages = MAX_NUM_DEVICES_TO_DISCOVER
-        return discovery
-
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         # This is for backwards compatibility.
@@ -99,7 +92,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_link()
 
         already_configured = self._async_current_ids(False)
-        discovery = self._async_get_roomba_discovery()
+        discovery = _async_get_roomba_discovery()
         devices = await self.hass.async_add_executor_job(discovery.get_all)
 
         if devices:
@@ -245,3 +238,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 }
             ),
         )
+
+
+@callback
+def _async_get_roomba_discovery(self):
+    """Create a discovery object."""
+    discovery = RoombaDiscovery()
+    discovery.amount_of_broadcasted_messages = MAX_NUM_DEVICES_TO_DISCOVER
+    return discovery

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "roomba",
-  "name": "iRobot Roomba",
+  "name": "iRobot Roomba and Braava",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roomba",
   "requirements": ["roombapy==1.6.2"],

--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -1,21 +1,39 @@
 {
   "config": {
     "step": {
-      "user": {
-        "title": "Connect to the device",
-        "description": "Currently retrieving the BLID and password is a manual process. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
+      "init": {
+        "title": "Automaticlly connect to the device",
+        "description": "Select a Roomba or Braava.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      },
+      "manual": {
+        "title": "Manually connect to the device",
+        "description": "No Roomba or Braava have been discovered on your network. The BLID is the portion of the device hostname after `iRobot-`. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "blid": "BLID",
-          "password": "[%key:common::config_flow::data::password%]",
-          "continuous": "Continuous",
-          "delay": "Delay"
+          "blid": "BLID"
         }
-      }
+      },      
+      "link": {
+        "title": "Retrieve Password",
+        "description": "Press and hold the Home button until the device generates a sound (about two seconds)."
+      },
+      "link_manual": {
+        "title": "Enter Password",
+        "description": "The password could not be retrivied from the device automaticlly. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }          
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
-    }
+    },
+    "abort": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    }    
   },
   "options": {
     "step": {

--- a/homeassistant/components/roomba/translations/en.json
+++ b/homeassistant/components/roomba/translations/en.json
@@ -1,30 +1,48 @@
 {
-    "config": {
-        "error": {
-            "cannot_connect": "Failed to connect"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "blid": "BLID",
-                    "continuous": "Continuous",
-                    "delay": "Delay",
-                    "host": "Host",
-                    "password": "Password"
-                },
-                "description": "Currently retrieving the BLID and password is a manual process. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
-                "title": "Connect to the device"
-            }
+  "config": {
+    "step": {
+      "init": {
+        "title": "Automaticlly connect to the device",
+        "description": "Select a Roomba or Braava.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
         }
+      },
+      "manual": {
+        "title": "Manually connect to the device",
+        "description": "No Roomba or Braava have been discovered on your network. The BLID is the portion of the device hostname after `iRobot-`. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "blid": "BLID"
+        }
+      },      
+      "link": {
+        "title": "Retrieve Password",
+        "description": "Press and hold the Home button until the device generates a sound (about two seconds)."
+      },
+      "link_manual": {
+        "title": "Enter Password",
+        "description": "The password could not be retrivied from the device automaticlly. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }          
     },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "continuous": "Continuous",
-                    "delay": "Delay"
-                }
-            }
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    }    
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "continuous": "Continuous",
+          "delay": "Delay"
         }
+      }
     }
+  }
 }

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -147,6 +147,35 @@ async def test_form_user_discovery_skips_known(hass):
     assert result["step_id"] == "manual"
 
 
+async def test_form_user_failed_discovery_aborts_already_configured(hass):
+    """Test if we manually configure an existing host we abort."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="blid")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        _mocked_failed_discovery,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "manual"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: MOCK_IP, CONF_BLID: "blid"},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["reason"] == "already_configured"
+
+
 async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
     """Test discovery skipped and we can auto fetch the password."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -411,3 +440,67 @@ async def test_form_user_discovery_fails_and_password_fetch_fails(hass):
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_user_discovery_fails_and_password_fetch_fails_and_cannot_connect(
+    hass,
+):
+    """Test discovery fails and password fetch fails then we cannot connect."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    mocked_roomba = _create_mocked_roomba(
+        connect=RoombaConnectionError,
+        roomba_connected=True,
+        master_state={"state": {"reported": {"name": "myroomba"}}},
+    )
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        _mocked_failed_discovery,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "manual"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: MOCK_IP, CONF_BLID: "blid"},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] is None
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaPassword",
+        _mocked_failed_getpassword,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.Roomba",
+        return_value=mocked_roomba,
+    ), patch(
+        "homeassistant.components.roomba.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.roomba.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {CONF_PASSWORD: "password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result4["errors"] == {"base": "cannot_connect"}
+    assert len(mock_setup.mock_calls) == 0
+    assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from roombapy import RoombaConnectionError
+from roombapy.roomba import RoombaInfo
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.roomba.const import (
@@ -14,15 +15,8 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
 from tests.common import MockConfigEntry
 
+MOCK_IP = "1.2.3.4"
 VALID_CONFIG = {CONF_HOST: "1.2.3.4", CONF_BLID: "blid", CONF_PASSWORD: "password"}
-
-VALID_YAML_CONFIG = {
-    CONF_HOST: "1.2.3.4",
-    CONF_BLID: "blid",
-    CONF_PASSWORD: "password",
-    CONF_CONTINUOUS: True,
-    CONF_DELAY: 1,
-}
 
 
 def _create_mocked_roomba(
@@ -36,14 +30,44 @@ def _create_mocked_roomba(
     return mocked_roomba
 
 
-async def test_form(hass):
-    """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+def _mocked_discovery(*_):
+    roomba_discovery = MagicMock()
+
+    roomba = RoombaInfo(
+        hostname="iRobot-blid",
+        robot_name="robot_name",
+        ip=MOCK_IP,
+        mac="mac",
+        firmware="firmware",
+        sku="sku",
+        capabilities="capabilities",
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {}
+
+    roomba_discovery.get_all = MagicMock(return_value=[roomba])
+    return roomba_discovery
+
+
+def _mocked_failed_discovery(*_):
+    roomba_discovery = MagicMock()
+    roomba_discovery.get_all = MagicMock(return_value=[])
+    return roomba_discovery
+
+
+def _mocked_getpassword(*_):
+    roomba_password = MagicMock()
+    roomba_password.get_password = MagicMock(return_value="password")
+    return roomba_password
+
+
+def _mocked_failed_getpassword(*_):
+    roomba_password = MagicMock()
+    roomba_password.get_password = MagicMock(return_value=None)
+    return roomba_password
+
+
+async def test_form_user_discovery_and_password_fetch(hass):
+    """Test we can discovery and fetch the password."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -51,40 +75,153 @@ async def test_form(hass):
     )
 
     with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "init"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: MOCK_IP},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] is None
+    assert result2["step_id"] == "link"
+
+    with patch(
         "homeassistant.components.roomba.config_flow.Roomba",
         return_value=mocked_roomba,
+    ), patch(
+        "homeassistant.components.roomba.config_flow.RoombaPassword",
+        _mocked_getpassword,
     ), patch(
         "homeassistant.components.roomba.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.roomba.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            VALID_CONFIG,
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {},
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "myroomba"
-
-    assert result2["result"].unique_id == "blid"
-    assert result2["data"] == {
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["title"] == "robot_name"
+    assert result3["result"].unique_id == "blid"
+    assert result3["data"] == {
         CONF_BLID: "blid",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
-        CONF_HOST: "1.2.3.4",
+        CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(hass):
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+async def test_form_user_discovery_skips_known(hass):
+    """Test discovery proceeds to manual if all discovered are already known."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="blid")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "manual"
+
+
+async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
+    """Test discovery skipped and we can auto fetch the password."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    mocked_roomba = _create_mocked_roomba(
+        roomba_connected=True,
+        master_state={"state": {"reported": {"name": "myroomba"}}},
     )
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "init"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: None},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] is None
+    assert result2["step_id"] == "manual"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {CONF_HOST: MOCK_IP, CONF_BLID: "blid"},
+    )
+    await hass.async_block_till_done()
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["errors"] is None
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.Roomba",
+        return_value=mocked_roomba,
+    ), patch(
+        "homeassistant.components.roomba.config_flow.RoombaPassword",
+        _mocked_getpassword,
+    ), patch(
+        "homeassistant.components.roomba.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.roomba.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["title"] == "myroomba"
+    assert result4["result"].unique_id == "blid"
+    assert result4["data"] == {
+        CONF_BLID: "blid",
+        CONF_CONTINUOUS: True,
+        CONF_DELAY: 1,
+        CONF_HOST: MOCK_IP,
+        CONF_PASSWORD: "password",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_connect(
+    hass,
+):
+    """Test discovery skipped and we can auto fetch the password then we fail to connect."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         connect=RoombaConnectionError,
@@ -93,25 +230,159 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "init"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: None},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] is None
+    assert result2["step_id"] == "manual"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {CONF_HOST: MOCK_IP, CONF_BLID: "blid"},
+    )
+    await hass.async_block_till_done()
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result3["errors"] is None
+
+    with patch(
         "homeassistant.components.roomba.config_flow.Roomba",
         return_value=mocked_roomba,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            VALID_CONFIG,
+    ), patch(
+        "homeassistant.components.roomba.config_flow.RoombaPassword",
+        _mocked_getpassword,
+    ), patch(
+        "homeassistant.components.roomba.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.roomba.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {},
         )
+        await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result4["reason"] == "cannot_connect"
+    assert len(mock_setup.mock_calls) == 0
+    assert len(mock_setup_entry.mock_calls) == 0
 
 
-async def test_form_import(hass):
-    """Test we can import yaml config."""
+async def test_form_user_discovery_fails_and_auto_password_fetch(hass):
+    """Test discovery fails and we can auto fetch the password."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
-        master_state={"state": {"reported": {"name": "imported_roomba"}}},
+        master_state={"state": {"reported": {"name": "myroomba"}}},
     )
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        _mocked_failed_discovery,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "manual"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: MOCK_IP, CONF_BLID: "blid"},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] is None
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.Roomba",
+        return_value=mocked_roomba,
+    ), patch(
+        "homeassistant.components.roomba.config_flow.RoombaPassword",
+        _mocked_getpassword,
+    ), patch(
+        "homeassistant.components.roomba.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.roomba.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["title"] == "myroomba"
+    assert result3["result"].unique_id == "blid"
+    assert result3["data"] == {
+        CONF_BLID: "blid",
+        CONF_CONTINUOUS: True,
+        CONF_DELAY: 1,
+        CONF_HOST: MOCK_IP,
+        CONF_PASSWORD: "password",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_user_discovery_fails_and_password_fetch_fails(hass):
+    """Test discovery fails and password fetch fails."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    mocked_roomba = _create_mocked_roomba(
+        roomba_connected=True,
+        master_state={"state": {"reported": {"name": "myroomba"}}},
+    )
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        _mocked_failed_discovery,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "manual"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: MOCK_IP, CONF_BLID: "blid"},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] is None
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaPassword",
+        _mocked_failed_getpassword,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
 
     with patch(
         "homeassistant.components.roomba.config_flow.Roomba",
@@ -122,39 +393,21 @@ async def test_form_import(hass):
         "homeassistant.components.roomba.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=VALID_YAML_CONFIG.copy(),
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {CONF_PASSWORD: "password"},
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["result"].unique_id == "blid"
-    assert result["title"] == "imported_roomba"
-    assert result["data"] == {
+    assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result4["title"] == "myroomba"
+    assert result4["result"].unique_id == "blid"
+    assert result4["data"] == {
         CONF_BLID: "blid",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
-        CONF_HOST: "1.2.3.4",
+        CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
-
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_import_dupe(hass):
-    """Test we get abort on duplicate import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="blid")
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data=VALID_YAML_CONFIG.copy(),
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update roomba config flow to walk users through pairing.

Manual pairing was painful.  This change replaces the complex
steps by adding discovery and linking support by pressing the home button.

@freekode already did all the work to update `roombapy` 👍 to make this possible.

## Breaking Change

Roomba has fully transitioned to configuration via UI. YAML configuration is no longer supported. Existing YAML configuration has already been imported automatically in the previous releases and can now safely be removed from your configuration files.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
