### PR TITLE
Prefill the ip address for powerwall discovery

### DIFF
--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Tesla Powerwall ({ip_address})",
     "step": {
       "user": {
         "title": "Connect to the powerwall",

--- a/homeassistant/components/powerwall/translations/en.json
+++ b/homeassistant/components/powerwall/translations/en.json
@@ -1,20 +1,21 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "unknown": "Unexpected error",
-            "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved."
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "ip_address": "IP Address"
-                },
-                "title": "Connect to the powerwall"
-            }
+  "config": {
+    "flow_title": "Tesla Powerwall ({ip_address})",
+    "step": {
+      "user": {
+        "title": "Connect to the powerwall",
+        "data": {
+          "ip_address": "[%key:common::config_flow::data::ip%]"
         }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  }
 }

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -144,9 +144,7 @@ async def test_already_configured(hass):
     """Test we abort when already configured."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_IP_ADDRESS: "1.1.1.1"}
-    )
+    config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_IP_ADDRESS: "1.1.1.1"})
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -145,7 +145,7 @@ async def test_already_configured_(hass):
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_IP_ADDRESS: "1.1.1.1"}, source="ignore"
+        domain=DOMAIN, data={CONF_IP_ADDRESS: "1.1.1.1"}
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -5,10 +5,13 @@ from unittest.mock import patch
 from tesla_powerwall import MissingAttributeError, PowerwallUnreachableError
 
 from homeassistant import config_entries, setup
+from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.powerwall.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS
 
 from .mocks import _mock_powerwall_side_effect, _mock_powerwall_site_name
+
+from tests.common import MockConfigEntry
 
 
 async def test_form_source_user(hass):
@@ -93,6 +96,27 @@ async def test_form_cannot_connect(hass):
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
+async def test_form_unknown_exeption(hass):
+    """Test we handle an unknown exception."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_powerwall = _mock_powerwall_side_effect(site_info=ValueError)
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_IP_ADDRESS: "1.2.3.4"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "unknown"}
+
+
 async def test_form_wrong_version(hass):
     """Test we can handle wrong version error."""
     result = await hass.config_entries.flow.async_init(
@@ -114,3 +138,86 @@ async def test_form_wrong_version(hass):
 
     assert result3["type"] == "form"
     assert result3["errors"] == {"base": "wrong_version"}
+
+
+async def test_already_configured_(hass):
+    """Test we abort when already configured."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_IP_ADDRESS: "1.1.1.1"}, source="ignore"
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data={
+            IP_ADDRESS: "1.1.1.1",
+            MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
+            HOSTNAME: "any",
+        },
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_already_configured_with_ignored(hass):
+    """Test ignored entries do not break checking for existing entries."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, source="ignore")
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data={
+            IP_ADDRESS: "1.1.1.1",
+            MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
+            HOSTNAME: "any",
+        },
+    )
+    assert result["type"] == "form"
+
+
+async def test_dhcp_discovery(hass):
+    """Test we can process the discovery from dhcp."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data={
+            IP_ADDRESS: "1.1.1.1",
+            MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
+            HOSTNAME: "any",
+        },
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ), patch(
+        "homeassistant.components.powerwall.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.powerwall.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_IP_ADDRESS: "1.1.1.1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Some site"
+    assert result2["data"] == {
+        CONF_IP_ADDRESS: "1.1.1.1",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -140,7 +140,7 @@ async def test_form_wrong_version(hass):
     assert result3["errors"] == {"base": "wrong_version"}
 
 
-async def test_already_configured_(hass):
+async def test_already_configured(hass):
     """Test we abort when already configured."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prefill the ip address for powerwall discovery

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
