### PR TITLE
Add zwave_js init module tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1092,7 +1092,6 @@ omit =
     homeassistant/components/zoneminder/*
     homeassistant/components/supla/*
     homeassistant/components/zwave/util.py
-    homeassistant/components/zwave_js/__init__.py
     homeassistant/components/zwave_js/discovery.py
     homeassistant/components/zwave_js/entity.py
     homeassistant/components/zwave_js/light.py

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -18,6 +18,7 @@ from .const import DATA_CLIENT, DATA_UNSUBSCRIBE, DOMAIN, PLATFORMS
 from .discovery import async_discover_values
 
 LOGGER = logging.getLogger(__name__)
+CONNECT_TIMEOUT = 10
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
@@ -113,7 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # connect and throw error if connection failed
     asyncio.create_task(client.connect())
     try:
-        async with timeout(10):
+        async with timeout(CONNECT_TIMEOUT):
             await initialized.wait()
     except asyncio.TimeoutError as err:
         for unsub in unsubs:

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -1,0 +1,2 @@
+"""Provide common test tools for Z-Wave JS."""
+AIR_TEMPERATURE_SENSOR = "sensor.multisensor_6_air_temperature"

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1,6 +1,6 @@
 """Provide common Z-Wave JS fixtures."""
 import json
-from unittest.mock import patch
+from unittest.mock import DEFAULT, patch
 
 import pytest
 from zwave_js_server.model.driver import Driver
@@ -49,6 +49,7 @@ async def integration_fixture(hass, client):
     def initialize_client(async_on_initialized):
         """Init the client."""
         hass.async_create_task(async_on_initialized())
+        return DEFAULT
 
     client.register_on_initialized.side_effect = initialize_client
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -6,7 +6,17 @@ import pytest
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 
+from homeassistant.helpers.device_registry import (
+    async_get_registry as async_get_device_registry,
+)
+
 from tests.common import MockConfigEntry, load_fixture
+
+
+@pytest.fixture(name="device_registry")
+async def device_registry_fixture(hass):
+    """Return the device registry."""
+    return await async_get_device_registry(hass)
 
 
 @pytest.fixture(name="controller_state", scope="session")

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1,5 +1,8 @@
 """Test the Z-Wave JS init module."""
 from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
+from homeassistant.const import STATE_UNAVAILABLE
+
+AIR_TEMPERATURE_SENSOR = "sensor.multisensor_6_air_temperature"
 
 
 async def test_entry_setup_unload(hass, client, integration):
@@ -26,3 +29,33 @@ async def test_home_assistant_stop(hass, client, integration):
     await hass.async_stop()
 
     assert client.disconnect.call_count == 1
+
+
+async def test_on_connect_disconnect(hass, client, multisensor_6, integration):
+    """Test we handle disconnect and reconnect."""
+    on_connect = client.register_on_connect.call_args[0][0]
+    on_disconnect = client.register_on_disconnect.call_args[0][0]
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    client.connected = False
+
+    await on_disconnect()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert state
+    assert state.state == STATE_UNAVAILABLE
+
+    client.connected = True
+
+    await on_connect()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert state
+    assert state.state != STATE_UNAVAILABLE

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1,0 +1,21 @@
+"""Test the Z-Wave JS init module."""
+from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
+
+
+async def test_entry_setup_unload(hass, client, integration):
+    """Test the integration set up and unload."""
+    entry = integration
+
+    assert client.connect.call_count == 1
+    assert client.register_on_initialized.call_count == 1
+    assert client.register_on_disconnect.call_count == 1
+    assert client.register_on_connect.call_count == 1
+    assert entry.state == ENTRY_STATE_LOADED
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+    assert client.disconnect.call_count == 1
+    assert client.register_on_initialized.return_value.call_count == 1
+    assert client.register_on_disconnect.return_value.call_count == 1
+    assert client.register_on_connect.return_value.call_count == 1
+    assert entry.state == ENTRY_STATE_NOT_LOADED

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -19,3 +19,10 @@ async def test_entry_setup_unload(hass, client, integration):
     assert client.register_on_disconnect.return_value.call_count == 1
     assert client.register_on_connect.return_value.call_count == 1
     assert entry.state == ENTRY_STATE_NOT_LOADED
+
+
+async def test_home_assistant_stop(hass, client, integration):
+    """Test we clean up on home assistant stop."""
+    await hass.async_stop()
+
+    assert client.disconnect.call_count == 1

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -156,6 +156,22 @@ async def test_on_node_added_not_ready(
     assert state.state != STATE_UNAVAILABLE
 
 
+async def test_existing_node_ready(
+    hass, client, multisensor_6, integration, device_registry
+):
+    """Test we handle a ready node that exist during integration setup."""
+    node = multisensor_6
+    air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
+
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert state  # entity and device added
+    assert state.state != STATE_UNAVAILABLE
+    assert device_registry.async_get_device(
+        identifiers={(DOMAIN, air_temperature_device_id)}
+    )
+
+
 async def test_existing_node_not_ready(hass, client, multisensor_6, device_registry):
     """Test we handle a non ready node that exist during integration setup."""
     node = multisensor_6

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -13,9 +13,9 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import STATE_UNAVAILABLE
 
-from tests.common import MockConfigEntry
+from .common import AIR_TEMPERATURE_SENSOR
 
-AIR_TEMPERATURE_SENSOR = "sensor.multisensor_6_air_temperature"
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="connect_timeout")

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1,6 +1,6 @@
 """Test the Z-Wave JS init module."""
 from copy import deepcopy
-from unittest.mock import patch
+from unittest.mock import DEFAULT, patch
 
 import pytest
 from zwave_js_server.model.node import Node
@@ -126,6 +126,39 @@ async def test_on_node_added_not_ready(hass, multisensor_6_state, client, integr
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
     assert not state  # device added in registry but entity not yet added
+
+    node.data["ready"] = True
+    node.emit("ready", event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert state
+    assert state.state != STATE_UNAVAILABLE  # entity added
+
+
+async def test_existing_node_not_ready(hass, client, multisensor_6):
+    """Test we handle a non ready node that exist during integration setup."""
+    node = multisensor_6
+    node.data = deepcopy(node.data)  # Copy to allow modification in tests.
+    node.data["ready"] = False
+    event = {"node": node}
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+
+    def initialize_client(async_on_initialized):
+        """Init the client."""
+        hass.async_create_task(async_on_initialized())
+        return DEFAULT
+
+    client.register_on_initialized.side_effect = initialize_client
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert not state  # node and entity not yet added
 
     node.data["ready"] = True
     node.emit("ready", event)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 import pytest
+from zwave_js_server.model.node import Node
 
 from homeassistant.config_entries import (
     ENTRY_STATE_LOADED,
@@ -87,3 +88,21 @@ async def test_initialized_timeout(hass, client, connect_timeout):
     await hass.async_block_till_done()
 
     assert entry.state == ENTRY_STATE_SETUP_RETRY
+
+
+async def test_on_node_added_ready(hass, multisensor_6_state, client, integration):
+    """Test we handle node added event."""
+    node = Node(client, multisensor_6_state)
+    event = {"node": node}
+
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert not state  # node and entity not yet added
+
+    client.driver.controller.emit("node added", event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    assert state
+    assert state.state != STATE_UNAVAILABLE  # node and entity added

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -159,7 +159,7 @@ async def test_on_node_added_not_ready(
 async def test_existing_node_ready(
     hass, client, multisensor_6, integration, device_registry
 ):
-    """Test we handle a ready node that exist during integration setup."""
+    """Test we handle a ready node that exists during integration setup."""
     node = multisensor_6
     air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
 
@@ -173,7 +173,7 @@ async def test_existing_node_ready(
 
 
 async def test_existing_node_not_ready(hass, client, multisensor_6, device_registry):
-    """Test we handle a non ready node that exist during integration setup."""
+    """Test we handle a non ready node that exists during integration setup."""
     node = multisensor_6
     node.data = deepcopy(node.data)  # Copy to allow modification in tests.
     node.data["ready"] = False

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -1,7 +1,7 @@
 """Test the Z-Wave JS sensor platform."""
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS
 
-AIR_TEMPERATURE_SENSOR = "sensor.multisensor_6_air_temperature"
+from .common import AIR_TEMPERATURE_SENSOR
 
 
 async def test_numeric_sensor(hass, multisensor_6, integration):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add tests for zwave_js init module.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
