### PR TITLE
Add RGBWW and RGBCW modes to flux_led

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -193,7 +193,6 @@ class FluxLight(LightEntity):
 
     def _connect(self):
         """Connect to Flux light."""
-
         self._bulb = WifiLedBulb(self._ipaddr, timeout=5)
         if self._protocol:
             self._bulb.setProtocol(self._protocol)
@@ -267,11 +266,13 @@ class FluxLight(LightEntity):
 
     @property
     def temperature_cw(self):
+        """Return the cold white temperature."""
         rgbww = self._bulb.getRgbww()
         return [rgbww[4], rgbww[3]]
 
     @property
     def temperature_ww(self):
+        """Return the warm white temperature."""
         rgbww = self._bulb.getRgbww()
         return rgbww[3]
 
@@ -376,17 +377,21 @@ class FluxLight(LightEntity):
                 kelvinMin = 2700
                 kelvinMax = 6500
 
-                # Map mired to kelvin specifically for the setWhiteTemperature since it wants 2700~6500 kelvin and 
+                # Map mired to kelvin specifically for the setWhiteTemperature since it wants 2700~6500 kelvin and
                 # we have 153~500 mired as an input which doesn't match up the way we want
-                color_temp_kelvin = (color_temp-miredMin)/(miredMax-miredMin)*(kelvinMax-kelvinMin)+kelvinMin
+                color_temp_kelvin = (color_temp - miredMin) / (miredMax - miredMin) * (
+                    kelvinMax - kelvinMin
+                ) + kelvinMin
 
-                color_temp_kelvin = max(color_temp_kelvin-2700, 0)
-                warm = 255 * (1 - (color_temp_kelvin/3800))
-                cold = min(255 * color_temp_kelvin/3800, 255)
-                warm *= white/255 # White controls brightness
-                cold *= white/255
+                color_temp_kelvin = max(color_temp_kelvin - 2700, 0)
+                warm = 255 * (1 - (color_temp_kelvin / 3800))
+                cold = min(255 * color_temp_kelvin / 3800, 255)
+                warm *= white / 255  # White controls brightness
+                cold *= white / 255
 
-                if warm > cold: # Warm side will activate both cold and warm leds at same rate (much brighter warm mode)
+                if (
+                    warm > cold
+                ):  # Warm side will activate both cold and warm leds at same rate (much brighter warm mode)
                     cold = warm
 
                 self._bulb.setRgbw(w=warm, w2=cold)
@@ -405,8 +410,8 @@ class FluxLight(LightEntity):
                 if not current_temp[0] and not current_temp[1]:
                     current_temp[0] = 255
                     current_temp[1] = 255
-                current_temp[0] *= white/255
-                current_temp[1] *= white/255
+                current_temp[0] *= white / 255
+                current_temp[1] *= white / 255
                 self._bulb.setRgbw(w=current_temp[1], w2=current_temp[0])
                 return
             elif self._mode == MODE_RGBWW:
@@ -421,7 +426,7 @@ class FluxLight(LightEntity):
         if rgb is None:
             rgb = self._bulb.getRgb()
             if self._mode == MODE_RGBW and rgb[0] == 0 and rgb[1] == 0 and rgb[2] == 0:
-                rgb = (255,255,255)
+                rgb = (255, 255, 255)
 
         if white is None and self._mode == MODE_RGBW:
             white = self.white_value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The integration doesn't work with controllers that handle RGB and White separately. This patch was originally made by @skylord123, I just ported it to the latest version of the integration.  


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
light:
# Example configuration.yaml entry
  - platform: flux_led
    devices:
      192.168.0.106:
        name: flux_lamppost
        mode: rgbww
      192.168.0.109:
        name: flux_living_room_lamp
        mode: rgbcw
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR fixes or closes issue: fixes #40038
- This PR is related to issue: #40038, #28940, #26879
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
