### PR TITLE
Allow notify services to update existing targets

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -173,7 +173,10 @@ class BaseNotificationService:
                 target_name = slugify(f"{self._target_service_name_prefix}_{name}")
                 if target_name in stale_targets:
                     stale_targets.remove(target_name)
-                if target_name in self.registered_targets:
+                if (
+                    target_name in self.registered_targets
+                    and target == self.registered_targets[target_name]
+                ):
                     continue
                 self.registered_targets[target_name] = target
                 self.hass.services.async_register(

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -1,13 +1,11 @@
 """The tests for notify services that change targets."""
-import unittest
-
 from homeassistant.components import notify
 from homeassistant.core import HomeAssistant
 
 
 async def test_same_targets(hass: HomeAssistant):
     """Test not changing the targets in a notify service."""
-    test = TestNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -22,7 +20,7 @@ async def test_same_targets(hass: HomeAssistant):
 
 async def test_change_targets(hass: HomeAssistant):
     """Test changing the targets in a notify service."""
-    test = TestNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -39,7 +37,7 @@ async def test_change_targets(hass: HomeAssistant):
 
 async def test_add_targets(hass: HomeAssistant):
     """Test adding the targets in a notify service."""
-    test = TestNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -56,7 +54,7 @@ async def test_add_targets(hass: HomeAssistant):
 
 async def test_remove_targets(hass: HomeAssistant):
     """Test removing targets from the targets in a notify service."""
-    test = TestNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -71,7 +69,7 @@ async def test_remove_targets(hass: HomeAssistant):
     assert test.registered_targets == {"test_c": 1}
 
 
-class TestNotificationService(notify.BaseNotificationService, unittest.TestCase):
+class NotificationService(notify.BaseNotificationService):
     """A test class for notification services."""
 
     def __init__(self, hass):

--- a/tests/components/notify/test_notify_targets.py
+++ b/tests/components/notify/test_notify_targets.py
@@ -1,0 +1,85 @@
+"""The tests for notify services that change targets."""
+import unittest
+
+from homeassistant.components import notify
+from homeassistant.core import HomeAssistant
+
+
+async def test_same_targets(hass: HomeAssistant):
+    """Test not changing the targets in a notify service."""
+    test = TestNotificationService(hass)
+    await test.async_setup(hass, "notify", "test")
+    await test.async_register_services()
+    await hass.async_block_till_done()
+
+    assert hasattr(test, "registered_targets")
+    assert test.registered_targets == {"test_a": 1, "test_b": 2}
+
+    await test.async_register_services()
+    await hass.async_block_till_done()
+    assert test.registered_targets == {"test_a": 1, "test_b": 2}
+
+
+async def test_change_targets(hass: HomeAssistant):
+    """Test changing the targets in a notify service."""
+    test = TestNotificationService(hass)
+    await test.async_setup(hass, "notify", "test")
+    await test.async_register_services()
+    await hass.async_block_till_done()
+
+    assert hasattr(test, "registered_targets")
+    assert test.registered_targets == {"test_a": 1, "test_b": 2}
+
+    test.target_list = {"a": 0}
+    await test.async_register_services()
+    await hass.async_block_till_done()
+    assert test.target_list == {"a": 0}
+    assert test.registered_targets == {"test_a": 0}
+
+
+async def test_add_targets(hass: HomeAssistant):
+    """Test adding the targets in a notify service."""
+    test = TestNotificationService(hass)
+    await test.async_setup(hass, "notify", "test")
+    await test.async_register_services()
+    await hass.async_block_till_done()
+
+    assert hasattr(test, "registered_targets")
+    assert test.registered_targets == {"test_a": 1, "test_b": 2}
+
+    test.target_list = {"a": 1, "b": 2, "c": 3}
+    await test.async_register_services()
+    await hass.async_block_till_done()
+    assert test.target_list == {"a": 1, "b": 2, "c": 3}
+    assert test.registered_targets == {"test_a": 1, "test_b": 2, "test_c": 3}
+
+
+async def test_remove_targets(hass: HomeAssistant):
+    """Test removing targets from the targets in a notify service."""
+    test = TestNotificationService(hass)
+    await test.async_setup(hass, "notify", "test")
+    await test.async_register_services()
+    await hass.async_block_till_done()
+
+    assert hasattr(test, "registered_targets")
+    assert test.registered_targets == {"test_a": 1, "test_b": 2}
+
+    test.target_list = {"c": 1}
+    await test.async_register_services()
+    await hass.async_block_till_done()
+    assert test.target_list == {"c": 1}
+    assert test.registered_targets == {"test_c": 1}
+
+
+class TestNotificationService(notify.BaseNotificationService, unittest.TestCase):
+    """A test class for notification services."""
+
+    def __init__(self, hass):
+        """Initialize the service."""
+        self.hass = hass
+        self.target_list = {"a": 1, "b": 2}
+
+    @property
+    def targets(self):
+        """Return a dictionary of devices."""
+        return self.target_list


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow targets returned from notify service to update existing targets. Currently, if a target exists, it is automatically skipped so notify components cannot update an existing entry.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
