### PR TITLE
Move switcher_kis services to entity services

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -4,35 +4,22 @@ from datetime import datetime, timedelta
 import logging
 from typing import Dict, Optional
 
-from aioswitcher.api import SwitcherV2Api
 from aioswitcher.bridge import SwitcherV2Bridge
-from aioswitcher.consts import COMMAND_ON
 import voluptuous as vol
 
-from homeassistant.auth.permissions.const import POLICY_EDIT
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import callback, split_entity_id
-from homeassistant.exceptions import Unauthorized, UnknownUser
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.discovery import async_listen_platform, async_load_platform
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.typing import (
-    ContextType,
-    DiscoveryInfoType,
-    EventType,
-    HomeAssistantType,
-    ServiceCallType,
-)
-from homeassistant.loader import bind_hass
+from homeassistant.helpers.typing import EventType, HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "switcher_kis"
 
-CONF_AUTO_OFF = "auto_off"
-CONF_TIMER_MINUTES = "timer_minutes"
 CONF_DEVICE_ID = "device_id"
 CONF_DEVICE_PASSWORD = "device_password"
 CONF_PHONE_ID = "phone_id"
@@ -57,39 +44,6 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-SERVICE_SET_AUTO_OFF_NAME = "set_auto_off"
-SERVICE_SET_AUTO_OFF_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-        vol.Required(CONF_AUTO_OFF): cv.time_period_str,
-    }
-)
-
-SERVICE_TURN_ON_WITH_TIMER_NAME = "turn_on_with_timer"
-SERVICE_TURN_ON_WITH_TIMER_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-        vol.Required(CONF_TIMER_MINUTES): vol.All(
-            cv.positive_int, vol.Range(min=1, max=90)
-        ),
-    }
-)
-
-
-@bind_hass
-async def _validate_edit_permission(
-    hass: HomeAssistantType, context: ContextType, entity_id: str
-) -> None:
-    """Use for validating user control permissions."""
-    splited = split_entity_id(entity_id)
-    if splited[0] != SWITCH_DOMAIN or not splited[1].startswith(DOMAIN):
-        raise Unauthorized(context=context, entity_id=entity_id, permission=POLICY_EDIT)
-    user = await hass.auth.async_get_user(context.user_id)
-    if user is None:
-        raise UnknownUser(context=context, entity_id=entity_id, permission=POLICY_EDIT)
-    if not user.permissions.check_entity(entity_id, POLICY_EDIT):
-        raise Unauthorized(context=context, entity_id=entity_id, permission=POLICY_EDIT)
 
 
 async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
@@ -116,53 +70,6 @@ async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
         await v2bridge.stop()
         return False
     hass.data[DOMAIN] = {DATA_DEVICE: device_data}
-
-    async def async_switch_platform_discovered(
-        platform: str, discovery_info: DiscoveryInfoType
-    ) -> None:
-        """Use for registering services after switch platform is discovered."""
-        if platform != DOMAIN:
-            return
-
-        async def async_set_auto_off_service(service: ServiceCallType) -> None:
-            """Use for handling setting device auto-off service calls."""
-
-            await _validate_edit_permission(
-                hass, service.context, service.data[ATTR_ENTITY_ID]
-            )
-
-            async with SwitcherV2Api(
-                hass.loop, device_data.ip_addr, phone_id, device_id, device_password
-            ) as swapi:
-                await swapi.set_auto_shutdown(service.data[CONF_AUTO_OFF])
-
-        async def async_turn_on_with_timer_service(service: ServiceCallType) -> None:
-            """Use for handling turning device on with a timer service calls."""
-
-            await _validate_edit_permission(
-                hass, service.context, service.data[ATTR_ENTITY_ID]
-            )
-
-            async with SwitcherV2Api(
-                hass.loop, device_data.ip_addr, phone_id, device_id, device_password
-            ) as swapi:
-                await swapi.control_device(COMMAND_ON, service.data[CONF_TIMER_MINUTES])
-
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_SET_AUTO_OFF_NAME,
-            async_set_auto_off_service,
-            schema=SERVICE_SET_AUTO_OFF_SCHEMA,
-        )
-
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_TURN_ON_WITH_TIMER_NAME,
-            async_turn_on_with_timer_service,
-            schema=SERVICE_TURN_ON_WITH_TIMER_SCHEMA,
-        )
-
-    async_listen_platform(hass, SWITCH_DOMAIN, async_switch_platform_discovered)
 
     hass.async_create_task(async_load_platform(hass, SWITCH_DOMAIN, DOMAIN, {}, config))
 

--- a/homeassistant/components/switcher_kis/services.yaml
+++ b/homeassistant/components/switcher_kis/services.yaml
@@ -15,5 +15,5 @@ turn_on_with_timer:
       description: "Name of the entity id associated with the integration, used for permission validation."
       example: "switch.switcher_kis_boiler"
     timer_minutes:
-      description: 'Minutes to turn on (valid range from 1 to 90)'
+      description: 'Minutes to turn on (valid range from 1 to 150)'
       example: '30'

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -11,6 +11,7 @@ from .consts import (
     DUMMY_AUTO_OFF_SET,
     DUMMY_DEVICE_ID,
     DUMMY_DEVICE_NAME,
+    DUMMY_DEVICE_PASSWORD,
     DUMMY_DEVICE_STATE,
     DUMMY_ELECTRIC_CURRENT,
     DUMMY_IP_ADDRESS,
@@ -78,6 +79,11 @@ class MockSwitcherV2Device:
     def phone_id(self) -> str:
         """Return the phone id."""
         return DUMMY_PHONE_ID
+
+    @property
+    def device_password(self) -> str:
+        """Return the device password."""
+        return DUMMY_DEVICE_PASSWORD
 
     @property
     def last_data_update(self) -> datetime:
@@ -169,10 +175,11 @@ def mock_api_fixture() -> Generator[AsyncMock, Any, None]:
 
     patchers = [
         patch(
-            "homeassistant.components.switcher_kis.SwitcherV2Api.connect", new=mock_api
+            "homeassistant.components.switcher_kis.switch.SwitcherV2Api.connect",
+            new=mock_api,
         ),
         patch(
-            "homeassistant.components.switcher_kis.SwitcherV2Api.disconnect",
+            "homeassistant.components.switcher_kis.switch.SwitcherV2Api.disconnect",
             new=mock_api,
         ),
     ]

--- a/tests/components/switcher_kis/consts.py
+++ b/tests/components/switcher_kis/consts.py
@@ -8,6 +8,7 @@ from homeassistant.components.switcher_kis import (
 )
 
 DUMMY_AUTO_OFF_SET = "01:30:00"
+DUMMY_TIMER_MINUTES_SET = "90"
 DUMMY_DEVICE_ID = "a123bc"
 DUMMY_DEVICE_NAME = "Device Name"
 DUMMY_DEVICE_PASSWORD = "12345678"
@@ -22,7 +23,7 @@ DUMMY_POWER_CONSUMPTION = 2780
 DUMMY_REMAINING_TIME = "01:29:32"
 
 # Adjust if any modification were made to DUMMY_DEVICE_NAME
-SWITCH_ENTITY_ID = "switch.switcher_kis_device_name"
+SWITCH_ENTITY_ID = "switch.device_name"
 
 MANDATORY_CONFIGURATION = {
     DOMAIN: {

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -1,8 +1,10 @@
 """Test cases for the switcher_kis component."""
-
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Generator
+from typing import Any, Generator
+from unittest.mock import patch
 
+from aioswitcher.consts import COMMAND_ON
+from aioswitcher.devices import SwitcherV2Device
 from pytest import raises
 
 from homeassistant.components.switcher_kis import (
@@ -14,13 +16,12 @@ from homeassistant.components.switcher_kis.switch import (
     CONF_AUTO_OFF,
     CONF_TIMER_MINUTES,
     SERVICE_SET_AUTO_OFF_NAME,
-    SERVICE_SET_AUTO_OFF_SCHEMA,
     SERVICE_TURN_ON_WITH_TIMER_NAME,
-    SERVICE_TURN_ON_WITH_TIMER_SCHEMA,
 )
 from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import Context, callback
 from homeassistant.exceptions import UnknownUser
+from homeassistant.helpers.config_validation import time_period_str
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
@@ -42,12 +43,7 @@ from .consts import (
     SWITCH_ENTITY_ID,
 )
 
-from tests.common import async_fire_time_changed, async_mock_service
-
-if TYPE_CHECKING:
-    from aioswitcher.devices import SwitcherV2Device
-
-    from tests.common import MockUser
+from tests.common import MockUser, async_fire_time_changed
 
 
 async def test_failed_config(
@@ -89,7 +85,7 @@ async def test_set_auto_off_service(
     hass: HomeAssistantType,
     mock_bridge: Generator[None, Any, None],
     mock_api: Generator[None, Any, None],
-    hass_owner_user: "MockUser",
+    hass_owner_user: MockUser,
 ) -> None:
     """Test the set_auto_off service."""
     assert await async_setup_component(hass, DOMAIN, MANDATORY_CONFIGURATION)
@@ -117,27 +113,27 @@ async def test_set_auto_off_service(
 
     assert unknown_user_exc.type is UnknownUser
 
-    service_calls = async_mock_service(
-        hass, DOMAIN, SERVICE_SET_AUTO_OFF_NAME, SERVICE_SET_AUTO_OFF_SCHEMA
-    )
+    with patch(
+        "homeassistant.components.switcher_kis.switch.SwitcherV2Api.set_auto_shutdown"
+    ) as mock_set_auto_shutdown:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_AUTO_OFF_NAME,
+            {CONF_ENTITY_ID: SWITCH_ENTITY_ID, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
+        )
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_AUTO_OFF_NAME,
-        {CONF_ENTITY_ID: SWITCH_ENTITY_ID, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
-    )
+        await hass.async_block_till_done()
 
-    await hass.async_block_till_done()
-
-    assert len(service_calls) == 1
-    assert str(service_calls[0].data[CONF_AUTO_OFF]) == DUMMY_AUTO_OFF_SET.lstrip("0")
+        mock_set_auto_shutdown.assert_called_once_with(
+            time_period_str(DUMMY_AUTO_OFF_SET)
+        )
 
 
 async def test_turn_on_with_timer_service(
     hass: HomeAssistantType,
     mock_bridge: Generator[None, Any, None],
     mock_api: Generator[None, Any, None],
-    hass_owner_user: "MockUser",
+    hass_owner_user: MockUser,
 ) -> None:
     """Test the set_auto_off service."""
     assert await async_setup_component(hass, DOMAIN, MANDATORY_CONFIGURATION)
@@ -168,22 +164,23 @@ async def test_turn_on_with_timer_service(
 
     assert unknown_user_exc.type is UnknownUser
 
-    service_calls = async_mock_service(
-        hass, DOMAIN, SERVICE_TURN_ON_WITH_TIMER_NAME, SERVICE_TURN_ON_WITH_TIMER_SCHEMA
-    )
+    with patch(
+        "homeassistant.components.switcher_kis.switch.SwitcherV2Api.control_device"
+    ) as mock_control_device:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TURN_ON_WITH_TIMER_NAME,
+            {
+                CONF_ENTITY_ID: SWITCH_ENTITY_ID,
+                CONF_TIMER_MINUTES: DUMMY_TIMER_MINUTES_SET,
+            },
+        )
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_TURN_ON_WITH_TIMER_NAME,
-        {CONF_ENTITY_ID: SWITCH_ENTITY_ID, CONF_TIMER_MINUTES: DUMMY_TIMER_MINUTES_SET},
-    )
+        await hass.async_block_till_done()
 
-    await hass.async_block_till_done()
-
-    assert len(service_calls) == 1
-    assert str(
-        service_calls[0].data[CONF_TIMER_MINUTES]
-    ) == DUMMY_TIMER_MINUTES_SET.lstrip("0")
+        mock_control_device.assert_called_once_with(
+            COMMAND_ON, int(DUMMY_TIMER_MINUTES_SET)
+        )
 
 
 async def test_signal_dispatcher(
@@ -195,7 +192,7 @@ async def test_signal_dispatcher(
     await hass.async_block_till_done()
 
     @callback
-    def verify_update_data(device: "SwitcherV2Device") -> None:
+    def verify_update_data(device: SwitcherV2Device) -> None:
         """Use as callback for signal dispatcher."""
         pass
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move switcher_kis services to entity services (bugfix).
Increase service `turn_on_with_timer` maximum value from 90 to 150  (bugfix).
Add tests for service ` turn_on_with_timer`.

This PR fixes service access errors as described here:
https://github.com/home-assistant/core/pull/39693
The original PR is stale for few months, I have taken the approach recommended by @MartinHjelmare:
https://github.com/home-assistant/core/pull/39693#discussion_r486837158
And moved the services to the switch entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16197

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
