### PR TITLE
Bump hatasmota to 0.2.5

### DIFF
--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota (beta)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.1.6"],
+  "requirements": ["hatasmota==0.2.5"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -735,7 +735,7 @@ hass-nabucasa==0.39.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.1.6
+hatasmota==0.2.5
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -376,7 +376,7 @@ hangups==0.4.11
 hass-nabucasa==0.39.0
 
 # homeassistant.components.tasmota
-hatasmota==0.1.6
+hatasmota==0.2.5
 
 # homeassistant.components.jewish_calendar
 hdate==0.9.12

--- a/tests/components/tasmota/test_light.py
+++ b/tests/components/tasmota/test_light.py
@@ -1059,6 +1059,69 @@ async def test_transition(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
 
+async def test_transition_fixed(hass, mqtt_mock, setup_tasmota):
+    """Test transition commands."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["rl"][0] = 2
+    config["lt_st"] = 5  # 5 channel light (RGBCW)
+    config["so"]["117"] = 1  # fading at fixed duration instead of fixed slew rate
+    mac = config["mac"]
+
+    async_fire_mqtt_message(
+        hass,
+        f"{DEFAULT_PREFIX}/{mac}/config",
+        json.dumps(config),
+    )
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    state = hass.states.get("light.test")
+    assert state.state == STATE_OFF
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    mqtt_mock.async_publish.reset_mock()
+
+    # Dim the light from 0->100: Speed should be 4*2=8
+    await common.async_turn_on(hass, "light.test", brightness=255, transition=4)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/Backlog",
+        "NoDelay;Fade 1;NoDelay;Speed 8;NoDelay;Dimmer 100",
+        0,
+        False,
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Dim the light from 0->100: Speed should be capped at 40
+    await common.async_turn_on(hass, "light.test", brightness=255, transition=100)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/Backlog",
+        "NoDelay;Fade 1;NoDelay;Speed 40;NoDelay;Dimmer 100",
+        0,
+        False,
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Dim the light from 0->0: Speed should be 4*2=8
+    await common.async_turn_on(hass, "light.test", brightness=0, transition=4)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/Backlog",
+        "NoDelay;Fade 1;NoDelay;Speed 8;NoDelay;Power1 OFF",
+        0,
+        False,
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    # Dim the light from 0->50: Speed should be 4*2=8
+    await common.async_turn_on(hass, "light.test", brightness=128, transition=4)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tasmota_49A3BC/cmnd/Backlog",
+        "NoDelay;Fade 1;NoDelay;Speed 8;NoDelay;Dimmer 50",
+        0,
+        False,
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+
 async def test_relay_as_light(hass, mqtt_mock, setup_tasmota):
     """Test relay show up as light in light mode."""
     config = copy.deepcopy(DEFAULT_CONFIG)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump hatasmota from 0.1.6 to 0.2.5

Changes:

 - 0.2.5 (https://github.com/emontnemery/hatasmota/releases/tag/0.2.5)
   - Support light fade_fixed_duration (SetOption117) [#64](https://github.com/emontnemery/hatasmota/pull/64) @emontnemery
 - 0.2.0 (https://github.com/emontnemery/hatasmota/releases/tag/0.2.0)
   - Add device status [#53](https://github.com/emontnemery/hatasmota/pull/53) @emontnemery
 
https://github.com/emontnemery/hatasmota/compare/0.1.6..0.2.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
