### PR TITLE
Sanitize user-agent in wrong_login message

### DIFF
--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -15,7 +15,7 @@ from homeassistant.const import HTTP_BAD_REQUEST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import dt as dt_util, yaml
+from homeassistant.util import dt as dt_util, re, yaml
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -107,8 +107,10 @@ async def process_wrong_login(request):
 
     msg = f"Login attempt or request with invalid authentication from {remote_host} ({remote_addr})"
 
-    user_agent = request.headers.get("user-agent")
-    if user_agent:
+    user_agent_raw = request.headers.get("user-agent")
+    if user_agent_raw:
+        # Sanitize user agent to limited charset
+        user_agent = re.sub(r"[^a-zA-Z0-9:;,./() ]", "_", user_agent_raw)
         msg = f"{msg} ({user_agent})"
 
     _LOGGER.warning(msg)

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -15,7 +15,7 @@ from homeassistant.const import HTTP_BAD_REQUEST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import dt as dt_util, re, yaml
+from homeassistant.util import dt as dt_util, yaml
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -105,18 +105,18 @@ async def process_wrong_login(request):
     except herror:
         pass
 
-    msg = f"Login attempt or request with invalid authentication from {remote_host} ({remote_addr})"
+    base_msg = f"Login attempt or request with invalid authentication from {remote_host} ({remote_addr})."
 
-    user_agent_raw = request.headers.get("user-agent")
-    if user_agent_raw:
-        # Sanitize user agent to limited charset
-        user_agent = re.sub(r"[^a-zA-Z0-9:;,./() ]", "_", user_agent_raw)
-        msg = f"{msg} ({user_agent})"
+    # The user-agent is unsanitized input so we only include it in the log
+    user_agent = request.headers.get("user-agent")
+    log_msg = f"{base_msg} ({user_agent})"
 
-    _LOGGER.warning(msg)
+    notification_msg = f"{base_msg} See the log for details."
+
+    _LOGGER.warning(log_msg)
 
     hass.components.persistent_notification.async_create(
-        msg, "Login attempt failed", NOTIFICATION_ID_LOGIN
+        notification_msg, "Login attempt failed", NOTIFICATION_ID_LOGIN
     )
 
     # Check if ban middleware is loaded

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -158,7 +158,9 @@ async def test_ip_bans_file_creation(hass, aiohttp_client):
     m_open = mock_open()
 
     with patch("homeassistant.components.http.ban.open", m_open, create=True):
-        resp = await client.get("/")
+        resp = await client.get(
+            "/", headers={"User-Agent": "Test Client 1.0/T1 <script>"}
+        )
         assert resp.status == 401
         assert len(app[KEY_BANNED_IPS]) == len(BANNED_IPS)
         assert m_open.call_count == 0
@@ -174,9 +176,10 @@ async def test_ip_bans_file_creation(hass, aiohttp_client):
 
         assert len(notification_calls) == 3
         assert (
-            "Login attempt or request with invalid authentication from example.com (200.201.202.204) (Python"
+            "Login attempt or request with invalid authentication from example.com (200.201.202.204) (Test Client 1.0/T1"
             in notification_calls[0].data["message"]
         )
+        assert "<script>" not in notification_calls[0].data["message"]
 
 
 async def test_failed_login_attempts_counter(hass, aiohttp_client):

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -158,9 +158,7 @@ async def test_ip_bans_file_creation(hass, aiohttp_client):
     m_open = mock_open()
 
     with patch("homeassistant.components.http.ban.open", m_open, create=True):
-        resp = await client.get(
-            "/", headers={"User-Agent": "Test Client 1.0/T1 <script>"}
-        )
+        resp = await client.get("/")
         assert resp.status == 401
         assert len(app[KEY_BANNED_IPS]) == len(BANNED_IPS)
         assert m_open.call_count == 0
@@ -176,10 +174,9 @@ async def test_ip_bans_file_creation(hass, aiohttp_client):
 
         assert len(notification_calls) == 3
         assert (
-            "Login attempt or request with invalid authentication from example.com (200.201.202.204) (Test Client 1.0/T1"
-            in notification_calls[0].data["message"]
+            notification_calls[0].data["message"]
+            == "Login attempt or request with invalid authentication from example.com (200.201.202.204). See the log for details."
         )
-        assert "<script>" not in notification_calls[0].data["message"]
 
 
 async def test_failed_login_attempts_counter(hass, aiohttp_client):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A wrong login attempt will trigger a persistent notification prominently displayed and rendered in markdown.
Since the user-agent header can be set to arbitrary values by the requestor, we can inject markdown and HTML content in this notification.

While the XSS filter applied later in the markdown renderer prevents javascript code injection, I still think we should remove this function:
1. Approved HTML/markdown such as images and links are still rendered, allowing for a phishing/spam angle,
2. this puts considerable trust in the XSS filter, especially since this endpoint is fully open to unauthenticated, remote requests.

I see only minimal utility for exposing the user agent at all, so I'm suggesting a full removal.
As an alternative, we could truncate the allowed character set to [a-zA-Z0-9:;./], which should cover all proper user agents.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
