### PR TITLE
Add zwave_js light platform tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1091,7 +1091,6 @@ omit =
     homeassistant/components/supla/*
     homeassistant/components/zwave/util.py
     homeassistant/components/zwave_js/discovery.py
-    homeassistant/components/zwave_js/entity.py
     homeassistant/components/zwave_js/light.py
     homeassistant/components/zwave_js/sensor.py
 

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -249,7 +249,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         if duration is None:  # type: ignore
             # no transition specified by user, use defaults
             duration = 7621  # anything over 7620 uses the factory default
-        else:
+        else:  # pragma: no cover
             # transition specified by user
             transition = duration
             if transition <= 127:
@@ -265,7 +265,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 
         # only send value if it differs from current
         # this prevents sending a command for nothing
-        if self._dimming_duration.value != duration:
+        if self._dimming_duration.value != duration:  # pragma: no cover
             await self.info.node.async_set_value(self._dimming_duration, duration)
 
     @callback

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -290,8 +290,10 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
                 and green_val.value is not None
                 and blue_val.value is not None
             ):
-                self._hs = color_util.color_RGB_to_hs(
-                    red_val.value, green_val.value, blue_val.value
+                self._hs_color = list(
+                    color_util.color_RGB_to_hs(
+                        red_val.value, green_val.value, blue_val.value
+                    )
                 )
 
         # White colors
@@ -320,3 +322,4 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         elif ww_val or cw_val:
             # only one white channel
             self._supports_white_value = True
+            # FIXME: Update self._white_value

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -1,6 +1,6 @@
 """Support for Z-Wave lights."""
 import logging
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional, Tuple
 
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass
@@ -68,7 +68,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         self._supports_color = False
         self._supports_white_value = False
         self._supports_color_temp = False
-        self._hs_color: Optional[List[float]] = None
+        self._hs_color: Optional[Tuple[float, float]] = None
         self._white_value: Optional[int] = None
         self._color_temp: Optional[int] = None
         self._min_mireds = 153  # 6500K as a safe default
@@ -111,7 +111,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         return self.brightness > 0
 
     @property
-    def hs_color(self) -> Optional[List[float]]:
+    def hs_color(self) -> Optional[Tuple[float, float]]:
         """Return the hs color."""
         return self._hs_color
 
@@ -291,10 +291,8 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
                 and green_val.value is not None
                 and blue_val.value is not None
             ):
-                self._hs_color = list(
-                    color_util.color_RGB_to_hs(
-                        red_val.value, green_val.value, blue_val.value
-                    )
+                self._hs_color = color_util.color_RGB_to_hs(
+                    red_val.value, green_val.value, blue_val.value
                 )
 
         # White colors

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -218,22 +218,23 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         self, brightness: Optional[int], transition: Optional[int] = None
     ) -> None:
         """Set new brightness to light."""
-        if self.info.primary_value.value == brightness:
-            # no point in setting same brightness
-            return
         if brightness is None and self.info.primary_value.value:
             # there is no point in setting default brightness when light is already on
             return
         if brightness is None:
             # Level 255 means to set it to previous value.
-            brightness = 255
+            zwave_brightness = 255
         else:
             # Zwave multilevel switches use a range of [0, 99] to control brightness.
-            brightness = byte_to_zwave_brightness(brightness)
+            zwave_brightness = byte_to_zwave_brightness(brightness)
+
+        if self.info.primary_value.value == zwave_brightness:
+            # no point in setting same brightness
+            return
         # set transition value before seinding new brightness
         await self._async_set_transition_duration(transition)
         # setting a value requires setting targetValue
-        await self.info.node.async_set_value(self._target_value, brightness)
+        await self.info.node.async_set_value(self._target_value, zwave_brightness)
 
     async def _async_set_transition_duration(
         self, duration: Optional[int] = None

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -37,6 +37,12 @@ def binary_switch_state_fixture():
     return json.loads(load_fixture("zwave_js/hank_binary_switch_state.json"))
 
 
+@pytest.fixture(name="bulb_6_multi_color_state", scope="session")
+def bulb_6_multi_color_state_fixture():
+    """Load the bulb 6 multi-color node state fixture data."""
+    return json.loads(load_fixture("zwave_js/bulb_6_multi_color_state.json"))
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state):
     """Mock a client."""
@@ -60,6 +66,14 @@ def multisensor_6_fixture(client, multisensor_6_state):
 def hank_binary_switch_fixture(client, hank_binary_switch_state):
     """Mock a binary switch node."""
     node = Node(client, hank_binary_switch_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="bulb_6_multi_color")
+def bulb_6_multi_color_fixture(client, bulb_6_multi_color_state):
+    """Mock a bulb 6 multi-color node."""
+    node = Node(client, bulb_6_multi_color_state)
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -264,4 +264,36 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 235
 
+    client.async_send_json_message.reset_mock()
+
+    # Test turning off
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 1
+    args = client.async_send_json_message.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 39
+    assert args["valueId"] == {
+        "commandClassName": "Multilevel Switch",
+        "commandClass": 38,
+        "endpoint": 0,
+        "property": "targetValue",
+        "propertyName": "targetValue",
+        "metadata": {
+            "label": "Target value",
+            "max": 99,
+            "min": 0,
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "label": "Target value",
+        },
+    }
+    assert args["value"] == 0
+
     print(state.attributes)

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -1,0 +1,16 @@
+"""Test the Z-Wave JS light platform."""
+from homeassistant.components.light import ATTR_MAX_MIREDS, ATTR_MIN_MIREDS
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_OFF
+
+BULB_6_MULTI_COLOR_LIGHT = "light.bulb_6_multi_color_current_value"
+
+
+async def test_light(hass, bulb_6_multi_color, integration):
+    """Test the light entity."""
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT)
+
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_MIN_MIREDS] == 153
+    assert state.attributes[ATTR_MAX_MIREDS] == 370
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 51

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -216,6 +216,18 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
 
     client.async_send_json_message.reset_mock()
 
+    # Test turning on with same rgb color
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, ATTR_RGB_COLOR: (255, 76, 255)},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 0
+
+    client.async_send_json_message.reset_mock()
+
     # Test turning on with color temp
     await hass.services.async_call(
         "light",

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -1,16 +1,267 @@
 """Test the Z-Wave JS light platform."""
-from homeassistant.components.light import ATTR_MAX_MIREDS, ATTR_MIN_MIREDS
-from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_OFF
+from copy import deepcopy
 
-BULB_6_MULTI_COLOR_LIGHT = "light.bulb_6_multi_color_current_value"
+from zwave_js_server.event import Event
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP,
+    ATTR_MAX_MIREDS,
+    ATTR_MIN_MIREDS,
+    ATTR_RGB_COLOR,
+)
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_OFF, STATE_ON
+
+BULB_6_MULTI_COLOR_LIGHT_ENTITY = "light.bulb_6_multi_color_current_value"
 
 
-async def test_light(hass, bulb_6_multi_color, integration):
+async def test_light(hass, client, bulb_6_multi_color, integration):
     """Test the light entity."""
-    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT)
+    node = bulb_6_multi_color
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
 
     assert state
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_MIN_MIREDS] == 153
     assert state.attributes[ATTR_MAX_MIREDS] == 370
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 51
+
+    # Test turning on
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 1
+    args = client.async_send_json_message.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 39
+    assert args["valueId"] == {
+        "commandClassName": "Multilevel Switch",
+        "commandClass": 38,
+        "endpoint": 0,
+        "property": "targetValue",
+        "propertyName": "targetValue",
+        "metadata": {
+            "label": "Target value",
+            "max": 99,
+            "min": 0,
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "label": "Target value",
+        },
+    }
+    assert args["value"] == 255
+
+    client.async_send_json_message.reset_mock()
+
+    # Test brightness update from value updated event
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 39,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 99,
+                "prevValue": 0,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 255
+    assert state.attributes[ATTR_COLOR_TEMP] == 370
+
+    # Test turning on with brightness
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, "brightness": 129},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 1
+    args = client.async_send_json_message.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 39
+    assert args["valueId"] == {
+        "commandClassName": "Multilevel Switch",
+        "commandClass": 38,
+        "endpoint": 0,
+        "property": "targetValue",
+        "propertyName": "targetValue",
+        "metadata": {
+            "label": "Target value",
+            "max": 99,
+            "min": 0,
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "label": "Target value",
+        },
+    }
+    assert args["value"] == 50
+
+    client.async_send_json_message.reset_mock()
+
+    # Test turning on with rgb color
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, ATTR_RGB_COLOR: (255, 76, 255)},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 4
+    warm_args = client.async_send_json_message.call_args_list[0][0][0]  # warm white 0
+    assert warm_args["command"] == "node.set_value"
+    assert warm_args["nodeId"] == 39
+    assert warm_args["valueId"]["commandClassName"] == "Color Switch"
+    assert warm_args["valueId"]["commandClass"] == 51
+    assert warm_args["valueId"]["endpoint"] == 0
+    assert warm_args["valueId"]["metadata"]["label"] == "Target value (Warm White)"
+    assert warm_args["valueId"]["property"] == "targetColor"
+    assert warm_args["valueId"]["propertyName"] == "targetColor"
+    assert warm_args["value"] == 0
+    red_args = client.async_send_json_message.call_args_list[1][0][0]  # red 255
+    assert red_args["command"] == "node.set_value"
+    assert red_args["nodeId"] == 39
+    assert red_args["valueId"]["commandClassName"] == "Color Switch"
+    assert red_args["valueId"]["commandClass"] == 51
+    assert red_args["valueId"]["endpoint"] == 0
+    assert red_args["valueId"]["metadata"]["label"] == "Target value (Red)"
+    assert red_args["valueId"]["property"] == "targetColor"
+    assert red_args["valueId"]["propertyName"] == "targetColor"
+    assert red_args["value"] == 255
+    green_args = client.async_send_json_message.call_args_list[2][0][0]  # green 76
+    assert green_args["command"] == "node.set_value"
+    assert green_args["nodeId"] == 39
+    assert green_args["valueId"]["commandClassName"] == "Color Switch"
+    assert green_args["valueId"]["commandClass"] == 51
+    assert green_args["valueId"]["endpoint"] == 0
+    assert green_args["valueId"]["metadata"]["label"] == "Target value (Green)"
+    assert green_args["valueId"]["property"] == "targetColor"
+    assert green_args["valueId"]["propertyName"] == "targetColor"
+    assert green_args["value"] == 76
+    blue_args = client.async_send_json_message.call_args_list[3][0][0]  # blue 255
+    assert blue_args["command"] == "node.set_value"
+    assert blue_args["nodeId"] == 39
+    assert blue_args["valueId"]["commandClassName"] == "Color Switch"
+    assert blue_args["valueId"]["commandClass"] == 51
+    assert blue_args["valueId"]["endpoint"] == 0
+    assert blue_args["valueId"]["metadata"]["label"] == "Target value (Blue)"
+    assert blue_args["valueId"]["property"] == "targetColor"
+    assert blue_args["valueId"]["propertyName"] == "targetColor"
+    assert blue_args["value"] == 255
+
+    # Test color update from value updated event
+    red_event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 39,
+            "args": {
+                "commandClassName": "Color Switch",
+                "commandClass": 51,
+                "endpoint": 0,
+                "property": "currentColor",
+                "newValue": 255,
+                "prevValue": 0,
+                "propertyKeyName": "Red",
+            },
+        },
+    )
+    green_event = deepcopy(red_event)
+    green_event.data["args"].update({"newValue": 76, "propertyKeyName": "Green"})
+    blue_event = deepcopy(red_event)
+    blue_event.data["args"]["propertyKeyName"] = "Blue"
+    warm_white_event = deepcopy(red_event)
+    warm_white_event.data["args"].update(
+        {"newValue": 0, "propertyKeyName": "Warm White"}
+    )
+    node.receive_event(warm_white_event)
+    node.receive_event(red_event)
+    node.receive_event(green_event)
+    node.receive_event(blue_event)
+
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 255
+    assert state.attributes[ATTR_COLOR_TEMP] == 370
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 76, 255)
+
+    client.async_send_json_message.reset_mock()
+
+    # Test turning on with color temp
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, ATTR_COLOR_TEMP: 170},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 5
+    red_args = client.async_send_json_message.call_args_list[0][0][0]  # red 0
+    assert red_args["command"] == "node.set_value"
+    assert red_args["nodeId"] == 39
+    assert red_args["valueId"]["commandClassName"] == "Color Switch"
+    assert red_args["valueId"]["commandClass"] == 51
+    assert red_args["valueId"]["endpoint"] == 0
+    assert red_args["valueId"]["metadata"]["label"] == "Target value (Red)"
+    assert red_args["valueId"]["property"] == "targetColor"
+    assert red_args["valueId"]["propertyName"] == "targetColor"
+    assert red_args["value"] == 0
+    red_args = client.async_send_json_message.call_args_list[1][0][0]  # green 0
+    assert red_args["command"] == "node.set_value"
+    assert red_args["nodeId"] == 39
+    assert red_args["valueId"]["commandClassName"] == "Color Switch"
+    assert red_args["valueId"]["commandClass"] == 51
+    assert red_args["valueId"]["endpoint"] == 0
+    assert red_args["valueId"]["metadata"]["label"] == "Target value (Green)"
+    assert red_args["valueId"]["property"] == "targetColor"
+    assert red_args["valueId"]["propertyName"] == "targetColor"
+    assert red_args["value"] == 0
+    red_args = client.async_send_json_message.call_args_list[2][0][0]  # blue 0
+    assert red_args["command"] == "node.set_value"
+    assert red_args["nodeId"] == 39
+    assert red_args["valueId"]["commandClassName"] == "Color Switch"
+    assert red_args["valueId"]["commandClass"] == 51
+    assert red_args["valueId"]["endpoint"] == 0
+    assert red_args["valueId"]["metadata"]["label"] == "Target value (Blue)"
+    assert red_args["valueId"]["property"] == "targetColor"
+    assert red_args["valueId"]["propertyName"] == "targetColor"
+    assert red_args["value"] == 0
+    warm_args = client.async_send_json_message.call_args_list[3][0][0]  # warm white 0
+    assert warm_args["command"] == "node.set_value"
+    assert warm_args["nodeId"] == 39
+    assert warm_args["valueId"]["commandClassName"] == "Color Switch"
+    assert warm_args["valueId"]["commandClass"] == 51
+    assert warm_args["valueId"]["endpoint"] == 0
+    assert warm_args["valueId"]["metadata"]["label"] == "Target value (Warm White)"
+    assert warm_args["valueId"]["property"] == "targetColor"
+    assert warm_args["valueId"]["propertyName"] == "targetColor"
+    assert warm_args["value"] == 20
+    red_args = client.async_send_json_message.call_args_list[4][0][0]  # cold white
+    assert red_args["command"] == "node.set_value"
+    assert red_args["nodeId"] == 39
+    assert red_args["valueId"]["commandClassName"] == "Color Switch"
+    assert red_args["valueId"]["commandClass"] == 51
+    assert red_args["valueId"]["endpoint"] == 0
+    assert red_args["valueId"]["metadata"]["label"] == "Target value (Cold White)"
+    assert red_args["valueId"]["property"] == "targetColor"
+    assert red_args["valueId"]["propertyName"] == "targetColor"
+    assert red_args["value"] == 235
+
+    print(state.attributes)

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -83,11 +83,23 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert state.attributes[ATTR_BRIGHTNESS] == 255
     assert state.attributes[ATTR_COLOR_TEMP] == 370
 
+    # Test turning on with same brightness
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, ATTR_BRIGHTNESS: 255},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 0
+
+    client.async_send_json_message.reset_mock()
+
     # Test turning on with brightness
     await hass.services.async_call(
         "light",
         "turn_on",
-        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, "brightness": 129},
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, ATTR_BRIGHTNESS: 129},
         blocking=True,
     )
 

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -334,6 +334,18 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert state.attributes[ATTR_COLOR_TEMP] == 170
     assert state.attributes[ATTR_RGB_COLOR] == (255, 255, 255)
 
+    # Test turning on with same color temp
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": BULB_6_MULTI_COLOR_LIGHT_ENTITY, ATTR_COLOR_TEMP: 170},
+        blocking=True,
+    )
+
+    assert len(client.async_send_json_message.call_args_list) == 0
+
+    client.async_send_json_message.reset_mock()
+
     # Test turning off
     await hass.services.async_call(
         "light",

--- a/tests/fixtures/zwave_js/bulb_6_multi_color_state.json
+++ b/tests/fixtures/zwave_js/bulb_6_multi_color_state.json
@@ -1,0 +1,632 @@
+{
+    "nodeId": 39,
+    "index": 0,
+    "installerIcon": 1536,
+    "userIcon": 1536,
+    "status": 4,
+    "ready": true,
+    "deviceClass": {
+        "basic": "Static Controller",
+        "generic": "Multilevel Switch",
+        "specific": "Multilevel Power Switch",
+        "mandatorySupportedCCs": [
+            "Basic",
+            "Multilevel Switch",
+            "All Switch"
+        ],
+        "mandatoryControlCCs": []
+    },
+    "isListening": true,
+    "isFrequentListening": false,
+    "isRouting": true,
+    "maxBaudRate": 40000,
+    "isSecure": "unknown",
+    "version": 4,
+    "isBeaming": true,
+    "manufacturerId": 881,
+    "productId": 2,
+    "productType": 259,
+    "firmwareVersion": "2.0",
+    "zwavePlusVersion": 1,
+    "nodeType": 0,
+    "roleType": 5,
+    "deviceConfig": {
+        "manufacturerId": 881,
+        "manufacturer": "Aeotec Ltd.",
+        "label": "ZWA002",
+        "description": "Bulb 6 Multi-Color",
+        "devices": [
+            {
+                "productType": "0x0003",
+                "productId": "0x0002"
+            },
+            {
+                "productType": "0x0103",
+                "productId": "0x0002"
+            }
+        ],
+        "firmwareVersion": {
+            "min": "0.0",
+            "max": "255.255"
+        },
+        "paramInformation": {
+            "_map": {}
+        }
+    },
+    "label": "ZWA002",
+    "neighbors": [
+        1,
+        32
+    ],
+    "interviewAttempts": 1,
+    "endpoints": [
+        {
+            "nodeId": 39,
+            "index": 0,
+            "installerIcon": 1536,
+            "userIcon": 1536
+        }
+    ],
+    "values": [
+        {
+            "commandClassName": "Multilevel Switch",
+            "commandClass": 38,
+            "endpoint": 0,
+            "property": "targetValue",
+            "propertyName": "targetValue",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 99,
+                "label": "Target value"
+            }
+        },
+        {
+            "commandClassName": "Multilevel Switch",
+            "commandClass": 38,
+            "endpoint": 0,
+            "property": "duration",
+            "propertyName": "duration",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": true,
+                "label": "Transition duration"
+            }
+        },
+        {
+            "commandClassName": "Multilevel Switch",
+            "commandClass": 38,
+            "endpoint": 0,
+            "property": "currentValue",
+            "propertyName": "currentValue",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 99,
+                "label": "Current value"
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Multilevel Switch",
+            "commandClass": 38,
+            "endpoint": 0,
+            "property": "Up",
+            "propertyName": "Up",
+            "metadata": {
+                "type": "boolean",
+                "readable": true,
+                "writeable": true,
+                "label": "Perform a level change (Up)",
+                "ccSpecific": {
+                    "switchType": 2
+                }
+            }
+        },
+        {
+            "commandClassName": "Multilevel Switch",
+            "commandClass": 38,
+            "endpoint": 0,
+            "property": "Down",
+            "propertyName": "Down",
+            "metadata": {
+                "type": "boolean",
+                "readable": true,
+                "writeable": true,
+                "label": "Perform a level change (Down)",
+                "ccSpecific": {
+                    "switchType": 2
+                }
+            }
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "duration",
+            "propertyName": "duration",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": true,
+                "label": "Transition duration"
+            }
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "currentColor",
+            "propertyKey": 0,
+            "propertyName": "currentColor",
+            "propertyKeyName": "Warm White",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 255,
+                "label": "Current value (Warm White)",
+                "description": "The current value of the Warm White color."
+            },
+            "value": 255
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "currentColor",
+            "propertyKey": 1,
+            "propertyName": "currentColor",
+            "propertyKeyName": "Cold White",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 255,
+                "label": "Current value (Cold White)",
+                "description": "The current value of the Cold White color."
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "currentColor",
+            "propertyKey": 2,
+            "propertyName": "currentColor",
+            "propertyKeyName": "Red",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 255,
+                "label": "Current value (Red)",
+                "description": "The current value of the Red color."
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "currentColor",
+            "propertyKey": 3,
+            "propertyName": "currentColor",
+            "propertyKeyName": "Green",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 255,
+                "label": "Current value (Green)",
+                "description": "The current value of the Green color."
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "currentColor",
+            "propertyKey": 4,
+            "propertyName": "currentColor",
+            "propertyKeyName": "Blue",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 255,
+                "label": "Current value (Blue)",
+                "description": "The current value of the Blue color."
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "targetColor",
+            "propertyKey": 0,
+            "propertyName": "targetColor",
+            "propertyKeyName": "Warm White",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 255,
+                "label": "Target value (Warm White)",
+                "description": "The target value of the Warm White color."
+            }
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "targetColor",
+            "propertyKey": 1,
+            "propertyName": "targetColor",
+            "propertyKeyName": "Cold White",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 255,
+                "label": "Target value (Cold White)",
+                "description": "The target value of the Cold White color."
+            }
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "targetColor",
+            "propertyKey": 2,
+            "propertyName": "targetColor",
+            "propertyKeyName": "Red",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 255,
+                "label": "Target value (Red)",
+                "description": "The target value of the Red color."
+            }
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "targetColor",
+            "propertyKey": 3,
+            "propertyName": "targetColor",
+            "propertyKeyName": "Green",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 255,
+                "label": "Target value (Green)",
+                "description": "The target value of the Green color."
+            }
+        },
+        {
+            "commandClassName": "Color Switch",
+            "commandClass": 51,
+            "endpoint": 0,
+            "property": "targetColor",
+            "propertyKey": 4,
+            "propertyName": "targetColor",
+            "propertyKeyName": "Blue",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 255,
+                "label": "Target value (Blue)",
+                "description": "The target value of the Blue color."
+            }
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 1,
+            "propertyName": "Use custom mode for LED animations",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 0,
+                "max": 2,
+                "default": 0,
+                "format": 0,
+                "allowManualEntry": false,
+                "states": {
+                    "0": "Disable",
+                    "1": "Blink Colors in order mode",
+                    "2": "Randomized blink color mode"
+                },
+                "label": "Use custom mode for LED animations",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 2,
+            "propertyName": "Enable/Disable Strobe over Custom Color",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 0,
+                "max": 1,
+                "default": 0,
+                "format": 0,
+                "allowManualEntry": false,
+                "states": {
+                    "0": "Disable",
+                    "1": "Enable"
+                },
+                "label": "Enable/Disable Strobe over Custom Color",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 3,
+            "propertyName": "Rate of change to next color in Custom Mode",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 4,
+                "min": 5,
+                "max": 8640000,
+                "default": 50,
+                "format": 0,
+                "allowManualEntry": true,
+                "label": "Rate of change to next color in Custom Mode",
+                "isFromConfig": true
+            },
+            "value": 50
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 16,
+            "propertyName": "Ramp rate when dimming using Multilevel Switch",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 0,
+                "max": 100,
+                "default": 20,
+                "format": 0,
+                "allowManualEntry": true,
+                "label": "Ramp rate when dimming using Multilevel Switch",
+                "isFromConfig": true
+            },
+            "value": 20
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 80,
+            "propertyName": "Enable notifications",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 0,
+                "max": 1,
+                "default": 1,
+                "format": 0,
+                "allowManualEntry": false,
+                "states": {
+                    "0": "Nothing",
+                    "1": "Basic CC report"
+                },
+                "label": "Enable notifications",
+                "description": "Enable notifications to associated devices (Group 1) when the state is changed",
+                "isFromConfig": true
+            },
+            "value": 1
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 81,
+            "propertyName": "Adjust color component of Warm White",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 2,
+                "min": 2700,
+                "max": 4999,
+                "default": 2700,
+                "format": 0,
+                "allowManualEntry": true,
+                "label": "Adjust color component of Warm White",
+                "isFromConfig": true
+            },
+            "value": 2700
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 82,
+            "propertyName": "Adjust color component of Cold White",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 2,
+                "min": 5000,
+                "max": 6500,
+                "default": 6500,
+                "format": 0,
+                "allowManualEntry": true,
+                "label": "Adjust color component of Cold White",
+                "isFromConfig": true
+            },
+            "value": 6500
+        },
+        {
+            "commandClassName": "Configuration",
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 4,
+            "propertyName": "Set color that LED Bulb blinks in (Blink Mode)",
+            "metadata": {
+                "type": "number",
+                "readable": false,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 1,
+                "max": 255,
+                "default": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "label": "Set color that LED Bulb blinks in (Blink Mode)",
+                "isFromConfig": true
+            }
+        },
+        {
+            "commandClassName": "Manufacturer Specific",
+            "commandClass": 114,
+            "endpoint": 0,
+            "property": "manufacturerId",
+            "propertyName": "manufacturerId",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Manufacturer ID"
+            },
+            "value": 881
+        },
+        {
+            "commandClassName": "Manufacturer Specific",
+            "commandClass": 114,
+            "endpoint": 0,
+            "property": "productType",
+            "propertyName": "productType",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Product type"
+            },
+            "value": 259
+        },
+        {
+            "commandClassName": "Manufacturer Specific",
+            "commandClass": 114,
+            "endpoint": 0,
+            "property": "productId",
+            "propertyName": "productId",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Product ID"
+            },
+            "value": 2
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "libraryType",
+            "propertyName": "libraryType",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Libary type"
+            },
+            "value": 3
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "protocolVersion",
+            "propertyName": "protocolVersion",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave protocol version"
+            },
+            "value": "4.38"
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "firmwareVersions",
+            "propertyName": "firmwareVersions",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip firmware versions"
+            },
+            "value": [
+                "2.0"
+            ]
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "hardwareVersion",
+            "propertyName": "hardwareVersion",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip hardware version"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add tests for the zwave_js light platform.
- The light tests are not complete yet. We're missing fixture data for white value light. We're also not testing the transition feature yet, as that is not supported at the moment. So until we reach more coverage we keep the light platform out of coverage calculation (currently: 92%).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
