### PR TITLE
Allow Influxdb CA path in verify_ssl

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -62,6 +62,7 @@ from .const import (
     CONF_PRECISION,
     CONF_RETRY_COUNT,
     CONF_SSL,
+    CONF_SSL_CA_CERT,
     CONF_TAGS,
     CONF_TAGS_ATTRIBUTES,
     CONF_TOKEN,
@@ -335,6 +336,9 @@ def get_influx_connection(conf, test_write=False, test_read=False):
         kwargs[CONF_URL] = conf[CONF_URL]
         kwargs[CONF_TOKEN] = conf[CONF_TOKEN]
         kwargs[INFLUX_CONF_ORG] = conf[CONF_ORG]
+        kwargs[CONF_VERIFY_SSL] = conf[CONF_VERIFY_SSL]
+        if CONF_SSL_CA_CERT in conf:
+            kwargs[CONF_SSL_CA_CERT] = conf[CONF_SSL_CA_CERT]
         bucket = conf.get(CONF_BUCKET)
         influx = InfluxDBClientV2(**kwargs)
         query_api = influx.query_api()
@@ -392,7 +396,10 @@ def get_influx_connection(conf, test_write=False, test_read=False):
         return InfluxClient(buckets, write_v2, query_v2, close_v2)
 
     # Else it's a V1 client
-    kwargs[CONF_VERIFY_SSL] = conf[CONF_VERIFY_SSL]
+    if CONF_SSL_CA_CERT in conf and conf[CONF_VERIFY_SSL]:
+        kwargs[CONF_VERIFY_SSL] = conf[CONF_SSL_CA_CERT]
+    else:
+        kwargs[CONF_VERIFY_SSL] = conf[CONF_VERIFY_SSL]
 
     if CONF_DB_NAME in conf:
         kwargs[CONF_DB_NAME] = conf[CONF_DB_NAME]

--- a/homeassistant/components/influxdb/const.py
+++ b/homeassistant/components/influxdb/const.py
@@ -31,6 +31,7 @@ CONF_COMPONENT_CONFIG_DOMAIN = "component_config_domain"
 CONF_RETRY_COUNT = "max_retries"
 CONF_IGNORE_ATTRIBUTES = "ignore_attributes"
 CONF_PRECISION = "precision"
+CONF_SSL_CA_CERT = "ssl_ca_cert"
 
 CONF_LANGUAGE = "language"
 CONF_QUERIES = "queries"
@@ -139,12 +140,13 @@ COMPONENT_CONFIG_SCHEMA_CONNECTION = {
     vol.Optional(CONF_PATH): cv.string,
     vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_SSL): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+    vol.Optional(CONF_SSL_CA_CERT): cv.isfile,
     vol.Optional(CONF_PRECISION): vol.In(["ms", "s", "us", "ns"]),
     # Connection config for V1 API only.
     vol.Inclusive(CONF_USERNAME, "authentication"): cv.string,
     vol.Inclusive(CONF_PASSWORD, "authentication"): cv.string,
     vol.Optional(CONF_DB_NAME, default=DEFAULT_DATABASE): cv.string,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
     # Connection config for V2 API only.
     vol.Inclusive(CONF_TOKEN, "v2_authentication"): cv.string,
     vol.Inclusive(CONF_ORG, "v2_authentication"): cv.string,

--- a/homeassistant/components/influxdb/manifest.json
+++ b/homeassistant/components/influxdb/manifest.json
@@ -2,6 +2,6 @@
   "domain": "influxdb",
   "name": "InfluxDB",
   "documentation": "https://www.home-assistant.io/integrations/influxdb",
-  "requirements": ["influxdb==5.2.3", "influxdb-client==1.8.0"],
+  "requirements": ["influxdb==5.2.3", "influxdb-client==1.14.0"],
   "codeowners": ["@fabaff", "@mdegat01"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -819,7 +819,7 @@ ihcsdk==2.7.0
 incomfort-client==0.4.0
 
 # homeassistant.components.influxdb
-influxdb-client==1.8.0
+influxdb-client==1.14.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -422,7 +422,7 @@ iaqualink==0.3.4
 icmplib==2.0
 
 # homeassistant.components.influxdb
-influxdb-client==1.8.0
+influxdb-client==1.14.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -132,10 +132,15 @@ async def test_setup_config_full(hass, mock_client, config_ext, get_write_api):
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext",
+    "mock_client, config_base, config_ext, expected_client_args",
     [
         (
             influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            {
+                "ssl": True,
+                "verify_ssl": False,
+            },
             {
                 "ssl": True,
                 "verify_ssl": False,
@@ -143,6 +148,11 @@ async def test_setup_config_full(hass, mock_client, config_ext, get_write_api):
         ),
         (
             influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            {
+                "ssl": True,
+                "verify_ssl": True,
+            },
             {
                 "ssl": True,
                 "verify_ssl": True,
@@ -150,53 +160,86 @@ async def test_setup_config_full(hass, mock_client, config_ext, get_write_api):
         ),
         (
             influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
             {
                 "ssl": True,
                 "verify_ssl": True,
                 "ssl_ca_cert": "fake/path/ca.pem",
             },
-        ),
-        (
-            influxdb.DEFAULT_API_VERSION,
             {
                 "ssl": True,
-                "ssl_ca_cert": "fake/path/ca.pem",
+                "verify_ssl": "fake/path/ca.pem",
             },
         ),
         (
             influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
+            {
+                "ssl": True,
+                "ssl_ca_cert": "fake/path/ca.pem",
+            },
+            {
+                "ssl": True,
+                "verify_ssl": "fake/path/ca.pem",
+            },
+        ),
+        (
+            influxdb.DEFAULT_API_VERSION,
+            BASE_V1_CONFIG,
             {
                 "ssl": True,
                 "verify_ssl": False,
                 "ssl_ca_cert": "fake/path/ca.pem",
             },
-        ),
-        (
-            influxdb.API_VERSION_2,
             {
-                "api_version": influxdb.API_VERSION_2,
+                "ssl": True,
                 "verify_ssl": False,
             },
         ),
         (
             influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
             {
                 "api_version": influxdb.API_VERSION_2,
+                "verify_ssl": False,
+            },
+            {
+                "verify_ssl": False,
+            },
+        ),
+        (
+            influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
+            {
+                "api_version": influxdb.API_VERSION_2,
+                "verify_ssl": True,
+            },
+            {
                 "verify_ssl": True,
             },
         ),
         (
             influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
             {
                 "api_version": influxdb.API_VERSION_2,
+                "verify_ssl": True,
+                "ssl_ca_cert": "fake/path/ca.pem",
+            },
+            {
                 "verify_ssl": True,
                 "ssl_ca_cert": "fake/path/ca.pem",
             },
         ),
         (
             influxdb.API_VERSION_2,
+            BASE_V2_CONFIG,
             {
                 "api_version": influxdb.API_VERSION_2,
+                "verify_ssl": False,
+                "ssl_ca_cert": "fake/path/ca.pem",
+            },
+            {
                 "verify_ssl": False,
                 "ssl_ca_cert": "fake/path/ca.pem",
             },
@@ -204,51 +247,21 @@ async def test_setup_config_full(hass, mock_client, config_ext, get_write_api):
     ],
     indirect=["mock_client"],
 )
-async def test_setup_config_ssl(hass, mock_client, config_ext):
+async def test_setup_config_ssl(
+    hass, mock_client, config_base, config_ext, expected_client_args
+):
     """Test the setup with various verify_ssl values."""
-    config = {
-        "influxdb": BASE_V2_CONFIG
-        if config_ext.get("api_version") == influxdb.API_VERSION_2
-        else BASE_V1_CONFIG
-    }
+    config = {"influxdb": config_base.copy()}
     config["influxdb"].update(config_ext)
 
     with patch("os.access", return_value=True):
-        with patch("os.path.isfile", return_value=True) as mock_isfile:
+        with patch("os.path.isfile", return_value=True):
             assert await async_setup_component(hass, influxdb.DOMAIN, config)
             await hass.async_block_till_done()
 
             assert hass.bus.listen.called
             assert EVENT_STATE_CHANGED == hass.bus.listen.call_args_list[0][0][0]
-
-            if config_ext.get("api_version") == influxdb.API_VERSION_2:
-                for arg in ("ssl_ca_cert", "verify_ssl"):
-                    if arg in config_ext:
-                        assert mock_client.call_args.kwargs.get(arg) == config_ext[arg]
-                    else:
-                        assert arg not in mock_client.call_args.kwargs
-            else:
-                if "ssl" in config_ext:
-                    assert mock_client.call_args.kwargs.get("ssl") == config_ext["ssl"]
-                else:
-                    assert "ssl" not in mock_client.call_args.kwargs
-
-                if "ssl_ca_cert" in config_ext:
-                    mock_isfile.assert_called_with(config_ext["ssl_ca_cert"])
-                    if config_ext.get("verify_ssl", True):
-                        assert (
-                            mock_client.call_args.kwargs.get("verify_ssl")
-                            == config_ext["ssl_ca_cert"]
-                        )
-                    else:
-                        assert (
-                            mock_client.call_args.kwargs.get("verify_ssl")
-                            == config_ext["verify_ssl"]
-                        )
-                else:
-                    assert mock_client.call_args.kwargs.get(
-                        "verify_ssl"
-                    ) == config_ext.get("verify_ssl", True)
+            assert expected_client_args.items() <= mock_client.call_args.kwargs.items()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Simple change to allow an optional CA path in the Influxdb configuration to verify SSL certificates. 
This applies to both V1 and V2 API.

```yaml
influxdb:
  ssl_ca_cert: /path/to/ca.crt
```

Additionally, `verify_ssl` is used for both V1 and V2 API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
influxdb:
  ssl: true
  ssl_cert_path: /path/to/ca.crt
  verify_ssl: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45269
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16369

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
