### PR TITLE
Introduce reauthentication flow to Axis integration

### DIFF
--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -144,7 +144,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
         self.discovery_schema = {
             vol.Required(CONF_HOST, default=device_config[CONF_HOST]): str,
             vol.Required(CONF_USERNAME, default=device_config[CONF_USERNAME]): str,
-            vol.Required(CONF_PASSWORD, default=device_config[CONF_PASSWORD]): str,
+            vol.Required(CONF_PASSWORD): str,
             vol.Required(CONF_PORT, default=device_config[CONF_PORT]): int,
         }
 

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -75,6 +75,8 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
                     updates={
                         CONF_HOST: user_input[CONF_HOST],
                         CONF_PORT: user_input[CONF_PORT],
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
                     }
                 )
 
@@ -130,6 +132,23 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
 
         title = f"{model} - {self.serial}"
         return self.async_create_entry(title=title, data=self.device_config)
+
+    async def async_step_reauth(self, device_config: dict):
+        """Trigger a reauthentication flow."""
+        # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
+        self.context["title_placeholders"] = {
+            CONF_NAME: device_config[CONF_NAME],
+            CONF_HOST: device_config[CONF_HOST],
+        }
+
+        self.discovery_schema = {
+            vol.Required(CONF_HOST, default=device_config[CONF_HOST]): str,
+            vol.Required(CONF_USERNAME, default=device_config[CONF_USERNAME]): str,
+            vol.Required(CONF_PASSWORD, default=device_config[CONF_PASSWORD]): str,
+            vol.Required(CONF_PORT, default=device_config[CONF_PORT]): int,
+        }
+
+        return await self.async_step_user()
 
     async def async_step_dhcp(self, discovery_info: dict):
         """Prepare configuration for a DHCP discovered Axis device."""

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -13,6 +13,7 @@ from axis.streammanager import SIGNAL_PLAYING, STATE_STOPPED
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
 from homeassistant.components.mqtt.models import Message
+from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -213,9 +214,14 @@ class AxisNetworkDevice:
         except CannotConnect as err:
             raise ConfigEntryNotReady from err
 
-        except Exception as err:  # pylint: disable=broad-except
-            LOGGER.error(
-                "Unknown error connecting with Axis device (%s): %s", self.host, err
+        except AuthenticationRequired as err:
+            LOGGER.error("Authentication error with (%s): %s", self.host, err)
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    AXIS_DOMAIN,
+                    context={"source": SOURCE_REAUTH},
+                    data=self.config_entry.data,
+                )
             )
             return False
 

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -214,8 +214,7 @@ class AxisNetworkDevice:
         except CannotConnect as err:
             raise ConfigEntryNotReady from err
 
-        except AuthenticationRequired as err:
-            LOGGER.error("Authentication error with (%s): %s", self.host, err)
+        except AuthenticationRequired:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
                     AXIS_DOMAIN,

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.config_entries import (
     SOURCE_DHCP,
     SOURCE_IGNORE,
+    SOURCE_REAUTH,
     SOURCE_USER,
     SOURCE_ZEROCONF,
 )
@@ -235,6 +236,40 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(hass):
     }
 
     assert result["data"][CONF_NAME] == "M1065-LW 2"
+
+
+async def test_reauth_flow_update_configuration(hass):
+    """Test that config flow fails on already configured device."""
+    config_entry = await setup_axis_integration(hass)
+    device = hass.data[AXIS_DOMAIN][config_entry.unique_id]
+
+    result = await hass.config_entries.flow.async_init(
+        AXIS_DOMAIN,
+        context={"source": SOURCE_REAUTH},
+        data=config_entry.data,
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == SOURCE_USER
+
+    with respx.mock:
+        mock_default_vapix_requests(respx, "2.3.4.5")
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "2.3.4.5",
+                CONF_USERNAME: "user2",
+                CONF_PASSWORD: "pass2",
+                CONF_PORT: 80,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+    assert device.host == "2.3.4.5"
+    assert device.username == "user2"
+    assert device.password == "pass2"
 
 
 async def test_dhcp_flow(hass):

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -113,33 +113,6 @@ async def test_manual_configuration_update_configuration(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_flow_fails_already_configured(hass):
-    """Test that config flow fails on already configured device."""
-    await setup_axis_integration(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        AXIS_DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["step_id"] == SOURCE_USER
-
-    with respx.mock:
-        mock_default_vapix_requests(respx)
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "1.2.3.4",
-                CONF_USERNAME: "user",
-                CONF_PASSWORD: "pass",
-                CONF_PORT: 80,
-            },
-        )
-
-    assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
-
-
 async def test_flow_fails_faulty_credentials(hass):
     """Test that config flow fails on faulty credentials."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -412,6 +412,16 @@ async def test_device_not_accessible(hass):
     assert hass.data[AXIS_DOMAIN] == {}
 
 
+async def test_device_trigger_reauth_flow(hass):
+    """Failed authentication trigger a reauthentication flow."""
+    with patch.object(
+        axis.device, "get_device", side_effect=axis.errors.AuthenticationRequired
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_flow_init:
+        await setup_axis_integration(hass)
+        mock_flow_init.assert_called_once()
+    assert hass.data[AXIS_DOMAIN] == {}
+
+
 async def test_device_unknown_error(hass):
     """Unknown errors are handled."""
     with patch.object(axis.device, "get_device", side_effect=Exception):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trigger reauth flow on AuthenticationRequired exception during setup

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
