### PR TITLE
Fix HomeKit climate integration for devices with a single set point in Heat_Cool mode.

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -346,7 +346,9 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
         heat_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
         cool_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}:
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
             if temp is None:
                 temp = (cool_temp + heat_temp) / 2
             await self.async_put_characteristics(
@@ -386,37 +388,54 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) not in {HVAC_MODE_HEAT, HVAC_MODE_COOL}:
-            return None
-        return self.service.value(CharacteristicsTypes.TEMPERATURE_TARGET)
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT, HVAC_MODE_COOL}) or (
+            (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL})
+            and not (SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features)
+        ):
+            return self.service.value(CharacteristicsTypes.TEMPERATURE_TARGET)
+        return None
 
     @property
     def target_temperature_high(self):
         """Return the highbound target temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) not in {HVAC_MODE_HEAT_COOL}:
-            return None
-        return self.service.value(CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD)
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
+            return self.service.value(
+                CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+            )
+        return None
 
     @property
     def target_temperature_low(self):
         """Return the lowbound target temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) not in {HVAC_MODE_HEAT_COOL}:
-            return None
-        return self.service.value(CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD)
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
+            return self.service.value(
+                CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+            )
+        return None
 
     @property
     def min_temp(self):
         """Return the minimum target temp."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}:
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
             min_temp = self.service[
                 CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
             ].minValue
             if min_temp is not None:
                 return min_temp
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT, HVAC_MODE_COOL}:
+        elif MODE_HOMEKIT_TO_HASS.get(value) in {
+            HVAC_MODE_HEAT,
+            HVAC_MODE_COOL,
+            HVAC_MODE_HEAT_COOL,
+        }:
             min_temp = self.service[CharacteristicsTypes.TEMPERATURE_TARGET].minValue
             if min_temp is not None:
                 return min_temp
@@ -426,13 +445,19 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
     def max_temp(self):
         """Return the maximum target temp."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}:
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
             max_temp = self.service[
                 CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
             ].maxValue
             if max_temp is not None:
                 return max_temp
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT, HVAC_MODE_COOL}:
+        elif MODE_HOMEKIT_TO_HASS.get(value) in {
+            HVAC_MODE_HEAT,
+            HVAC_MODE_COOL,
+            HVAC_MODE_HEAT_COOL,
+        }:
             max_temp = self.service[CharacteristicsTypes.TEMPERATURE_TARGET].maxValue
             if max_temp is not None:
                 return max_temp

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -309,7 +309,7 @@ def create_thermostat_single_set_point_auto(accessory):
 
 
 async def test_climate_check_min_max_values_per_mode_sspa_device(hass, utcnow):
-    """Test that we we get the appropriate min/max values for each mode"""
+    """Test appropriate min/max values for each mode on sspa devices."""
     helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
 
     await hass.services.async_call(

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -283,6 +283,106 @@ async def test_climate_cannot_set_thermostat_temp_range_in_wrong_mode(hass, utcn
     assert helper.characteristics[THERMOSTAT_TEMPERATURE_COOLING_THRESHOLD].value == 0
 
 
+def create_thermostat_single_set_point_auto(accessory):
+    """Define thermostat characteristics with a single set point in auto."""
+    service = accessory.add_service(ServicesTypes.THERMOSTAT)
+
+    char = service.add_char(CharacteristicsTypes.HEATING_COOLING_TARGET)
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.HEATING_COOLING_CURRENT)
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.TEMPERATURE_TARGET)
+    char.minValue = 7
+    char.maxValue = 35
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.TEMPERATURE_CURRENT)
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET)
+    char.value = 0
+
+    char = service.add_char(CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT)
+    char.value = 0
+
+
+async def test_climate_check_min_max_values_per_mode_sspa_device(hass, utcnow):
+    """Test that we we get the appropriate min/max values for each mode"""
+    helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_HEAT},
+        blocking=True,
+    )
+    climate_state = await helper.poll_and_get_state()
+    assert climate_state.attributes["min_temp"] == 7
+    assert climate_state.attributes["max_temp"] == 35
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_COOL},
+        blocking=True,
+    )
+    climate_state = await helper.poll_and_get_state()
+    assert climate_state.attributes["min_temp"] == 7
+    assert climate_state.attributes["max_temp"] == 35
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_HEAT_COOL},
+        blocking=True,
+    )
+    climate_state = await helper.poll_and_get_state()
+    assert climate_state.attributes["min_temp"] == 7
+    assert climate_state.attributes["max_temp"] == 35
+
+
+async def test_climate_set_thermostat_temp_on_sspa_device(hass, utcnow):
+    """Test setting temperature in different modes on device with single set point in auto."""
+    helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_HEAT},
+        blocking=True,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {"entity_id": "climate.testdevice", "temperature": 21},
+        blocking=True,
+    )
+    assert helper.characteristics[TEMPERATURE_TARGET].value == 21
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": "climate.testdevice", "hvac_mode": HVAC_MODE_HEAT_COOL},
+        blocking=True,
+    )
+    assert helper.characteristics[TEMPERATURE_TARGET].value == 21
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            "entity_id": "climate.testdevice",
+            "hvac_mode": HVAC_MODE_HEAT_COOL,
+            "temperature": 22,
+        },
+        blocking=True,
+    )
+    assert helper.characteristics[TEMPERATURE_TARGET].value == 22
+
+
 async def test_climate_change_thermostat_humidity(hass, utcnow):
     """Test that we can turn a HomeKit thermostat on and off again."""
     helper = await setup_test_component(hass, create_thermostat_service)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Changed code to check SUPPORTED_FLAGS to decide if single or dual set points should be presented and used. Some HomeKit thermostats only present a single set point to HomeKit when in Auto (`Heat_Cool`) mode. The code added in 2021-01 to initially support temperature range, broke compatibility with some HomeKit thermostats. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#44932]
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
