### PR TITLE
Fix memory leak in dhcp integration

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -207,12 +207,7 @@ class DHCPWatcher(WatcherBase):
     async def async_start(self):
         """Start watching for dhcp packets."""
         try:
-            # Try to create the socket
-            # to see if we have permissions
-            # since AsyncSniffer will do it another
-            # thread so we will not be able to capture
-            # any permission or bind errors.
-            conf.L2socket()
+            _verify_l2socket_creation_permission()
         except (Scapy_Exception, OSError) as ex:
             if os.geteuid() == 0:
                 _LOGGER.error("Cannot watch for dhcp packets: %s", ex)
@@ -275,3 +270,15 @@ def _decode_dhcp_option(dhcp_options, key):
 def _format_mac(mac_address):
     """Format a mac address for matching."""
     return format_mac(mac_address).replace(":", "")
+
+
+def _verify_l2socket_creation_permission():
+    """Create a socket using the scapy configured l2socket.
+
+    Try to create the socket
+    to see if we have permissions
+    since AsyncSniffer will do it another
+    thread so we will not be able to capture
+     any permission or bind errors.
+    """
+    conf.L2socket()

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -221,6 +221,7 @@ class DHCPWatcher(WatcherBase):
             filter=FILTER,
             started_callback=self._started.set,
             prn=self.handle_dhcp_packet,
+            store=0,
         )
         self._sniffer.start()
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -8,7 +8,6 @@ import os
 import threading
 
 from scapy.config import conf
-from scapy.data import ETH_P_ALL
 from scapy.error import Scapy_Exception
 from scapy.layers.dhcp import DHCP
 from scapy.layers.l2 import Ether
@@ -208,14 +207,12 @@ class DHCPWatcher(WatcherBase):
     async def async_start(self):
         """Start watching for dhcp packets."""
         try:
-            sniff_socket = conf.L2socket(type=ETH_P_ALL)
-            self._sniffer = AsyncSniffer(
-                filter=FILTER,
-                opened_socket=[sniff_socket],
-                started_callback=self._started.set,
-                prn=self.handle_dhcp_packet,
-            )
-            self._sniffer.start()
+            # Try to create the socket
+            # to see if we have permissions
+            # since AsyncSniffer will do it another
+            # thread so we will not be able to capture
+            # any permission or bind errors.
+            conf.L2socket()
         except (Scapy_Exception, OSError) as ex:
             if os.geteuid() == 0:
                 _LOGGER.error("Cannot watch for dhcp packets: %s", ex)
@@ -224,6 +221,13 @@ class DHCPWatcher(WatcherBase):
                     "Cannot watch for dhcp packets without root or CAP_NET_RAW: %s", ex
                 )
             return
+
+        self._sniffer = AsyncSniffer(
+            filter=FILTER,
+            started_callback=self._started.set,
+            prn=self.handle_dhcp_packet,
+        )
+        self._sniffer.start()
 
     def handle_dhcp_packet(self, packet):
         """Process a dhcp packet."""

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -279,6 +279,6 @@ def _verify_l2socket_creation_permission():
     to see if we have permissions
     since AsyncSniffer will do it another
     thread so we will not be able to capture
-     any permission or bind errors.
+    any permission or bind errors.
     """
     conf.L2socket()

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -303,7 +303,8 @@ async def test_setup_fails_as_root(hass, caplog):
     wait_event = threading.Event()
 
     with patch("os.geteuid", return_value=0), patch(
-        "homeassistant.components.dhcp.AsyncSniffer.start", side_effect=Scapy_Exception
+        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
+        side_effect=Scapy_Exception,
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -327,7 +328,8 @@ async def test_setup_fails_non_root(hass, caplog):
     wait_event = threading.Event()
 
     with patch("os.geteuid", return_value=10), patch(
-        "homeassistant.components.dhcp.AsyncSniffer.start", side_effect=Scapy_Exception
+        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
+        side_effect=Scapy_Exception,
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Passing the L2socket to AsyncSniffer caused the packet
filter to misbehave.  Since we only need to see if we can
create a socket, we can avoid passing it.

To ensure we can create a socket,
we do a test creation before starting AsyncSniffer
since the sniffer will create it in another thread
and we cannot see any permission error otherwise.

Additionally the default value was to store 
packets, this has been turned off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
