### PR TITLE
Create shortcuts for config entry parameters in Axis device

### DIFF
--- a/homeassistant/components/axis/camera.py
+++ b/homeassistant/components/axis/camera.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_NAME,
     CONF_PASSWORD,
-    CONF_PORT,
     CONF_USERNAME,
     HTTP_DIGEST_AUTHENTICATION,
 )
@@ -41,9 +40,9 @@ class AxisCamera(AxisEntityBase, MjpegCamera):
         AxisEntityBase.__init__(self, device)
 
         config = {
-            CONF_NAME: device.config_entry.data[CONF_NAME],
-            CONF_USERNAME: device.config_entry.data[CONF_USERNAME],
-            CONF_PASSWORD: device.config_entry.data[CONF_PASSWORD],
+            CONF_NAME: device.name,
+            CONF_USERNAME: device.username,
+            CONF_PASSWORD: device.password,
             CONF_MJPEG_URL: self.mjpeg_source,
             CONF_STILL_IMAGE_URL: self.image_source,
             CONF_AUTHENTICATION: HTTP_DIGEST_AUTHENTICATION,
@@ -78,7 +77,7 @@ class AxisCamera(AxisEntityBase, MjpegCamera):
     @property
     def image_source(self):
         """Return still image URL for device."""
-        return f"http://{self.device.host}:{self.device.config_entry.data[CONF_PORT]}/axis-cgi/jpg/image.cgi"
+        return f"http://{self.device.host}:{self.device.port}/axis-cgi/jpg/image.cgi"
 
     @property
     def mjpeg_source(self):
@@ -87,7 +86,7 @@ class AxisCamera(AxisEntityBase, MjpegCamera):
         if self.device.option_stream_profile != DEFAULT_STREAM_PROFILE:
             options = f"?&streamprofile={self.device.option_stream_profile}"
 
-        return f"http://{self.device.host}:{self.device.config_entry.data[CONF_PORT]}/axis-cgi/mjpg/video.cgi{options}"
+        return f"http://{self.device.host}:{self.device.port}/axis-cgi/mjpg/video.cgi{options}"
 
     async def stream_source(self):
         """Return the stream source."""
@@ -95,4 +94,4 @@ class AxisCamera(AxisEntityBase, MjpegCamera):
         if self.device.option_stream_profile != DEFAULT_STREAM_PROFILE:
             options = f"&streamprofile={self.device.option_stream_profile}"
 
-        return f"rtsp://{self.device.config_entry.data[CONF_USERNAME]}:{self.device.config_entry.data[CONF_PASSWORD]}@{self.device.host}/axis-media/media.amp?videocodec=h264{options}"
+        return f"rtsp://{self.device.username}:{self.device.password}@{self.device.host}/axis-media/media.amp?videocodec=h264{options}"

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -60,8 +60,23 @@ class AxisNetworkDevice:
 
     @property
     def host(self):
-        """Return the host of this device."""
+        """Return the host address of this device."""
         return self.config_entry.data[CONF_HOST]
+
+    @property
+    def port(self):
+        """Return the HTTP port of this device."""
+        return self.config_entry.data[CONF_PORT]
+
+    @property
+    def username(self):
+        """Return the username of this device."""
+        return self.config_entry.data[CONF_USERNAME]
+
+    @property
+    def password(self):
+        """Return the password of this device."""
+        return self.config_entry.data[CONF_PASSWORD]
 
     @property
     def model(self):
@@ -189,10 +204,10 @@ class AxisNetworkDevice:
         try:
             self.api = await get_device(
                 self.hass,
-                host=self.config_entry.data[CONF_HOST],
-                port=self.config_entry.data[CONF_PORT],
-                username=self.config_entry.data[CONF_USERNAME],
-                password=self.config_entry.data[CONF_PASSWORD],
+                host=self.host,
+                port=self.port,
+                username=self.username,
+                password=self.password,
             )
 
         except CannotConnect as err:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minor refactoring removing direct access to config entry object outside of axis device class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
