### PR TITLE
Revert "Update azure-pipelines-ci.yml to enable black mode in isort"

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -62,7 +62,7 @@ stages:
             displayName: "Run bandit"
           - script: |
               . venv/bin/activate
-              pre-commit run isort --all-files --show-diff-on-failure --profile black
+              pre-commit run isort --all-files --show-diff-on-failure
             displayName: "Run isort"
           - script: |
               . venv/bin/activate


### PR DESCRIPTION
Reverts home-assistant/core#45371

This reverts the above PR. isort configuration via pre-commit configuration options is not how this should be done.

The project toml file provides the configuration of isort.

Reasoning for reverting/rejecting this change: We want the same behavior during local dev and in CI. This is breaking that.