### PR TITLE
Remove YAML support from nuheat

### DIFF
--- a/homeassistant/components/nuheat/__init__.py
+++ b/homeassistant/components/nuheat/__init__.py
@@ -15,11 +15,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONF_SERIAL_NUMBER, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/homeassistant/components/nuheat/__init__.py
+++ b/homeassistant/components/nuheat/__init__.py
@@ -5,11 +5,9 @@ import logging
 
 import nuheat
 import requests
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_DEVICES,
     CONF_PASSWORD,
     CONF_USERNAME,
     HTTP_BAD_REQUEST,
@@ -17,56 +15,16 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONF_SERIAL_NUMBER, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Required(CONF_DEVICES, default=[]): vol.All(
-                    cv.ensure_list, [cv.string]
-                ),
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the NuHeat component."""
     hass.data.setdefault(DOMAIN, {})
-    conf = config.get(DOMAIN)
-    if not conf:
-        return True
-
-    for serial_number in conf[CONF_DEVICES]:
-        # Since the api currently doesn't permit fetching the serial numbers
-        # and they have to be specified we create a separate config entry for
-        # each serial number. This won't increase the number of http
-        # requests as each thermostat has to be updated anyways.
-        # This also allows us to validate that the entered valid serial
-        # numbers and do not end up with a config entry where half of the
-        # devices work.
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data={
-                    CONF_USERNAME: conf[CONF_USERNAME],
-                    CONF_PASSWORD: conf[CONF_PASSWORD],
-                    CONF_SERIAL_NUMBER: serial_number,
-                },
-            )
-        )
-
     return True
 
 

--- a/homeassistant/components/nuheat/config_flow.py
+++ b/homeassistant/components/nuheat/config_flow.py
@@ -92,13 +92,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
 
-    async def async_step_import(self, user_input):
-        """Handle import."""
-        await self.async_set_unique_id(user_input[CONF_SERIAL_NUMBER])
-        self._abort_if_unique_id_configured()
-
-        return await self.async_step_user(user_input)
-
 
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""

--- a/tests/components/nuheat/mocks.py
+++ b/tests/components/nuheat/mocks.py
@@ -3,8 +3,14 @@ from unittest.mock import MagicMock, Mock
 
 from nuheat.config import SCHEDULE_HOLD, SCHEDULE_RUN, SCHEDULE_TEMPORARY_HOLD
 
-from homeassistant.components.nuheat.const import DOMAIN
+from homeassistant.components.nuheat.const import CONF_SERIAL_NUMBER, DOMAIN
 from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
+
+MOCK_CONFIG_ENTRY = {
+    CONF_USERNAME: "me",
+    CONF_PASSWORD: "secret",
+    CONF_SERIAL_NUMBER: 12345,
+}
 
 
 def _get_mock_thermostat_run():

--- a/tests/components/nuheat/test_climate.py
+++ b/tests/components/nuheat/test_climate.py
@@ -4,19 +4,18 @@ from unittest.mock import patch
 
 from homeassistant.components.nuheat.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from .mocks import (
+    MOCK_CONFIG_ENTRY,
     _get_mock_nuheat,
     _get_mock_thermostat_run,
     _get_mock_thermostat_schedule_hold_available,
     _get_mock_thermostat_schedule_hold_unavailable,
     _get_mock_thermostat_schedule_temporary_hold,
-    _mock_get_config,
 )
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_climate_thermostat_run(hass):
@@ -28,7 +27,9 @@ async def test_climate_thermostat_run(hass):
         "homeassistant.components.nuheat.nuheat.NuHeat",
         return_value=mock_nuheat,
     ):
-        assert await async_setup_component(hass, DOMAIN, _mock_get_config())
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("climate.master_bathroom")
@@ -59,7 +60,9 @@ async def test_climate_thermostat_schedule_hold_unavailable(hass):
         "homeassistant.components.nuheat.nuheat.NuHeat",
         return_value=mock_nuheat,
     ):
-        assert await async_setup_component(hass, DOMAIN, _mock_get_config())
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("climate.guest_bathroom")
@@ -87,7 +90,9 @@ async def test_climate_thermostat_schedule_hold_available(hass):
         "homeassistant.components.nuheat.nuheat.NuHeat",
         return_value=mock_nuheat,
     ):
-        assert await async_setup_component(hass, DOMAIN, _mock_get_config())
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("climate.available_bathroom")
@@ -119,7 +124,9 @@ async def test_climate_thermostat_schedule_temporary_hold(hass):
         "homeassistant.components.nuheat.nuheat.NuHeat",
         return_value=mock_nuheat,
     ):
-        assert await async_setup_component(hass, DOMAIN, _mock_get_config())
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("climate.temp_bathroom")

--- a/tests/components/nuheat/test_config_flow.py
+++ b/tests/components/nuheat/test_config_flow.py
@@ -53,45 +53,6 @@ async def test_form_user(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_import(hass):
-    """Test we get the form with import source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    mock_thermostat = _get_mock_thermostat_run()
-
-    with patch(
-        "homeassistant.components.nuheat.config_flow.nuheat.NuHeat.authenticate",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.nuheat.config_flow.nuheat.NuHeat.get_thermostat",
-        return_value=mock_thermostat,
-    ), patch(
-        "homeassistant.components.nuheat.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.nuheat.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                CONF_SERIAL_NUMBER: "12345",
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "Master bathroom"
-    assert result["data"] == {
-        CONF_SERIAL_NUMBER: "12345",
-        CONF_USERNAME: "test-username",
-        CONF_PASSWORD: "test-password",
-    }
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 async def test_form_invalid_auth(hass):
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/nuheat/test_init.py
+++ b/tests/components/nuheat/test_init.py
@@ -2,9 +2,10 @@
 from unittest.mock import patch
 
 from homeassistant.components.nuheat.const import DOMAIN
-from homeassistant.setup import async_setup_component
 
-from .mocks import _get_mock_nuheat
+from .mocks import MOCK_CONFIG_ENTRY, _get_mock_nuheat
+
+from tests.common import MockConfigEntry
 
 VALID_CONFIG = {
     "nuheat": {"username": "warm", "password": "feet", "devices": "thermostat123"}
@@ -20,5 +21,7 @@ async def test_init_success(hass):
         "homeassistant.components.nuheat.nuheat.NuHeat",
         return_value=mock_nuheat,
     ):
-        assert await async_setup_component(hass, DOMAIN, VALID_CONFIG)
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Nuheat has fully transitioned to configuration via UI. YAML configuration has been removed. Existing YAML configuration has already been imported automatically in the previous releases and can now safely be removed from your configuration files.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16250

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
