### PR TITLE
Soma: fix battery drain issue caused by excess update requests

### DIFF
--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 
 from api.soma_api import SomaApi
-from requests import RequestException
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/soma/__init__.py
+++ b/homeassistant/components/soma/__init__.py
@@ -1,6 +1,5 @@
 """Support for Soma Smartshades."""
 import asyncio
-import logging
 
 from api.soma_api import SomaApi
 from requests import RequestException
@@ -16,8 +15,6 @@ from homeassistant.helpers.typing import HomeAssistantType
 from .const import API, DOMAIN, HOST, PORT
 
 DEVICES = "devices"
-
-_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -113,43 +110,3 @@ class SomaEntity(Entity):
             "name": self.name,
             "manufacturer": "Wazombi Labs",
         }
-
-    async def async_update(self):
-        """Update the device with the latest data."""
-        try:
-            response = await self.hass.async_add_executor_job(
-                self.api.get_shade_state, self.device["mac"]
-            )
-        except RequestException:
-            _LOGGER.error("Connection to SOMA Connect failed")
-            self.is_available = False
-            return
-        if response["result"] != "success":
-            _LOGGER.error(
-                "Unable to reach device %s (%s)", self.device["name"], response["msg"]
-            )
-            self.is_available = False
-            return
-        self.current_position = 100 - response["position"]
-        try:
-            response = await self.hass.async_add_executor_job(
-                self.api.get_battery_level, self.device["mac"]
-            )
-        except RequestException:
-            _LOGGER.error("Connection to SOMA Connect failed")
-            self.is_available = False
-            return
-        if response["result"] != "success":
-            _LOGGER.error(
-                "Unable to reach device %s (%s)", self.device["name"], response["msg"]
-            )
-            self.is_available = False
-            return
-        # https://support.somasmarthome.com/hc/en-us/articles/360026064234-HTTP-API
-        # battery_level response is expected to be min = 360, max 410 for
-        # 0-100% levels above 410 are consider 100% and below 360, 0% as the
-        # device considers 360 the minimum to move the motor.
-        _battery = round(2 * (response["battery_level"] - 360))
-        battery = max(min(100, _battery), 0)
-        self.battery_state = battery
-        self.is_available = True

--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -67,3 +67,23 @@ class SomaCover(SomaEntity, CoverEntity):
     def is_closed(self):
         """Return if the cover is closed."""
         return self.current_position == 0
+
+    async def async_update(self):
+        """Update the cover with the latest data."""
+        try:
+            _LOGGER.debug("Soma Cover Update")
+            response = await self.hass.async_add_executor_job(
+                self.api.get_shade_state, self.device["mac"]
+            )
+        except RequestException:
+            _LOGGER.error("Connection to SOMA Connect failed")
+            self.is_available = False
+            return
+        if response["result"] != "success":
+            _LOGGER.error(
+                "Unable to reach device %s (%s)", self.device["name"], response["msg"]
+            )
+            self.is_available = False
+            return
+        self.current_position = 100 - response["position"]
+        self.is_available = True

--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -1,6 +1,7 @@
 """Support for Soma Covers."""
 
 import logging
+from requests import RequestException
 
 from homeassistant.components.cover import ATTR_POSITION, CoverEntity
 from homeassistant.components.soma import API, DEVICES, DOMAIN, SomaEntity

--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -1,6 +1,7 @@
 """Support for Soma Covers."""
 
 import logging
+
 from requests import RequestException
 
 from homeassistant.components.cover import ATTR_POSITION, CoverEntity

--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -1,9 +1,17 @@
 """Support for Soma sensors."""
+from datetime import timedelta
+import logging
+
 from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
 from . import DEVICES, SomaEntity
 from .const import API, DOMAIN
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -38,3 +46,30 @@ class SomaSensor(SomaEntity, Entity):
     def unit_of_measurement(self):
         """Return the unit of measurement this sensor expresses itself in."""
         return PERCENTAGE
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    async def async_update(self):
+        """Update the sensor with the latest data."""
+        try:
+            _LOGGER.debug("Soma Sensor Update")
+            response = await self.hass.async_add_executor_job(
+                self.api.get_battery_level, self.device["mac"]
+            )
+        except RequestException:
+            _LOGGER.error("Connection to SOMA Connect failed")
+            self.is_available = False
+            return
+        if response["result"] != "success":
+            _LOGGER.error(
+                "Unable to reach device %s (%s)", self.device["name"], response["msg"]
+            )
+            self.is_available = False
+            return
+        # https://support.somasmarthome.com/hc/en-us/articles/360026064234-HTTP-API
+        # battery_level response is expected to be min = 360, max 410 for
+        # 0-100% levels above 410 are consider 100% and below 360, 0% as the
+        # device considers 360 the minimum to move the motor.
+        _battery = round(2 * (response["battery_level"] - 360))
+        battery = max(min(100, _battery), 0)
+        self.battery_state = battery
+        self.is_available = True

--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -1,6 +1,7 @@
 """Support for Soma sensors."""
 from datetime import timedelta
 import logging
+from requests import RequestException
 
 from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/soma/sensor.py
+++ b/homeassistant/components/soma/sensor.py
@@ -1,6 +1,7 @@
 """Support for Soma sensors."""
 from datetime import timedelta
 import logging
+
 from requests import RequestException
 
 from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The addition of the battery level sensor to Soma has added a lot of calls to the Soma Connect API, which translate into Bluetooth requests to the blind motor which are unnecessary. This has had a negative effect on the battery life of the blind motor. 

Before this change both the required requests for updating the sensor and cover were in one generic update procedure, so both were called each time an update to either the sensor or cover happened.
This means we went from 1 URL request every 15 second, so 240 requests per hour when there was just a cover to update, to 2 URL requests (1 not needed) every 15 seconds for the cover, plus another 2 every 30 seconds, again 1 not needed for the sensor, when the battery level sensor was added - this works out at 720 URL requests per hour. 

This update splits up the update procedure so that the cover and sensor only call the URL request they need to update their data. Also the update on the sensor is throttled, as a battery in a blind, which probably only operates a few times a day is not going to change level rapidly. Therefore an update period less frequently than every 30 seconds seemed more appropriate. With these changes the URL request are now at a more sensible level - back to the original 240 requests per hour for the cover, with an additional 2 requests per hour for the battery level sensor. This should improve the battery life, that a previous update decreased.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
