### PR TITLE
Add explicit address to google_domains component

### DIFF
--- a/tests/components/google_domains/test_init.py
+++ b/tests/components/google_domains/test_init.py
@@ -12,14 +12,19 @@ from tests.common import async_fire_time_changed
 DOMAIN = "test.example.com"
 USERNAME = "abc123"
 PASSWORD = "xyz789"
+ADDRESS = "0.0.0.0"
 
+IPIFY_URL = "https://api.ipify.org"
 UPDATE_URL = f"https://{USERNAME}:{PASSWORD}@domains.google.com/nic/update"
 
 
 @pytest.fixture
 def setup_google_domains(hass, aioclient_mock):
-    """Fixture that sets up NamecheapDNS."""
-    aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="ok 0.0.0.0")
+    """Fixture that sets up Google Domains."""
+    aioclient_mock.get(IPIFY_URL, text=ADDRESS)
+    aioclient_mock.get(
+        UPDATE_URL, params={"hostname": DOMAIN, "myip": ADDRESS}, text="good 0.0.0.0"
+    )
 
     hass.loop.run_until_complete(
         async_setup_component(
@@ -38,7 +43,10 @@ def setup_google_domains(hass, aioclient_mock):
 
 async def test_setup(hass, aioclient_mock):
     """Test setup works if update passes."""
-    aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="nochg 0.0.0.0")
+    aioclient_mock.get(IPIFY_URL, text=ADDRESS)
+    aioclient_mock.get(
+        UPDATE_URL, params={"hostname": DOMAIN, "myip": ADDRESS}, text="nochg 0.0.0.0"
+    )
 
     result = await async_setup_component(
         hass,
@@ -52,16 +60,19 @@ async def test_setup(hass, aioclient_mock):
         },
     )
     assert result
-    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.call_count == 2
 
     async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 2
+    assert aioclient_mock.call_count == 3
 
 
 async def test_setup_fails_if_update_fails(hass, aioclient_mock):
     """Test setup fails if first update fails."""
-    aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="nohost")
+    aioclient_mock.get(IPIFY_URL, text=ADDRESS)
+    aioclient_mock.get(
+        UPDATE_URL, params={"hostname": DOMAIN, "myip": ADDRESS}, text="nohost"
+    )
 
     result = await async_setup_component(
         hass,
@@ -75,4 +86,4 @@ async def test_setup_fails_if_update_fails(hass, aioclient_mock):
         },
     )
     assert not result
-    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.call_count == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Google Domains automatic IP detection does not always work properly. This checks ipify.org and supplies that address instead.
This also keeps track of the last address and only updates if it changes, in accordance with Google's [documentation](https://support.google.com/domains/answer/6147083#zippy=%2Cusing-the-api-to-update-your-dynamic-dns-record):
> Please ensure you interpret the response correctly, or you risk having your client blocked from our system.
> ...
> You should not attempt another update until your IP address changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36774
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
