### PR TITLE
Add selectors for text and arbitrary objects

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -175,4 +175,4 @@ class ObjectSelector(Selector):
 class StringSelector(Selector):
     """Selector for a multi-line text string."""
 
-    CONFIG_SCHEMA = vol.Schema({})
+    CONFIG_SCHEMA = vol.Schema({vol.Optional("multiline", default=False): bool})

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -162,3 +162,17 @@ class ActionSelector(Selector):
     """Selector of an action sequence (script syntax)."""
 
     CONFIG_SCHEMA = vol.Schema({})
+
+
+@SELECTORS.register("object")
+class ObjectSelector(Selector):
+    """Selector for an arbitrary object."""
+
+    CONFIG_SCHEMA = vol.Schema({})
+
+
+@SELECTORS.register("text")
+class StringSelector(Selector):
+    """Selector for a multi-line text string."""
+
+    CONFIG_SCHEMA = vol.Schema({})

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -182,7 +182,7 @@ def test_object_selector_schema(schema):
 
 @pytest.mark.parametrize(
     "schema",
-    ({},),
+    ({}, {"multiline": True}, {"multiline": False}),
 )
 def test_text_selector_schema(schema):
     """Test text selector."""

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -169,3 +169,21 @@ def test_target_selector_schema(schema):
 def test_action_selector_schema(schema):
     """Test action sequence selector."""
     selector.validate_selector({"action": schema})
+
+
+@pytest.mark.parametrize(
+    "schema",
+    ({},),
+)
+def test_object_selector_schema(schema):
+    """Test object selector."""
+    selector.validate_selector({"object": schema})
+
+
+@pytest.mark.parametrize(
+    "schema",
+    ({},),
+)
+def test_text_selector_schema(schema):
+    """Test text selector."""
+    selector.validate_selector({"text": schema})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Architecture discussion: home-assistant/architecture#486

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds two new selectors for blueprints. One for multiline text strings, and one for arbitrary objects (lists/dictionaries).

Both of those formats can currently be used in automations defined in yaml, but the frontend will clobber the values (turns them into `"[object Object]"`) if the automation is ever edited there.

Frontend PR: home-assistant/frontend#8152

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `blueprint.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
blueprint:
  name: Test inputs
  description: ""
  domain: automation
  input:
    object_input:
      name: Advanced object
      default:
        a: 1
        b: 2
        c:
          - c1
          - c2
          - c3
      selector:
        object:

    string_input:
      name: Multiline string
      default: |
        This is a string...
        ... of many lines
      selector:
        text:

trigger: []
action: []

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
