### PR TITLE
Update xknx to 0.16.1 - register services

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -5,7 +5,6 @@ import logging
 import voluptuous as vol
 from xknx import XKNX
 from xknx.core.telegram_queue import TelegramQueue
-from xknx.devices import DateTime, ExposeSensor
 from xknx.dpt import DPTArray, DPTBase, DPTBinary
 from xknx.exceptions import XKNXException
 from xknx.io import (
@@ -18,26 +17,20 @@ from xknx.telegram import AddressFilter, GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueResponse, GroupValueWrite
 
 from homeassistant.const import (
-    CONF_ENTITY_ID,
     CONF_HOST,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
     SERVICE_RELOAD,
-    STATE_OFF,
-    STATE_ON,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
 )
-from homeassistant.core import callback
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import async_get_platforms
-from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ServiceCallType
 
 from .const import DOMAIN, SupportedPlatforms
+from .expose import create_knx_exposure
 from .factory import create_knx_device
 from .schema import (
     BinarySensorSchema,
@@ -174,13 +167,18 @@ async def async_setup(hass, config):
     """Set up the KNX component."""
     try:
         hass.data[DOMAIN] = KNXModule(hass, config)
-        hass.data[DOMAIN].async_create_exposures()
         await hass.data[DOMAIN].start()
     except XKNXException as ex:
         _LOGGER.warning("Could not connect to KNX interface: %s", ex)
         hass.components.persistent_notification.async_create(
             f"Could not connect to KNX interface: <br><b>{ex}</b>", title="KNX"
         )
+
+    if CONF_KNX_EXPOSE in config[DOMAIN]:
+        for expose_config in config[DOMAIN][CONF_KNX_EXPOSE]:
+            hass.data[DOMAIN].exposures.append(
+                create_knx_exposure(hass, hass.data[DOMAIN].xknx, expose_config)
+            )
 
     for platform in SupportedPlatforms:
         if platform.value in config[DOMAIN]:
@@ -316,34 +314,6 @@ class KNXModule:
             auto_reconnect=True,
         )
 
-    @callback
-    def async_create_exposures(self):
-        """Create exposures."""
-        if CONF_KNX_EXPOSE not in self.config[DOMAIN]:
-            return
-        for to_expose in self.config[DOMAIN][CONF_KNX_EXPOSE]:
-            expose_type = to_expose.get(ExposeSchema.CONF_KNX_EXPOSE_TYPE)
-            entity_id = to_expose.get(CONF_ENTITY_ID)
-            attribute = to_expose.get(ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE)
-            default = to_expose.get(ExposeSchema.CONF_KNX_EXPOSE_DEFAULT)
-            address = to_expose.get(ExposeSchema.CONF_KNX_EXPOSE_ADDRESS)
-            if expose_type.lower() in ["time", "date", "datetime"]:
-                exposure = KNXExposeTime(self.xknx, expose_type, address)
-                exposure.async_register()
-                self.exposures.append(exposure)
-            else:
-                exposure = KNXExposeSensor(
-                    self.hass,
-                    self.xknx,
-                    expose_type,
-                    entity_id,
-                    attribute,
-                    default,
-                    address,
-                )
-                exposure.async_register()
-                self.exposures.append(exposure)
-
     async def telegram_received_cb(self, telegram):
         """Call invoked after a KNX telegram was received."""
         data = None
@@ -404,93 +374,3 @@ class KNXModule:
             payload=GroupValueWrite(calculate_payload(attr_payload)),
         )
         await self.xknx.telegrams.put(telegram)
-
-
-class KNXExposeTime:
-    """Object to Expose Time/Date object to KNX bus."""
-
-    def __init__(self, xknx: XKNX, expose_type: str, address: str):
-        """Initialize of Expose class."""
-        self.xknx = xknx
-        self.expose_type = expose_type
-        self.address = address
-        self.device = None
-
-    @callback
-    def async_register(self):
-        """Register listener."""
-        self.device = DateTime(
-            self.xknx,
-            name=self.expose_type.capitalize(),
-            broadcast_type=self.expose_type.upper(),
-            localtime=True,
-            group_address=self.address,
-        )
-
-
-class KNXExposeSensor:
-    """Object to Expose Home Assistant entity to KNX bus."""
-
-    def __init__(self, hass, xknx, expose_type, entity_id, attribute, default, address):
-        """Initialize of Expose class."""
-        self.hass = hass
-        self.xknx = xknx
-        self.type = expose_type
-        self.entity_id = entity_id
-        self.expose_attribute = attribute
-        self.expose_default = default
-        self.address = address
-        self.device = None
-
-    @callback
-    def async_register(self):
-        """Register listener."""
-        if self.expose_attribute is not None:
-            _name = self.entity_id + "__" + self.expose_attribute
-        else:
-            _name = self.entity_id
-        self.device = ExposeSensor(
-            self.xknx,
-            name=_name,
-            group_address=self.address,
-            value_type=self.type,
-        )
-        async_track_state_change_event(
-            self.hass, [self.entity_id], self._async_entity_changed
-        )
-
-    async def _async_entity_changed(self, event):
-        """Handle entity change."""
-        new_state = event.data.get("new_state")
-        if new_state is None:
-            return
-        if new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            return
-
-        if self.expose_attribute is not None:
-            new_attribute = new_state.attributes.get(self.expose_attribute)
-            old_state = event.data.get("old_state")
-
-            if old_state is not None:
-                old_attribute = old_state.attributes.get(self.expose_attribute)
-                if old_attribute == new_attribute:
-                    # don't send same value sequentially
-                    return
-            await self._async_set_knx_value(new_attribute)
-        else:
-            await self._async_set_knx_value(new_state.state)
-
-    async def _async_set_knx_value(self, value):
-        """Set new value on xknx ExposeSensor."""
-        if value is None:
-            if self.expose_default is None:
-                return
-            value = self.expose_default
-
-        if self.type == "binary":
-            if value == STATE_ON:
-                value = True
-            elif value == STATE_OFF:
-                value = False
-
-        await self.device.set(value)

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 import voluptuous as vol
 from xknx import XKNX
+from xknx.core.telegram_queue import TelegramQueue
 from xknx.devices import DateTime, ExposeSensor
 from xknx.dpt import DPTArray, DPTBase, DPTBinary
 from xknx.exceptions import XKNXException
@@ -59,7 +60,7 @@ CONF_KNX_CONFIG = "config_file"
 CONF_KNX_ROUTING = "routing"
 CONF_KNX_TUNNELING = "tunneling"
 CONF_KNX_FIRE_EVENT = "fire_event"
-CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
+CONF_KNX_EVENT_FILTER = "event_filter"
 CONF_KNX_INDIVIDUAL_ADDRESS = "individual_address"
 CONF_KNX_MCAST_GRP = "multicast_group"
 CONF_KNX_MCAST_PORT = "multicast_port"
@@ -71,62 +72,72 @@ SERVICE_KNX_SEND = "send"
 SERVICE_KNX_ATTR_ADDRESS = "address"
 SERVICE_KNX_ATTR_PAYLOAD = "payload"
 SERVICE_KNX_ATTR_TYPE = "type"
+SERVICE_KNX_ATTR_REMOVE = "remove"
+SERVICE_KNX_EVENT_REGISTER = "event_register"
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_KNX_CONFIG): cv.string,
-                vol.Exclusive(
-                    CONF_KNX_ROUTING, "connection_type"
-                ): ConnectionSchema.ROUTING_SCHEMA,
-                vol.Exclusive(
-                    CONF_KNX_TUNNELING, "connection_type"
-                ): ConnectionSchema.TUNNELING_SCHEMA,
-                vol.Inclusive(CONF_KNX_FIRE_EVENT, "fire_ev"): cv.boolean,
-                vol.Inclusive(CONF_KNX_FIRE_EVENT_FILTER, "fire_ev"): vol.All(
-                    cv.ensure_list, [cv.string]
-                ),
-                vol.Optional(
-                    CONF_KNX_INDIVIDUAL_ADDRESS, default=XKNX.DEFAULT_ADDRESS
-                ): cv.string,
-                vol.Optional(CONF_KNX_MCAST_GRP, default=DEFAULT_MCAST_GRP): cv.string,
-                vol.Optional(CONF_KNX_MCAST_PORT, default=DEFAULT_MCAST_PORT): cv.port,
-                vol.Optional(CONF_KNX_STATE_UPDATER, default=True): cv.boolean,
-                vol.Optional(CONF_KNX_RATE_LIMIT, default=20): vol.All(
-                    vol.Coerce(int), vol.Range(min=1, max=100)
-                ),
-                vol.Optional(CONF_KNX_EXPOSE): vol.All(
-                    cv.ensure_list, [ExposeSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.cover.value): vol.All(
-                    cv.ensure_list, [CoverSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.binary_sensor.value): vol.All(
-                    cv.ensure_list, [BinarySensorSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.light.value): vol.All(
-                    cv.ensure_list, [LightSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.climate.value): vol.All(
-                    cv.ensure_list, [ClimateSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.notify.value): vol.All(
-                    cv.ensure_list, [NotifySchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.switch.value): vol.All(
-                    cv.ensure_list, [SwitchSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.sensor.value): vol.All(
-                    cv.ensure_list, [SensorSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.scene.value): vol.All(
-                    cv.ensure_list, [SceneSchema.SCHEMA]
-                ),
-                vol.Optional(SupportedPlatforms.weather.value): vol.All(
-                    cv.ensure_list, [WeatherSchema.SCHEMA]
-                ),
-            }
+        DOMAIN: vol.All(
+            cv.deprecated(CONF_KNX_FIRE_EVENT),
+            cv.deprecated("fire_event_filter", replacement_key=CONF_KNX_EVENT_FILTER),
+            vol.Schema(
+                {
+                    vol.Optional(CONF_KNX_CONFIG): cv.string,
+                    vol.Exclusive(
+                        CONF_KNX_ROUTING, "connection_type"
+                    ): ConnectionSchema.ROUTING_SCHEMA,
+                    vol.Exclusive(
+                        CONF_KNX_TUNNELING, "connection_type"
+                    ): ConnectionSchema.TUNNELING_SCHEMA,
+                    vol.Optional(CONF_KNX_FIRE_EVENT): cv.boolean,
+                    vol.Optional(CONF_KNX_EVENT_FILTER, default=[]): vol.All(
+                        cv.ensure_list, [cv.string]
+                    ),
+                    vol.Optional(
+                        CONF_KNX_INDIVIDUAL_ADDRESS, default=XKNX.DEFAULT_ADDRESS
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_KNX_MCAST_GRP, default=DEFAULT_MCAST_GRP
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_KNX_MCAST_PORT, default=DEFAULT_MCAST_PORT
+                    ): cv.port,
+                    vol.Optional(CONF_KNX_STATE_UPDATER, default=True): cv.boolean,
+                    vol.Optional(CONF_KNX_RATE_LIMIT, default=20): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=100)
+                    ),
+                    vol.Optional(CONF_KNX_EXPOSE): vol.All(
+                        cv.ensure_list, [ExposeSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.cover.value): vol.All(
+                        cv.ensure_list, [CoverSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.binary_sensor.value): vol.All(
+                        cv.ensure_list, [BinarySensorSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.light.value): vol.All(
+                        cv.ensure_list, [LightSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.climate.value): vol.All(
+                        cv.ensure_list, [ClimateSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.notify.value): vol.All(
+                        cv.ensure_list, [NotifySchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.switch.value): vol.All(
+                        cv.ensure_list, [SwitchSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.sensor.value): vol.All(
+                        cv.ensure_list, [SensorSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.scene.value): vol.All(
+                        cv.ensure_list, [SceneSchema.SCHEMA]
+                    ),
+                    vol.Optional(SupportedPlatforms.weather.value): vol.All(
+                        cv.ensure_list, [WeatherSchema.SCHEMA]
+                    ),
+                }
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -149,6 +160,13 @@ SERVICE_KNX_SEND_SCHEMA = vol.Any(
             ),
         }
     ),
+)
+
+SERVICE_KNX_EVENT_REGISTER_SCHEMA = vol.Schema(
+    {
+        vol.Required(SERVICE_KNX_ATTR_ADDRESS): cv.string,
+        vol.Optional(SERVICE_KNX_ATTR_REMOVE, default=False): cv.boolean,
+    }
 )
 
 
@@ -188,6 +206,14 @@ async def async_setup(hass, config):
         schema=SERVICE_KNX_SEND_SCHEMA,
     )
 
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_KNX_EVENT_REGISTER,
+        hass.data[DOMAIN].service_event_register_modify,
+        schema=SERVICE_KNX_EVENT_REGISTER_SCHEMA,
+    )
+
     async def reload_service_handler(service_call: ServiceCallType) -> None:
         """Remove all KNX components and load new ones from config."""
 
@@ -221,9 +247,10 @@ class KNXModule:
         self.hass = hass
         self.config = config
         self.connected = False
-        self.init_xknx()
-        self.register_callbacks()
         self.exposures = []
+
+        self.init_xknx()
+        self._knx_event_callback: TelegramQueue.Callback = self.register_callback()
 
     def init_xknx(self):
         """Initialize of KNX object."""
@@ -289,19 +316,6 @@ class KNXModule:
             auto_reconnect=True,
         )
 
-    def register_callbacks(self):
-        """Register callbacks within XKNX object."""
-        if (
-            CONF_KNX_FIRE_EVENT in self.config[DOMAIN]
-            and self.config[DOMAIN][CONF_KNX_FIRE_EVENT]
-        ):
-            address_filters = list(
-                map(AddressFilter, self.config[DOMAIN][CONF_KNX_FIRE_EVENT_FILTER])
-            )
-            self.xknx.telegram_queue.register_telegram_received_cb(
-                self.telegram_received_cb, address_filters
-            )
-
     @callback
     def async_create_exposures(self):
         """Create exposures."""
@@ -348,6 +362,25 @@ class KNXModule:
                 "telegramtype": telegram.payload.__class__.__name__,
             },
         )
+
+    def register_callback(self) -> TelegramQueue.Callback:
+        """Register callback within XKNX TelegramQueue."""
+        address_filters = list(
+            map(AddressFilter, self.config[DOMAIN][CONF_KNX_EVENT_FILTER])
+        )
+        return self.xknx.telegram_queue.register_telegram_received_cb(
+            self.telegram_received_cb,
+            address_filters=address_filters,
+            group_addresses=[],
+        )
+
+    async def service_event_register_modify(self, call):
+        """Service for adding or removing a GroupAddress to the knx_event filter."""
+        group_address = GroupAddress(call.data.get(SERVICE_KNX_ATTR_ADDRESS))
+        if call.data.get(SERVICE_KNX_ATTR_REMOVE):
+            self._knx_event_callback.group_addresses.remove(group_address)
+        elif group_address not in self._knx_event_callback.group_addresses:
+            self._knx_event_callback.group_addresses.append(group_address)
 
     async def service_send_to_knx_bus(self, call):
         """Service for sending an arbitrary KNX message to the KNX bus."""

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -67,6 +67,7 @@ SERVICE_KNX_ATTR_PAYLOAD = "payload"
 SERVICE_KNX_ATTR_TYPE = "type"
 SERVICE_KNX_ATTR_REMOVE = "remove"
 SERVICE_KNX_EVENT_REGISTER = "event_register"
+SERVICE_KNX_EXPOSURE_REGISTER = "exposure_register"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -162,6 +163,22 @@ SERVICE_KNX_EVENT_REGISTER_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_KNX_EXPOSURE_REGISTER_SCHEMA = vol.Any(
+    ExposeSchema.SCHEMA.extend(
+        {
+            vol.Optional(SERVICE_KNX_ATTR_REMOVE, default=False): cv.boolean,
+        }
+    ),
+    vol.Schema(
+        # for removing only `address` is required
+        {
+            vol.Required(SERVICE_KNX_ATTR_ADDRESS): cv.string,
+            vol.Required(SERVICE_KNX_ATTR_REMOVE): vol.All(cv.boolean, True),
+        },
+        extra=vol.ALLOW_EXTRA,
+    ),
+)
+
 
 async def async_setup(hass, config):
     """Set up the KNX component."""
@@ -212,6 +229,14 @@ async def async_setup(hass, config):
         schema=SERVICE_KNX_EVENT_REGISTER_SCHEMA,
     )
 
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_KNX_EXPOSURE_REGISTER,
+        hass.data[DOMAIN].service_exposure_register_modify,
+        schema=SERVICE_KNX_EXPOSURE_REGISTER_SCHEMA,
+    )
+
     async def reload_service_handler(service_call: ServiceCallType) -> None:
         """Remove all KNX components and load new ones from config."""
 
@@ -246,6 +271,7 @@ class KNXModule:
         self.config = config
         self.connected = False
         self.exposures = []
+        self.service_exposures = {}
 
         self.init_xknx()
         self._knx_event_callback: TelegramQueue.Callback = self.register_callback()
@@ -348,9 +374,51 @@ class KNXModule:
         """Service for adding or removing a GroupAddress to the knx_event filter."""
         group_address = GroupAddress(call.data.get(SERVICE_KNX_ATTR_ADDRESS))
         if call.data.get(SERVICE_KNX_ATTR_REMOVE):
-            self._knx_event_callback.group_addresses.remove(group_address)
+            try:
+                self._knx_event_callback.group_addresses.remove(group_address)
+            except ValueError:
+                _LOGGER.warning(
+                    "Service event_register could not remove event for '%s'",
+                    group_address,
+                )
         elif group_address not in self._knx_event_callback.group_addresses:
             self._knx_event_callback.group_addresses.append(group_address)
+            _LOGGER.debug(
+                "Service event_register registered event for '%s'",
+                group_address,
+            )
+
+    async def service_exposure_register_modify(self, call):
+        """Service for adding or removing an exposure to KNX bus."""
+        group_address = call.data.get(SERVICE_KNX_ATTR_ADDRESS)
+
+        if call.data.get(SERVICE_KNX_ATTR_REMOVE):
+            try:
+                removed_exposure = self.service_exposures.pop(group_address)
+            except KeyError:
+                _LOGGER.warning(
+                    "Service exposure_register could not remove exposure for '%s'",
+                    group_address,
+                )
+            else:
+                removed_exposure.shutdown()
+            return
+
+        if group_address in self.service_exposures:
+            replaced_exposure = self.service_exposures.pop(group_address)
+            _LOGGER.warning(
+                "Service exposure_register replacing already registered exposure for '%s' - %s",
+                group_address,
+                replaced_exposure.device.name,
+            )
+            replaced_exposure.shutdown()
+        exposure = create_knx_exposure(self.hass, self.xknx, call.data)
+        self.service_exposures[group_address] = exposure
+        _LOGGER.debug(
+            "Service exposure_register registered exposure for '%s' - %s",
+            group_address,
+            exposure.device.name,
+        )
 
     async def service_send_to_knx_bus(self, call):
         """Service for sending an arbitrary KNX message to the KNX bus."""

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -2,7 +2,7 @@
 from typing import List, Optional
 
 from xknx.devices import Climate as XknxClimate
-from xknx.dpt import HVACControllerMode, HVACOperationMode
+from xknx.dpt.dpt_hvac_mode import HVACControllerMode, HVACOperationMode
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -57,6 +57,7 @@ class KNXExposeSensor:
         self.expose_default = default
         self.address = address
         self.device = None
+        self._remove_listener = None
 
     @callback
     def async_register(self):
@@ -71,9 +72,16 @@ class KNXExposeSensor:
             group_address=self.address,
             value_type=self.type,
         )
-        async_track_state_change_event(
+        self._remove_listener = async_track_state_change_event(
             self.hass, [self.entity_id], self._async_entity_changed
         )
+
+    def shutdown(self) -> None:
+        """Prepare for deletion."""
+        if self._remove_listener is not None:
+            self._remove_listener()
+        if self.device is not None:
+            self.device.shutdown()
 
     async def _async_entity_changed(self, event):
         """Handle entity change."""
@@ -132,3 +140,8 @@ class KNXExposeTime:
             localtime=True,
             group_address=self.address,
         )
+
+    def shutdown(self):
+        """Prepare for deletion."""
+        if self.device is not None:
+            self.device.shutdown()

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -1,0 +1,134 @@
+"""Exposures to KNX bus."""
+from typing import Union
+
+from xknx import XKNX
+from xknx.devices import DateTime, ExposeSensor
+
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.typing import ConfigType
+
+from .schema import ExposeSchema
+
+
+def create_knx_exposure(
+    hass: HomeAssistant, xknx: XKNX, config: ConfigType
+) -> Union["KNXExposeSensor", "KNXExposeTime"]:
+    """Create exposures from config."""
+    expose_type = config.get(ExposeSchema.CONF_KNX_EXPOSE_TYPE)
+    entity_id = config.get(CONF_ENTITY_ID)
+    attribute = config.get(ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE)
+    default = config.get(ExposeSchema.CONF_KNX_EXPOSE_DEFAULT)
+    address = config.get(ExposeSchema.CONF_KNX_EXPOSE_ADDRESS)
+    if expose_type.lower() in ["time", "date", "datetime"]:
+        exposure = KNXExposeTime(xknx, expose_type, address)
+        exposure.async_register()
+    else:
+        exposure = KNXExposeSensor(
+            hass,
+            xknx,
+            expose_type,
+            entity_id,
+            attribute,
+            default,
+            address,
+        )
+        exposure.async_register()
+    return exposure
+
+
+class KNXExposeSensor:
+    """Object to Expose Home Assistant entity to KNX bus."""
+
+    def __init__(self, hass, xknx, expose_type, entity_id, attribute, default, address):
+        """Initialize of Expose class."""
+        self.hass = hass
+        self.xknx = xknx
+        self.type = expose_type
+        self.entity_id = entity_id
+        self.expose_attribute = attribute
+        self.expose_default = default
+        self.address = address
+        self.device = None
+
+    @callback
+    def async_register(self):
+        """Register listener."""
+        if self.expose_attribute is not None:
+            _name = self.entity_id + "__" + self.expose_attribute
+        else:
+            _name = self.entity_id
+        self.device = ExposeSensor(
+            self.xknx,
+            name=_name,
+            group_address=self.address,
+            value_type=self.type,
+        )
+        async_track_state_change_event(
+            self.hass, [self.entity_id], self._async_entity_changed
+        )
+
+    async def _async_entity_changed(self, event):
+        """Handle entity change."""
+        new_state = event.data.get("new_state")
+        if new_state is None:
+            return
+        if new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            return
+
+        if self.expose_attribute is not None:
+            new_attribute = new_state.attributes.get(self.expose_attribute)
+            old_state = event.data.get("old_state")
+
+            if old_state is not None:
+                old_attribute = old_state.attributes.get(self.expose_attribute)
+                if old_attribute == new_attribute:
+                    # don't send same value sequentially
+                    return
+            await self._async_set_knx_value(new_attribute)
+        else:
+            await self._async_set_knx_value(new_state.state)
+
+    async def _async_set_knx_value(self, value):
+        """Set new value on xknx ExposeSensor."""
+        if value is None:
+            if self.expose_default is None:
+                return
+            value = self.expose_default
+
+        if self.type == "binary":
+            if value == STATE_ON:
+                value = True
+            elif value == STATE_OFF:
+                value = False
+
+        await self.device.set(value)
+
+
+class KNXExposeTime:
+    """Object to Expose Time/Date object to KNX bus."""
+
+    def __init__(self, xknx: XKNX, expose_type: str, address: str):
+        """Initialize of Expose class."""
+        self.xknx = xknx
+        self.expose_type = expose_type
+        self.address = address
+        self.device = None
+
+    @callback
+    def async_register(self):
+        """Register listener."""
+        self.device = DateTime(
+            self.xknx,
+            name=self.expose_type.capitalize(),
+            broadcast_type=self.expose_type.upper(),
+            localtime=True,
+            group_address=self.address,
+        )

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.16.0"],
+  "requirements": ["xknx==0.16.1"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "silver"
 }

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -186,6 +186,7 @@ class LightSchema:
             }
         ),
         vol.Any(
+            # either global "address" or all addresses for individual colors are required
             vol.Schema(
                 {
                     vol.Required(CONF_INDIVIDUAL_COLORS): {

--- a/homeassistant/components/knx/services.yaml
+++ b/homeassistant/components/knx/services.yaml
@@ -10,3 +10,11 @@ send:
     type:
       description: "Optional. If set, the payload will not be sent as raw bytes, but encoded as given DPT. Knx sensor types are valid values (see https://www.home-assistant.io/integrations/sensor.knx)."
       example: "temperature"
+event_register:
+  description: "Add or remove single group address to knx_event filter for triggering `knx_event`s. Only addresses added with this service can be removed."
+  fields:
+    address:
+      description: "Group address that shall be added or removed."
+      example: "1/1/0"
+    remove:
+      description: "Optional. If `True` the group address will be removed. Defaults to `False`."

--- a/homeassistant/components/knx/services.yaml
+++ b/homeassistant/components/knx/services.yaml
@@ -18,3 +18,25 @@ event_register:
       example: "1/1/0"
     remove:
       description: "Optional. If `True` the group address will be removed. Defaults to `False`."
+exposure_register:
+  description: "Add or remove exposures to KNX bus. Only exposures added with this service can be removed."
+  fields:
+    address:
+      description: "Required. Group address state or attribute updates will be sent to. GroupValueRead requests will be answered. Per address only one exposure can be registered."
+      example: "1/1/0"
+    type:
+      description: "Required. Telegrams will be encoded as given DPT. 'binary' and all Knx sensor types are valid values (see https://www.home-assistant.io/integrations/sensor.knx)"
+      example: "percentU8"
+    entity_id:
+      description: "Required. Entity id to be exposed."
+      example: "light.kitchen"
+      required: true
+    attribute:
+      description: "Optional. Attribute of the entity that shall be sent to the KNX bus. If not set the state will be sent. Eg. for a light the state is eigther “on” or “off” - with attribute you can expose its “brightness”."
+      example: "brightness"
+      required: false
+    default:
+      description: "Optional. Default value to send to the bus if the state or attribute value is None. Eg. a light with state “off” has no brightness attribute so a default value of 0 could be used. If not set (or None) no value would be sent to the bus and a GroupReadRequest to the address would return the last known value."
+      example: "0"
+    remove:
+      description: "Optional. If `True` the exposure will be removed. Only `address` is required for removal."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2311,7 +2311,7 @@ xboxapi==2.0.1
 xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
-xknx==0.16.0
+xknx==0.16.1
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- `fire_event` in knx configuration is deprecated
- `fire_event_filter` in knx configuration is renamed to `event_filter`

The update to 0.16.0 #44749 will already introduce breaking changes to `knx_event` in HA 2021.2 so I think it is a good time to also change the name for its configuration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- update xknx to 0.16.1
  - [release notes / changelog](https://github.com/XKNX/xknx/releases/tag/0.16.1)
  - this release contains mostly changes to make the new HA services possible (and type annotations)
- moved KNXExposeTime and KNXExposeSensor classes to module `expose.py`
- add a HA service to add/remove knx_event
- add a HA service to add/remove knx exposures


With this it is possible to build automations using knx_event or expose state to the KNX bus on the fly without changing or even reloading configuration. 
So an automation could listen to automation_reloaded
```yaml
automation:
  trigger:
    platform: event
    event_type: automation_reloaded
  action:
    service: knx.event_register
    data:
      address: "1/2/3"
```
to setup a group address listener for itself and later on use the registered knx_event. I think this could be used to create really powerful blueprints.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
knx:
  event_filter: ["0/0/*"]

# instead of the now deprecated
knx:
  fire_event: true
  fire_event_filter: ["0/0/*"]
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16202

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
