### PR TITLE
Improve Roon media player play_media

### DIFF
--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
   "requirements": [
-    "roonapi==0.0.30"
+    "roonapi==0.0.31"
   ],
   "codeowners": [
     "@pavoni"

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -1,7 +1,7 @@
 """MediaPlayer platform for Roon integration."""
 import logging
-import os
 
+from roonapi import split_media_path
 import voluptuous as vol
 
 from homeassistant.components.media_player import MediaPlayerEntity
@@ -477,22 +477,7 @@ class RoonDevice(MediaPlayerEntity):
         """Send the play_media command to the media player."""
         # media_id is treated as a path matching the Roon menu structure
 
-        def splitall(path):
-            allparts = []
-            while 1:
-                parts = os.path.split(path)
-                if parts[0] == path:  # sentinel for absolute paths
-                    allparts.insert(0, parts[0])
-                    break
-                elif parts[1] == path:  # sentinel for relative paths
-                    allparts.insert(0, parts[1])
-                    break
-                else:
-                    path = parts[0]
-                    allparts.insert(0, parts[1])
-            return allparts
-
-        path_list = splitall(media_id)
+        path_list = split_media_path(media_id)
         if not self._server.roonapi.play_media(self.zone_id, path_list):
             _LOGGER.error(
                 "Playback request for %s / %s was unsuccessful", media_id, path_list

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1955,7 +1955,7 @@ rokuecp==0.6.0
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.30
+roonapi==0.0.31
 
 # homeassistant.components.rova
 rova==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -966,7 +966,7 @@ rokuecp==0.6.0
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.30
+roonapi==0.0.31
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This PR changes how the `play_media` call works for roon players.

The previous implementation was very limited - but anyone using it in automations will need to change their calls to the new structure.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR contains a rewrite of the `play_media` call. Previously this couldn't navigate the roon library properly - and so limited users to playing top level items. The previous code also hard coded roon API strings. A roon software release late last year required a HA patch to resolve - this code removes that dependency.

The new code allow media_id to be a path, so that a media_id of `Library/Artists/Neil Young/Harvest` will play an album and `My Live Radio/BBC Radio 4` will play a radio station. Some helpful error messages have been added to the roon library - to assist people in navigating their library. I will also update the HA documentation.

The path parser is in the roon library - which required a version bump. That is the only change.

https://github.com/pavoni/pyroon/compare/0.0.30...0.0.31

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16213

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
