### PR TITLE
Set hyperion icon to lightbulb when off

### DIFF
--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -348,10 +348,9 @@ class HyperionLight(LightEntity):
         if self.is_on:
             if self.effect == KEY_EFFECT_SOLID:
                 return ICON_LIGHTBULB
-            elif self.effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES:
+            if self.effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES:
                 return ICON_EXTERNAL_SOURCE
-            else:
-                return ICON_EFFECT
+            return ICON_EFFECT
 
         return ICON_LIGHTBULB
 

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -520,6 +520,7 @@ class HyperionLight(LightEntity):
 
     def _update_components(self, _: Optional[Dict[str, Any]] = None) -> None:
         """Update Hyperion components."""
+        self._set_internal_state()
         self.async_write_ha_state()
 
     def _update_adjustment(self, _: Optional[Dict[str, Any]] = None) -> None:

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -346,12 +346,10 @@ class HyperionLight(LightEntity):
     def icon(self) -> str:
         """Return state specific icon."""
         if self.is_on:
-            if self.effect == KEY_EFFECT_SOLID:
-                return ICON_LIGHTBULB
             if self.effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES:
                 return ICON_EXTERNAL_SOURCE
-            return ICON_EFFECT
-
+            if self.effect != KEY_EFFECT_SOLID:
+                return ICON_EFFECT
         return ICON_LIGHTBULB
 
     @property

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -515,6 +515,8 @@ class HyperionLight(LightEntity):
                 self._icon = ICON_EXTERNAL_SOURCE
             else:
                 self._icon = ICON_EFFECT
+        if not self.is_on():
+            self._icon = ICON_LIGHTBULB
 
     def _update_components(self, _: Optional[Dict[str, Any]] = None) -> None:
         """Update Hyperion components."""

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -515,7 +515,7 @@ class HyperionLight(LightEntity):
                 self._icon = ICON_EXTERNAL_SOURCE
             else:
                 self._icon = ICON_EFFECT
-        if not self.is_on():
+        if not self.is_on:
             self._icon = ICON_LIGHTBULB
 
     def _update_components(self, _: Optional[Dict[str, Any]] = None) -> None:

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -314,7 +314,6 @@ class HyperionLight(LightEntity):
         self._brightness: int = 255
         self._rgb_color: Sequence[int] = DEFAULT_COLOR
         self._effect: str = KEY_EFFECT_SOLID
-        self._icon: str = ICON_LIGHTBULB
 
         self._effect_list: List[str] = []
 
@@ -346,7 +345,15 @@ class HyperionLight(LightEntity):
     @property
     def icon(self) -> str:
         """Return state specific icon."""
-        return self._icon
+        if self.is_on:
+            if self.effect == KEY_EFFECT_SOLID:
+                return ICON_LIGHTBULB
+            elif self.effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES:
+                return ICON_EXTERNAL_SOURCE
+            else:
+                return ICON_EFFECT
+
+        return ICON_LIGHTBULB
 
     @property
     def effect(self) -> str:
@@ -509,18 +516,9 @@ class HyperionLight(LightEntity):
             self._rgb_color = rgb_color
         if effect is not None:
             self._effect = effect
-            if effect == KEY_EFFECT_SOLID:
-                self._icon = ICON_LIGHTBULB
-            elif effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES:
-                self._icon = ICON_EXTERNAL_SOURCE
-            else:
-                self._icon = ICON_EFFECT
-        if not self.is_on:
-            self._icon = ICON_LIGHTBULB
 
     def _update_components(self, _: Optional[Dict[str, Any]] = None) -> None:
         """Update Hyperion components."""
-        self._set_internal_state()
         self.async_write_ha_state()
 
     def _update_adjustment(self, _: Optional[Dict[str, Any]] = None) -> None:

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -609,6 +609,11 @@ async def test_light_async_turn_off(hass: HomeAssistantType) -> None:
         }
     )
 
+    _call_registered_callback(client, "components-update")
+    entity_state = hass.states.get(TEST_ENTITY_ID_1)
+    assert entity_state
+    assert entity_state.attributes["icon"] == hyperion_light.ICON_LIGHTBULB
+
     # No calls if no state loaded.
     client.has_loaded_state = False
     client.async_send_set_component = AsyncMock(return_value=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the icon to "lightbulb" if the light is OFF, instead of the last icon it was when it was still ON.
I like that better since that makes the user interface more clean if all lights in the house are off (all have the same icon).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Config flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
