### PR TITLE
Wait for all triggers when one fails to attach

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -462,8 +462,8 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
     ) -> Optional[Callable[[], None]]:
         """Set up the triggers."""
 
-        def log_cb(level, msg):
-            self._logger.log(level, "%s %s", msg, self._name)
+        def log_cb(level, msg, **kwargs):
+            self._logger.log(level, "%s %s", msg, self._name, **kwargs)
 
         return await async_initialize_triggers(
             cast(HomeAssistant, self.hass),

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -230,9 +230,9 @@ class _ScriptRun:
     def _log(
         self, msg: str, *args: Any, level: int = logging.INFO, **kwargs: Any
     ) -> None:
-        self._script._log(
+        self._script._log(  # pylint: disable=protected-access
             msg, *args, level=level, **kwargs
-        )  # pylint: disable=protected-access
+        )
 
     async def async_run(self) -> None:
         """Run script."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -227,8 +227,12 @@ class _ScriptRun:
         # pylint: disable=protected-access
         return await self._script._async_get_condition(config)
 
-    def _log(self, msg: str, *args: Any, level: int = logging.INFO) -> None:
-        self._script._log(msg, *args, level=level)  # pylint: disable=protected-access
+    def _log(
+        self, msg: str, *args: Any, level: int = logging.INFO, **kwargs: Any
+    ) -> None:
+        self._script._log(
+            msg, *args, level=level, **kwargs
+        )  # pylint: disable=protected-access
 
     async def async_run(self) -> None:
         """Run script."""
@@ -623,8 +627,8 @@ class _ScriptRun:
             }
             done.set()
 
-        def log_cb(level, msg):
-            self._log(msg, level=level)
+        def log_cb(level, msg, **kwargs):
+            self._log(msg, level=level, **kwargs)
 
         to_context = None
         remove_triggers = await async_initialize_triggers(
@@ -1128,11 +1132,13 @@ class Script:
             self._choose_data[step] = choose_data
         return choose_data
 
-    def _log(self, msg: str, *args: Any, level: int = logging.INFO) -> None:
+    def _log(
+        self, msg: str, *args: Any, level: int = logging.INFO, **kwargs: Any
+    ) -> None:
         msg = f"%s: {msg}"
         args = (self.name, *args)
 
         if level == _LOG_EXCEPTION:
-            self._logger.exception(msg, *args)
+            self._logger.exception(msg, *args, **kwargs)
         else:
-            self._logger.log(level, msg, *args)
+            self._logger.log(level, msg, *args, **kwargs)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a trigger failed to attach the gather would return right
away even though some of triggers where still in the process
of attaching. This meant that we would not store the remove
callbacks for these triggers.

Fixes

```
2021-01-20 15:52:06 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/automation/__init__.py", line 437, in async_enable_automation
    self._async_detach_triggers = await self._async_attach_triggers(True)
  File "/usr/src/homeassistant/homeassistant/components/automation/__init__.py", line 468, in _async_attach_triggers
    return await async_initialize_triggers(
  File "/usr/src/homeassistant/homeassistant/helpers/trigger.py", line 78, in async_initialize_triggers
    removes = await asyncio.gather(*triggers)
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 31, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 244, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: 'NoneType' object is not subscriptable
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
