### PR TITLE
Revert "Update .pre-commit-config.yaml to prevent loops between isort and black"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,6 @@ repos:
     rev: 5.5.3
     hooks:
       - id: isort
-        args:
-          - --profile
-          - black
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:


### PR DESCRIPTION
Reverts home-assistant/core#45321

This should be fixed differently.

This should be part of the project configuration, not the pre-commit settings. This causes isort via pre-commit to behave potentially differently compared to running it standalone. We should not configure things on multiple places.