### PR TITLE
Add total energy, preheater and RMOT sensors to comfoconnect

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -144,7 +144,7 @@ omit =
     homeassistant/components/co2signal/*
     homeassistant/components/coinbase/*
     homeassistant/components/comed_hourly_pricing/sensor.py
-    homeassistant/components/comfoconnect/*
+    homeassistant/components/comfoconnect/fan.py
     homeassistant/components/concord232/alarm_control_panel.py
     homeassistant/components/concord232/binary_sensor.py
     homeassistant/components/control4/__init__.py

--- a/homeassistant/components/comfoconnect/sensor.py
+++ b/homeassistant/components/comfoconnect/sensor.py
@@ -3,6 +3,7 @@ import logging
 
 from pycomfoconnect import (
     SENSOR_BYPASS_STATE,
+    SENSOR_CURRENT_RMOT,
     SENSOR_DAYS_TO_REPLACE_FILTER,
     SENSOR_FAN_EXHAUST_DUTY,
     SENSOR_FAN_EXHAUST_FLOW,
@@ -15,7 +16,9 @@ from pycomfoconnect import (
     SENSOR_HUMIDITY_OUTDOOR,
     SENSOR_HUMIDITY_SUPPLY,
     SENSOR_POWER_CURRENT,
+    SENSOR_POWER_TOTAL,
     SENSOR_PREHEATER_POWER_CURRENT,
+    SENSOR_PREHEATER_POWER_TOTAL,
     SENSOR_TEMPERATURE_EXHAUST,
     SENSOR_TEMPERATURE_EXTRACT,
     SENSOR_TEMPERATURE_OUTDOOR,
@@ -27,9 +30,11 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     CONF_RESOURCES,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
+    ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
     POWER_WATT,
     TEMP_CELSIUS,
@@ -46,6 +51,7 @@ ATTR_AIR_FLOW_EXHAUST = "air_flow_exhaust"
 ATTR_AIR_FLOW_SUPPLY = "air_flow_supply"
 ATTR_BYPASS_STATE = "bypass_state"
 ATTR_CURRENT_HUMIDITY = "current_humidity"
+ATTR_CURRENT_RMOT = "current_rmot"
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 ATTR_DAYS_TO_REPLACE_FILTER = "days_to_replace_filter"
 ATTR_EXHAUST_FAN_DUTY = "exhaust_fan_duty"
@@ -55,7 +61,9 @@ ATTR_EXHAUST_TEMPERATURE = "exhaust_temperature"
 ATTR_OUTSIDE_HUMIDITY = "outside_humidity"
 ATTR_OUTSIDE_TEMPERATURE = "outside_temperature"
 ATTR_POWER_CURRENT = "power_usage"
+ATTR_POWER_TOTAL = "power_total"
 ATTR_PREHEATER_POWER_CURRENT = "preheater_power_usage"
+ATTR_PREHEATER_POWER_TOTAL = "preheater_power_total"
 ATTR_SUPPLY_FAN_DUTY = "supply_fan_duty"
 ATTR_SUPPLY_FAN_SPEED = "supply_fan_speed"
 ATTR_SUPPLY_HUMIDITY = "supply_humidity"
@@ -74,7 +82,7 @@ SENSOR_TYPES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_LABEL: "Inside Temperature",
         ATTR_UNIT: TEMP_CELSIUS,
-        ATTR_ICON: "mdi:thermometer",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_TEMPERATURE_EXTRACT,
         ATTR_MULTIPLIER: 0.1,
     },
@@ -82,14 +90,22 @@ SENSOR_TYPES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_LABEL: "Inside Humidity",
         ATTR_UNIT: PERCENTAGE,
-        ATTR_ICON: "mdi:water-percent",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_HUMIDITY_EXTRACT,
+    },
+    ATTR_CURRENT_RMOT: {
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        ATTR_LABEL: "Current RMOT",
+        ATTR_UNIT: TEMP_CELSIUS,
+        ATTR_ICON: None,
+        ATTR_ID: SENSOR_CURRENT_RMOT,
+        ATTR_MULTIPLIER: 0.1,
     },
     ATTR_OUTSIDE_TEMPERATURE: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_LABEL: "Outside Temperature",
         ATTR_UNIT: TEMP_CELSIUS,
-        ATTR_ICON: "mdi:thermometer",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_TEMPERATURE_OUTDOOR,
         ATTR_MULTIPLIER: 0.1,
     },
@@ -97,14 +113,14 @@ SENSOR_TYPES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_LABEL: "Outside Humidity",
         ATTR_UNIT: PERCENTAGE,
-        ATTR_ICON: "mdi:water-percent",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_HUMIDITY_OUTDOOR,
     },
     ATTR_SUPPLY_TEMPERATURE: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_LABEL: "Supply Temperature",
         ATTR_UNIT: TEMP_CELSIUS,
-        ATTR_ICON: "mdi:thermometer",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_TEMPERATURE_SUPPLY,
         ATTR_MULTIPLIER: 0.1,
     },
@@ -112,7 +128,7 @@ SENSOR_TYPES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_LABEL: "Supply Humidity",
         ATTR_UNIT: PERCENTAGE,
-        ATTR_ICON: "mdi:water-percent",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_HUMIDITY_SUPPLY,
     },
     ATTR_SUPPLY_FAN_SPEED: {
@@ -147,7 +163,7 @@ SENSOR_TYPES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_LABEL: "Exhaust Temperature",
         ATTR_UNIT: TEMP_CELSIUS,
-        ATTR_ICON: "mdi:thermometer",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_TEMPERATURE_EXHAUST,
         ATTR_MULTIPLIER: 0.1,
     },
@@ -155,7 +171,7 @@ SENSOR_TYPES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_LABEL: "Exhaust Humidity",
         ATTR_UNIT: PERCENTAGE,
-        ATTR_ICON: "mdi:water-percent",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_HUMIDITY_EXHAUST,
     },
     ATTR_AIR_FLOW_SUPPLY: {
@@ -190,8 +206,15 @@ SENSOR_TYPES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_LABEL: "Power usage",
         ATTR_UNIT: POWER_WATT,
-        ATTR_ICON: "mdi:flash",
+        ATTR_ICON: None,
         ATTR_ID: SENSOR_POWER_CURRENT,
+    },
+    ATTR_POWER_TOTAL: {
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
+        ATTR_LABEL: "Power total",
+        ATTR_UNIT: ENERGY_KILO_WATT_HOUR,
+        ATTR_ICON: None,
+        ATTR_ID: SENSOR_POWER_TOTAL,
     },
     ATTR_PREHEATER_POWER_CURRENT: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
@@ -199,6 +222,13 @@ SENSOR_TYPES = {
         ATTR_UNIT: POWER_WATT,
         ATTR_ICON: None,
         ATTR_ID: SENSOR_PREHEATER_POWER_CURRENT,
+    },
+    ATTR_PREHEATER_POWER_TOTAL: {
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
+        ATTR_LABEL: "Preheater power total",
+        ATTR_UNIT: ENERGY_KILO_WATT_HOUR,
+        ATTR_ICON: None,
+        ATTR_ID: SENSOR_PREHEATER_POWER_TOTAL,
     },
 }
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -669,6 +669,9 @@ pycfdns==1.2.1
 # homeassistant.components.cast
 pychromecast==7.7.2
 
+# homeassistant.components.comfoconnect
+pycomfoconnect==0.4
+
 # homeassistant.components.coolmaster
 pycoolmasternet-async==0.1.2
 

--- a/tests/components/comfoconnect/__init__.py
+++ b/tests/components/comfoconnect/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the comfoconnect component."""

--- a/tests/components/comfoconnect/test_sensor.py
+++ b/tests/components/comfoconnect/test_sensor.py
@@ -1,0 +1,93 @@
+"""Tests for the comfoconnect sensor platform."""
+# import json
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.setup import async_setup_component
+
+from tests.common import assert_setup_component
+
+COMPONENT = "comfoconnect"
+VALID_CONFIG = {
+    COMPONENT: {"host": "1.2.3.4"},
+    DOMAIN: {
+        "platform": COMPONENT,
+        "resources": [
+            "current_humidity",
+            "current_temperature",
+            "supply_fan_duty",
+            "power_usage",
+            "preheater_power_total",
+        ],
+    },
+}
+
+
+@pytest.fixture
+def mock_bridge_discover():
+    """Mock the bridge discover method."""
+    with patch("pycomfoconnect.bridge.Bridge.discover") as mock_bridge_discover:
+        mock_bridge_discover.return_value[0].uuid.hex.return_value = "00"
+        yield mock_bridge_discover
+
+
+@pytest.fixture
+def mock_comfoconnect_command():
+    """Mock the ComfoConnect connect method."""
+    with patch(
+        "pycomfoconnect.comfoconnect.ComfoConnect._command"
+    ) as mock_comfoconnect_command:
+        yield mock_comfoconnect_command
+
+
+@pytest.fixture
+async def setup_sensor(hass, mock_bridge_discover, mock_comfoconnect_command):
+    """Set up demo sensor component."""
+    with assert_setup_component(1, DOMAIN):
+        await async_setup_component(hass, DOMAIN, VALID_CONFIG)
+        await hass.async_block_till_done()
+
+
+async def test_sensors(hass, setup_sensor):
+    """Test the sensors."""
+    state = hass.states.get("sensor.comfoairq_inside_humidity")
+    assert state is not None
+
+    assert state.name == "ComfoAirQ Inside Humidity"
+    assert state.attributes.get("unit_of_measurement") == "%"
+    assert state.attributes.get("device_class") == "humidity"
+    assert state.attributes.get("icon") is None
+
+    state = hass.states.get("sensor.comfoairq_inside_temperature")
+    assert state is not None
+
+    assert state.name == "ComfoAirQ Inside Temperature"
+    assert state.attributes.get("unit_of_measurement") == "°C"
+    assert state.attributes.get("device_class") == "temperature"
+    assert state.attributes.get("icon") is None
+
+    state = hass.states.get("sensor.comfoairq_supply_fan_duty")
+    assert state is not None
+
+    assert state.name == "ComfoAirQ Supply Fan Duty"
+    assert state.attributes.get("unit_of_measurement") == "%"
+    assert state.attributes.get("device_class") is None
+    assert state.attributes.get("icon") == "mdi:fan"
+
+    state = hass.states.get("sensor.comfoairq_power_usage")
+    assert state is not None
+
+    assert state.name == "ComfoAirQ Power usage"
+    assert state.attributes.get("unit_of_measurement") == "W"
+    assert state.attributes.get("device_class") == "power"
+    assert state.attributes.get("icon") is None
+
+    state = hass.states.get("sensor.comfoairq_preheater_power_total")
+    assert state is not None
+
+    assert state.name == "ComfoAirQ Preheater power total"
+    assert state.attributes.get("unit_of_measurement") == "kWh"
+    assert state.attributes.get("device_class") == "energy"
+    assert state.attributes.get("icon") is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add preheater, current energy and current RMOT sensors to comfoconnect.
Add basic sensor tests.
Fix sensor icon for sensors with device_class set. (https://github.com/home-assistant/core/pull/44083#discussion_r558633554)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor: 
  - platform: comfoconnect
    resources:
      - air_flow_exhaust
      - air_flow_supply
      - bypass_state
      - current_humidity
      - current_temperature
      - days_to_replace_filter
      - exhaust_fan_duty
      - exhaust_fan_speed
      - exhaust_humidity
      - exhaust_temperature
      - outside_humidity
      - outside_temperature
      - power_usage
      - preheater_power_usage
      - power_total
      - preheater_power_total
      - supply_fan_duty
      - supply_fan_speed
      - supply_humidity
      - supply_temperature
      - current_rmot
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16244

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
