### PR TITLE
Include config entry id in zwave_js signal names

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -66,12 +66,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         LOGGER.info("Connected to Zwave JS Server")
         if initialized.is_set():
             # update entity availability
-            async_dispatcher_send(hass, f"{DOMAIN}_connection_state")
+            async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
 
     async def async_on_disconnect() -> None:
         """Handle websocket is disconnected."""
         LOGGER.info("Disconnected from Zwave JS Server")
-        async_dispatcher_send(hass, f"{DOMAIN}_connection_state")
+        async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
 
     async def async_on_initialized() -> None:
         """Handle initial full state received."""
@@ -89,7 +89,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # run discovery on all node values and create/update entities
         for disc_info in async_discover_values(node):
             LOGGER.debug("Discovered entity: %s", disc_info)
-            async_dispatcher_send(hass, f"{DOMAIN}_add_{disc_info.platform}", disc_info)
+            async_dispatcher_send(
+                hass, f"{DOMAIN}_{entry.entry_id}_add_{disc_info.platform}", disc_info
+            )
 
     @callback
     def async_on_node_added(node: ZwaveNode) -> None:

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -265,16 +265,18 @@ async def async_setup_entry(
         entities: List[ZWaveBaseEntity] = []
 
         if info.platform_hint == "notification":
-            entities.append(ZWaveNotificationBinarySensor(client, info))
+            entities.append(ZWaveNotificationBinarySensor(config_entry, client, info))
         else:
             # boolean sensor
-            entities.append(ZWaveBooleanBinarySensor(client, info))
+            entities.append(ZWaveBooleanBinarySensor(config_entry, client, info))
 
         async_add_entities(entities)
 
     hass.data[DOMAIN][config_entry.entry_id][DATA_UNSUBSCRIBE].append(
         async_dispatcher_connect(
-            hass, f"{DOMAIN}_add_{BINARY_SENSOR_DOMAIN}", async_add_binary_sensor
+            hass,
+            f"{DOMAIN}_{config_entry.entry_id}_add_{BINARY_SENSOR_DOMAIN}",
+            async_add_binary_sensor,
         )
     )
 
@@ -308,9 +310,11 @@ class ZWaveBooleanBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
 class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     """Representation of a Z-Wave binary_sensor from Notification CommandClass."""
 
-    def __init__(self, client: ZwaveClient, info: ZwaveDiscoveryInfo) -> None:
+    def __init__(
+        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+    ) -> None:
         """Initialize a ZWaveNotificationBinarySensor entity."""
-        super().__init__(client, info)
+        super().__init__(config_entry, client, info)
         # check if we have a custom mapping for this value
         self._mapping_info = self._get_sensor_mapping()
 

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -94,13 +94,15 @@ async def async_setup_entry(
     def async_add_climate(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Climate."""
         entities: List[ZWaveBaseEntity] = []
-        entities.append(ZWaveClimate(client, info))
+        entities.append(ZWaveClimate(config_entry, client, info))
 
         async_add_entities(entities)
 
     hass.data[DOMAIN][config_entry.entry_id][DATA_UNSUBSCRIBE].append(
         async_dispatcher_connect(
-            hass, f"{DOMAIN}_add_{CLIMATE_DOMAIN}", async_add_climate
+            hass,
+            f"{DOMAIN}_{config_entry.entry_id}_add_{CLIMATE_DOMAIN}",
+            async_add_climate,
         )
     )
 
@@ -108,9 +110,11 @@ async def async_setup_entry(
 class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     """Representation of a Z-Wave climate."""
 
-    def __init__(self, client: ZwaveClient, info: ZwaveDiscoveryInfo) -> None:
+    def __init__(
+        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+    ) -> None:
         """Initialize lock."""
-        super().__init__(client, info)
+        super().__init__(config_entry, client, info)
         self._hvac_modes: Dict[str, Optional[int]] = {}
         self._hvac_presets: Dict[str, Optional[int]] = {}
 

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.model.value import Value as ZwaveValue, get_value_id
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -21,8 +22,11 @@ EVENT_VALUE_UPDATED = "value updated"
 class ZWaveBaseEntity(Entity):
     """Generic Entity Class for a Z-Wave Device."""
 
-    def __init__(self, client: ZwaveClient, info: ZwaveDiscoveryInfo) -> None:
+    def __init__(
+        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+    ) -> None:
         """Initialize a generic Z-Wave device entity."""
+        self.config_entry = config_entry
         self.client = client
         self.info = info
         # entities requiring additional values, can add extra ids to this list
@@ -42,9 +46,12 @@ class ZWaveBaseEntity(Entity):
         self.async_on_remove(
             self.info.node.on(EVENT_VALUE_UPDATED, self._value_changed)
         )
+
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass, f"{DOMAIN}_connection_state", self.async_write_ha_state
+                self.hass,
+                f"{DOMAIN}_{self.config_entry.entry_id}_connection_state",
+                self.async_write_ha_state,
             )
         )
 

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -41,11 +41,15 @@ async def async_setup_entry(
     def async_add_light(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Light."""
 
-        light = ZwaveLight(client, info)
+        light = ZwaveLight(config_entry, client, info)
         async_add_entities([light])
 
     hass.data[DOMAIN][config_entry.entry_id][DATA_UNSUBSCRIBE].append(
-        async_dispatcher_connect(hass, f"{DOMAIN}_add_{LIGHT_DOMAIN}", async_add_light)
+        async_dispatcher_connect(
+            hass,
+            f"{DOMAIN}_{config_entry.entry_id}_add_{LIGHT_DOMAIN}",
+            async_add_light,
+        )
     )
 
 
@@ -62,9 +66,11 @@ def byte_to_zwave_brightness(value: int) -> int:
 class ZwaveLight(ZWaveBaseEntity, LightEntity):
     """Representation of a Z-Wave light."""
 
-    def __init__(self, client: ZwaveClient, info: ZwaveDiscoveryInfo) -> None:
+    def __init__(
+        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+    ) -> None:
         """Initialize the light."""
-        super().__init__(client, info)
+        super().__init__(config_entry, client, info)
         self._supports_color = False
         self._supports_white_value = False
         self._supports_color_temp = False

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -45,12 +45,14 @@ async def async_setup_entry(
     def async_add_lock(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Lock."""
         entities: List[ZWaveBaseEntity] = []
-        entities.append(ZWaveLock(client, info))
+        entities.append(ZWaveLock(config_entry, client, info))
 
         async_add_entities(entities)
 
     hass.data[DOMAIN][config_entry.entry_id][DATA_UNSUBSCRIBE].append(
-        async_dispatcher_connect(hass, f"{DOMAIN}_add_{LOCK_DOMAIN}", async_add_lock)
+        async_dispatcher_connect(
+            hass, f"{DOMAIN}_{config_entry.entry_id}_add_{LOCK_DOMAIN}", async_add_lock
+        )
     )
 
 

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -36,9 +36,9 @@ async def async_setup_entry(
         entities: List[ZWaveBaseEntity] = []
 
         if info.platform_hint == "string_sensor":
-            entities.append(ZWaveStringSensor(client, info))
+            entities.append(ZWaveStringSensor(config_entry, client, info))
         elif info.platform_hint == "numeric_sensor":
-            entities.append(ZWaveNumericSensor(client, info))
+            entities.append(ZWaveNumericSensor(config_entry, client, info))
         else:
             LOGGER.warning(
                 "Sensor not implemented for %s/%s",
@@ -51,7 +51,9 @@ async def async_setup_entry(
 
     hass.data[DOMAIN][config_entry.entry_id][DATA_UNSUBSCRIBE].append(
         async_dispatcher_connect(
-            hass, f"{DOMAIN}_add_{SENSOR_DOMAIN}", async_add_sensor
+            hass,
+            f"{DOMAIN}_{config_entry.entry_id}_add_{SENSOR_DOMAIN}",
+            async_add_sensor,
         )
     )
 

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -27,13 +27,15 @@ async def async_setup_entry(
     def async_add_switch(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Switch."""
         entities: List[ZWaveBaseEntity] = []
-        entities.append(ZWaveSwitch(client, info))
+        entities.append(ZWaveSwitch(config_entry, client, info))
 
         async_add_entities(entities)
 
     hass.data[DOMAIN][config_entry.entry_id][DATA_UNSUBSCRIBE].append(
         async_dispatcher_connect(
-            hass, f"{DOMAIN}_add_{SWITCH_DOMAIN}", async_add_switch
+            hass,
+            f"{DOMAIN}_{config_entry.entry_id}_add_{SWITCH_DOMAIN}",
+            async_add_switch,
         )
     )
 


### PR DESCRIPTION
## Proposed change

Add the config entry ID to the zwave_js signal names. Currently, if multiple zwave_js integrations are installed, each config entry instance connects to the same signals. This means events from one zwave-js-server are broadcast to all listening integration instances. For example:

- Entity discovery - when entities are discovered for one server, the "add platform" callback is dispatched for all config entries, causing invalid entities and devices to be created
- Server connection status - when a server connection is lost, unrelated integration instances for other servers will write the state for all of their entities.

Adding the config entry ID to the signal names means that only the relevant instance will handle it.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #45272
- This PR is related to issue: 
- Link to documentation pull request: 

The draft PR for the cover platform has this problem, and should be updated.
- https://github.com/home-assistant/core/pull/45193

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

No new tests added. If those are desired, I could use some suggestions on how that would be done.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
