### PR TITLE
Move device tracker scanner attributes to ScannerEntity

### DIFF
--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -71,7 +71,7 @@ class BaseTrackerEntity(Entity):
             attr[ATTR_BATTERY_LEVEL] = self.battery_level
         if self.ip_address is not None:
             attr[ATTR_IP] = self.ip_address
-        if self.ip_address is not None:
+        if self.mac_address is not None:
             attr[ATTR_MAC] = self.mac_address
         if self.hostname is not None:
             attr[ATTR_HOST_NAME] = self.hostname

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -48,33 +48,12 @@ class BaseTrackerEntity(Entity):
         raise NotImplementedError
 
     @property
-    def ip_address(self) -> str:
-        """Return the primary ip address of the device."""
-        return None
-
-    @property
-    def mac_address(self) -> str:
-        """Return the mac address of the device."""
-        return None
-
-    @property
-    def hostname(self) -> str:
-        """Return hostname of the device."""
-        return None
-
-    @property
     def state_attributes(self):
         """Return the device state attributes."""
         attr = {ATTR_SOURCE_TYPE: self.source_type}
 
         if self.battery_level:
             attr[ATTR_BATTERY_LEVEL] = self.battery_level
-        if self.ip_address is not None:
-            attr[ATTR_IP] = self.ip_address
-        if self.mac_address is not None:
-            attr[ATTR_MAC] = self.mac_address
-        if self.hostname is not None:
-            attr[ATTR_HOST_NAME] = self.hostname
 
         return attr
 
@@ -152,6 +131,21 @@ class ScannerEntity(BaseTrackerEntity):
     """Represent a tracked device that is on a scanned network."""
 
     @property
+    def ip_address(self) -> str:
+        """Return the primary ip address of the device."""
+        return None
+
+    @property
+    def mac_address(self) -> str:
+        """Return the mac address of the device."""
+        return None
+
+    @property
+    def hostname(self) -> str:
+        """Return hostname of the device."""
+        return None
+
+    @property
     def state(self):
         """Return the state of the device."""
         if self.is_connected:
@@ -162,3 +156,17 @@ class ScannerEntity(BaseTrackerEntity):
     def is_connected(self):
         """Return true if the device is connected to the network."""
         raise NotImplementedError
+
+    @property
+    def state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        attr.update(super().state_attributes)
+        if self.ip_address is not None:
+            attr[ATTR_IP] = self.ip_address
+        if self.mac_address is not None:
+            attr[ATTR_MAC] = self.mac_address
+        if self.hostname is not None:
+            attr[ATTR_HOST_NAME] = self.hostname
+
+        return attr

--- a/tests/components/device_tracker/test_entities.py
+++ b/tests/components/device_tracker/test_entities.py
@@ -6,6 +6,9 @@ from homeassistant.components.device_tracker.config_entry import (
     ScannerEntity,
 )
 from homeassistant.components.device_tracker.const import (
+    ATTR_HOST_NAME,
+    ATTR_IP,
+    ATTR_MAC,
     ATTR_SOURCE_TYPE,
     DOMAIN,
     SOURCE_TYPE_ROUTER,
@@ -28,6 +31,9 @@ async def test_scanner_entity_device_tracker(hass):
     assert entity_state.attributes == {
         ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER,
         ATTR_BATTERY_LEVEL: 100,
+        ATTR_IP: "0.0.0.0",
+        ATTR_MAC: "ad:de:ef:be:ed:fe:",
+        ATTR_HOST_NAME: "test.hostname.org",
     }
     assert entity_state.state == STATE_NOT_HOME
 
@@ -49,6 +55,9 @@ def test_scanner_entity():
     with pytest.raises(NotImplementedError):
         assert entity.state == STATE_NOT_HOME
     assert entity.battery_level is None
+    assert entity.ip_address is None
+    assert entity.mac_address is None
+    assert entity.hostname is None
 
 
 def test_base_tracker_entity():
@@ -59,6 +68,3 @@ def test_base_tracker_entity():
     assert entity.battery_level is None
     with pytest.raises(NotImplementedError):
         assert entity.state_attributes is None
-    assert entity.ip_address is None
-    assert entity.mac_address is None
-    assert entity.hostname is None

--- a/tests/testing_config/custom_components/test/device_tracker.py
+++ b/tests/testing_config/custom_components/test/device_tracker.py
@@ -16,6 +16,9 @@ class MockScannerEntity(ScannerEntity):
     def __init__(self):
         """Init."""
         self.connected = False
+        self._hostname = "test.hostname.org"
+        self._ip_address = "0.0.0.0"
+        self._mac_address = "ad:de:ef:be:ed:fe:"
 
     @property
     def source_type(self):
@@ -29,6 +32,21 @@ class MockScannerEntity(ScannerEntity):
         Percentage from 0-100.
         """
         return 100
+
+    @property
+    def ip_address(self) -> str:
+        """Return the primary ip address of the device."""
+        return self._ip_address
+
+    @property
+    def mac_address(self) -> str:
+        """Return the mac address of the device."""
+        return self._mac_address
+
+    @property
+    def hostname(self) -> str:
+        """Return hostname of the device."""
+        return self._hostname
 
     @property
     def is_connected(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We recently added these attributes to the device tracker entity. We added them to the base entity, but they belong in the ScannerEntity, since they are only relevant for router based device trackers.
- This PR moves the attributes and properties to the `ScannerEntity` class.
- Also fixed the check for mac address attribute that used to check for ip address.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
