### PR TITLE
Fix tests for `input_datetime`

### DIFF
--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -131,7 +131,7 @@ async def test_set_datetime(hass):
 
     entity_id = "input_datetime.test_datetime"
 
-    dt_obj = datetime.datetime(2017, 9, 7, 19, 46, 30)
+    dt_obj = datetime.datetime(2017, 9, 7, 19, 46, 30, tzinfo=datetime.timezone.utc)
 
     await async_set_date_and_time(hass, entity_id, dt_obj)
 
@@ -157,7 +157,7 @@ async def test_set_datetime_2(hass):
 
     entity_id = "input_datetime.test_datetime"
 
-    dt_obj = datetime.datetime(2017, 9, 7, 19, 46, 30)
+    dt_obj = datetime.datetime(2017, 9, 7, 19, 46, 30, tzinfo=datetime.timezone.utc)
 
     await async_set_datetime(hass, entity_id, dt_obj)
 
@@ -183,7 +183,7 @@ async def test_set_datetime_3(hass):
 
     entity_id = "input_datetime.test_datetime"
 
-    dt_obj = datetime.datetime(2017, 9, 7, 19, 46, 30)
+    dt_obj = datetime.datetime(2017, 9, 7, 19, 46, 30, tzinfo=datetime.timezone.utc)
 
     await async_set_timestamp(hass, entity_id, dt_util.as_utc(dt_obj).timestamp())
 
@@ -677,6 +677,7 @@ async def test_timestamp(hass):
         # initial has been converted to the set timezone
         state_with_tz = hass.states.get("input_datetime.test_datetime_initial_with_tz")
         assert state_with_tz is not None
+        # Timezone LA is UTC-8 => timestamp carries +01:00 => delta is -9 => 10:00 - 09:00 => 01:00
         assert state_with_tz.state == "2020-12-13 01:00:00"
         assert (
             dt_util.as_local(
@@ -691,6 +692,13 @@ async def test_timestamp(hass):
         )
         assert state_without_tz is not None
         assert state_without_tz.state == "2020-12-13 10:00:00"
+        # Timezone LA is UTC-8 => timestamp has no zone (= assumed local) => delta to UTC is +8 => 10:00 + 08:00 => 18:00
+        assert (
+            dt_util.utc_from_timestamp(
+                state_without_tz.attributes[ATTR_TIMESTAMP]
+            ).strftime(FMT_DATETIME)
+            == "2020-12-13 18:00:00"
+        )
         assert (
             dt_util.as_local(
                 dt_util.utc_from_timestamp(state_without_tz.attributes[ATTR_TIMESTAMP])
@@ -701,7 +709,7 @@ async def test_timestamp(hass):
         assert (
             dt_util.as_local(
                 datetime.datetime.fromtimestamp(
-                    state_without_tz.attributes[ATTR_TIMESTAMP]
+                    state_without_tz.attributes[ATTR_TIMESTAMP], datetime.timezone.utc
                 )
             ).strftime(FMT_DATETIME)
             == "2020-12-13 10:00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
The timezone dependent tests did not work. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
