### PR TITLE
Remove YAML support from powerwall

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -29,6 +30,8 @@ from .const import (
     POWERWALL_OBJECT,
     UPDATE_INTERVAL,
 )
+
+CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
 PLATFORMS = ["binary_sensor", "sensor"]
 

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -5,14 +5,12 @@ import logging
 
 import requests
 from tesla_powerwall import MissingAttributeError, Powerwall, PowerwallUnreachableError
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -32,11 +30,6 @@ from .const import (
     UPDATE_INTERVAL,
 )
 
-CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: vol.Schema({vol.Required(CONF_IP_ADDRESS): cv.string})},
-    extra=vol.ALLOW_EXTRA,
-)
-
 PLATFORMS = ["binary_sensor", "sensor"]
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,18 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Tesla Powerwall component."""
     hass.data.setdefault(DOMAIN, {})
-    conf = config.get(DOMAIN)
 
-    if not conf:
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=conf,
-        )
-    )
     return True
 
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -83,13 +83,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(self, user_input):
-        """Handle import."""
-        await self.async_set_unique_id(user_input[CONF_IP_ADDRESS])
-        self._abort_if_unique_id_configured()
-
-        return await self.async_step_user(user_input)
-
     @callback
     def _async_ip_address_already_configured(self, ip_address):
         """See if we already have an entry matching the ip_address."""

--- a/tests/components/powerwall/mocks.py
+++ b/tests/components/powerwall/mocks.py
@@ -14,9 +14,6 @@ from tesla_powerwall import (
     SiteMaster,
 )
 
-from homeassistant.components.powerwall.const import DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS
-
 from tests.common import load_fixture
 
 
@@ -85,8 +82,3 @@ async def _async_load_json_fixture(hass, path):
         load_fixture, os.path.join("powerwall", path)
     )
     return json.loads(fixture)
-
-
-def _mock_get_config():
-    """Return a default powerwall config."""
-    return {DOMAIN: {CONF_IP_ADDRESS: "1.2.3.4"}}

--- a/tests/components/powerwall/test_binary_sensor.py
+++ b/tests/components/powerwall/test_binary_sensor.py
@@ -3,10 +3,11 @@
 from unittest.mock import patch
 
 from homeassistant.components.powerwall.const import DOMAIN
-from homeassistant.const import STATE_ON
-from homeassistant.setup import async_setup_component
+from homeassistant.const import CONF_IP_ADDRESS, STATE_ON
 
-from .mocks import _mock_get_config, _mock_powerwall_with_fixtures
+from .mocks import _mock_powerwall_with_fixtures
+
+from tests.common import MockConfigEntry
 
 
 async def test_sensors(hass):
@@ -14,14 +15,15 @@ async def test_sensors(hass):
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)
 
+    config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_IP_ADDRESS: "1.2.3.4"})
+    config_entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.powerwall.config_flow.Powerwall",
         return_value=mock_powerwall,
     ), patch(
-        "homeassistant.components.powerwall.Powerwall",
-        return_value=mock_powerwall,
+        "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
     ):
-        assert await async_setup_component(hass, DOMAIN, _mock_get_config())
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.grid_status")

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -47,34 +47,6 @@ async def test_form_source_user(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_source_import(hass):
-    """Test we setup the config entry via import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    mock_powerwall = await _mock_powerwall_site_name(hass, "Imported site")
-    with patch(
-        "homeassistant.components.powerwall.config_flow.Powerwall",
-        return_value=mock_powerwall,
-    ), patch(
-        "homeassistant.components.powerwall.async_setup", return_value=True
-    ) as mock_setup, patch(
-        "homeassistant.components.powerwall.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_IP_ADDRESS: "1.2.3.4"},
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "Imported site"
-    assert result["data"] == {CONF_IP_ADDRESS: "1.2.3.4"}
-    assert len(mock_setup.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 async def test_form_cannot_connect(hass):
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -3,10 +3,11 @@
 from unittest.mock import patch
 
 from homeassistant.components.powerwall.const import DOMAIN
-from homeassistant.const import PERCENTAGE
-from homeassistant.setup import async_setup_component
+from homeassistant.const import CONF_IP_ADDRESS, PERCENTAGE
 
-from .mocks import _mock_get_config, _mock_powerwall_with_fixtures
+from .mocks import _mock_powerwall_with_fixtures
+
+from tests.common import MockConfigEntry
 
 
 async def test_sensors(hass):
@@ -14,13 +15,15 @@ async def test_sensors(hass):
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)
 
+    config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_IP_ADDRESS: "1.2.3.4"})
+    config_entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.powerwall.config_flow.Powerwall",
         return_value=mock_powerwall,
     ), patch(
         "homeassistant.components.powerwall.Powerwall", return_value=mock_powerwall
     ):
-        assert await async_setup_component(hass, DOMAIN, _mock_get_config())
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     device_registry = await hass.helpers.device_registry.async_get_registry()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
powerwall has fully transitioned to configuration via UI. YAML configuration has been removed. Existing YAML configuration has already been imported automatically in the previous releases and can now safely be removed from your configuration files.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16251

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
