### PR TITLE
Prettier Zeroconf discovery name for Axis devices

### DIFF
--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -49,6 +49,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
         self.device_config = {}
         self.discovery_schema = {}
         self.import_schema = {}
+        self.serial = None
 
     async def async_step_user(self, user_input=None):
         """Handle a Axis config flow start.
@@ -67,7 +68,8 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
                     password=user_input[CONF_PASSWORD],
                 )
 
-                await self.async_set_unique_id(format_mac(device.vapix.serial_number))
+                self.serial = device.vapix.serial_number
+                await self.async_set_unique_id(format_mac(self.serial))
 
                 self._abort_if_unique_id_configured(
                     updates={
@@ -126,7 +128,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
 
         self.device_config[CONF_NAME] = name
 
-        title = f"{model} - {self.unique_id}"
+        title = f"{model} - {self.serial}"
         return self.async_create_entry(title=title, data=self.device_config)
 
     async def async_step_dhcp(self, discovery_info: dict):

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -29,15 +29,6 @@ from .device import get_device
 from .errors import AuthenticationRequired, CannotConnect
 
 AXIS_OUI = {"00:40:8c", "ac:cc:8e", "b8:a4:4f"}
-
-CONFIG_FILE = "axis.conf"
-
-EVENT_TYPES = ["motion", "vmd3", "pir", "sound", "daynight", "tampering", "input"]
-
-PLATFORMS = ["camera"]
-
-AXIS_INCLUDE = EVENT_TYPES + PLATFORMS
-
 DEFAULT_PORT = 80
 
 
@@ -155,7 +146,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
             {
                 CONF_HOST: discovery_info[CONF_HOST],
                 CONF_MAC: format_mac(discovery_info["properties"]["macaddress"]),
-                CONF_NAME: discovery_info["hostname"][:-7],
+                CONF_NAME: discovery_info["name"].split(".", 1)[0],
                 CONF_PORT: discovery_info[CONF_PORT],
             }
         )

--- a/homeassistant/components/axis/strings.json
+++ b/homeassistant/components/axis/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Axis device: {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "user": {
         "title": "Set up Axis device",

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -376,10 +376,15 @@ async def test_zeroconf_flow(hass):
     result = await hass.config_entries.flow.async_init(
         AXIS_DOMAIN,
         data={
-            CONF_HOST: "1.2.3.4",
-            CONF_PORT: 80,
-            "hostname": "name",
-            "properties": {"macaddress": MAC},
+            "host": "1.2.3.4",
+            "port": 80,
+            "hostname": f"axis-{MAC.lower()}.local.",
+            "type": "_axis-video._tcp.local.",
+            "name": f"AXIS M1065-L - {MAC}._axis-video._tcp.local.",
+            "properties": {
+                "_raw": {"macaddress": MAC.encode()},
+                "macaddress": MAC,
+            },
         },
         context={"source": SOURCE_ZEROCONF},
     )
@@ -424,7 +429,7 @@ async def test_zeroconf_flow_already_configured(hass):
         data={
             CONF_HOST: "1.2.3.4",
             CONF_PORT: 80,
-            "hostname": "name",
+            "name": "name",
             "properties": {"macaddress": MAC},
         },
         context={"source": SOURCE_ZEROCONF},
@@ -459,7 +464,7 @@ async def test_zeroconf_flow_updated_configuration(hass):
             data={
                 CONF_HOST: "2.3.4.5",
                 CONF_PORT: 8080,
-                "hostname": "name",
+                "name": "name",
                 "properties": {"macaddress": MAC},
             },
             context={"source": SOURCE_ZEROCONF},
@@ -486,7 +491,7 @@ async def test_zeroconf_flow_ignore_non_axis_device(hass):
         data={
             CONF_HOST: "169.254.3.4",
             CONF_PORT: 80,
-            "hostname": "",
+            "name": "",
             "properties": {"macaddress": "01234567890"},
         },
         context={"source": SOURCE_ZEROCONF},
@@ -503,7 +508,7 @@ async def test_zeroconf_flow_ignore_link_local_address(hass):
         data={
             CONF_HOST: "169.254.3.4",
             CONF_PORT: 80,
-            "hostname": "",
+            "name": "",
             "properties": {"macaddress": MAC},
         },
         context={"source": SOURCE_ZEROCONF},

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -33,7 +33,6 @@ from homeassistant.data_entry_flow import (
 )
 
 from .test_device import (
-    FORMATTED_MAC,
     MAC,
     MODEL,
     NAME,
@@ -68,7 +67,7 @@ async def test_flow_manual_configuration(hass):
         )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {FORMATTED_MAC}"
+    assert result["title"] == f"M1065-LW - {MAC}"
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
         CONF_USERNAME: "user",
@@ -225,7 +224,7 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(hass):
         )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {FORMATTED_MAC}"
+    assert result["title"] == f"M1065-LW - {MAC}"
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
         CONF_USERNAME: "user",
@@ -266,7 +265,7 @@ async def test_dhcp_flow(hass):
         )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {FORMATTED_MAC}"
+    assert result["title"] == f"M1065-LW - {MAC}"
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
         CONF_USERNAME: "user",
@@ -405,7 +404,7 @@ async def test_zeroconf_flow(hass):
         )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == f"M1065-LW - {FORMATTED_MAC}"
+    assert result["title"] == f"M1065-LW - {MAC}"
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
         CONF_USERNAME: "user",

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -378,7 +378,7 @@ async def test_update_address(hass):
             data={
                 "host": "2.3.4.5",
                 "port": 80,
-                "hostname": "name",
+                "name": "name",
                 "properties": {"macaddress": MAC},
             },
             context={"source": SOURCE_ZEROCONF},


### PR DESCRIPTION

Have a full zeroconf discovery message in tests
Clean up unusued globals

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change zeroconf name to be based of prettier name rather than hostname to help user understand what device is discovered
It will be "AXIS M1065-L - 00408C123456 (IP)" rather than "Axis device: axis-00408c123456 (IP)"
Config entry title will look very similar as well "M1065-L - 00408C123456" rather than "M1065-L - 00:40:8c:12:34:56"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
