### PR TITLE
Remove login details before logging stream source

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -39,6 +39,8 @@ from .hls import async_setup_hls
 
 _LOGGER = logging.getLogger(__name__)
 
+STREAM_SOURCE_RE = re.compile("//(.*):(.*)@")
+
 
 def create_stream(hass, stream_source, options=None):
     """Create a stream with the specified identfier based on the source url.
@@ -175,7 +177,7 @@ class Stream:
             )
             self._thread.start()
             _LOGGER.info(
-                "Started stream: %s", re.sub("//.*:.*@", "//", str(self.source))
+                "Started stream: %s", STREAM_SOURCE_RE.sub("//", str(self.source))
             )
 
     def update_source(self, new_source):
@@ -243,7 +245,7 @@ class Stream:
             self._thread.join()
             self._thread = None
             _LOGGER.info(
-                "Stopped stream: %s", re.sub("//.*:.*@", "//", str(self.source))
+                "Stopped stream: %s", STREAM_SOURCE_RE.sub("//", str(self.source))
             )
 
     async def async_record(self, video_path, duration=30, lookback=5):

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -174,7 +174,9 @@ class Stream:
                 target=self._run_worker,
             )
             self._thread.start()
-            _LOGGER.info("Started stream: %s", re.sub("//.*:.*@", "//", self.source))
+            _LOGGER.info(
+                "Started stream: %s", re.sub("//.*:.*@", "//", str(self.source))
+            )
 
     def update_source(self, new_source):
         """Restart the stream with a new stream source."""
@@ -240,7 +242,9 @@ class Stream:
             self._thread_quit.set()
             self._thread.join()
             self._thread = None
-            _LOGGER.info("Stopped stream: %s", re.sub("//.*:.*@", "//", self.source))
+            _LOGGER.info(
+                "Stopped stream: %s", re.sub("//.*:.*@", "//", str(self.source))
+            )
 
     async def async_record(self, video_path, duration=30, lookback=5):
         """Make a .mp4 recording from a provided stream."""

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -15,6 +15,7 @@ tokens are expired. Alternatively, a Stream can be configured with keepalive
 to always keep workers active.
 """
 import logging
+import re
 import secrets
 import threading
 import time
@@ -173,7 +174,7 @@ class Stream:
                 target=self._run_worker,
             )
             self._thread.start()
-            _LOGGER.info("Started stream: %s", self.source)
+            _LOGGER.info("Started stream: %s", re.sub("//.*:.*@", "//", self.source))
 
     def update_source(self, new_source):
         """Restart the stream with a new stream source."""
@@ -239,7 +240,7 @@ class Stream:
             self._thread_quit.set()
             self._thread.join()
             self._thread = None
-            _LOGGER.info("Stopped stream: %s", self.source)
+            _LOGGER.info("Stopped stream: %s", re.sub("//.*:.*@", "//", self.source))
 
     async def async_record(self, video_path, duration=30, lookback=5):
         """Make a .mp4 recording from a provided stream."""

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -5,6 +5,8 @@ import logging
 
 import av
 
+from homeassistant.components.stream import STREAM_SOURCE_RE
+
 from .const import (
     AUDIO_CODECS,
     MAX_MISSING_DTS,
@@ -127,7 +129,9 @@ def stream_worker(source, options, segment_buffer, quit_event):
     try:
         container = av.open(source, options=options, timeout=STREAM_TIMEOUT)
     except av.AVError:
-        _LOGGER.error("Error opening stream %s", source)
+        _LOGGER.error(
+            "Error opening stream %s", STREAM_SOURCE_RE.sub("//", str(source))
+        )
         return
     try:
         video_stream = container.streams.video[0]

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -5,7 +5,7 @@ import logging
 
 import av
 
-from homeassistant.components.stream import STREAM_SOURCE_RE
+from . import STREAM_SOURCE_RE
 
 from .const import (
     AUDIO_CODECS,

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -6,7 +6,6 @@ import logging
 import av
 
 from . import STREAM_SOURCE_RE
-
 from .const import (
     AUDIO_CODECS,
     MAX_MISSING_DTS,

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -257,3 +257,13 @@ async def test_record_stream_audio(
         # Verify that the save worker was invoked, then block until its
         # thread completes and is shutdown completely to avoid thread leaks.
         await record_worker_sync.join()
+
+
+async def test_recorder_log(hass, caplog):
+    """Test starting a stream to record logs the url without username and password."""
+    await async_setup_component(hass, "stream", {"stream": {}})
+    stream = create_stream(hass, "https://abcd:efgh@foo.bar")
+    with patch.object(hass.config, "is_allowed_path", return_value=True):
+        await stream.async_record("/example/path")
+    assert "https://abcd:efgh@foo.bar" not in caplog.text
+    assert "https://foo.bar" in caplog.text

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -574,3 +574,18 @@ async def test_update_stream_source(hass):
 
         # Ccleanup
         stream.stop()
+
+
+async def test_worker_log(hass, caplog):
+    """Test that the worker logs the url without username and password."""
+    stream = Stream(hass, "https://abcd:efgh@foo.bar")
+    stream.add_provider(STREAM_OUTPUT_FORMAT)
+    with patch("av.open") as av_open:
+        av_open.side_effect = av.error.InvalidDataError(-2, "error")
+        segment_buffer = SegmentBuffer(stream.outputs)
+        stream_worker(
+            "https://abcd:efgh@foo.bar", {}, segment_buffer, threading.Event()
+        )
+        await hass.async_block_till_done()
+    assert "https://abcd:efgh@foo.bar" not in caplog.text
+    assert "https://foo.bar" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The stream logger currently outputs the entire stream source url which may include camera login details. While login details in the log might be useful for some, it seems like more users would prefer these details to be excluded. This PR uses a simple regex replacement to remove the login details from the url before logging.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42904
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
