### PR TITLE
Change Dyson PureCoolLink fan speeds to adhere the standard

### DIFF
--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -1,5 +1,6 @@
 """Support for Dyson Pure Cool link fan."""
 import logging
+from typing import Optional
 
 from libpurecool.const import FanMode, FanSpeed, NightMode, Oscillation
 from libpurecool.dyson_pure_cool import DysonPureCool
@@ -232,7 +233,7 @@ class DysonPureCoolLinkEntity(DysonFanEntity):
         """Initialize the fan."""
         super().__init__(device, DysonPureCoolState)
 
-    def turn_on(self, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: Optional[str] = None, **kwargs) -> None:
         """Turn on the fan."""
         _LOGGER.debug("Turn on fan %s with speed %s", self.name, speed)
         if speed is not None:
@@ -298,7 +299,7 @@ class DysonPureCoolEntity(DysonFanEntity):
         """Initialize the fan."""
         super().__init__(device, DysonPureCoolV2State)
 
-    def turn_on(self, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: Optional[str] = None, **kwargs) -> None:
         """Turn on the fan."""
         _LOGGER.debug("Turn on fan %s", self.name)
 

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -295,7 +295,7 @@ class DysonPureCoolLinkEntity(DysonFanEntity):
         _LOGGER.debug("Turn off fan %s", self.name)
         self._device.set_configuration(fan_mode=FanMode.OFF)
 
-    def set_dyson_speed(self, speed: str = None) -> None:
+    def set_dyson_speed(self, speed: str) -> None:
         """Set the exact speed of the purecool fan."""
         _LOGGER.debug("Set exact speed for fan %s", self.name)
 
@@ -368,7 +368,7 @@ class DysonPureCoolEntity(DysonFanEntity):
         _LOGGER.debug("Turn off fan %s", self.name)
         self._device.turn_off()
 
-    def set_dyson_speed(self, speed: str = None) -> None:
+    def set_dyson_speed(self, speed: str) -> None:
         """Set the exact speed of the purecool fan."""
         _LOGGER.debug("Set exact speed for fan %s", self.name)
 

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -183,9 +183,77 @@ class DysonFanEntity(DysonEntity, FanEntity):
     """Representation of a Dyson fan."""
 
     @property
+    def speed(self):
+        """Return the current speed."""
+        speed_map = {
+            FanSpeed.FAN_SPEED_1.value: SPEED_LOW,
+            FanSpeed.FAN_SPEED_2.value: SPEED_LOW,
+            FanSpeed.FAN_SPEED_3.value: SPEED_LOW,
+            FanSpeed.FAN_SPEED_4.value: SPEED_LOW,
+            FanSpeed.FAN_SPEED_AUTO.value: SPEED_MEDIUM,
+            FanSpeed.FAN_SPEED_5.value: SPEED_MEDIUM,
+            FanSpeed.FAN_SPEED_6.value: SPEED_MEDIUM,
+            FanSpeed.FAN_SPEED_7.value: SPEED_MEDIUM,
+            FanSpeed.FAN_SPEED_8.value: SPEED_HIGH,
+            FanSpeed.FAN_SPEED_9.value: SPEED_HIGH,
+            FanSpeed.FAN_SPEED_10.value: SPEED_HIGH,
+        }
+
+        return speed_map[self._device.state.speed]
+
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        return [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+    @property
+    def dyson_speed(self):
+        """Return the current speed."""
+        if self._device.state:
+            if self._device.state.speed == FanSpeed.FAN_SPEED_AUTO.value:
+                return self._device.state.speed
+            return int(self._device.state.speed)
+
+    @property
+    def dyson_speed_list(self) -> list:
+        """Get the list of available dyson speeds."""
+        return [
+            int(FanSpeed.FAN_SPEED_1.value),
+            int(FanSpeed.FAN_SPEED_2.value),
+            int(FanSpeed.FAN_SPEED_3.value),
+            int(FanSpeed.FAN_SPEED_4.value),
+            int(FanSpeed.FAN_SPEED_5.value),
+            int(FanSpeed.FAN_SPEED_6.value),
+            int(FanSpeed.FAN_SPEED_7.value),
+            int(FanSpeed.FAN_SPEED_8.value),
+            int(FanSpeed.FAN_SPEED_9.value),
+            int(FanSpeed.FAN_SPEED_10.value),
+        ]
+
+    @property
     def night_mode(self):
         """Return Night mode."""
         return self._device.state.night_mode == "ON"
+
+    @property
+    def auto_mode(self):
+        """Return auto mode."""
+        raise NotImplementedError
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_OSCILLATE | SUPPORT_SET_SPEED
+
+    @property
+    def device_state_attributes(self) -> dict:
+        """Return optional state attributes."""
+        return {
+            ATTR_NIGHT_MODE: self.night_mode,
+            ATTR_AUTO_MODE: self.auto_mode,
+            ATTR_DYSON_SPEED: self.dyson_speed,
+            ATTR_DYSON_SPEED_LIST: self.dyson_speed_list,
+        }
 
 
 class DysonPureCoolLinkEntity(DysonFanEntity):
@@ -244,13 +312,6 @@ class DysonPureCoolLinkEntity(DysonFanEntity):
         """Return true if the entity is on."""
         return self._device.state.fan_mode in ["FAN", "AUTO"]
 
-    @property
-    def speed(self) -> str:
-        """Return the current speed."""
-        if self._device.state.speed == FanSpeed.FAN_SPEED_AUTO.value:
-            return self._device.state.speed
-        return int(self._device.state.speed)
-
     def set_night_mode(self, night_mode: bool) -> None:
         """Turn fan in night mode."""
         _LOGGER.debug("Set %s night mode %s", self.name, night_mode)
@@ -271,35 +332,6 @@ class DysonPureCoolLinkEntity(DysonFanEntity):
             self._device.set_configuration(fan_mode=FanMode.AUTO)
         else:
             self._device.set_configuration(fan_mode=FanMode.FAN)
-
-    @property
-    def speed_list(self) -> list:
-        """Get the list of available speeds."""
-        supported_speeds = [
-            FanSpeed.FAN_SPEED_AUTO.value,
-            int(FanSpeed.FAN_SPEED_1.value),
-            int(FanSpeed.FAN_SPEED_2.value),
-            int(FanSpeed.FAN_SPEED_3.value),
-            int(FanSpeed.FAN_SPEED_4.value),
-            int(FanSpeed.FAN_SPEED_5.value),
-            int(FanSpeed.FAN_SPEED_6.value),
-            int(FanSpeed.FAN_SPEED_7.value),
-            int(FanSpeed.FAN_SPEED_8.value),
-            int(FanSpeed.FAN_SPEED_9.value),
-            int(FanSpeed.FAN_SPEED_10.value),
-        ]
-
-        return supported_speeds
-
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        return SUPPORT_OSCILLATE | SUPPORT_SET_SPEED
-
-    @property
-    def device_state_attributes(self) -> dict:
-        """Return optional state attributes."""
-        return {ATTR_NIGHT_MODE: self.night_mode, ATTR_AUTO_MODE: self.auto_mode}
 
 
 class DysonPureCoolEntity(DysonFanEntity):
@@ -408,33 +440,6 @@ class DysonPureCoolEntity(DysonFanEntity):
         return self._device.state.fan_power == "ON"
 
     @property
-    def speed(self):
-        """Return the current speed."""
-        speed_map = {
-            FanSpeed.FAN_SPEED_1.value: SPEED_LOW,
-            FanSpeed.FAN_SPEED_2.value: SPEED_LOW,
-            FanSpeed.FAN_SPEED_3.value: SPEED_LOW,
-            FanSpeed.FAN_SPEED_4.value: SPEED_LOW,
-            FanSpeed.FAN_SPEED_AUTO.value: SPEED_MEDIUM,
-            FanSpeed.FAN_SPEED_5.value: SPEED_MEDIUM,
-            FanSpeed.FAN_SPEED_6.value: SPEED_MEDIUM,
-            FanSpeed.FAN_SPEED_7.value: SPEED_MEDIUM,
-            FanSpeed.FAN_SPEED_8.value: SPEED_HIGH,
-            FanSpeed.FAN_SPEED_9.value: SPEED_HIGH,
-            FanSpeed.FAN_SPEED_10.value: SPEED_HIGH,
-        }
-
-        return speed_map[self._device.state.speed]
-
-    @property
-    def dyson_speed(self):
-        """Return the current speed."""
-        if self._device.state:
-            if self._device.state.speed == FanSpeed.FAN_SPEED_AUTO.value:
-                return self._device.state.speed
-            return int(self._device.state.speed)
-
-    @property
     def auto_mode(self):
         """Return Auto mode."""
         return self._device.state.auto_mode == "ON"
@@ -472,43 +477,14 @@ class DysonPureCoolEntity(DysonFanEntity):
         return int(self._device.state.carbon_filter_state)
 
     @property
-    def speed_list(self) -> list:
-        """Get the list of available speeds."""
-        return [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
-
-    @property
-    def dyson_speed_list(self) -> list:
-        """Get the list of available dyson speeds."""
-        return [
-            int(FanSpeed.FAN_SPEED_1.value),
-            int(FanSpeed.FAN_SPEED_2.value),
-            int(FanSpeed.FAN_SPEED_3.value),
-            int(FanSpeed.FAN_SPEED_4.value),
-            int(FanSpeed.FAN_SPEED_5.value),
-            int(FanSpeed.FAN_SPEED_6.value),
-            int(FanSpeed.FAN_SPEED_7.value),
-            int(FanSpeed.FAN_SPEED_8.value),
-            int(FanSpeed.FAN_SPEED_9.value),
-            int(FanSpeed.FAN_SPEED_10.value),
-        ]
-
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        return SUPPORT_OSCILLATE | SUPPORT_SET_SPEED
-
-    @property
     def device_state_attributes(self) -> dict:
         """Return optional state attributes."""
         return {
-            ATTR_NIGHT_MODE: self.night_mode,
-            ATTR_AUTO_MODE: self.auto_mode,
+            **super().device_state_attributes,
             ATTR_ANGLE_LOW: self.angle_low,
             ATTR_ANGLE_HIGH: self.angle_high,
             ATTR_FLOW_DIRECTION_FRONT: self.flow_direction_front,
             ATTR_TIMER: self.timer,
             ATTR_HEPA_FILTER: self.hepa_filter,
             ATTR_CARBON_FILTER: self.carbon_filter,
-            ATTR_DYSON_SPEED: self.dyson_speed,
-            ATTR_DYSON_SPEED_LIST: self.dyson_speed_list,
         }

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -232,10 +232,9 @@ class DysonFanEntity(DysonEntity, FanEntity):
     @property
     def dyson_speed(self):
         """Return the current speed."""
-        if self._device.state:
-            if self._device.state.speed == FanSpeed.FAN_SPEED_AUTO.value:
-                return self._device.state.speed
-            return int(self._device.state.speed)
+        if self._device.state.speed == FanSpeed.FAN_SPEED_AUTO.value:
+            return self._device.state.speed
+        return int(self._device.state.speed)
 
     @property
     def dyson_speed_list(self) -> list:

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -176,6 +176,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     hass.services.register(
         DYSON_DOMAIN, SERVICE_SET_AUTO_MODE, service_handle, schema=SET_AUTO_MODE_SCHEMA
     )
+
+    hass.services.register(
+        DYSON_DOMAIN,
+        SERVICE_SET_DYSON_SPEED,
+        service_handle,
+        schema=SET_DYSON_SPEED_SCHEMA,
+    )
+
     if has_purecool_devices:
         hass.services.register(
             DYSON_DOMAIN, SERVICE_SET_ANGLE, service_handle, schema=SET_ANGLE_SCHEMA
@@ -190,13 +198,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         hass.services.register(
             DYSON_DOMAIN, SERVICE_SET_TIMER, service_handle, schema=SET_TIMER_SCHEMA
-        )
-
-        hass.services.register(
-            DYSON_DOMAIN,
-            SERVICE_SET_DYSON_SPEED,
-            service_handle,
-            schema=SET_DYSON_SPEED_SCHEMA,
         )
 
 
@@ -290,6 +291,13 @@ class DysonPureCoolLinkEntity(DysonFanEntity):
         """Turn off the fan."""
         _LOGGER.debug("Turn off fan %s", self.name)
         self._device.set_configuration(fan_mode=FanMode.OFF)
+
+    def set_dyson_speed(self, speed: str = None) -> None:
+        """Set the exact speed of the purecool fan."""
+        _LOGGER.debug("Set exact speed for fan %s", self.name)
+
+        fan_speed = FanSpeed(f"{int(speed):04d}")
+        self._device.set_configuration(fan_mode=FanMode.FAN, fan_speed=fan_speed)
 
     def oscillate(self, oscillating: bool) -> None:
         """Turn on/off oscillating."""

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -17,7 +17,7 @@ from homeassistant.components.fan import (
     FanEntity,
 )
 from homeassistant.const import ATTR_ENTITY_ID
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv
 
 from . import DYSON_DEVICES, DysonEntity
 
@@ -124,7 +124,7 @@ SPEED_HA_TO_DYSON = {
 }
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Dyson fan components."""
 
     if discovery_info is None:
@@ -147,8 +147,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 dyson_entity = DysonPureCoolLinkEntity(device)
                 hass.data[DYSON_FAN_DEVICES].append(dyson_entity)
 
-    add_entities(hass.data[DYSON_FAN_DEVICES])
+    async_add_entities(hass.data[DYSON_FAN_DEVICES])
 
+    await hass.async_add_executor_job(_register_services, hass, has_purecool_devices)
+
+
+def _register_services(hass, has_purecool_devices):
     def service_handle(service):
         """Handle the Dyson services."""
         entity_id = service.data[ATTR_ENTITY_ID]

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -88,6 +88,21 @@ SET_DYSON_SPEED_SCHEMA = vol.Schema(
 )
 
 
+SPEED_LIST_HA = [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+SPEED_LIST_DYSON = [
+    int(FanSpeed.FAN_SPEED_1.value),
+    int(FanSpeed.FAN_SPEED_2.value),
+    int(FanSpeed.FAN_SPEED_3.value),
+    int(FanSpeed.FAN_SPEED_4.value),
+    int(FanSpeed.FAN_SPEED_5.value),
+    int(FanSpeed.FAN_SPEED_6.value),
+    int(FanSpeed.FAN_SPEED_7.value),
+    int(FanSpeed.FAN_SPEED_8.value),
+    int(FanSpeed.FAN_SPEED_9.value),
+    int(FanSpeed.FAN_SPEED_10.value),
+]
+
 SPEED_DYSON_TO_HA = {
     FanSpeed.FAN_SPEED_1.value: SPEED_LOW,
     FanSpeed.FAN_SPEED_2.value: SPEED_LOW,
@@ -212,7 +227,7 @@ class DysonFanEntity(DysonEntity, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+        return SPEED_LIST_HA
 
     @property
     def dyson_speed(self):
@@ -225,18 +240,7 @@ class DysonFanEntity(DysonEntity, FanEntity):
     @property
     def dyson_speed_list(self) -> list:
         """Get the list of available dyson speeds."""
-        return [
-            int(FanSpeed.FAN_SPEED_1.value),
-            int(FanSpeed.FAN_SPEED_2.value),
-            int(FanSpeed.FAN_SPEED_3.value),
-            int(FanSpeed.FAN_SPEED_4.value),
-            int(FanSpeed.FAN_SPEED_5.value),
-            int(FanSpeed.FAN_SPEED_6.value),
-            int(FanSpeed.FAN_SPEED_7.value),
-            int(FanSpeed.FAN_SPEED_8.value),
-            int(FanSpeed.FAN_SPEED_9.value),
-            int(FanSpeed.FAN_SPEED_10.value),
-        ]
+        return SPEED_LIST_DYSON
 
     @property
     def night_mode(self):

--- a/tests/components/dyson/conftest.py
+++ b/tests/components/dyson/conftest.py
@@ -15,7 +15,7 @@ from tests.common import async_setup_component
 BASE_PATH = "homeassistant.components.dyson"
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 async def device(hass: HomeAssistant, request) -> DysonDevice:
     """Fixture to provide Dyson 360 Eye device."""
     platform = request.module.PLATFORM_DOMAIN

--- a/tests/components/dyson/conftest.py
+++ b/tests/components/dyson/conftest.py
@@ -15,7 +15,7 @@ from tests.common import async_setup_component
 BASE_PATH = "homeassistant.components.dyson"
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def device(hass: HomeAssistant, request) -> DysonDevice:
     """Fixture to provide Dyson 360 Eye device."""
     platform = request.module.PLATFORM_DOMAIN

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -394,7 +394,7 @@ async def test_custom_services_purecool(
 )
 @pytest.mark.parametrize("device", [DysonPureCool], indirect=True)
 async def test_custom_services_invalid_data(
-    hass: HomeAssistant, domain: str, service: str, data: dict
+    hass: HomeAssistant, device: DysonPureCool, domain: str, service: str, data: dict
 ) -> None:
     """Test custom services calling with invalid data."""
     with pytest.raises(ValueError):

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -93,10 +93,10 @@ async def test_state_purecoollink(
     attributes = state.attributes
     assert attributes[ATTR_NIGHT_MODE] is True
     assert attributes[ATTR_OSCILLATING] is True
-    assert attributes[ATTR_SPEED] == 1
-    assert attributes[ATTR_SPEED_LIST] == [FanSpeed.FAN_SPEED_AUTO.value] + list(
-        range(1, 11)
-    )
+    assert attributes[ATTR_SPEED] == SPEED_LOW
+    assert attributes[ATTR_SPEED_LIST] == [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+    assert attributes[ATTR_DYSON_SPEED] == 1
+    assert attributes[ATTR_DYSON_SPEED_LIST] == list(range(1, 11))
     assert attributes[ATTR_AUTO_MODE] is False
     assert attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_OSCILLATE | SUPPORT_SET_SPEED
 
@@ -115,7 +115,8 @@ async def test_state_purecoollink(
     attributes = state.attributes
     assert attributes[ATTR_NIGHT_MODE] is False
     assert attributes[ATTR_OSCILLATING] is False
-    assert attributes[ATTR_SPEED] == "AUTO"
+    assert attributes[ATTR_SPEED] == SPEED_MEDIUM
+    assert attributes[ATTR_DYSON_SPEED] == "AUTO"
     assert attributes[ATTR_AUTO_MODE] is True
 
 

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -174,11 +174,10 @@ async def test_state_purecool(hass: HomeAssistant, device: DysonPureCool) -> Non
     "service,service_data,configuration_args",
     [
         (SERVICE_TURN_ON, {}, {"fan_mode": FanMode.FAN}),
-        (SERVICE_TURN_ON, {ATTR_SPEED: "AUTO"}, {"fan_mode": FanMode.AUTO}),
         (
             SERVICE_TURN_ON,
-            {ATTR_SPEED: 5},
-            {"fan_mode": FanMode.FAN, "fan_speed": FanSpeed("0005")},
+            {ATTR_SPEED: SPEED_LOW},
+            {"fan_mode": FanMode.FAN, "fan_speed": FanSpeed.FAN_SPEED_4},
         ),
         (SERVICE_TURN_OFF, {}, {"fan_mode": FanMode.OFF}),
         (
@@ -191,11 +190,20 @@ async def test_state_purecool(hass: HomeAssistant, device: DysonPureCool) -> Non
             {ATTR_OSCILLATING: False},
             {"oscillation": Oscillation.OSCILLATION_OFF},
         ),
-        (SERVICE_SET_SPEED, {ATTR_SPEED: "AUTO"}, {"fan_mode": FanMode.AUTO}),
         (
             SERVICE_SET_SPEED,
-            {ATTR_SPEED: 5},
-            {"fan_mode": FanMode.FAN, "fan_speed": FanSpeed("0005")},
+            {ATTR_SPEED: SPEED_LOW},
+            {"fan_mode": FanMode.FAN, "fan_speed": FanSpeed.FAN_SPEED_4},
+        ),
+        (
+            SERVICE_SET_SPEED,
+            {ATTR_SPEED: SPEED_MEDIUM},
+            {"fan_mode": FanMode.FAN, "fan_speed": FanSpeed.FAN_SPEED_7},
+        ),
+        (
+            SERVICE_SET_SPEED,
+            {ATTR_SPEED: SPEED_HIGH},
+            {"fan_mode": FanMode.FAN, "fan_speed": FanSpeed.FAN_SPEED_10},
         ),
     ],
 )

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -382,3 +382,32 @@ async def test_custom_services_purecool(
         blocking=True,
     )
     getattr(device, command).assert_called_once_with(*command_args)
+
+
+@pytest.mark.parametrize(
+    "domain,service,data",
+    [
+        (PLATFORM_DOMAIN, SERVICE_TURN_ON, {ATTR_SPEED: "AUTO"}),
+        (PLATFORM_DOMAIN, SERVICE_SET_SPEED, {ATTR_SPEED: "AUTO"}),
+        (DOMAIN, SERVICE_SET_DYSON_SPEED, {ATTR_DYSON_SPEED: "11"}),
+    ],
+)
+@pytest.mark.parametrize("device", [DysonPureCool], indirect=True)
+async def test_custom_services_invalid_data(
+    hass: HomeAssistant, domain: str, service: str, data: dict
+) -> None:
+    """Test custom services calling with invalid data."""
+    try:
+        await hass.services.async_call(
+            domain,
+            service,
+            {
+                ATTR_ENTITY_ID: ENTITY_ID,
+                **data,
+            },
+            blocking=True,
+        )
+    except ValueError:
+        pass
+    else:
+        assert False

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -298,6 +298,11 @@ async def test_commands_purecool(
         ),
         (SERVICE_SET_AUTO_MODE, {"auto_mode": True}, {"fan_mode": FanMode.AUTO}),
         (SERVICE_SET_AUTO_MODE, {"auto_mode": False}, {"fan_mode": FanMode.FAN}),
+        (
+            SERVICE_SET_DYSON_SPEED,
+            {ATTR_DYSON_SPEED: "4"},
+            {"fan_mode": FanMode.FAN, "fan_speed": FanSpeed.FAN_SPEED_4},
+        ),
     ],
 )
 @pytest.mark.parametrize("device", [DysonPureCoolLink], indirect=True)

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -397,7 +397,7 @@ async def test_custom_services_invalid_data(
     hass: HomeAssistant, domain: str, service: str, data: dict
 ) -> None:
     """Test custom services calling with invalid data."""
-    try:
+    with pytest.raises(ValueError):
         await hass.services.async_call(
             domain,
             service,
@@ -407,7 +407,3 @@ async def test_custom_services_invalid_data(
             },
             blocking=True,
         )
-    except ValueError:
-        pass
-    else:
-        assert False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The speed of the Dyson Pure Cool Link fan is now one of "low", "medium", and "high" instead of the original "auto" and integer 1 to 10. In order to set the fan speed more precisely and switch auto mode, users should use the services `dyson.set_speed` and `dyson.set_auto_mode`.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The speeds of `DysonPureCoolLinkEntity` are changed to adhere [the standard](https://developers.home-assistant.io/docs/core/entity/fan/#properties). `DysonPureCoolLinkEntity` now supports custom service `dyson.set_speed`. Similar code of `DysonPureCoolEntity` and `DysonPureCoolLinkEntity` is moved to the base class `DysonFanEntity`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43487
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#16238

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
