### PR TITLE
Basic logbook support for deCONZ events

### DIFF
--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -21,7 +21,7 @@ def async_describe_events(hass, async_describe_event):
 
         return {
             "name": f"{deconz_event.device.name}",
-            "message": f"'{event.data[CONF_EVENT]}' was fired.",
+            "message": f"fired event '{event.data[CONF_EVENT]}'.",
         }
 
     async_describe_event(DECONZ_DOMAIN, CONF_DECONZ_EVENT, async_describe_deconz_event)

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -1,0 +1,27 @@
+"""Describe deCONZ logbook events."""
+
+from homeassistant.const import ATTR_DEVICE_ID, CONF_EVENT
+from homeassistant.core import callback
+
+from .const import DOMAIN as DECONZ_DOMAIN
+from .deconz_event import CONF_DECONZ_EVENT
+from .device_trigger import _get_deconz_event_from_device_id
+
+
+@callback
+def async_describe_events(hass, async_describe_event):
+    """Describe logbook events."""
+
+    @callback
+    def async_describe_deconz_event(event):
+        """Describe deCONZ logbook event."""
+        deconz_event = _get_deconz_event_from_device_id(
+            hass, event.data[ATTR_DEVICE_ID]
+        )
+
+        return {
+            "name": f"{deconz_event.device.name}",
+            "message": f"'{event.data[CONF_EVENT]}' was fired.",
+        }
+
+    async_describe_event(DECONZ_DOMAIN, CONF_DECONZ_EVENT, async_describe_deconz_event)

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -1,21 +1,27 @@
 """Describe deCONZ logbook events."""
 
+from typing import Callable, Optional
+
 from homeassistant.const import ATTR_DEVICE_ID, CONF_EVENT
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import Event
 
 from .const import DOMAIN as DECONZ_DOMAIN
-from .deconz_event import CONF_DECONZ_EVENT
+from .deconz_event import CONF_DECONZ_EVENT, DeconzEvent
 from .device_trigger import _get_deconz_event_from_device_id
 
 
 @callback
-def async_describe_events(hass, async_describe_event):
+def async_describe_events(
+    hass: HomeAssistant,
+    async_describe_event: Callable[[str, str, Callable[[Event], dict]], None],
+) -> None:
     """Describe logbook events."""
 
     @callback
-    def async_describe_deconz_event(event):
+    def async_describe_deconz_event(event: Event) -> dict:
         """Describe deCONZ logbook event."""
-        deconz_event = _get_deconz_event_from_device_id(
+        deconz_event: Optional[DeconzEvent] = _get_deconz_event_from_device_id(
             hass, event.data[ATTR_DEVICE_ID]
         )
 

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -55,4 +55,4 @@ async def test_humanifying_deconz_event(hass):
 
     assert event1["name"] == "Switch 1"
     assert event1["domain"] == "deconz"
-    assert event1["message"] == "'2000' was fired."
+    assert event1["message"] == "fired event '2000'."

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -1,0 +1,58 @@
+"""The tests for deCONZ logbook."""
+
+from copy import deepcopy
+
+from homeassistant.components import logbook
+from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
+from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
+from homeassistant.const import CONF_DEVICE_ID, CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
+from homeassistant.setup import async_setup_component
+
+from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
+
+from tests.components.logbook.test_init import MockLazyEventPartialState
+
+
+async def test_humanifying_deconz_event(hass):
+    """Test humanifying deCONZ event."""
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["sensors"] = {
+        "0": {
+            "id": "Switch 1 id",
+            "name": "Switch 1",
+            "type": "ZHASwitch",
+            "state": {"buttonevent": 1000},
+            "config": {},
+            "uniqueid": "00:00:00:00:00:00:00:01-00",
+        }
+    }
+    config_entry = await setup_deconz_integration(hass, get_state_response=data)
+    gateway = get_gateway_from_config_entry(hass, config_entry)
+    event = gateway.events[0]
+
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "logbook", {})
+    entity_attr_cache = logbook.EntityAttributeCache(hass)
+
+    event1 = list(
+        logbook.humanify(
+            hass,
+            [
+                MockLazyEventPartialState(
+                    CONF_DECONZ_EVENT,
+                    {
+                        CONF_DEVICE_ID: event.device_id,
+                        CONF_EVENT: 2000,
+                        CONF_ID: event.event_id,
+                        CONF_UNIQUE_ID: event.serial,
+                    },
+                ),
+            ],
+            entity_attr_cache,
+            {},
+        )
+    )[0]
+
+    assert event1["name"] == "Switch 1"
+    assert event1["domain"] == "deconz"
+    assert event1["message"] == "'2000' was fired."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Basic logbook support for deCONZ events

<img width="296" alt="Screenshot 2021-01-21 at 20 37 04" src="https://user-images.githubusercontent.com/24575746/105403011-736e7c80-5c28-11eb-902b-11d45d059dd9.png">

I plan on expanding this with using the device trigger lists to translate to more human readable format, but not all devices are added there so small steps :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
