### PR TITLE
2021.1.4

### DIFF
--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -104,7 +104,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                     if ATTR_BRIGHTNESS in kwargs:
                         brightness = 10 + ceil(kwargs[ATTR_BRIGHTNESS] / 255 * 90)
 
-                    hs_color = kwargs.get(ATTR_HS_COLOR, default=self._hs_color)
+                    hs_color = kwargs.get(ATTR_HS_COLOR, self._hs_color)
 
                     if hs_color is not None:
                         rgb = color_util.color_hsv_to_RGB(*hs_color, brightness)

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -346,7 +346,9 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
         heat_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
         cool_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}:
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
             if temp is None:
                 temp = (cool_temp + heat_temp) / 2
             await self.async_put_characteristics(
@@ -386,37 +388,54 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) not in {HVAC_MODE_HEAT, HVAC_MODE_COOL}:
-            return None
-        return self.service.value(CharacteristicsTypes.TEMPERATURE_TARGET)
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT, HVAC_MODE_COOL}) or (
+            (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL})
+            and not (SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features)
+        ):
+            return self.service.value(CharacteristicsTypes.TEMPERATURE_TARGET)
+        return None
 
     @property
     def target_temperature_high(self):
         """Return the highbound target temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) not in {HVAC_MODE_HEAT_COOL}:
-            return None
-        return self.service.value(CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD)
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
+            return self.service.value(
+                CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
+            )
+        return None
 
     @property
     def target_temperature_low(self):
         """Return the lowbound target temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) not in {HVAC_MODE_HEAT_COOL}:
-            return None
-        return self.service.value(CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD)
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
+            return self.service.value(
+                CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
+            )
+        return None
 
     @property
     def min_temp(self):
         """Return the minimum target temp."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}:
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
             min_temp = self.service[
                 CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD
             ].minValue
             if min_temp is not None:
                 return min_temp
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT, HVAC_MODE_COOL}:
+        elif MODE_HOMEKIT_TO_HASS.get(value) in {
+            HVAC_MODE_HEAT,
+            HVAC_MODE_COOL,
+            HVAC_MODE_HEAT_COOL,
+        }:
             min_temp = self.service[CharacteristicsTypes.TEMPERATURE_TARGET].minValue
             if min_temp is not None:
                 return min_temp
@@ -426,13 +445,19 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
     def max_temp(self):
         """Return the maximum target temp."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}:
+        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+            SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
+        ):
             max_temp = self.service[
                 CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD
             ].maxValue
             if max_temp is not None:
                 return max_temp
-        if MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT, HVAC_MODE_COOL}:
+        elif MODE_HOMEKIT_TO_HASS.get(value) in {
+            HVAC_MODE_HEAT,
+            HVAC_MODE_COOL,
+            HVAC_MODE_HEAT_COOL,
+        }:
             max_temp = self.service[CharacteristicsTypes.TEMPERATURE_TARGET].maxValue
             if max_temp is not None:
                 return max_temp

--- a/homeassistant/components/openweathermap/sensor.py
+++ b/homeassistant/components/openweathermap/sensor.py
@@ -1,10 +1,7 @@
 """Support for the OpenWeatherMap (OWM) service."""
-import datetime
-
 from .abstract_owm_sensor import AbstractOpenWeatherMapSensor
 from .const import (
     ATTR_API_FORECAST,
-    DEVICE_CLASS_TIMESTAMP,
     DOMAIN,
     ENTRY_NAME,
     ENTRY_WEATHER_COORDINATOR,
@@ -98,10 +95,5 @@ class OpenWeatherMapForecastSensor(AbstractOpenWeatherMapSensor):
         """Return the state of the device."""
         forecasts = self._weather_coordinator.data.get(ATTR_API_FORECAST)
         if forecasts is not None and len(forecasts) > 0:
-            value = forecasts[0].get(self._sensor_type, None)
-            if self._device_class is DEVICE_CLASS_TIMESTAMP:
-                value = datetime.datetime.fromtimestamp(
-                    value, datetime.timezone.utc
-                ).isoformat()
-            return value
+            return forecasts[0].get(self._sensor_type, None)
         return None

--- a/homeassistant/components/openweathermap/weather_update_coordinator.py
+++ b/homeassistant/components/openweathermap/weather_update_coordinator.py
@@ -138,7 +138,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
     def _convert_forecast(self, entry):
         forecast = {
-            ATTR_FORECAST_TIME: entry.reference_time("unix"),
+            ATTR_FORECAST_TIME: dt.utc_from_timestamp(entry.reference_time("unix")),
             ATTR_FORECAST_PRECIPITATION: self._calc_precipitation(
                 entry.rain, entry.snow
             ),

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -10,7 +10,7 @@
     "zha-quirks==0.0.51",
     "zigpy-cc==0.5.2",
     "zigpy-deconz==0.11.1",
-    "zigpy==0.29.0",
+    "zigpy==0.30.0",
     "zigpy-xbee==0.13.0",
     "zigpy-zigate==0.7.3",
     "zigpy-znp==0.3.0"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 2021
 MINOR_VERSION = 1
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2363,7 +2363,7 @@ zigpy-zigate==0.7.3
 zigpy-znp==0.3.0
 
 # homeassistant.components.zha
-zigpy==0.29.0
+zigpy==0.30.0
 
 # homeassistant.components.zoneminder
 zm-py==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1162,4 +1162,4 @@ zigpy-zigate==0.7.3
 zigpy-znp==0.3.0
 
 # homeassistant.components.zha
-zigpy==0.29.0
+zigpy==0.30.0


### PR DESCRIPTION
- Fix Home Connect ambient color ([@Sjack-Sch] - [#45038]) ([home_connect docs])
- Fix HomeKit climate integration for devices with a single set point in Heat_Cool mode. ([@thevoltagesource] - [#45065]) ([homekit_controller docs])
- Fix all forecast datetime values in OpenWeatherMap ([@spacegaier] - [#45202]) ([openweathermap docs])
- Bump up ZHA dependency ([@Adminiuga] - [#45230]) ([zha docs])

[#45038]: https://github.com/home-assistant/core/pull/45038
[#45065]: https://github.com/home-assistant/core/pull/45065
[#45202]: https://github.com/home-assistant/core/pull/45202
[#45230]: https://github.com/home-assistant/core/pull/45230
[@Adminiuga]: https://github.com/Adminiuga
[@Sjack-Sch]: https://github.com/Sjack-Sch
[@spacegaier]: https://github.com/spacegaier
[@thevoltagesource]: https://github.com/thevoltagesource
[home_connect docs]: https://www.home-assistant.io/integrations/home_connect/
[homekit_controller docs]: https://www.home-assistant.io/integrations/homekit_controller/
[openweathermap docs]: https://www.home-assistant.io/integrations/openweathermap/
[zha docs]: https://www.home-assistant.io/integrations/zha/