### PR TITLE
Switch frequently used unifi controller properties to attributes

### DIFF
--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -89,7 +89,6 @@ class UniFiController:
     def __init__(self, hass, config_entry):
         """Initialize the system."""
         self.hass = hass
-        self.config_entry = config_entry
         self.available = True
         self.api = None
         self.progress = None
@@ -103,7 +102,61 @@ class UniFiController:
         self._heartbeat_dispatch = {}
         self._heartbeat_time = {}
 
+        self.load_config_entry_options(config_entry)
+
         self.entities = {}
+
+    def load_config_entry_options(self, config_entry):
+        """Store attributes to avoid property call overhead since they are called frequently."""
+        # Device tracker options
+        self.config_entry = config_entry
+
+        options = self.config_entry.options
+
+        # Config entry option to not track clients.
+        self.option_track_clients = options.get(
+            CONF_TRACK_CLIENTS, DEFAULT_TRACK_CLIENTS
+        )
+        # Config entry option to not track wired clients.
+        self.option_track_wired_clients = options.get(
+            CONF_TRACK_WIRED_CLIENTS, DEFAULT_TRACK_WIRED_CLIENTS
+        )
+        # Config entry option to not track devices.
+        self.option_track_devices = options.get(
+            CONF_TRACK_DEVICES, DEFAULT_TRACK_DEVICES
+        )
+        # Config entry option listing what SSIDs are being used to track clients.
+        self.option_ssid_filter = set(options.get(CONF_SSID_FILTER, []))
+        # Config entry option defining number of seconds from last seen to away
+        self.option_detection_time = timedelta(
+            seconds=options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
+        )
+        # Config entry option to ignore wired bug.
+        self.option_ignore_wired_bug = options.get(
+            CONF_IGNORE_WIRED_BUG, DEFAULT_IGNORE_WIRED_BUG
+        )
+
+        # Client control options
+
+        # Config entry option to control poe clients.
+        self.option_poe_clients = options.get(CONF_POE_CLIENTS, DEFAULT_POE_CLIENTS)
+        # Config entry option with list of clients to control network access.
+        self.option_block_clients = options.get(CONF_BLOCK_CLIENT, [])
+        # Config entry option to control DPI restriction groups.
+        self.option_dpi_restrictions = options.get(
+            CONF_DPI_RESTRICTIONS, DEFAULT_DPI_RESTRICTIONS
+        )
+
+        # Statistics sensor options
+
+        # Config entry option to allow bandwidth sensors.
+        self.option_allow_bandwidth_sensors = options.get(
+            CONF_ALLOW_BANDWIDTH_SENSORS, DEFAULT_ALLOW_BANDWIDTH_SENSORS
+        )
+        # Config entry option to allow uptime sensors.
+        self.option_allow_uptime_sensors = options.get(
+            CONF_ALLOW_UPTIME_SENSORS, DEFAULT_ALLOW_UPTIME_SENSORS
+        )
 
     @property
     def controller_id(self):
@@ -137,81 +190,6 @@ class UniFiController:
             if self.host == client.ip:
                 return client.mac
         return None
-
-    # Device tracker options
-
-    @property
-    def option_track_clients(self):
-        """Config entry option to not track clients."""
-        return self.config_entry.options.get(CONF_TRACK_CLIENTS, DEFAULT_TRACK_CLIENTS)
-
-    @property
-    def option_track_wired_clients(self):
-        """Config entry option to not track wired clients."""
-        return self.config_entry.options.get(
-            CONF_TRACK_WIRED_CLIENTS, DEFAULT_TRACK_WIRED_CLIENTS
-        )
-
-    @property
-    def option_track_devices(self):
-        """Config entry option to not track devices."""
-        return self.config_entry.options.get(CONF_TRACK_DEVICES, DEFAULT_TRACK_DEVICES)
-
-    @property
-    def option_ssid_filter(self):
-        """Config entry option listing what SSIDs are being used to track clients."""
-        return self.config_entry.options.get(CONF_SSID_FILTER, [])
-
-    @property
-    def option_detection_time(self):
-        """Config entry option defining number of seconds from last seen to away."""
-        return timedelta(
-            seconds=self.config_entry.options.get(
-                CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME
-            )
-        )
-
-    @property
-    def option_ignore_wired_bug(self):
-        """Config entry option to ignore wired bug."""
-        return self.config_entry.options.get(
-            CONF_IGNORE_WIRED_BUG, DEFAULT_IGNORE_WIRED_BUG
-        )
-
-    # Client control options
-
-    @property
-    def option_poe_clients(self):
-        """Config entry option to control poe clients."""
-        return self.config_entry.options.get(CONF_POE_CLIENTS, DEFAULT_POE_CLIENTS)
-
-    @property
-    def option_block_clients(self):
-        """Config entry option with list of clients to control network access."""
-        return self.config_entry.options.get(CONF_BLOCK_CLIENT, [])
-
-    @property
-    def option_dpi_restrictions(self):
-        """Config entry option to control DPI restriction groups."""
-        return self.config_entry.options.get(
-            CONF_DPI_RESTRICTIONS, DEFAULT_DPI_RESTRICTIONS
-        )
-
-    # Statistics sensor options
-
-    @property
-    def option_allow_bandwidth_sensors(self):
-        """Config entry option to allow bandwidth sensors."""
-        return self.config_entry.options.get(
-            CONF_ALLOW_BANDWIDTH_SENSORS, DEFAULT_ALLOW_BANDWIDTH_SENSORS
-        )
-
-    @property
-    def option_allow_uptime_sensors(self):
-        """Config entry option to allow uptime sensors."""
-        return self.config_entry.options.get(
-            CONF_ALLOW_UPTIME_SENSORS, DEFAULT_ALLOW_UPTIME_SENSORS
-        )
 
     @callback
     def async_unifi_signalling_callback(self, signal, data):
@@ -434,6 +412,7 @@ class UniFiController:
         if config_entry.entry_id not in hass.data[UNIFI_DOMAIN]:
             return
         controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+        controller.load_config_entry_options(config_entry)
         async_dispatcher_send(hass, controller.signal_options_update)
 
     @callback

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -89,6 +89,7 @@ class UniFiController:
     def __init__(self, hass, config_entry):
         """Initialize the system."""
         self.hass = hass
+        self.config_entry = config_entry
         self.available = True
         self.api = None
         self.progress = None
@@ -102,15 +103,13 @@ class UniFiController:
         self._heartbeat_dispatch = {}
         self._heartbeat_time = {}
 
-        self.load_config_entry_options(config_entry)
+        self.load_config_entry_options()
 
         self.entities = {}
 
-    def load_config_entry_options(self, config_entry):
+    def load_config_entry_options(self):
         """Store attributes to avoid property call overhead since they are called frequently."""
         # Device tracker options
-        self.config_entry = config_entry
-
         options = self.config_entry.options
 
         # Config entry option to not track clients.
@@ -412,7 +411,7 @@ class UniFiController:
         if config_entry.entry_id not in hass.data[UNIFI_DOMAIN]:
             return
         controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-        controller.load_config_entry_options(config_entry)
+        controller.load_config_entry_options()
         async_dispatcher_send(hass, controller.signal_options_update)
 
     @callback

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -289,12 +289,8 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         """Set up tracked device."""
         super().__init__(device, controller)
 
+        self.device = self._item
         self._is_connected = device.state == 1
-
-    @property
-    def device(self):
-        """Wrap item."""
-        return self._item
 
     async def async_added_to_hass(self) -> None:
         """Watch object when added."""

--- a/homeassistant/components/unifi/unifi_client.py
+++ b/homeassistant/components/unifi/unifi_client.py
@@ -12,11 +12,7 @@ class UniFiClient(UniFiBase):
         super().__init__(client, controller)
 
         self._is_wired = client.mac not in controller.wireless_clients
-
-    @property
-    def client(self):
-        """Wrap item."""
-        return self._item
+        self.client = self._item
 
     @property
     def is_wired(self):
@@ -29,6 +25,7 @@ class UniFiClient(UniFiBase):
 
         if self.controller.option_ignore_wired_bug:
             return self.client.is_wired
+
         return self._is_wired
 
     @property

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -197,7 +197,7 @@ async def test_controller_setup(hass):
     assert controller.option_track_devices == DEFAULT_TRACK_DEVICES
     assert controller.option_track_wired_clients == DEFAULT_TRACK_WIRED_CLIENTS
     assert controller.option_detection_time == timedelta(seconds=DEFAULT_DETECTION_TIME)
-    assert isinstance(controller.option_ssid_filter, list)
+    assert isinstance(controller.option_ssid_filter, set)
 
     assert controller.mac is None
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -606,6 +606,7 @@ async def test_option_ssid_filter(hass):
         controller.config_entry,
         options={CONF_SSID_FILTER: []},
     )
+    await hass.async_block_till_done()
     event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_copy]}
     controller.api.message_handler(event)
     event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_3_copy]}
@@ -626,6 +627,9 @@ async def test_option_ssid_filter(hass):
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1.state == "not_home"
 
+    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_3_copy]}
+    controller.api.message_handler(event)
+    await hass.async_block_till_done()
     # Client won't go away until after next update
     client_3 = hass.states.get("device_tracker.client_3")
     assert client_3.state == "home"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In reviewing a profile there were 600000 property lookups per
minute from device tracker updates. property calls have a
much higher overhead than attribute lookups which use a faster
dict under the hood.

This cut the cpu usage by ~35% for a very active (500) client
unifi setup.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
