### PR TITLE
Add node_status websocket API command to zwave_js

### DIFF
--- a/tests/components/zwave_js/test_websocket_api.py
+++ b/tests/components/zwave_js/test_websocket_api.py
@@ -2,11 +2,11 @@
 from zwave_js_server.event import Event
 
 from homeassistant.components.zwave_js.const import DOMAIN
-from homeassistant.components.zwave_js.websocket_api import ENTRY_ID, ID, TYPE
+from homeassistant.components.zwave_js.websocket_api import ENTRY_ID, ID, NODE_ID, TYPE
 from homeassistant.helpers.device_registry import async_get_registry
 
 
-async def test_websocket_api(hass, integration, hass_ws_client):
+async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     """Test the network_status websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
@@ -19,6 +19,20 @@ async def test_websocket_api(hass, integration, hass_ws_client):
 
     assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"
     assert result["client"]["server_version"] == "1.0.0"
+
+    node = multisensor_6
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/node_status",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: node.node_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+    result = msg["result"]
+    assert result[NODE_ID] == 52
+    assert result["ready"]
 
 
 async def test_add_node(

--- a/tests/components/zwave_js/test_websocket_api.py
+++ b/tests/components/zwave_js/test_websocket_api.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.device_registry import async_get_registry
 
 
 async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
-    """Test the network_status websocket command."""
+    """Test the network and node status websocket commands."""
     entry = integration
     ws_client = await hass_ws_client(hass)
 
@@ -31,8 +31,12 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     )
     msg = await ws_client.receive_json()
     result = msg["result"]
+
     assert result[NODE_ID] == 52
     assert result["ready"]
+    assert result["is_routing"]
+    assert not result["is_secure"]
+    assert result["status"] == 1
 
 
 async def test_add_node(


### PR DESCRIPTION
## Proposed change
Add a node_status websocket command to the zwave_js integration. Used to return the current status of a node for the Devices page in the frontend


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.