### PR TITLE
Bump pyVicare to 0.2.5

### DIFF
--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -3,5 +3,5 @@
   "name": "Viessmann ViCare",
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "codeowners": ["@oischinger"],
-  "requirements": ["PyViCare==0.2.0"]
+  "requirements": ["PyViCare==0.2.5"]
 }

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -8,11 +8,9 @@ from homeassistant.const import (
     CONF_ICON,
     CONF_NAME,
     CONF_UNIT_OF_MEASUREMENT,
-    DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
     ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
-    POWER_WATT,
     TEMP_CELSIUS,
 )
 from homeassistant.helpers.entity import Entity
@@ -155,13 +153,6 @@ SENSOR_TYPES = {
         CONF_GETTER: lambda api: api.getBurnerHours(),
         CONF_DEVICE_CLASS: None,
     },
-    SENSOR_BURNER_POWER: {
-        CONF_NAME: "Burner Current Power",
-        CONF_ICON: None,
-        CONF_UNIT_OF_MEASUREMENT: POWER_WATT,
-        CONF_GETTER: lambda api: api.getCurrentPower(),
-        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
-    },
     # heatpump sensors
     SENSOR_COMPRESSOR_STARTS: {
         CONF_NAME: "Compressor Starts",
@@ -194,7 +185,6 @@ SENSORS_BY_HEATINGTYPE = {
         SENSOR_BURNER_HOURS,
         SENSOR_BURNER_MODULATION,
         SENSOR_BURNER_STARTS,
-        SENSOR_BURNER_POWER,
         SENSOR_DHW_GAS_CONSUMPTION_TODAY,
         SENSOR_DHW_GAS_CONSUMPTION_THIS_WEEK,
         SENSOR_DHW_GAS_CONSUMPTION_THIS_MONTH,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -64,7 +64,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.4.0
 
 # homeassistant.components.vicare
-PyViCare==0.2.0
+PyViCare==0.2.5
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.13.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The current power sensor has been removed since it was not provided by the Viessmann API anymore.

## Proposed change
Update to pyVicare 0.2.5 which most prominently fixes errors on API token expiry that were visible in the home assistant logs.

[Full diff between 0.2.0 and 0.2.5](https://github.com/somm15/PyViCare/compare/b602c1670ea6041337782269b20851c5dedba32c...b443a4df75a7f976f762d3656fead5dd5e727545)

Also removes the power sensor that is no more supported

## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
