### PR TITLE
Introduce reauthentication flow to UniFi integration

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -185,7 +185,7 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
         self.reauth_schema = {
             vol.Required(CONF_HOST, default=self.reauth_config[CONF_HOST]): str,
             vol.Required(CONF_USERNAME, default=self.reauth_config[CONF_USERNAME]): str,
-            vol.Required(CONF_PASSWORD, default=self.reauth_config[CONF_PASSWORD]): str,
+            vol.Required(CONF_PASSWORD): str,
             vol.Required(CONF_PORT, default=self.reauth_config[CONF_PORT]): int,
             vol.Required(
                 CONF_VERIFY_SSL, default=self.reauth_config[CONF_VERIFY_SSL]

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -179,7 +179,7 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context["title_placeholders"] = {
             CONF_HOST: self.reauth_config[CONF_HOST],
-            CONF_SITE_ID: self.reauth_config[CONF_SITE_ID],
+            CONF_SITE_ID: config_entry.title,
         }
 
         self.reauth_schema = {

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -344,8 +344,7 @@ class UniFiController:
         except CannotConnect as err:
             raise ConfigEntryNotReady from err
 
-        except AuthenticationRequired as err:
-            LOGGER.error("Authentication error with (%s): %s", self.host, err)
+        except AuthenticationRequired:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
                     UNIFI_DOMAIN,
@@ -535,6 +534,10 @@ async def get_controller(
     ) as err:
         LOGGER.error("Error connecting to the UniFi controller at %s: %s", host, err)
         raise CannotConnect from err
+
+    except aiounifi.LoginRequired as err:
+        LOGGER.warning("Connected to UniFi at %s but login required: %s", host, err)
+        raise AuthenticationRequired from err
 
     except aiounifi.AiounifiException as err:
         LOGGER.exception("Unknown UniFi communication error occurred: %s", err)

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "{host} ({site})",
+    "flow_title": "{site} ({host})",
     "step": {
       "user": {
         "title": "Set up UniFi Controller",

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{host} ({site})",
     "step": {
       "user": {
         "title": "Set up UniFi Controller",
@@ -19,7 +20,8 @@
       "unknown_client_mac": "No client available on that MAC address"
     },
     "abort": {
-      "already_configured": "Controller site is already configured"
+      "already_configured": "Controller site is already configured",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/homeassistant/components/unifi/translations/en.json
+++ b/homeassistant/components/unifi/translations/en.json
@@ -1,13 +1,15 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Controller site is already configured"
+            "already_configured": "Controller site is already configured",
+            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
         },
         "error": {
             "faulty_credentials": "Invalid authentication",
             "service_unavailable": "Failed to connect",
             "unknown_client_mac": "No client available on that MAC address"
         },
+        "flow_title": "{host} ({site})",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/unifi/translations/en.json
+++ b/homeassistant/components/unifi/translations/en.json
@@ -9,7 +9,7 @@
             "service_unavailable": "Failed to connect",
             "unknown_client_mac": "No client available on that MAC address"
         },
-        "flow_title": "{host} ({site})",
+        "flow_title": "{site} ({host})",
         "step": {
             "user": {
                 "data": {

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -184,8 +184,8 @@ async def test_flow_works_multiple_sites(hass, aioclient_mock):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "site"
-    assert result["data_schema"]({"site": "site name"})
-    assert result["data_schema"]({"site": "site2 name"})
+    assert result["data_schema"]({"site": "default"})
+    assert result["data_schema"]({"site": "site2"})
 
 
 async def test_flow_fails_site_already_configured(hass, aioclient_mock):

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.components.unifi.const import (
     CONF_TRACK_WIRED_CLIENTS,
     DOMAIN as UNIFI_DOMAIN,
 )
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -312,6 +313,54 @@ async def test_flow_fails_unknown_problem(hass, aioclient_mock):
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+
+
+async def test_reauth_flow_update_configuration(hass, aioclient_mock):
+    """Verify reauth flow can update controller configuration."""
+    controller = await setup_unifi_integration(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        UNIFI_DOMAIN,
+        context={"source": SOURCE_REAUTH},
+        data=controller.config_entry,
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == SOURCE_USER
+
+    aioclient_mock.get("https://1.2.3.4:1234", status=302)
+
+    aioclient_mock.post(
+        "https://1.2.3.4:1234/api/login",
+        json={"data": "login successful", "meta": {"rc": "ok"}},
+        headers={"content-type": CONTENT_TYPE_JSON},
+    )
+
+    aioclient_mock.get(
+        "https://1.2.3.4:1234/api/self/sites",
+        json={
+            "data": [{"desc": "Site name", "name": "site_id", "role": "admin"}],
+            "meta": {"rc": "ok"},
+        },
+        headers={"content-type": CONTENT_TYPE_JSON},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "1.2.3.4",
+            CONF_USERNAME: "new_name",
+            CONF_PASSWORD: "new_pass",
+            CONF_PORT: 1234,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_successful"
+    assert controller.host == "1.2.3.4"
+    assert controller.config_entry.data[CONF_CONTROLLER][CONF_USERNAME] == "new_name"
+    assert controller.config_entry.data[CONF_CONTROLLER][CONF_PASSWORD] == "new_pass"
 
 
 async def test_advanced_option_flow(hass):

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -222,6 +222,17 @@ async def test_controller_not_accessible(hass):
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
+async def test_controller_trigger_reauth_flow(hass):
+    """Failed authentication trigger a reauthentication flow."""
+    with patch(
+        "homeassistant.components.unifi.controller.get_controller",
+        side_effect=AuthenticationRequired,
+    ), patch.object(hass.config_entries.flow, "async_init") as mock_flow_init:
+        await setup_unifi_integration(hass)
+        mock_flow_init.assert_called_once()
+    assert hass.data[UNIFI_DOMAIN] == {}
+
+
 async def test_controller_unknown_error(hass):
     """Unknown errors are handled."""
     with patch(

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -330,6 +330,14 @@ async def test_get_controller_controller_unavailable(hass):
         await get_controller(hass, **CONTROLLER_DATA)
 
 
+async def test_get_controller_login_required(hass):
+    """Check that get_controller can handle unknown errors."""
+    with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(
+        "aiounifi.Controller.login", side_effect=aiounifi.LoginRequired
+    ), pytest.raises(AuthenticationRequired):
+        await get_controller(hass, **CONTROLLER_DATA)
+
+
 async def test_get_controller_unknown_error(hass):
     """Check that get_controller can handle unknown errors."""
     with patch("aiounifi.Controller.check_unifi_os", return_value=True), patch(

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -276,7 +276,7 @@ def mock_aiohttp_client():
     """Context manager to mock aiohttp client."""
     mocker = AiohttpClientMocker()
 
-    def create_session(hass, *args):
+    def create_session(hass, *args, **kwargs):
         session = mocker.create_session(hass.loop)
 
         async def close_session(event):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add possibility to reauthenticate if failed during setup of integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
