### PR TITLE
Switch dhcp to use async sniff for faster shutdown

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -7,10 +7,12 @@ import logging
 import os
 import threading
 
+from scapy.config import conf
+from scapy.data import ETH_P_ALL
 from scapy.error import Scapy_Exception
 from scapy.layers.dhcp import DHCP
 from scapy.layers.l2 import Ether
-from scapy.sendrecv import sniff
+from scapy.sendrecv import AsyncSniffer
 
 from homeassistant.components.device_tracker.const import (
     ATTR_HOST_NAME,
@@ -54,15 +56,12 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
         for cls in (DHCPWatcher, DeviceTrackerWatcher):
             watcher = cls(hass, address_data, integration_matchers)
-            watcher.async_start()
+            await watcher.async_start()
             watchers.append(watcher)
 
         async def _async_stop(*_):
             for watcher in watchers:
-                if hasattr(watcher, "async_stop"):
-                    watcher.async_stop()
-                else:
-                    await hass.async_add_executor_job(watcher.stop)
+                await watcher.async_stop()
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop)
 
@@ -144,15 +143,13 @@ class DeviceTrackerWatcher(WatcherBase):
         super().__init__(hass, address_data, integration_matchers)
         self._unsub = None
 
-    @callback
-    def async_stop(self):
+    async def async_stop(self):
         """Stop watching for new device trackers."""
         if self._unsub:
             self._unsub()
             self._unsub = None
 
-    @callback
-    def async_start(self):
+    async def async_start(self):
         """Stop watching for new device trackers."""
         self._unsub = async_track_state_added_domain(
             self.hass, [DEVICE_TRACKER_DOMAIN], self._async_process_device_event
@@ -190,33 +187,35 @@ class DeviceTrackerWatcher(WatcherBase):
         self.hass.async_create_task(task)
 
 
-class DHCPWatcher(WatcherBase, threading.Thread):
+class DHCPWatcher(WatcherBase):
     """Class to watch dhcp requests."""
 
     def __init__(self, hass, address_data, integration_matchers):
         """Initialize class."""
         super().__init__(hass, address_data, integration_matchers)
-        self.name = "dhcp-discovery"
-        self._stop_event = threading.Event()
+        self._sniffer = None
+        self._started = threading.Event()
 
-    def stop(self):
+    async def async_stop(self):
+        """Stop watching for new device trackers."""
+        await self.hass.async_add_executor_job(self._stop)
+
+    def _stop(self):
         """Stop the thread."""
-        self._stop_event.set()
-        self.join()
+        if self._started.is_set():
+            self._sniffer.stop()
 
-    @callback
-    def async_start(self):
-        """Start the thread."""
-        self.start()
-
-    def run(self):
+    async def async_start(self):
         """Start watching for dhcp packets."""
         try:
-            sniff(
+            sniff_socket = conf.L2socket(type=ETH_P_ALL)
+            self._sniffer = AsyncSniffer(
                 filter=FILTER,
+                opened_socket=[sniff_socket],
+                started_callback=self._started.set,
                 prn=self.handle_dhcp_packet,
-                stop_filter=lambda _: self._stop_event.is_set(),
             )
+            self._sniffer.start()
         except (Scapy_Exception, OSError) as ex:
             if os.geteuid() == 0:
                 _LOGGER.error("Cannot watch for dhcp packets: %s", ex)

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -280,18 +280,11 @@ async def test_setup_and_stop(hass):
     )
     await hass.async_block_till_done()
 
-    wait_event = threading.Event()
-
-    def _sniff_wait():
-        wait_event.wait()
-
-    with patch("homeassistant.components.dhcp.sniff", _sniff_wait):
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
-    wait_event.set()
 
 
 async def test_setup_fails_as_root(hass, caplog):
@@ -307,7 +300,7 @@ async def test_setup_fails_as_root(hass, caplog):
     wait_event = threading.Event()
 
     with patch("os.geteuid", return_value=0), patch(
-        "homeassistant.components.dhcp.sniff", side_effect=Scapy_Exception
+        "homeassistant.components.dhcp.AsyncSniffer.start", side_effect=Scapy_Exception
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -331,7 +324,7 @@ async def test_setup_fails_non_root(hass, caplog):
     wait_event = threading.Event()
 
     with patch("os.geteuid", return_value=10), patch(
-        "homeassistant.components.dhcp.sniff", side_effect=Scapy_Exception
+        "homeassistant.components.dhcp.AsyncSniffer.start", side_effect=Scapy_Exception
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -363,9 +356,9 @@ async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):
             {},
             [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
         )
-        device_tracker_watcher.async_start()
+        await device_tracker_watcher.async_start()
         await hass.async_block_till_done()
-        device_tracker_watcher.async_stop()
+        await device_tracker_watcher.async_stop()
         await hass.async_block_till_done()
 
     assert len(mock_init.mock_calls) == 1
@@ -389,7 +382,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start(hass):
             {},
             [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
         )
-        device_tracker_watcher.async_start()
+        await device_tracker_watcher.async_start()
         await hass.async_block_till_done()
         hass.states.async_set(
             "device_tracker.august_connect",
@@ -402,7 +395,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start(hass):
             },
         )
         await hass.async_block_till_done()
-        device_tracker_watcher.async_stop()
+        await device_tracker_watcher.async_stop()
         await hass.async_block_till_done()
 
     assert len(mock_init.mock_calls) == 1
@@ -426,7 +419,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_home(hass)
             {},
             [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
         )
-        device_tracker_watcher.async_start()
+        await device_tracker_watcher.async_start()
         await hass.async_block_till_done()
         hass.states.async_set(
             "device_tracker.august_connect",
@@ -439,7 +432,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_home(hass)
             },
         )
         await hass.async_block_till_done()
-        device_tracker_watcher.async_stop()
+        await device_tracker_watcher.async_stop()
         await hass.async_block_till_done()
 
     assert len(mock_init.mock_calls) == 0
@@ -456,7 +449,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_router(has
             {},
             [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
         )
-        device_tracker_watcher.async_start()
+        await device_tracker_watcher.async_start()
         await hass.async_block_till_done()
         hass.states.async_set(
             "device_tracker.august_connect",
@@ -469,7 +462,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_router(has
             },
         )
         await hass.async_block_till_done()
-        device_tracker_watcher.async_stop()
+        await device_tracker_watcher.async_stop()
         await hass.async_block_till_done()
 
     assert len(mock_init.mock_calls) == 0
@@ -488,7 +481,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_hostname_missi
             {},
             [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
         )
-        device_tracker_watcher.async_start()
+        await device_tracker_watcher.async_start()
         await hass.async_block_till_done()
         hass.states.async_set(
             "device_tracker.august_connect",
@@ -500,7 +493,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_hostname_missi
             },
         )
         await hass.async_block_till_done()
-        device_tracker_watcher.async_stop()
+        await device_tracker_watcher.async_stop()
         await hass.async_block_till_done()
 
     assert len(mock_init.mock_calls) == 0
@@ -527,9 +520,9 @@ async def test_device_tracker_ignore_self_assigned_ips_before_start(hass):
             {},
             [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
         )
-        device_tracker_watcher.async_start()
+        await device_tracker_watcher.async_start()
         await hass.async_block_till_done()
-        device_tracker_watcher.async_stop()
+        await device_tracker_watcher.async_stop()
         await hass.async_block_till_done()
 
     assert len(mock_init.mock_calls) == 0

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -280,11 +280,14 @@ async def test_setup_and_stop(hass):
     )
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    await hass.async_block_till_done()
+    with patch("homeassistant.components.dhcp.AsyncSniffer.start") as start_call:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
+
+    start_call.assert_called_once()
 
 
 async def test_setup_fails_as_root(hass, caplog):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch dhcp to use async sniff for faster shutdown

Shutdown was blocking when the network was idle since scapy
would not wake up to see the stop event.

Solved by switching to the async version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
