### PR TITLE
Remove YAML support from harmony

### DIFF
--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -129,19 +129,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_import(self, validated_input):
-        """Handle import."""
-        await self.async_set_unique_id(
-            validated_input[UNIQUE_ID], raise_on_progress=False
-        )
-        self._abort_if_unique_id_configured()
-
-        # Everything was validated in remote async_setup_platform
-        # all we do now is create.
-        return await self._async_create_entry_from_valid_input(
-            validated_input, validated_input
-        )
-
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):

--- a/homeassistant/components/harmony/util.py
+++ b/homeassistant/components/harmony/util.py
@@ -2,9 +2,7 @@
 import aioharmony.exceptions as harmony_exceptions
 from aioharmony.harmonyapi import HarmonyAPI
 
-from homeassistant.const import CONF_HOST, CONF_NAME
-
-from .const import DOMAIN
+from homeassistant.const import CONF_NAME
 
 
 def find_unique_id_for_remote(harmony: HarmonyAPI):
@@ -41,22 +39,3 @@ async def get_harmony_client_if_available(ip_address: str):
     await harmony.close()
 
     return harmony
-
-
-def find_matching_config_entries_for_host(hass, host):
-    """Search existing config entries for one matching the host."""
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.data[CONF_HOST] == host:
-            return entry
-    return None
-
-
-def list_names_from_hublist(hub_list):
-    """Extract the name key value from a hub list of names."""
-    if not hub_list:
-        return []
-    return [
-        element["name"]
-        for element in hub_list
-        if element.get("name") and element.get("id") != -1
-    ]

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -49,49 +49,6 @@ async def test_user_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_import(hass):
-    """Test we get the form with import source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    harmonyapi = _get_mock_harmonyapi(connect=True)
-    with patch(
-        "homeassistant.components.harmony.util.HarmonyAPI",
-        return_value=harmonyapi,
-    ), patch(
-        "homeassistant.components.harmony.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.harmony.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                "host": "1.2.3.4",
-                "name": "friend",
-                "activity": "Watch TV",
-                "delay_secs": 0.9,
-                "unique_id": "555234534543",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result["result"].unique_id == "555234534543"
-    assert result["type"] == "create_entry"
-    assert result["title"] == "friend"
-    assert result["data"] == {
-        "host": "1.2.3.4",
-        "name": "friend",
-        "activity": "Watch TV",
-        "delay_secs": 0.9,
-    }
-    # It is not possible to import options at this time
-    # so they end up in the config entry data and are
-    # used a fallback when they are not in options
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 async def test_form_ssdp(hass):
     """Test we get the form with ssdp source."""
     await setup.async_setup_component(hass, "persistent_notification", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Harmony has fully transitioned to configuration via UI. YAML configuration has been removed. Existing YAML configuration has already been imported automatically in the previous releases and can now safely be removed from your configuration files.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16183

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
