### PR TITLE
Add Webex presence sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -81,6 +81,7 @@ homeassistant/components/cert_expiry/* @Cereal2nd @jjlawren
 homeassistant/components/circuit/* @braam
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
+homeassistant/components/cisco_webex/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/cloud/* @home-assistant/cloud
 homeassistant/components/cloudflare/* @ludeeus @ctalkington

--- a/homeassistant/components/cisco_webex/__init__.py
+++ b/homeassistant/components/cisco_webex/__init__.py
@@ -1,0 +1,53 @@
+"""The cisco_webex integration."""
+import asyncio
+
+import voluptuous as vol
+from webexteamssdk import WebexTeamsAPI
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+from .const import API, DOMAIN
+
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+PLATFORMS = ["sensor"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the cisco_webex component."""
+
+    hass.data.setdefault(DOMAIN, {})
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up cisco_webex from a config entry."""
+    hass.data[DOMAIN][entry.entry_id] = {
+        CONF_TOKEN: entry.data[CONF_TOKEN],
+        API: WebexTeamsAPI(access_token=entry.data[CONF_TOKEN]),
+    }
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/cisco_webex/__init__.py
+++ b/homeassistant/components/cisco_webex/__init__.py
@@ -24,7 +24,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up cisco_webex from a config entry."""
-    hass.data[DOMAIN][entry.entry_id] = {
+    hass.data[DOMAIN][entry.unique_id] = {
         CONF_TOKEN: entry.data[CONF_TOKEN],
         API: WebexTeamsAPI(access_token=entry.data[CONF_TOKEN]),
     }
@@ -48,6 +48,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
     )
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.unique_id)
 
     return unload_ok

--- a/homeassistant/components/cisco_webex/__init__.py
+++ b/homeassistant/components/cisco_webex/__init__.py
@@ -16,7 +16,6 @@ PLATFORMS = ["sensor"]
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the cisco_webex component."""
-
     hass.data.setdefault(DOMAIN, {})
 
     return True

--- a/homeassistant/components/cisco_webex/config_flow.py
+++ b/homeassistant/components/cisco_webex/config_flow.py
@@ -1,0 +1,149 @@
+"""Config flow for cisco_webex integration."""
+import logging
+
+import requests
+import voluptuous as vol
+import webexteamssdk
+
+from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_EMAIL, CONF_TOKEN
+
+from .const import DEFAULT_NAME, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema({CONF_TOKEN: str, CONF_EMAIL: str})
+
+
+class ConfigValidationHub:
+    """Methods for config validation."""
+
+    def validate_config(self, token, email) -> bool:
+        """Test if we can find a Webex user with email."""
+
+        api = webexteamssdk.WebexTeamsAPI(access_token=token)
+
+        self.validate_auth(api)
+        return self.validate_email(api, email)
+
+    def validate_auth(self, api) -> bool:
+        """Test if we can authenticate with Webex."""
+        try:
+            try:
+                # maybe check here it is a bot token as personal access tokens expire after 12 hours.
+                _LOGGER.debug("Authenticating with Webex")
+                api.people.me()
+                _LOGGER.debug("Authenticating OK.")
+            except webexteamssdk.ApiError as error:
+                _LOGGER.error(error)
+                if error.status_code == 401:
+                    raise InvalidAuth
+                raise error
+
+        except requests.exceptions.ConnectionError as connection_error:
+            _LOGGER.error(connection_error)
+            raise CannotConnect
+
+        return False
+
+    def validate_email(self, api, email) -> bool:
+        """Test if we can find a Webex user with email."""
+
+        try:
+            try:
+                _LOGGER.debug("Listing people with email: '%s'", email)
+                people_list = list(api.people.list(email=email))
+                if len(people_list) > 0:
+                    _LOGGER.debug("Listing people with email: '%s' success.", email)
+                    return True
+            except webexteamssdk.ApiError as error:
+                _LOGGER.error(error)
+                if error.status_code == 400:
+                    raise EmailNotFound
+                raise error
+        except requests.exceptions.ConnectionError as connection_error:
+            _LOGGER.error(connection_error)
+            raise CannotConnect
+
+        return False
+
+
+async def validate_token_and_email(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    try:
+        # pylint: disable=no-value-for-parameter
+        vol.Email()(data[CONF_EMAIL])
+    except vol.error.EmailInvalid:
+        raise InvalidEmail
+
+    hub = ConfigValidationHub()
+
+    await hass.async_add_executor_job(
+        hub.validate_config, data[CONF_TOKEN], data[CONF_EMAIL]
+    )
+
+    # Return info that you want to store in the config entry.
+    return {"title": f"{DEFAULT_NAME} {data[CONF_EMAIL]}"}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for cisco_webex."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                description_placeholders={
+                    "bot_docs_url": "https://developer.webex.com/docs/bots"
+                },
+                data_schema=STEP_USER_DATA_SCHEMA,
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_token_and_email(self.hass, user_input)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except EmailNotFound:
+            errors["base"] = "email_not_found"
+        except InvalidEmail:
+            errors["base"] = "invalid_email"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return self.async_create_entry(title="Demo", data={})
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""
+
+
+class InvalidEmail(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid email."""
+
+
+class EmailNotFound(exceptions.HomeAssistantError):
+    """Error to indicate email is not known to webex."""

--- a/homeassistant/components/cisco_webex/config_flow.py
+++ b/homeassistant/components/cisco_webex/config_flow.py
@@ -63,8 +63,6 @@ class ConfigValidationHub:
             _LOGGER.error(connection_error)
             raise CannotConnect
 
-        return False
-
 
 async def validate_token_and_email(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect.

--- a/homeassistant/components/cisco_webex/config_flow.py
+++ b/homeassistant/components/cisco_webex/config_flow.py
@@ -122,15 +122,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
+
+            # Check if already configured
+            await self.async_set_unique_id(f"webex_{user_input[CONF_EMAIL]}")
+            self._abort_if_unique_id_configured()
+
             return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
-
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        return self.async_create_entry(title="Demo", data={})
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/cisco_webex/config_flow.py
+++ b/homeassistant/components/cisco_webex/config_flow.py
@@ -8,7 +8,7 @@ import webexteamssdk
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_EMAIL, CONF_TOKEN
 
-from .const import DATA_BOT_EMAIL, DATA_DISPLAY_NAME, DOMAIN
+from .const import DATA_DISPLAY_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,6 @@ class ConfigValidationHub:
                 _LOGGER.debug("Authenticated OK.")
                 _LOGGER.debug("api.people.me: %s", person_me)
 
-                data[DATA_BOT_EMAIL] = person_me.emails[0]
                 if person_me.type != "bot":
                     _LOGGER.error(
                         "Although auth passed, an invalid token type is being used: %s",
@@ -48,7 +47,6 @@ class ConfigValidationHub:
                         person,
                     )
                     data[DATA_DISPLAY_NAME] = person.displayName
-
                     return True
                 else:
                     _LOGGER.error("Cannot find any Webex user with email: %s", email)
@@ -81,6 +79,7 @@ async def validate_token_and_email(hass: core.HomeAssistant, data):
 
     hub = ConfigValidationHub()
     api = webexteamssdk.WebexTeamsAPI(access_token=data[CONF_TOKEN])
+    data[DATA_DISPLAY_NAME] = "unknown"
 
     await hass.async_add_executor_job(hub.validate_config, api, data)
 

--- a/homeassistant/components/cisco_webex/const.py
+++ b/homeassistant/components/cisco_webex/const.py
@@ -1,0 +1,6 @@
+"""Constants for the cisco_webex integration."""
+
+DOMAIN = "cisco_webex"
+API = "api"
+
+DEFAULT_NAME = "Webex Presence"

--- a/homeassistant/components/cisco_webex/const.py
+++ b/homeassistant/components/cisco_webex/const.py
@@ -5,5 +5,4 @@ API = "api"
 
 DEFAULT_SENSOR_NAME = "Webex Status"
 
-DATA_BOT_EMAIL = "bot_email"
 DATA_DISPLAY_NAME = "display_name"

--- a/homeassistant/components/cisco_webex/const.py
+++ b/homeassistant/components/cisco_webex/const.py
@@ -6,3 +6,4 @@ API = "api"
 DEFAULT_SENSOR_NAME = "Webex Status"
 
 DATA_BOT_EMAIL = "bot_email"
+DATA_DISPLAY_NAME = "display_name"

--- a/homeassistant/components/cisco_webex/const.py
+++ b/homeassistant/components/cisco_webex/const.py
@@ -3,4 +3,6 @@
 DOMAIN = "cisco_webex"
 API = "api"
 
-DEFAULT_NAME = "Webex Presence"
+DEFAULT_SENSOR_NAME = "Webex Status"
+
+DATA_BOT_EMAIL = "bot_email"

--- a/homeassistant/components/cisco_webex/manifest.json
+++ b/homeassistant/components/cisco_webex/manifest.json
@@ -1,0 +1,16 @@
+{
+  "domain": "cisco_webex",
+  "name": "Cisco Webex",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/cisco_webex",
+  "requirements": [
+    "webexteamssdk==1.6"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@fbradyirl"
+  ]
+}

--- a/homeassistant/components/cisco_webex/sensor.py
+++ b/homeassistant/components/cisco_webex/sensor.py
@@ -50,6 +50,7 @@ class WebexPresenceSensor(Entity):
         self._attributes = {}
         self._api = api
         self._name = name
+        self.uid = f"webex_status_{email}"
 
     @property
     def name(self):
@@ -71,6 +72,11 @@ class WebexPresenceSensor(Entity):
     def device_class(self):
         """Return the device class of this binary sensor."""
         return DEVICE_CLASS_PRESENCE
+
+    @property
+    def unique_id(self):
+        """Return a unique id identifying the entity."""
+        self.uid
 
     def update(self):
         """Update device state."""

--- a/homeassistant/components/cisco_webex/sensor.py
+++ b/homeassistant/components/cisco_webex/sensor.py
@@ -1,0 +1,99 @@
+"""Platform for sensor integration."""
+import logging
+
+from homeassistant.components.binary_sensor import DEVICE_CLASS_PRESENCE, Entity
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_EMAIL
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import API, DEFAULT_NAME, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Import the platform into a config entry."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up Webex sensor based on a config entry."""
+
+    webex_domain_data = hass.data[DOMAIN][config_entry.entry_id]
+    config = config_entry.data
+
+    async_add_entities(
+        [
+            WebexPresenceSensor(
+                api=webex_domain_data[API],
+                email=config[CONF_EMAIL],
+                name=f"{DEFAULT_NAME} {config[CONF_EMAIL]}",
+            )
+        ]
+    )
+
+
+class WebexPresenceSensor(Entity):
+    """Representation of a Webex Presence Sensor."""
+
+    def __init__(self, api, email, name):
+        """Initialize the sensor."""
+        self._state = None
+        self._user_id = None
+        self._email = email
+        self._attributes = {}
+        self._api = api
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the name of the binary sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the status of the binary sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        self._attributes["on_a_call"] = self._state in ["call", "meeting", "presenting"]
+        return self._attributes
+
+    @property
+    def device_class(self):
+        """Return the device class of this binary sensor."""
+        return DEVICE_CLASS_PRESENCE
+
+    def update(self):
+        """Update device state."""
+        if self._user_id is None:
+
+            people_list = list(self._api.people.list(email=self._email))
+            if len(people_list) > 0:
+                person = people_list[0]
+                self._user_id = person.id
+                self.update_with_data(person)
+                _LOGGER.debug(
+                    "WebexPresenceSensor init with _user_id: %s", self._user_id
+                )
+            else:
+                _LOGGER.error("Cannot find any Webex user with email: %s", self._email)
+                return
+
+        self.update_with_data(self._api.people.get(self._user_id))
+
+    def update_with_data(self, person):
+        """Update local data with the latest person."""
+        self._attributes = person.to_dict()
+        # available states documented here
+        # https://developer.webex.com/docs/api/v1/people/list-people
+        self._state = person.status
+        _LOGGER.debug("WebexPeopleSensor person state: %s", self._state)

--- a/homeassistant/components/cisco_webex/sensor.py
+++ b/homeassistant/components/cisco_webex/sensor.py
@@ -15,7 +15,6 @@ async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up Webex sensor based on a config entry."""
-
     webex_domain_data = hass.data[DOMAIN][config_entry.unique_id]
     config = config_entry.data
 

--- a/homeassistant/components/cisco_webex/sensor.py
+++ b/homeassistant/components/cisco_webex/sensor.py
@@ -35,7 +35,7 @@ class WebexPresenceSensor(Entity):
 
     def __init__(self, api, email, name):
         """Initialize the sensor."""
-        self._state = None
+        self._status = None
         self._user_id = None
         self._email = email
         self._attributes = {}
@@ -51,12 +51,16 @@ class WebexPresenceSensor(Entity):
     @property
     def state(self):
         """Return the status of the binary sensor."""
-        return self._state
+        return self._status
 
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        self._attributes["on_a_call"] = self._state in ["call", "meeting", "presenting"]
+        self._attributes["on_a_call"] = self._status in [
+            "call",
+            "meeting",
+            "presenting",
+        ]
         return self._attributes
 
     @property
@@ -106,8 +110,8 @@ class WebexPresenceSensor(Entity):
     def update_with_data(self, person):
         """Update local data with the latest person."""
         self._attributes = person.to_dict()
-        # available states documented here
+        # available status documented here
         # https://developer.webex.com/docs/api/v1/people/list-people
-        self._state = person.status
+        self._status = person.status
         self._avatar = person.avatar
-        _LOGGER.debug("%s state: %s", self._email, self._state)
+        _LOGGER.debug("%s state: %s", self._email, self._status)

--- a/homeassistant/components/cisco_webex/strings.json
+++ b/homeassistant/components/cisco_webex/strings.json
@@ -1,0 +1,22 @@
+{
+  "title": "cisco_webex",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]"
+        },
+        "title": "Cisco Webex",
+        "description": "[%key:common::config_flow::description%]"
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/cisco_webex/translations/en.json
+++ b/homeassistant/components/cisco_webex/translations/en.json
@@ -1,0 +1,24 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect. Check your internet connection.",
+            "invalid_auth": "Invalid authentication. Ensure your auth token is from a bot at developer.webex.com/docs/bots",
+            "invalid_email": "Invalid email.",
+            "email_not_found": "Email provided is not a Webex user.",
+            "unknown": "An unexpected error occurred."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "token": "Bot Token",
+                    "email": "Email Address"
+                },
+                "description": "Learn how to create a bot token here: \n\n[developer.webex.com/docs/bots]({bot_docs_url})"
+            }
+        }
+    },
+    "title": "cisco_webex"
+}

--- a/homeassistant/components/cisco_webex/translations/en.json
+++ b/homeassistant/components/cisco_webex/translations/en.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect. Check your internet connection.",
             "invalid_auth": "Invalid authentication. Ensure your auth token is from a bot at developer.webex.com/docs/bots",
+            "invalid_auth_token_type": "You are using an invalid token type. Only bot tokens are valid. Personal Access Token's expire after a few hours and are not allowed.",
             "invalid_email": "Invalid email.",
             "email_not_found": "Email provided is not a Webex user.",
             "unknown": "An unexpected error occurred."

--- a/homeassistant/components/cisco_webex/translations/en.json
+++ b/homeassistant/components/cisco_webex/translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "You have already configured an integration with this Webex email account."
         },
         "error": {
             "cannot_connect": "Failed to connect. Check your internet connection.",

--- a/homeassistant/components/cisco_webex_teams/manifest.json
+++ b/homeassistant/components/cisco_webex_teams/manifest.json
@@ -2,6 +2,6 @@
   "domain": "cisco_webex_teams",
   "name": "Cisco Webex Teams",
   "documentation": "https://www.home-assistant.io/integrations/cisco_webex_teams",
-  "requirements": ["webexteamssdk==1.1.1"],
+  "requirements": ["webexteamssdk==1.6"],
   "codeowners": ["@fbradyirl"]
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -38,6 +38,7 @@ FLOWS = [
     "canary",
     "cast",
     "cert_expiry",
+    "cisco_webex",
     "cloudflare",
     "control4",
     "coolmaster",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2278,7 +2278,7 @@ watchdog==0.8.3
 waterfurnace==1.1.0
 
 # homeassistant.components.cisco_webex_teams
-webexteamssdk==1.1.1
+webexteamssdk==1.6
 
 # homeassistant.components.gpmdp
 websocket-client==0.54.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2277,6 +2277,7 @@ watchdog==0.8.3
 # homeassistant.components.waterfurnace
 waterfurnace==1.1.0
 
+# homeassistant.components.cisco_webex
 # homeassistant.components.cisco_webex_teams
 webexteamssdk==1.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1124,6 +1124,10 @@ wakeonlan==1.1.6
 # homeassistant.components.folder_watcher
 watchdog==0.8.3
 
+# homeassistant.components.cisco_webex
+# homeassistant.components.cisco_webex_teams
+webexteamssdk==1.6
+
 # homeassistant.components.wiffi
 wiffi==1.0.1
 

--- a/tests/components/cisco_webex/__init__.py
+++ b/tests/components/cisco_webex/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Cisco Webex integration."""

--- a/tests/components/cisco_webex/mocks.py
+++ b/tests/components/cisco_webex/mocks.py
@@ -16,8 +16,18 @@ class MockPeopleAPI:
     def list(self, email):
         return [MockPerson()]
 
+    def get(self, user_id):
+        return MockPerson()
+
 
 class MockPerson:
+    @property
+    def id(self):
+        return "77777"
+
+    def to_dict(self):
+        return {}
+
     @property
     def type(self):
         return "bot"
@@ -25,6 +35,14 @@ class MockPerson:
     @property
     def displayName(self):
         return "Test user"
+
+    @property
+    def status(self):
+        return "active"
+
+    @property
+    def avatar(self):
+        return "http://www.com/pic.png"
 
 
 class MockApiError(webexteamssdk.ApiError):

--- a/tests/components/cisco_webex/mocks.py
+++ b/tests/components/cisco_webex/mocks.py
@@ -1,0 +1,34 @@
+import webexteamssdk
+from webexteamssdk import WebexTeamsAPI
+
+
+class MockWebexTeamsAPI(WebexTeamsAPI):
+    """Mocked WebexTeamsAPI that doesn't do anything."""
+
+    def __init__(self, access_token):
+        self.people = MockPeopleAPI()
+
+
+class MockPeopleAPI:
+    def me(self):
+        return MockPerson()
+
+    def list(self, email):
+        return [MockPerson()]
+
+
+class MockPerson:
+    @property
+    def type(self):
+        return "bot"
+
+    @property
+    def displayName(self):
+        return "Test user"
+
+
+class MockApiError(webexteamssdk.ApiError):
+    """Mock for empty api error"""
+
+    def __init__(self):
+        pass

--- a/tests/components/cisco_webex/mocks.py
+++ b/tests/components/cisco_webex/mocks.py
@@ -1,3 +1,4 @@
+"""Mocks used for testing cisco_webex integration."""
 import webexteamssdk
 from webexteamssdk import WebexTeamsAPI
 
@@ -6,47 +7,62 @@ class MockWebexTeamsAPI(WebexTeamsAPI):
     """Mocked WebexTeamsAPI that doesn't do anything."""
 
     def __init__(self, access_token):
+        """Blank init."""
         self.people = MockPeopleAPI()
 
 
 class MockPeopleAPI:
+    """Mock PeopleAPI."""
+
     def me(self):
+        """Mock me."""
         return MockPerson()
 
     def list(self, email):
+        """Mock list."""
         return [MockPerson()]
 
     def get(self, user_id):
+        """Mock get."""
         return MockPerson()
 
 
 class MockPerson:
+    """Mock Person object."""
+
     @property
     def id(self):
+        """Mock id."""
         return "77777"
 
     def to_dict(self):
+        """Mock to_dict."""
         return {}
 
     @property
     def type(self):
+        """Mock type."""
         return "bot"
 
     @property
     def displayName(self):
+        """Mock displayName."""
         return "Test user"
 
     @property
     def status(self):
+        """Mock status."""
         return "active"
 
     @property
     def avatar(self):
+        """Mock avatar."""
         return "http://www.com/pic.png"
 
 
 class MockApiError(webexteamssdk.ApiError):
-    """Mock for empty api error"""
+    """Mock for empty api error."""
 
     def __init__(self):
+        """Mock init."""
         pass

--- a/tests/components/cisco_webex/test_config_flow.py
+++ b/tests/components/cisco_webex/test_config_flow.py
@@ -1,4 +1,6 @@
 """Test the Cisco Webex config flow."""
+from unittest.mock import patch
+
 import pytest
 import requests
 
@@ -13,7 +15,6 @@ from homeassistant.components.cisco_webex.config_flow import (
 )
 from homeassistant.components.cisco_webex.const import DOMAIN
 
-from tests.async_mock import patch
 from tests.components.cisco_webex.mocks import MockApiError, MockWebexTeamsAPI
 
 TEST_DATA = {"email": "fff@fff.com"}

--- a/tests/components/cisco_webex/test_config_flow.py
+++ b/tests/components/cisco_webex/test_config_flow.py
@@ -35,8 +35,12 @@ async def test_form(hass):
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
-    assert result2["title"] == "Webex Presence test-email@test.com"
-    assert result2["data"] == {"token": "asdasdas", "email": "test-email@test.com"}
+    assert result2["title"] == "unknown - test-email@test.com"
+    assert result2["data"] == {
+        "token": "asdasdas",
+        "email": "test-email@test.com",
+        "display_name": "unknown",
+    }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/cisco_webex/test_config_flow.py
+++ b/tests/components/cisco_webex/test_config_flow.py
@@ -31,8 +31,8 @@ async def test_form(hass):
     assert result["errors"] is None
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.validate_config",
-            return_value=True,
+        "homeassistant.components.cisco_webex.config_flow.validate_config",
+        return_value=True,
     ), patch(
         "homeassistant.components.cisco_webex.async_setup", return_value=True
     ) as mock_setup, patch(
@@ -68,8 +68,8 @@ async def test_validate_config_not_bot_raises_invalid_token_type(hass):
     """Test validate_config raises InvalidAuthTokenType."""
 
     with patch(
-            "tests.components.cisco_webex.mocks.MockPerson.type",
-            return_value="person",
+        "tests.components.cisco_webex.mocks.MockPerson.type",
+        return_value="person",
     ):
         with pytest.raises(InvalidAuthTokenType):
             validate_config(MOCK_API, TEST_DATA)
@@ -81,8 +81,8 @@ async def test_validate_config_raises_email_not_found_api_error(hass):
     exception_to_raise = MockApiError
     exception_to_raise.status_code = 400
     with patch(
-            "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
-            side_effect=exception_to_raise,
+        "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
+        side_effect=exception_to_raise,
     ):
         with pytest.raises(EmailNotFound):
             validate_config(MOCK_API, TEST_DATA)
@@ -91,8 +91,8 @@ async def test_validate_config_raises_email_not_found_api_error(hass):
 async def test_validate_config_raises_email_not_found_person_none(hass):
     """Test validate_config raises EmailNotFound."""
     with patch(
-            "tests.components.cisco_webex.mocks.MockPeopleAPI.list",
-            return_value=[],
+        "tests.components.cisco_webex.mocks.MockPeopleAPI.list",
+        return_value=[],
     ):
         with pytest.raises(EmailNotFound):
             validate_config(MOCK_API, TEST_DATA)
@@ -104,8 +104,8 @@ async def test_validate_config_raises_invalid_auth_api_error(hass):
     exception_to_raise = MockApiError
     exception_to_raise.status_code = 401
     with patch(
-            "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
-            side_effect=exception_to_raise,
+        "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
+        side_effect=exception_to_raise,
     ):
         with pytest.raises(InvalidAuth):
             validate_config(MOCK_API, TEST_DATA)
@@ -117,8 +117,8 @@ async def test_validate_config_raises_general_error(hass):
     exception_to_raise = MockApiError
     exception_to_raise.status_code = 500
     with patch(
-            "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
-            side_effect=exception_to_raise,
+        "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
+        side_effect=exception_to_raise,
     ):
         with pytest.raises(exception_to_raise):
             validate_config(MOCK_API, TEST_DATA)
@@ -130,8 +130,8 @@ async def test_validate_config_raises_cannot_connect_error(hass):
     exception_to_raise = MockApiError
     exception_to_raise.status_code = 500
     with patch(
-            "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
-            side_effect=requests.exceptions.ConnectionError,
+        "tests.components.cisco_webex.mocks.MockPeopleAPI.me",
+        side_effect=requests.exceptions.ConnectionError,
     ):
         with pytest.raises(CannotConnect):
             validate_config(MOCK_API, TEST_DATA)
@@ -144,8 +144,8 @@ async def test_form_invalid_email(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.validate_config",
-            side_effect=InvalidEmail,
+        "homeassistant.components.cisco_webex.config_flow.validate_config",
+        side_effect=InvalidEmail,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -163,8 +163,8 @@ async def test_form_email_not_found(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.validate_config",
-            side_effect=EmailNotFound,
+        "homeassistant.components.cisco_webex.config_flow.validate_config",
+        side_effect=EmailNotFound,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -182,8 +182,8 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.validate_config",
-            side_effect=InvalidAuth,
+        "homeassistant.components.cisco_webex.config_flow.validate_config",
+        side_effect=InvalidAuth,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -201,8 +201,8 @@ async def test_form_general_exception(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.validate_config",
-            side_effect=Exception,
+        "homeassistant.components.cisco_webex.config_flow.validate_config",
+        side_effect=Exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -220,8 +220,8 @@ async def test_form_invalid_auth_token_type(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.validate_config",
-            side_effect=InvalidAuthTokenType,
+        "homeassistant.components.cisco_webex.config_flow.validate_config",
+        side_effect=InvalidAuthTokenType,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -239,8 +239,8 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.validate_config",
-            side_effect=CannotConnect,
+        "homeassistant.components.cisco_webex.config_flow.validate_config",
+        side_effect=CannotConnect,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/cisco_webex/test_config_flow.py
+++ b/tests/components/cisco_webex/test_config_flow.py
@@ -1,20 +1,20 @@
 """Test the Cisco Webex config flow."""
 import pytest
 import requests
-import webexteamssdk
 
 from homeassistant import config_entries, setup
 from homeassistant.components.cisco_webex.config_flow import (
     CannotConnect,
+    ConfigValidationHub,
     EmailNotFound,
-    InvalidEmail,
-    InvalidAuthTokenType,
     InvalidAuth,
-    ConfigValidationHub
+    InvalidAuthTokenType,
+    InvalidEmail,
 )
 from homeassistant.components.cisco_webex.const import DOMAIN
+
 from tests.async_mock import patch
-from tests.components.cisco_webex.mocks import MockWebexTeamsAPI, MockApiError
+from tests.components.cisco_webex.mocks import MockApiError, MockWebexTeamsAPI
 
 TEST_DATA = {
     "email": "fff@fff.com"

--- a/tests/components/cisco_webex/test_config_flow.py
+++ b/tests/components/cisco_webex/test_config_flow.py
@@ -1,0 +1,98 @@
+"""Test the Cisco Webex config flow."""
+from homeassistant import config_entries, setup
+from homeassistant.components.cisco_webex.config_flow import (
+    CannotConnect,
+    EmailNotFound,
+    InvalidEmail,
+)
+from homeassistant.components.cisco_webex.const import DOMAIN
+
+from tests.async_mock import patch
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.cisco_webex.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.cisco_webex.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"token": "asdasdas", "email": "test-email@test.com"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Webex Presence test-email@test.com"
+    assert result2["data"] == {"token": "asdasdas", "email": "test-email@test.com"}
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_email(hass):
+    """Test we handle invalid email format."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+        side_effect=InvalidEmail,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"token": "asdasdas", "email": "test-email"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_email"}
+
+
+async def test_form_email_not_found(hass):
+    """Test we handle email not found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+        side_effect=EmailNotFound,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"token": "asdasdas", "email": "test-email@test.com"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "email_not_found"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"token": "asdasdas", "email": "test-email@test.com"},
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/cisco_webex/test_config_flow.py
+++ b/tests/components/cisco_webex/test_config_flow.py
@@ -8,16 +8,15 @@ from homeassistant.components.cisco_webex.config_flow import (
     EmailNotFound,
     InvalidAuth,
     InvalidAuthTokenType,
-    InvalidEmail, validate_config,
+    InvalidEmail,
+    validate_config,
 )
 from homeassistant.components.cisco_webex.const import DOMAIN
 
 from tests.async_mock import patch
 from tests.components.cisco_webex.mocks import MockApiError, MockWebexTeamsAPI
 
-TEST_DATA = {
-    "email": "fff@fff.com"
-}
+TEST_DATA = {"email": "fff@fff.com"}
 
 MOCK_API = MockWebexTeamsAPI(access_token="123")
 
@@ -60,8 +59,7 @@ async def test_form(hass):
 async def test_validate_config_ok(hass):
     """Test validate_config method."""
 
-    result = validate_config(
-        MOCK_API, TEST_DATA)
+    result = validate_config(MOCK_API, TEST_DATA)
 
     assert result is True
 
@@ -74,8 +72,7 @@ async def test_validate_config_not_bot_raises_invalid_token_type(hass):
             return_value="person",
     ):
         with pytest.raises(InvalidAuthTokenType):
-            validate_config(
-                MOCK_API, TEST_DATA)
+            validate_config(MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_email_not_found_api_error(hass):
@@ -88,8 +85,7 @@ async def test_validate_config_raises_email_not_found_api_error(hass):
             side_effect=exception_to_raise,
     ):
         with pytest.raises(EmailNotFound):
-            validate_config(
-                MOCK_API, TEST_DATA)
+            validate_config(MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_email_not_found_person_none(hass):
@@ -99,8 +95,7 @@ async def test_validate_config_raises_email_not_found_person_none(hass):
             return_value=[],
     ):
         with pytest.raises(EmailNotFound):
-            validate_config(
-                MOCK_API, TEST_DATA)
+            validate_config(MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_invalid_auth_api_error(hass):
@@ -113,8 +108,7 @@ async def test_validate_config_raises_invalid_auth_api_error(hass):
             side_effect=exception_to_raise,
     ):
         with pytest.raises(InvalidAuth):
-            validate_config(
-                MOCK_API, TEST_DATA)
+            validate_config(MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_general_error(hass):
@@ -127,8 +121,7 @@ async def test_validate_config_raises_general_error(hass):
             side_effect=exception_to_raise,
     ):
         with pytest.raises(exception_to_raise):
-            validate_config(
-                MOCK_API, TEST_DATA)
+            validate_config(MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_cannot_connect_error(hass):
@@ -141,8 +134,7 @@ async def test_validate_config_raises_cannot_connect_error(hass):
             side_effect=requests.exceptions.ConnectionError,
     ):
         with pytest.raises(CannotConnect):
-            validate_config(
-                MOCK_API, TEST_DATA)
+            validate_config(MOCK_API, TEST_DATA)
 
 
 async def test_form_invalid_email(hass):

--- a/tests/components/cisco_webex/test_config_flow.py
+++ b/tests/components/cisco_webex/test_config_flow.py
@@ -5,11 +5,10 @@ import requests
 from homeassistant import config_entries, setup
 from homeassistant.components.cisco_webex.config_flow import (
     CannotConnect,
-    ConfigValidationHub,
     EmailNotFound,
     InvalidAuth,
     InvalidAuthTokenType,
-    InvalidEmail,
+    InvalidEmail, validate_config,
 )
 from homeassistant.components.cisco_webex.const import DOMAIN
 
@@ -33,7 +32,7 @@ async def test_form(hass):
     assert result["errors"] is None
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+            "homeassistant.components.cisco_webex.config_flow.validate_config",
             return_value=True,
     ), patch(
         "homeassistant.components.cisco_webex.async_setup", return_value=True
@@ -61,7 +60,7 @@ async def test_form(hass):
 async def test_validate_config_ok(hass):
     """Test validate_config method."""
 
-    result = ConfigValidationHub().validate_config(
+    result = validate_config(
         MOCK_API, TEST_DATA)
 
     assert result is True
@@ -75,7 +74,7 @@ async def test_validate_config_not_bot_raises_invalid_token_type(hass):
             return_value="person",
     ):
         with pytest.raises(InvalidAuthTokenType):
-            ConfigValidationHub().validate_config(
+            validate_config(
                 MOCK_API, TEST_DATA)
 
 
@@ -89,7 +88,7 @@ async def test_validate_config_raises_email_not_found_api_error(hass):
             side_effect=exception_to_raise,
     ):
         with pytest.raises(EmailNotFound):
-            ConfigValidationHub().validate_config(
+            validate_config(
                 MOCK_API, TEST_DATA)
 
 
@@ -100,12 +99,12 @@ async def test_validate_config_raises_email_not_found_person_none(hass):
             return_value=[],
     ):
         with pytest.raises(EmailNotFound):
-            ConfigValidationHub().validate_config(
+            validate_config(
                 MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_invalid_auth_api_error(hass):
-    """Test validate_config raises InvalidAuth."""
+    """Test validate_config raises InvalidAuth via Api error."""
 
     exception_to_raise = MockApiError
     exception_to_raise.status_code = 401
@@ -114,12 +113,12 @@ async def test_validate_config_raises_invalid_auth_api_error(hass):
             side_effect=exception_to_raise,
     ):
         with pytest.raises(InvalidAuth):
-            ConfigValidationHub().validate_config(
+            validate_config(
                 MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_general_error(hass):
-    """Test validate_config raises api error."""
+    """Test validate_config raises general error."""
 
     exception_to_raise = MockApiError
     exception_to_raise.status_code = 500
@@ -128,12 +127,12 @@ async def test_validate_config_raises_general_error(hass):
             side_effect=exception_to_raise,
     ):
         with pytest.raises(exception_to_raise):
-            ConfigValidationHub().validate_config(
+            validate_config(
                 MOCK_API, TEST_DATA)
 
 
 async def test_validate_config_raises_cannot_connect_error(hass):
-    """Test validate_config raises api error."""
+    """Test validate_config raises cannot connect error."""
 
     exception_to_raise = MockApiError
     exception_to_raise.status_code = 500
@@ -142,18 +141,18 @@ async def test_validate_config_raises_cannot_connect_error(hass):
             side_effect=requests.exceptions.ConnectionError,
     ):
         with pytest.raises(CannotConnect):
-            ConfigValidationHub().validate_config(
+            validate_config(
                 MOCK_API, TEST_DATA)
 
 
 async def test_form_invalid_email(hass):
-    """Test we handle invalid email format."""
+    """Test form handles invalid email format."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+            "homeassistant.components.cisco_webex.config_flow.validate_config",
             side_effect=InvalidEmail,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -166,13 +165,13 @@ async def test_form_invalid_email(hass):
 
 
 async def test_form_email_not_found(hass):
-    """Test we handle email not found."""
+    """Test form handles email not found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+            "homeassistant.components.cisco_webex.config_flow.validate_config",
             side_effect=EmailNotFound,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -191,7 +190,7 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+            "homeassistant.components.cisco_webex.config_flow.validate_config",
             side_effect=InvalidAuth,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -210,7 +209,7 @@ async def test_form_general_exception(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+            "homeassistant.components.cisco_webex.config_flow.validate_config",
             side_effect=Exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -229,7 +228,7 @@ async def test_form_invalid_auth_token_type(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+            "homeassistant.components.cisco_webex.config_flow.validate_config",
             side_effect=InvalidAuthTokenType,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -248,7 +247,7 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-            "homeassistant.components.cisco_webex.config_flow.ConfigValidationHub.validate_config",
+            "homeassistant.components.cisco_webex.config_flow.validate_config",
             side_effect=CannotConnect,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/cisco_webex/test_init.py
+++ b/tests/components/cisco_webex/test_init.py
@@ -1,0 +1,48 @@
+"""Test the Cisco Webex config flow."""
+
+from homeassistant.components.cisco_webex import (
+    async_setup,
+    async_setup_entry,
+    async_unload_entry,
+)
+from homeassistant.components.cisco_webex.const import DOMAIN
+
+from tests.common import MockConfigEntry
+from tests.components.cisco_webex.mocks import MockWebexTeamsAPI
+
+TEST_DATA = {
+    "email": "fff@fff.com"
+}
+
+MOCK_API = MockWebexTeamsAPI(access_token="123")
+MOCK_CONFIG = {"token": "123", "email": "ff@ff.com"}
+MOCK_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN,
+    data=MOCK_CONFIG,
+    unique_id="0923"
+)
+
+
+async def test_init_setup(hass):
+    """Test init setup method."""
+    setup_result = await async_setup(hass, MOCK_CONFIG)
+    assert setup_result is True
+
+
+async def test_init_setup_entry(hass):
+    """Test init setup entry method."""
+    hass.data.setdefault(DOMAIN, {})
+    setup_entry_result = await async_setup_entry(hass, MOCK_CONFIG_ENTRY)
+    assert setup_entry_result is True
+
+
+async def test_unload_entry(hass):
+    """Test being able to unload an entry."""
+    MOCK_CONFIG_ENTRY.add_to_hass(hass)
+    await hass.config_entries.async_setup(MOCK_CONFIG_ENTRY.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.data[DOMAIN]
+
+    assert await async_unload_entry(hass, MOCK_CONFIG_ENTRY)
+    assert not hass.data[DOMAIN]

--- a/tests/components/cisco_webex/test_init.py
+++ b/tests/components/cisco_webex/test_init.py
@@ -10,17 +10,11 @@ from homeassistant.components.cisco_webex.const import DOMAIN
 from tests.common import MockConfigEntry
 from tests.components.cisco_webex.mocks import MockWebexTeamsAPI
 
-TEST_DATA = {
-    "email": "fff@fff.com"
-}
+TEST_DATA = {"email": "fff@fff.com"}
 
 MOCK_API = MockWebexTeamsAPI(access_token="123")
 MOCK_CONFIG = {"token": "123", "email": "ff@ff.com"}
-MOCK_CONFIG_ENTRY = MockConfigEntry(
-    domain=DOMAIN,
-    data=MOCK_CONFIG,
-    unique_id="0923"
-)
+MOCK_CONFIG_ENTRY = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, unique_id="0923")
 
 
 async def test_init_setup(hass):

--- a/tests/components/cisco_webex/test_sensor.py
+++ b/tests/components/cisco_webex/test_sensor.py
@@ -1,0 +1,29 @@
+"""Test the Cisco Webex config flow."""
+
+from homeassistant.components.cisco_webex.sensor import WebexPresenceSensor
+
+from tests.async_mock import patch
+from tests.components.cisco_webex.mocks import MockWebexTeamsAPI
+
+MOCK_API = MockWebexTeamsAPI(access_token="123")
+
+
+async def test_update(hass):
+    """Test update method."""
+
+    WebexPresenceSensor(
+        api=MOCK_API,
+        email="test@123.com",
+        name="Name").update()
+
+
+async def test_update_people_not_found(hass):
+    """Test update finds no people."""
+    with patch(
+            "tests.components.cisco_webex.mocks.MockPeopleAPI.list",
+            return_value=[],
+    ):
+        WebexPresenceSensor(
+            api=MOCK_API,
+            email="test@123.com",
+            name="Name").update()

--- a/tests/components/cisco_webex/test_sensor.py
+++ b/tests/components/cisco_webex/test_sensor.py
@@ -6,15 +6,25 @@ from tests.async_mock import patch
 from tests.components.cisco_webex.mocks import MockWebexTeamsAPI
 
 MOCK_API = MockWebexTeamsAPI(access_token="123")
+SENSOR = WebexPresenceSensor(
+    api=MOCK_API,
+    email="test@123.com",
+    name="Name")
 
 
 async def test_update(hass):
-    """Test update method."""
+    """Test update success."""
 
-    WebexPresenceSensor(
+    sensor = WebexPresenceSensor(
         api=MOCK_API,
         email="test@123.com",
-        name="Name").update()
+        name="Name")
+    sensor.update()
+
+    assert sensor._status == "active"
+    assert sensor._avatar == "http://www.com/pic.png"
+    assert sensor._name == "Webex Test user"
+    assert sensor._user_id == "77777"
 
 
 async def test_update_people_not_found(hass):
@@ -23,7 +33,13 @@ async def test_update_people_not_found(hass):
             "tests.components.cisco_webex.mocks.MockPeopleAPI.list",
             return_value=[],
     ):
-        WebexPresenceSensor(
+        sensor = WebexPresenceSensor(
             api=MOCK_API,
             email="test@123.com",
-            name="Name").update()
+            name="Name")
+        sensor.update()
+
+    assert sensor._status is None
+    assert sensor._avatar is None
+    assert sensor._name == "Name"
+    assert sensor._user_id is None

--- a/tests/components/cisco_webex/test_sensor.py
+++ b/tests/components/cisco_webex/test_sensor.py
@@ -24,8 +24,8 @@ async def test_update(hass):
 async def test_update_people_not_found(hass):
     """Test update finds no people."""
     with patch(
-            "tests.components.cisco_webex.mocks.MockPeopleAPI.list",
-            return_value=[],
+        "tests.components.cisco_webex.mocks.MockPeopleAPI.list",
+        return_value=[],
     ):
         sensor = WebexPresenceSensor(api=MOCK_API, email="test@123.com", name="Name")
         sensor.update()

--- a/tests/components/cisco_webex/test_sensor.py
+++ b/tests/components/cisco_webex/test_sensor.py
@@ -1,8 +1,9 @@
 """Test the Cisco Webex config flow."""
 
+from unittest.mock import patch
+
 from homeassistant.components.cisco_webex.sensor import WebexPresenceSensor
 
-from tests.async_mock import patch
 from tests.components.cisco_webex.mocks import MockWebexTeamsAPI
 
 MOCK_API = MockWebexTeamsAPI(access_token="123")

--- a/tests/components/cisco_webex/test_sensor.py
+++ b/tests/components/cisco_webex/test_sensor.py
@@ -6,19 +6,13 @@ from tests.async_mock import patch
 from tests.components.cisco_webex.mocks import MockWebexTeamsAPI
 
 MOCK_API = MockWebexTeamsAPI(access_token="123")
-SENSOR = WebexPresenceSensor(
-    api=MOCK_API,
-    email="test@123.com",
-    name="Name")
+SENSOR = WebexPresenceSensor(api=MOCK_API, email="test@123.com", name="Name")
 
 
 async def test_update(hass):
     """Test update success."""
 
-    sensor = WebexPresenceSensor(
-        api=MOCK_API,
-        email="test@123.com",
-        name="Name")
+    sensor = WebexPresenceSensor(api=MOCK_API, email="test@123.com", name="Name")
     sensor.update()
 
     assert sensor._status == "active"
@@ -33,10 +27,7 @@ async def test_update_people_not_found(hass):
             "tests.components.cisco_webex.mocks.MockPeopleAPI.list",
             return_value=[],
     ):
-        sensor = WebexPresenceSensor(
-            api=MOCK_API,
-            email="test@123.com",
-            name="Name")
+        sensor = WebexPresenceSensor(api=MOCK_API, email="test@123.com", name="Name")
         sensor.update()
 
     assert sensor._status is None


### PR DESCRIPTION
## Proposed change

### Note
* This is a replacement for PR #44331
* This is a re-write of that PR to use config flow and 100% unit test coverage.

### Summary
Using [Webex Developer API](https://developer.webex.com/docs/api/v1/people/get-person-details)'s, it is possible to get the current status of any users which are sharing presence. This sensor polls that API for a specific user, and sets state in HA based on user status. It also sets lots of other attributes as returned in the payload.

* This PR adds a new integration, added via config flow, which performs validation on the token and email entered.

<img width="396" alt="image" src="https://user-images.githubusercontent.com/254309/104808681-ba4f1300-57df-11eb-8e32-aff0e19710be.png">
* The integration can be added by the user many times, to have a sensor on multiple persons presence in their team or office.

* This will enable a user to automate things like, changing a light colour based on being in a meeting, presenting, inactive or active.

* `notify` will also be added in a future PR. Right now, just the sensor is added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44331
- Link to documentation pull request:  **🚧 WIP 🚧**

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] **🚧 WIP 🚧**

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
