### PR TITLE
Update broadlink module to 0.16.1

### DIFF
--- a/homeassistant/components/broadlink/manifest.json
+++ b/homeassistant/components/broadlink/manifest.json
@@ -2,7 +2,7 @@
   "domain": "broadlink",
   "name": "Broadlink",
   "documentation": "https://www.home-assistant.io/integrations/broadlink",
-  "requirements": ["broadlink==0.16.0"],
+  "requirements": ["broadlink==0.16.1"],
   "codeowners": ["@danielhiversen", "@felipediel"],
   "config_flow": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -377,7 +377,7 @@ boto3==1.9.252
 bravia-tv==1.0.8
 
 # homeassistant.components.broadlink
-broadlink==0.16.0
+broadlink==0.16.1
 
 # homeassistant.components.brother
 brother==0.1.20

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -204,7 +204,7 @@ bond-api==0.1.8
 bravia-tv==1.0.8
 
 # homeassistant.components.broadlink
-broadlink==0.16.0
+broadlink==0.16.1
 
 # homeassistant.components.brother
 brother==0.1.20


### PR DESCRIPTION
## Proposed change
Update broadlink to latest version to support latest broadlink smart devices such as RM4C and RM4 Pro

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #42983, #45320, #45178, #45155, #44530 , #44216 , #43567 #42983 #42839
- This PR is related to issue: Above
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

