### PR TITLE
Repair stream test_recorder.py and mark not flaky

### DIFF
--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -1,4 +1,5 @@
 """Provide functionality to record stream."""
+import logging
 import os
 import threading
 from typing import List
@@ -8,6 +9,8 @@ import av
 from homeassistant.core import callback
 
 from .core import PROVIDERS, Segment, StreamOutput
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback
@@ -109,6 +112,7 @@ class RecorderOutput(StreamOutput):
 
     def cleanup(self):
         """Write recording and clean up."""
+        _LOGGER.debug("Starting recorder worker thread")
         thread = threading.Thread(
             name="recorder_save_worker",
             target=recorder_save_worker,

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -43,7 +43,6 @@ class WorkerSync:
             # the segments under test.
             logging.error("blocking worker")
             self._event.wait()
-        logging.error("put segment, %s", segment)
 
         # Forward to actual StreamOutput.put
         self._put_original(stream_output, segment)

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -1,0 +1,61 @@
+"""Test fixtures for the stream component.
+
+The tests encode stream (as an h264 video), then load the stream and verify
+that it is decoded properly. The background worker thread responsible for
+decoding will decode the stream as fast as possible, and when completed
+clears all output buffers. This can be a problem for the test that wishes
+to retrieve and verify decoded segments. If the worker finishes first, there is
+nothing for the test to verify. The solution is the WorkerSync class that
+allows the tests to pause the worker thread before finalizing the stream
+so that it can inspect the output.
+"""
+
+import logging
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.stream.core import Segment, StreamOutput
+
+
+class WorkerSync:
+    """Test fixture that intercepts stream worker calls to StreamOutput."""
+
+    def __init__(self):
+        """Initialize WorkerSync."""
+        self._event = None
+        self._put_original = StreamOutput.put
+
+    def pause(self):
+        """Pause the worker before it finalizes the stream."""
+        self._event = threading.Event()
+
+    def resume(self):
+        """Allow the worker thread to finalize the stream."""
+        self._event.set()
+
+    def blocking_put(self, stream_output: StreamOutput, segment: Segment):
+        """Proxy StreamOutput.put, intercepted for test to pause worker."""
+        if segment is None and self._event:
+            # Worker is ending the stream, which clears all output buffers.
+            # Block the worker thread until the test has a chance to verify
+            # the segments under test.
+            logging.error("blocking worker")
+            self._event.wait()
+        logging.error("put segment, %s", segment)
+
+        # Forward to actual StreamOutput.put
+        self._put_original(stream_output, segment)
+
+
+@pytest.fixture()
+def worker_sync(hass):
+    """Patch StreamOutput to allow test to synchronize worker stream end."""
+    sync = WorkerSync()
+    with patch(
+        "homeassistant.components.stream.core.StreamOutput.put",
+        side_effect=sync.blocking_put,
+        autospec=True,
+    ):
+        yield sync

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -49,7 +49,7 @@ class WorkerSync:
 
 
 @pytest.fixture()
-def worker_sync(hass):
+def stream_worker_sync(hass):
     """Patch StreamOutput to allow test to synchronize worker stream end."""
     sync = WorkerSync()
     with patch(

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -14,7 +14,7 @@ from tests.common import async_fire_time_changed
 from tests.components.stream.common import generate_h264_video, preload_stream
 
 
-async def test_hls_stream(hass, hass_client, worker_sync):
+async def test_hls_stream(hass, hass_client, stream_worker_sync):
     """
     Test hls stream.
 
@@ -23,7 +23,7 @@ async def test_hls_stream(hass, hass_client, worker_sync):
     """
     await async_setup_component(hass, "stream", {"stream": {}})
 
-    worker_sync.pause()
+    stream_worker_sync.pause()
 
     # Setup demo HLS track
     source = generate_h264_video()
@@ -54,7 +54,7 @@ async def test_hls_stream(hass, hass_client, worker_sync):
     segment_response = await http_client.get(segment_url)
     assert segment_response.status == 200
 
-    worker_sync.resume()
+    stream_worker_sync.resume()
 
     # Stop stream, if it hasn't quit already
     stream.stop()
@@ -64,11 +64,11 @@ async def test_hls_stream(hass, hass_client, worker_sync):
     assert fail_response.status == HTTP_NOT_FOUND
 
 
-async def test_stream_timeout(hass, hass_client, worker_sync):
+async def test_stream_timeout(hass, hass_client, stream_worker_sync):
     """Test hls stream timeout."""
     await async_setup_component(hass, "stream", {"stream": {}})
 
-    worker_sync.pause()
+    stream_worker_sync.pause()
 
     # Setup demo HLS track
     source = generate_h264_video()
@@ -93,7 +93,7 @@ async def test_stream_timeout(hass, hass_client, worker_sync):
     playlist_response = await http_client.get(parsed_url.path)
     assert playlist_response.status == 200
 
-    worker_sync.resume()
+    stream_worker_sync.resume()
 
     # Wait 5 minutes
     future = dt_util.utcnow() + timedelta(minutes=5)
@@ -104,11 +104,11 @@ async def test_stream_timeout(hass, hass_client, worker_sync):
     assert fail_response.status == HTTP_NOT_FOUND
 
 
-async def test_stream_ended(hass, worker_sync):
+async def test_stream_ended(hass, stream_worker_sync):
     """Test hls stream packets ended."""
     await async_setup_component(hass, "stream", {"stream": {}})
 
-    worker_sync.pause()
+    stream_worker_sync.pause()
 
     # Setup demo HLS track
     source = generate_h264_video()
@@ -126,7 +126,7 @@ async def test_stream_ended(hass, worker_sync):
         segments = segment.sequence
         # Allow worker to finalize once enough of the stream is been consumed
         if segments > 1:
-            worker_sync.resume()
+            stream_worker_sync.resume()
 
     assert segments > 1
     assert not track.get_segment()

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -1,70 +1,17 @@
-"""The tests for hls streams.
-
-The tests encode stream (as an h264 video), then load the stream and verify
-that it is decoded properly. The background worker thread responsible for
-decoding will decode the stream as fast as possible, and when completed
-clears all output buffers. This can be a problem for the test that wishes
-to retrieve and verify decoded segments. If the worker finishes first, there is
-nothing for the test to verify. The solution is the WorkerSync class that
-allows the tests to pause the worker thread before finalizing the stream
-so that it can inspect the output.
-"""
+"""The tests for hls streams."""
 from datetime import timedelta
-import threading
 from unittest.mock import patch
 from urllib.parse import urlparse
 
 import av
-import pytest
 
 from homeassistant.components.stream import request_stream
-from homeassistant.components.stream.core import Segment, StreamOutput
 from homeassistant.const import HTTP_NOT_FOUND
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 from tests.components.stream.common import generate_h264_video, preload_stream
-
-
-class WorkerSync:
-    """Test fixture that intercepts stream worker calls to StreamOutput."""
-
-    def __init__(self):
-        """Initialize WorkerSync."""
-        self._event = None
-        self._put_original = StreamOutput.put
-
-    def pause(self):
-        """Pause the worker before it finalizes the stream."""
-        self._event = threading.Event()
-
-    def resume(self):
-        """Allow the worker thread to finalize the stream."""
-        self._event.set()
-
-    def blocking_put(self, stream_output: StreamOutput, segment: Segment):
-        """Proxy StreamOutput.put, intercepted for test to pause worker."""
-        if segment is None and self._event:
-            # Worker is ending the stream, which clears all output buffers.
-            # Block the worker thread until the test has a chance to verify
-            # the segments under test.
-            self._event.wait()
-
-        # Forward to actual StreamOutput.put
-        self._put_original(stream_output, segment)
-
-
-@pytest.fixture()
-def worker_sync(hass):
-    """Patch StreamOutput to allow test to synchronize worker stream end."""
-    sync = WorkerSync()
-    with patch(
-        "homeassistant.components.stream.core.StreamOutput.put",
-        side_effect=sync.blocking_put,
-        autospec=True,
-    ):
-        yield sync
 
 
 async def test_hls_stream(hass, hass_client, worker_sync):

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -6,6 +6,7 @@ import threading
 from unittest.mock import patch
 
 import av
+import pytest
 
 from homeassistant.components.stream.core import Segment
 from homeassistant.components.stream.recorder import recorder_save_worker
@@ -18,7 +19,49 @@ from tests.components.stream.common import generate_h264_video, preload_stream
 TEST_TIMEOUT = 10
 
 
-async def test_record_stream(hass, hass_client, worker_sync):
+class SaveRecordWorkerSync:
+    """
+    Test fixture to manage RecordOutput thread for recorder_save_worker.
+
+    This is used to assert that the worker is started and stopped cleanly
+    to avoid thread leaks in tests.
+    """
+
+    def __init__(self):
+        """Initialize SaveRecordWorkerSync."""
+        self.reset()
+
+    def recorder_save_worker(self, *args, **kwargs):
+        """Mock method for patch."""
+        logging.debug("recorder_save_worker thread started")
+        assert self._save_thread is None
+        self._save_thread = threading.current_thread()
+        self._save_event.set()
+
+    def join(self):
+        """Verify save worker was invoked and block on shutdown."""
+        assert self._save_event.wait(timeout=TEST_TIMEOUT)
+        self._save_thread.join()
+
+    def reset(self):
+        """Reset callback state for reuse in tests."""
+        self._save_thread = None
+        self._save_event = threading.Event()
+
+
+@pytest.fixture()
+def record_worker_sync(hass):
+    """Patch recorder_save_worker for clean thread shutdown for test."""
+    sync = SaveRecordWorkerSync()
+    with patch(
+        "homeassistant.components.stream.recorder.recorder_save_worker",
+        side_effect=sync.recorder_save_worker,
+        autospec=True,
+    ):
+        yield sync
+
+
+async def test_record_stream(hass, hass_client, stream_worker_sync, record_worker_sync):
     """
     Test record stream.
 
@@ -28,46 +71,31 @@ async def test_record_stream(hass, hass_client, worker_sync):
     """
     await async_setup_component(hass, "stream", {"stream": {}})
 
-    worker_sync.pause()
+    stream_worker_sync.pause()
 
-    save_thread = None
-    save_invoked = threading.Event()
+    # Setup demo track
+    source = generate_h264_video()
+    stream = preload_stream(hass, source)
+    recorder = stream.add_provider("recorder")
+    stream.start()
 
-    def capture_save_worker(*args, **kwargs):
-        """Capture save worker thread for clean shutdown below."""
-        nonlocal save_thread
-        logging.debug("Recorder save worker invoked")
-        save_thread = threading.current_thread()
-        save_invoked.set()
+    while True:
+        segment = await recorder.recv()
+        if not segment:
+            break
+        segments = segment.sequence
+        if segments > 1:
+            stream_worker_sync.resume()
 
-    with patch(
-        "homeassistant.components.stream.recorder.recorder_save_worker",
-        side_effect=capture_save_worker,
-    ):
-        # Setup demo track
-        source = generate_h264_video()
-        stream = preload_stream(hass, source)
-        recorder = stream.add_provider("recorder")
-        stream.start()
+    stream.stop()
+    assert segments > 1
 
-        while True:
-            segment = await recorder.recv()
-            if not segment:
-                break
-            segments = segment.sequence
-            if segments > 1:
-                worker_sync.resume()
-
-        stream.stop()
-        assert segments > 1
-
-        # Verify that the save worker was invoked, then block until its
-        # thread completes and is shutdown completely to avoid thread leaks.
-        assert save_invoked.wait(timeout=TEST_TIMEOUT)
-        save_thread.join()
+    # Verify that the save worker was invoked, then block until its
+    # thread completes and is shutdown completely to avoid thread leaks.
+    record_worker_sync.join()
 
 
-async def test_recorder_timeout(hass, hass_client, worker_sync):
+async def test_recorder_timeout(hass, hass_client, stream_worker_sync):
     """
     Test recorder timeout.
 
@@ -76,7 +104,7 @@ async def test_recorder_timeout(hass, hass_client, worker_sync):
     """
     await async_setup_component(hass, "stream", {"stream": {}})
 
-    worker_sync.pause()
+    stream_worker_sync.pause()
 
     with patch(
         "homeassistant.components.stream.recorder.RecorderOutput.cleanup"
@@ -96,7 +124,7 @@ async def test_recorder_timeout(hass, hass_client, worker_sync):
 
         assert mock_cleanup.called
 
-        worker_sync.resume()
+        stream_worker_sync.resume()
         stream.stop()
         await hass.async_block_till_done()
         await hass.async_block_till_done()
@@ -115,7 +143,9 @@ async def test_recorder_save(tmpdir):
     assert os.path.exists(filename)
 
 
-async def test_record_stream_audio(hass, hass_client, worker_sync):
+async def test_record_stream_audio(
+    hass, hass_client, stream_worker_sync, record_worker_sync
+):
     """
     Test treatment of different audio inputs.
 
@@ -130,27 +160,31 @@ async def test_record_stream_audio(hass, hass_client, worker_sync):
         ("empty", 0),  # audio stream with no packets
         (None, 0),  # no audio stream
     ):
-        worker_sync.pause()
+        record_worker_sync.reset()
+        stream_worker_sync.pause()
 
-        with patch("homeassistant.components.stream.recorder.recorder_save_worker"):
-            # Setup demo track
-            source = generate_h264_video(
-                container_format="mov", audio_codec=a_codec
-            )  # mov can store PCM
-            stream = preload_stream(hass, source)
-            recorder = stream.add_provider("recorder")
-            stream.start()
+        # Setup demo track
+        source = generate_h264_video(
+            container_format="mov", audio_codec=a_codec
+        )  # mov can store PCM
+        stream = preload_stream(hass, source)
+        recorder = stream.add_provider("recorder")
+        stream.start()
 
-            while True:
-                segment = await recorder.recv()
-                if not segment:
-                    break
-                last_segment = segment
-                worker_sync.resume()
+        while True:
+            segment = await recorder.recv()
+            if not segment:
+                break
+            last_segment = segment
+            stream_worker_sync.resume()
 
-            result = av.open(last_segment.segment, "r", format="mp4")
+        result = av.open(last_segment.segment, "r", format="mp4")
 
-            assert len(result.streams.audio) == expected_audio_streams
-            result.close()
-            stream.stop()
-            await hass.async_block_till_done()
+        assert len(result.streams.audio) == expected_audio_streams
+        result.close()
+        stream.stop()
+        await hass.async_block_till_done()
+
+        # Verify that the save worker was invoked, then block until its
+        # thread completes and is shutdown completely to avoid thread leaks.
+        record_worker_sync.join()

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -73,6 +73,7 @@ async def test_recorder_timeout(hass, hass_client, worker_sync):
         worker_sync.resume()
         stream.stop()
         await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
 
 async def test_recorder_save(tmpdir):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix recorder stream tests to no longer be flaky, and bring tests up to day with
changes that have happened since they were initially disabled.  This is a follow up of https://github.com/home-assistant/core/pull/45025 and part of the plan outlined in https://github.com/home-assistant/architecture/issues/482

Breakdown of changes:
- Fix test to pass a stream instead of a BytesIO given changes in the
  recorder that assume a stream path is passed in
- Share test fixture with test_hls.py for synchronization with worker
- Fix race conditions where the stream worker thread may exit before the
  test can consume streams
- Fix teardown thread leaks by running all event loop callbacks that may
  invoke cleanup under patch


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/issues/482
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
