### PR TITLE
Add WebSocket API Foundation for zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DATA_CLIENT, DATA_UNSUBSCRIBE, DOMAIN, PLATFORMS
 from .discovery import async_discover_values
+from .websocket_api import async_register_api
 
 LOGGER = logging.getLogger(__name__)
 CONNECT_TIMEOUT = 10
@@ -126,6 +127,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DATA_CLIENT: client,
         DATA_UNSUBSCRIBE: unsubs,
     }
+
+    # Set up websocket API
+    async_register_api(hass)
 
     async def start_platforms() -> None:
         """Start platforms and perform discovery."""

--- a/homeassistant/components/zwave_js/websocket_api.py
+++ b/homeassistant/components/zwave_js/websocket_api.py
@@ -1,0 +1,49 @@
+"""Websocket API for Z-Wave JS."""
+
+import logging
+from typing import Dict
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.connection import ActiveConnection
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DATA_CLIENT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+ID = "id"
+ENTRY_ID = "entry_id"
+TYPE = "type"
+
+
+@callback
+def async_register_api(hass: HomeAssistant) -> None:
+    """Register all of our api endpoints."""
+    websocket_api.async_register_command(hass, websocket_network_status)
+
+
+@websocket_api.require_admin
+@websocket_api.async_response
+@websocket_api.websocket_command(
+    {vol.Required(TYPE): "zwave_js/network_status", vol.Required(ENTRY_ID): str}
+)
+async def websocket_network_status(
+    hass: HomeAssistant, connection: ActiveConnection, msg: Dict
+) -> None:
+    """Get the status of the Z-Wave JS network."""
+    entry_id = msg[ENTRY_ID]
+    client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
+    data = {
+        "client": {
+            "ws_server_url": client.ws_server_url,
+            "state": client.state,
+            "version": client.version.__dict__,
+        },
+        "controller": client.driver.controller.data,
+    }
+    connection.send_result(
+        msg[ID],
+        data,
+    )

--- a/homeassistant/components/zwave_js/websocket_api.py
+++ b/homeassistant/components/zwave_js/websocket_api.py
@@ -1,7 +1,7 @@
 """Websocket API for Z-Wave JS."""
 
+from dataclasses import asdict
 import logging
-from typing import Dict
 
 import voluptuous as vol
 
@@ -32,7 +32,7 @@ def async_register_api(hass: HomeAssistant) -> None:
     {vol.Required(TYPE): "zwave_js/network_status", vol.Required(ENTRY_ID): str}
 )
 async def websocket_network_status(
-    hass: HomeAssistant, connection: ActiveConnection, msg: Dict
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ) -> None:
     """Get the status of the Z-Wave JS network."""
     entry_id = msg[ENTRY_ID]
@@ -41,7 +41,7 @@ async def websocket_network_status(
         "client": {
             "ws_server_url": client.ws_server_url,
             "state": client.state,
-            "version": client.version.__dict__,
+            "version": asdict(client.version),
         },
         "controller": client.driver.controller.data,
     }

--- a/homeassistant/components/zwave_js/websocket_api.py
+++ b/homeassistant/components/zwave_js/websocket_api.py
@@ -24,14 +24,12 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_network_status)
 
 
-# Decorator causes typing error from mypy, ignoring locally until it is
-# fixed in the core websocket_api class
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {vol.Required(TYPE): "zwave_js/network_status", vol.Required(ENTRY_ID): str}
 )
-async def websocket_network_status(
+@callback
+def websocket_network_status(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ) -> None:
     """Get the status of the Z-Wave JS network."""

--- a/homeassistant/components/zwave_js/websocket_api.py
+++ b/homeassistant/components/zwave_js/websocket_api.py
@@ -1,6 +1,5 @@
 """Websocket API for Z-Wave JS."""
 
-from dataclasses import asdict
 import logging
 
 import voluptuous as vol
@@ -39,9 +38,13 @@ def websocket_network_status(
         "client": {
             "ws_server_url": client.ws_server_url,
             "state": client.state,
-            "version": asdict(client.version),
+            "driver_version": client.version.driver_version,
+            "server_version": client.version.server_version,
         },
-        "controller": client.driver.controller.data,
+        "controller": {
+            "home_id": client.driver.controller.data["homeId"],
+            "node_count": len(client.driver.controller.nodes),
+        },
     }
     connection.send_result(
         msg[ID],

--- a/homeassistant/components/zwave_js/websocket_api.py
+++ b/homeassistant/components/zwave_js/websocket_api.py
@@ -24,7 +24,9 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_network_status)
 
 
-@websocket_api.require_admin
+# Decorator causes typing error from mypy, ignoring locally until it is
+# fixed in the core websocket_api class
+@websocket_api.require_admin  # type: ignore
 @websocket_api.async_response
 @websocket_api.websocket_command(
     {vol.Required(TYPE): "zwave_js/network_status", vol.Required(ENTRY_ID): str}

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import DEFAULT, patch
 import pytest
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
+from zwave_js_server.version import VersionInfo
 
 from homeassistant.helpers.device_registry import (
     async_get_registry as async_get_device_registry,
@@ -23,6 +24,12 @@ async def device_registry_fixture(hass):
 def controller_state_fixture():
     """Load the controller state fixture data."""
     return json.loads(load_fixture("zwave_js/controller_state.json"))
+
+
+@pytest.fixture(name="version_state", scope="session")
+def version_state_fixture():
+    """Load the version state fixture data."""
+    return json.loads(load_fixture("zwave_js/version_state.json"))
 
 
 @pytest.fixture(name="multisensor_6_state", scope="session")
@@ -44,13 +51,17 @@ def bulb_6_multi_color_state_fixture():
 
 
 @pytest.fixture(name="client")
-def mock_client_fixture(controller_state):
+def mock_client_fixture(controller_state, version_state):
     """Mock a client."""
     with patch(
         "homeassistant.components.zwave_js.ZwaveClient", autospec=True
     ) as client_class:
         driver = Driver(client_class.return_value, controller_state)
+        version = VersionInfo.from_message(version_state)
         client_class.return_value.driver = driver
+        client_class.return_value.version = version
+        client_class.return_value.ws_server_url = "ws://test:3000/zjs"
+        client_class.return_value.state = "connected"
         yield client_class.return_value
 
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -29,7 +29,12 @@ def controller_state_fixture():
 @pytest.fixture(name="version_state", scope="session")
 def version_state_fixture():
     """Load the version state fixture data."""
-    return json.loads(load_fixture("zwave_js/version_state.json"))
+    return {
+        "type": "version",
+        "driverVersion": "6.0.0-beta.0",
+        "serverVersion": "1.0.0",
+        "homeId": 1234567890,
+    }
 
 
 @pytest.fixture(name="multisensor_6_state", scope="session")

--- a/tests/components/zwave_js/test_websocket_api.py
+++ b/tests/components/zwave_js/test_websocket_api.py
@@ -1,0 +1,20 @@
+"""Test the Z-Wave JS Websocket API."""
+
+from homeassistant.components.zwave_js.websocket_api import ENTRY_ID, ID, TYPE
+
+
+async def test_websocket_api(hass, client, integration, hass_ws_client):
+    """Test the network_status websocket command."""
+    entry = integration
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {ID: 2, TYPE: "zwave_js/network_status", ENTRY_ID: entry.entry_id}
+    )
+    msg = await client.receive_json()
+    result = msg["result"]
+
+    print(result)
+
+    assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"
+    assert result["client"]["version"]["server_version"] == "1.0.0"

--- a/tests/components/zwave_js/test_websocket_api.py
+++ b/tests/components/zwave_js/test_websocket_api.py
@@ -14,7 +14,5 @@ async def test_websocket_api(hass, client, integration, hass_ws_client):
     msg = await client.receive_json()
     result = msg["result"]
 
-    print(result)
-
     assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"
     assert result["client"]["version"]["server_version"] == "1.0.0"

--- a/tests/components/zwave_js/test_websocket_api.py
+++ b/tests/components/zwave_js/test_websocket_api.py
@@ -15,4 +15,4 @@ async def test_websocket_api(hass, integration, hass_ws_client):
     result = msg["result"]
 
     assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"
-    assert result["client"]["version"]["server_version"] == "1.0.0"
+    assert result["client"]["server_version"] == "1.0.0"

--- a/tests/components/zwave_js/test_websocket_api.py
+++ b/tests/components/zwave_js/test_websocket_api.py
@@ -3,15 +3,15 @@
 from homeassistant.components.zwave_js.websocket_api import ENTRY_ID, ID, TYPE
 
 
-async def test_websocket_api(hass, client, integration, hass_ws_client):
+async def test_websocket_api(hass, integration, hass_ws_client):
     """Test the network_status websocket command."""
     entry = integration
-    client = await hass_ws_client(hass)
+    ws_client = await hass_ws_client(hass)
 
-    await client.send_json(
+    await ws_client.send_json(
         {ID: 2, TYPE: "zwave_js/network_status", ENTRY_ID: entry.entry_id}
     )
-    msg = await client.receive_json()
+    msg = await ws_client.receive_json()
     result = msg["result"]
 
     assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"

--- a/tests/fixtures/zwave_js/version_state.json
+++ b/tests/fixtures/zwave_js/version_state.json
@@ -1,6 +1,0 @@
-{
-    "type": "version",
-    "driverVersion": "6.0.0-beta.0",
-    "serverVersion": "1.0.0",
-    "homeId": 3245146787
-}

--- a/tests/fixtures/zwave_js/version_state.json
+++ b/tests/fixtures/zwave_js/version_state.json
@@ -1,0 +1,6 @@
+{
+    "type": "version",
+    "driverVersion": "6.0.0-beta.0",
+    "serverVersion": "1.0.0",
+    "homeId": 3245146787
+}


### PR DESCRIPTION
## Proposed change
This PR begins the foundations for the zwave_js websocket API. Initial PR just has a network_status command.
Will be used for frontend config panel, adding/removing nodes, etc.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
