### PR TITLE
Allow manual configuration of ignored singleton config entries

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -954,12 +954,14 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         If the flow is user initiated, filter out ignored entries unless include_ignore is True.
         """
         assert self.hass is not None
+        config_entries = self.hass.config_entries.async_entries(self.handler)
+
+        if include_ignore:
+            return config_entries
+
         return [
-            entry
-            for entry in self.hass.config_entries.async_entries(self.handler)
-            if include_ignore
-            or self.source != SOURCE_USER
-            or entry.source != SOURCE_IGNORE
+            entry for entry in config_entries
+            if entry.source not in (SOURCE_USER, SOURCE_IGNORE)
         ]
 
     @callback

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -960,8 +960,9 @@ class ConfigFlow(data_entry_flow.FlowHandler):
             return config_entries
 
         return [
-            entry for entry in config_entries
-            if entry.source not in (SOURCE_USER, SOURCE_IGNORE)
+            entry
+            for entry in config_entries
+            if self.source != SOURCE_USER or entry.source != SOURCE_IGNORE
         ]
 
     @callback

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -956,13 +956,13 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         assert self.hass is not None
         config_entries = self.hass.config_entries.async_entries(self.handler)
 
-        if include_ignore:
+        if include_ignore or self.source != SOURCE_USER:
             return config_entries
 
         return [
             entry
             for entry in config_entries
-            if self.source != SOURCE_USER or entry.source != SOURCE_IGNORE
+            if entry.source != SOURCE_IGNORE
         ]
 
     @callback

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -959,11 +959,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         if include_ignore or self.source != SOURCE_USER:
             return config_entries
 
-        return [
-            entry
-            for entry in config_entries
-            if entry.source != SOURCE_IGNORE
-        ]
+        return [entry for entry in config_entries if entry.source != SOURCE_IGNORE]
 
     @callback
     def _async_current_ids(self, include_ignore: bool = True) -> Set[Optional[str]]:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -897,7 +897,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         if self.unique_id is None:
             return
 
-        for entry in self._async_current_entries():
+        for entry in self._async_current_entries(include_ignore=True):
             if entry.unique_id == self.unique_id:
                 if updates is not None:
                     changed = self.hass.config_entries.async_update_entry(
@@ -941,17 +941,26 @@ class ConfigFlow(data_entry_flow.FlowHandler):
                 if progress["context"].get("unique_id") == DEFAULT_DISCOVERY_UNIQUE_ID:
                     self.hass.config_entries.flow.async_abort(progress["flow_id"])
 
-        for entry in self._async_current_entries():
+        for entry in self._async_current_entries(include_ignore=True):
             if entry.unique_id == unique_id:
                 return entry
 
         return None
 
     @callback
-    def _async_current_entries(self) -> List[ConfigEntry]:
-        """Return current entries."""
+    def _async_current_entries(self, include_ignore: bool = False) -> List[ConfigEntry]:
+        """Return current entries.
+
+        If the flow is user initiated, filter out ignored entries unless include_ignore is True.
+        """
         assert self.hass is not None
-        return self.hass.config_entries.async_entries(self.handler)
+        return [
+            entry
+            for entry in self.hass.config_entries.async_entries(self.handler)
+            if include_ignore
+            or self.source != SOURCE_USER
+            or entry.source != SOURCE_IGNORE
+        ]
 
     @callback
     def _async_current_ids(self, include_ignore: bool = True) -> Set[Optional[str]]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow manual configuration of ignored singleton config entries

This is the same idea as in #43947, but exended to config flows which block multiple config entries using this pattern:
```py
    async def async_step_user(self, user_input=None):
        """Handle a flow initialized by the user."""
        if self._async_current_entries():
            return self.async_abort(reason="single_instance_allowed")

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
