### PR TITLE
Allow multiple recipients for XMPP

### DIFF
--- a/homeassistant/components/xmpp/notify.py
+++ b/homeassistant/components/xmpp/notify.py
@@ -55,7 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_SENDER): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_RECIPIENT): cv.string,
+        vol.Required(CONF_RECIPIENT): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_RESOURCE, default=DEFAULT_RESOURCE): cv.string,
         vol.Optional(CONF_ROOM, default=""): cv.string,
         vol.Optional(CONF_TLS, default=True): cv.boolean,
@@ -87,7 +87,7 @@ class XmppNotificationService(BaseNotificationService):
         self._sender = sender
         self._resource = resource
         self._password = password
-        self._recipient = recipient
+        self._recipients = recipient
         self._tls = tls
         self._verify = verify
         self._room = room
@@ -102,7 +102,7 @@ class XmppNotificationService(BaseNotificationService):
         await async_send_message(
             f"{self._sender}/{self._resource}",
             self._password,
-            self._recipient,
+            self._recipients,
             self._tls,
             self._verify,
             self._room,
@@ -116,7 +116,7 @@ class XmppNotificationService(BaseNotificationService):
 async def async_send_message(
     sender,
     password,
-    recipient,
+    recipients,
     use_tls,
     verify_certificate,
     room,
@@ -182,19 +182,21 @@ async def async_send_message(
                 url = await self.upload_file(timeout=timeout)
 
                 _LOGGER.info("Upload success")
-                if room:
-                    _LOGGER.info("Sending file to %s", room)
-                    message = self.Message(sto=room, stype="groupchat")
-                else:
-                    _LOGGER.info("Sending file to %s", recipient)
-                    message = self.Message(sto=recipient, stype="chat")
-
-                message["body"] = url
-                message["oob"]["url"] = url
-                try:
-                    message.send()
-                except (IqError, IqTimeout, XMPPError) as ex:
-                    _LOGGER.error("Could not send image message %s", ex)
+                for recipient in recipients:
+                    if room:
+                        _LOGGER.info("Sending file to %s", room)
+                        message = self.Message(sto=room, stype="groupchat")
+                    else:
+                        _LOGGER.info("Sending file to %s", recipient)
+                        message = self.Message(sto=recipient, stype="chat")
+                    message["body"] = url
+                    message["oob"]["url"] = url
+                    try:
+                        message.send()
+                    except (IqError, IqTimeout, XMPPError) as ex:
+                        _LOGGER.error("Could not send image message %s", ex)
+                    if room:
+                        break
             except (IqError, IqTimeout, XMPPError) as ex:
                 _LOGGER.error("Upload error, could not send message %s", ex)
             except NotConnectedError as ex:
@@ -336,8 +338,9 @@ async def async_send_message(
                     self.plugin["xep_0045"].join_muc(room, sender, wait=True)
                     self.send_message(mto=room, mbody=message, mtype="groupchat")
                 else:
-                    _LOGGER.debug("Sending message to %s", recipient)
-                    self.send_message(mto=recipient, mbody=message, mtype="chat")
+                    for recipient in recipients:
+                        _LOGGER.debug("Sending message to %s", recipient)
+                        self.send_message(mto=recipient, mbody=message, mtype="chat")
             except (IqError, IqTimeout, XMPPError) as ex:
                 _LOGGER.error("Could not send text message %s", ex)
             except NotConnectedError as ex:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current implementation makes it necessary to call the notify service multiple times if a message shall be sent to more than one recipients.
This has the following drawbacks:
* If there is data attached to the message, the data must be uploaded multiple times (e.g. a picture send to all home users if the doorbell rings).
* Automations and scripts get unnecessarily big if multiple recipients are addressed.
* The XMPP component might not be ready to send another message directly following a previous one as the slixmpp client is not ready yet (it takes time to connect and disconnect before and after a message is send) leading to a loss of messages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
notify:
  - name: jabber_all_home_users
    platform: xmpp
    sender: !secret xmpp_user
    password: !secret xmpp_password
    recipient: 
        - <recipient_1>
        - <recipient_2>
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16231

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
