### PR TITLE
Add advanced Hyperion entities

### DIFF
--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -294,7 +294,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             f"{hyperion_const.KEY_INSTANCE}-{hyperion_const.KEY_UPDATE}": async_instances_to_clients,
         }
     )
-    await async_instances_to_clients_raw(hyperion_client.instances)
 
     # Must only listen for option updates after the setup is complete, as otherwise
     # the YAML->ConfigEntry migration code triggers an options update, which causes a
@@ -307,6 +306,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 for component in PLATFORMS
             ]
         )
+        assert hyperion_client
+        await async_instances_to_clients_raw(hyperion_client.instances)
         hass.data[DOMAIN][config_entry.entry_id][CONF_ON_UNLOAD].append(
             config_entry.add_update_listener(_async_entry_updated)
         )

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -329,7 +329,7 @@ async def async_unload_entry(
                 config_data[CONF_INSTANCE_CLIENTS][
                     instance_num
                 ].async_client_disconnect()
-                for instance_num in list(config_data[CONF_INSTANCE_CLIENTS])
+                for instance_num in config_data[CONF_INSTANCE_CLIENTS]
             ]
         )
 

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 from hyperion import client, const as hyperion_const
 from pkg_resources import parse_version
@@ -13,15 +13,22 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SOURCE, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity_registry import (
+    async_entries_for_config_entry,
+    async_get_registry,
+)
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from .const import (
+    CONF_INSTANCE_CLIENTS,
     CONF_ON_UNLOAD,
     CONF_ROOT_CLIENT,
+    DEFAULT_NAME,
     DOMAIN,
     HYPERION_RELEASES_URL,
     HYPERION_VERSION_WARN_CUTOFF,
-    SIGNAL_INSTANCES_UPDATED,
+    SIGNAL_INSTANCE_ADD,
+    SIGNAL_INSTANCE_REMOVE,
 )
 
 PLATFORMS = [LIGHT_DOMAIN]
@@ -57,6 +64,17 @@ _LOGGER = logging.getLogger(__name__)
 def get_hyperion_unique_id(server_id: str, instance: int, name: str) -> str:
     """Get a unique_id for a Hyperion instance."""
     return f"{server_id}_{instance}_{name}"
+
+
+def split_hyperion_unique_id(unique_id: str) -> Optional[Tuple[str, int, str]]:
+    """Split a unique_id into a (server_id, instance, type) tuple."""
+    data = tuple(unique_id.split("_", 2))
+    if len(data) != 3:
+        return None
+    try:
+        return (data[0], int(data[1]), data[2])
+    except ValueError:
+        return None
 
 
 def create_hyperion_client(
@@ -151,22 +169,86 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         await hyperion_client.async_client_disconnect()
         raise ConfigEntryNotReady
 
-    hyperion_client.set_callbacks(
-        {
-            f"{hyperion_const.KEY_INSTANCE}-{hyperion_const.KEY_UPDATE}": lambda json: (
-                async_dispatcher_send(
-                    hass,
-                    SIGNAL_INSTANCES_UPDATED.format(config_entry.entry_id),
-                    json,
-                )
-            )
-        }
-    )
-
+    # We need 1 root client (to manage instances being removed/added) and then 1 client
+    # per Hyperion server instance which is shared for all entities associated with
+    # that instance.
     hass.data[DOMAIN][config_entry.entry_id] = {
         CONF_ROOT_CLIENT: hyperion_client,
+        CONF_INSTANCE_CLIENTS: {},
         CONF_ON_UNLOAD: [],
     }
+
+    async def async_instances_to_clients(response: Dict[str, Any]) -> None:
+        """Convert instances to Hyperion clients."""
+        if not response or hyperion_const.KEY_DATA not in response:
+            return
+        await async_instances_to_clients_raw(response[hyperion_const.KEY_DATA])
+
+    async def async_instances_to_clients_raw(instances: List[Dict[str, Any]]) -> None:
+        """Convert instances to Hyperion clients."""
+        registry = await async_get_registry(hass)
+        running_instances: Set[int] = set()
+        stopped_instances: Set[int] = set()
+        existing_instances = hass.data[DOMAIN][config_entry.entry_id][
+            CONF_INSTANCE_CLIENTS
+        ]
+        server_id = cast(str, config_entry.unique_id)
+
+        # In practice, an instance can be in 3 states as seen by this function:
+        #
+        #    * Exists, and is running: Should be present in HASS/registry.
+        #    * Exists, but is not running: Cannot add it yet, but entity may have be
+        #      registered from a previous time it was running.
+        #    * No longer exists at all: Should not be present in HASS/registry.
+
+        # Add instances that are missing.
+        for instance in instances:
+            instance_num = instance.get(hyperion_const.KEY_INSTANCE)
+            if instance_num is None:
+                continue
+            if not instance.get(hyperion_const.KEY_RUNNING, False):
+                stopped_instances.add(instance_num)
+                continue
+            running_instances.add(instance_num)
+            if instance_num in existing_instances:
+                continue
+            hyperion_client = await async_create_connect_hyperion_client(
+                host, port, instance=instance_num, token=token
+            )
+            if not hyperion_client:
+                continue
+            existing_instances[instance_num] = hyperion_client
+            instance_name = instance.get(hyperion_const.KEY_FRIENDLY_NAME, DEFAULT_NAME)
+            async_dispatcher_send(
+                hass,
+                SIGNAL_INSTANCE_ADD.format(config_entry.entry_id),
+                instance_num,
+                instance_name,
+            )
+
+        # Remove entities that are are not running instances on Hyperion.
+        for instance_num in set(existing_instances) - running_instances:
+            del existing_instances[instance_num]
+            async_dispatcher_send(
+                hass, SIGNAL_INSTANCE_REMOVE.format(config_entry.entry_id), instance_num
+            )
+
+        # Deregister entities that belong to removed instances.
+        for entry in async_entries_for_config_entry(registry, config_entry.entry_id):
+            data = split_hyperion_unique_id(entry.unique_id)
+            if not data:
+                continue
+            if data[0] == server_id and data[1] not in running_instances.union(
+                stopped_instances
+            ):
+                registry.async_remove(entry.entity_id)
+
+    hyperion_client.set_callbacks(
+        {
+            f"{hyperion_const.KEY_INSTANCE}-{hyperion_const.KEY_UPDATE}": async_instances_to_clients,
+        }
+    )
+    await async_instances_to_clients_raw(hyperion_client.instances)
 
     # Must only listen for option updates after the setup is complete, as otherwise
     # the YAML->ConfigEntry migration code triggers an options update, which causes a

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -292,6 +292,13 @@ async def async_unload_entry(
         config_data = hass.data[DOMAIN].pop(config_entry.entry_id)
         for func in config_data[CONF_ON_UNLOAD]:
             func()
+
+        # Disconnect the shared instance clients.
+        for instance_num in list(config_data[CONF_INSTANCE_CLIENTS]):
+            instance_client = config_data[CONF_INSTANCE_CLIENTS][instance_num]
+            await instance_client.async_client_disconnect()
+
+        # Disconnect the root client.
         root_client = config_data[CONF_ROOT_CLIENT]
         await root_client.async_client_disconnect()
     return unload_ok

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -8,6 +8,7 @@ from hyperion import client, const as hyperion_const
 from pkg_resources import parse_version
 
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SOURCE, CONF_TOKEN
 from homeassistant.core import HomeAssistant
@@ -34,7 +35,7 @@ from .const import (
     SIGNAL_INSTANCE_REMOVE,
 )
 
-PLATFORMS = [LIGHT_DOMAIN]
+PLATFORMS = [LIGHT_DOMAIN, SWITCH_DOMAIN]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -142,24 +142,6 @@ def listen_for_instance_updates(
     )
 
 
-def add_instances_from_root_client(
-    hass: HomeAssistant, config_entry: ConfigEntry, add_func: Callable
-) -> None:
-    """Call the add_func for all instances in the root client."""
-    # Note: When the YAML migration code is removed, this can be simplified by allowing
-    # instance_add(...) to be called directly via the signal in __init__.py without
-    # needing to be also called synchronously here.
-    entry_data = hass.data[DOMAIN][config_entry.entry_id]
-    for instance in entry_data[CONF_ROOT_CLIENT].instances:
-        instance_num = instance.get(hyperion_const.KEY_INSTANCE)
-        if (
-            instance_num is not None
-            and instance_num in entry_data[CONF_INSTANCE_CLIENTS]
-        ):
-            instance_name = instance.get(hyperion_const.KEY_FRIENDLY_NAME, DEFAULT_NAME)
-            add_func(instance_num, instance_name)
-
-
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Hyperion from a config entry."""
     host = config_entry.data[CONF_HOST]

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -1,5 +1,29 @@
 """Constants for Hyperion integration."""
 
+from hyperion.const import (
+    KEY_COMPONENTID_ALL,
+    KEY_COMPONENTID_BLACKBORDER,
+    KEY_COMPONENTID_BOBLIGHTSERVER,
+    KEY_COMPONENTID_FORWARDER,
+    KEY_COMPONENTID_GRABBER,
+    KEY_COMPONENTID_LEDDEVICE,
+    KEY_COMPONENTID_SMOOTHING,
+    KEY_COMPONENTID_V4L,
+)
+
+# Maps between Hyperion API component names to Hyperion UI names. This allows Home
+# Assistant to use names that match what Hyperion users may expect from the Hyperion UI.
+COMPONENT_TO_NAME = {
+    KEY_COMPONENTID_ALL: "All",
+    KEY_COMPONENTID_SMOOTHING: "Smoothing",
+    KEY_COMPONENTID_BLACKBORDER: "Blackbar Detection",
+    KEY_COMPONENTID_FORWARDER: "Forwarder",
+    KEY_COMPONENTID_BOBLIGHTSERVER: "Boblight Server",
+    KEY_COMPONENTID_GRABBER: "Platform Capture",
+    KEY_COMPONENTID_LEDDEVICE: "LED Device",
+    KEY_COMPONENTID_V4L: "USB Capture",
+}
+
 CONF_AUTH_ID = "auth_id"
 CONF_CREATE_TOKEN = "create_token"
 CONF_INSTANCE = "instance"

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -3,6 +3,7 @@
 CONF_AUTH_ID = "auth_id"
 CONF_CREATE_TOKEN = "create_token"
 CONF_INSTANCE = "instance"
+CONF_INSTANCE_CLIENTS = "INSTANCE_CLIENTS"
 CONF_ON_UNLOAD = "ON_UNLOAD"
 CONF_PRIORITY = "priority"
 CONF_ROOT_CLIENT = "ROOT_CLIENT"
@@ -16,7 +17,8 @@ DOMAIN = "hyperion"
 HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/releases"
 HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.9"
 
-SIGNAL_INSTANCES_UPDATED = f"{DOMAIN}_instances_updated_signal." "{}"
-SIGNAL_INSTANCE_REMOVED = f"{DOMAIN}_instance_removed_signal." "{}"
+SIGNAL_INSTANCE_ADD = f"{DOMAIN}_instance_add_signal." "{}"
+SIGNAL_INSTANCE_REMOVE = f"{DOMAIN}_instance_remove_signal." "{}"
+SIGNAL_ENTITY_REMOVE = f"{DOMAIN}_entity_remove_signal." "{}"
 
 TYPE_HYPERION_LIGHT = "hyperion_light"

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -18,7 +18,8 @@ HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/release
 HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.9"
 
 NAME_SUFFIX_HYPERION_LIGHT = ""
-NAME_SUFFIX_HYPERION_PRIORITY_LIGHT = "Priority Light"
+NAME_SUFFIX_HYPERION_PRIORITY_LIGHT = "Priority"
+NAME_SUFFIX_HYPERION_COMPONENT_SWITCH = "Component"
 
 SIGNAL_INSTANCE_ADD = f"{DOMAIN}_instance_add_signal." "{}"
 SIGNAL_INSTANCE_REMOVE = f"{DOMAIN}_instance_remove_signal." "{}"
@@ -26,3 +27,4 @@ SIGNAL_ENTITY_REMOVE = f"{DOMAIN}_entity_remove_signal." "{}"
 
 TYPE_HYPERION_LIGHT = "hyperion_light"
 TYPE_HYPERION_PRIORITY_LIGHT = "hyperion_priority_light"
+TYPE_HYPERION_COMPONENT_SWITCH_BASE = "hyperion_component_switch"

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -22,3 +22,4 @@ SIGNAL_INSTANCE_REMOVE = f"{DOMAIN}_instance_remove_signal." "{}"
 SIGNAL_ENTITY_REMOVE = f"{DOMAIN}_entity_remove_signal." "{}"
 
 TYPE_HYPERION_LIGHT = "hyperion_light"
+TYPE_HYPERION_PRIORITY_LIGHT = "hyperion_priority_light"

--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -17,6 +17,9 @@ DOMAIN = "hyperion"
 HYPERION_RELEASES_URL = "https://github.com/hyperion-project/hyperion.ng/releases"
 HYPERION_VERSION_WARN_CUTOFF = "2.0.0-alpha.9"
 
+NAME_SUFFIX_HYPERION_LIGHT = ""
+NAME_SUFFIX_HYPERION_PRIORITY_LIGHT = "Priority Light"
+
 SIGNAL_INSTANCE_ADD = f"{DOMAIN}_instance_add_signal." "{}"
 SIGNAL_INSTANCE_REMOVE = f"{DOMAIN}_instance_remove_signal." "{}"
 SIGNAL_ENTITY_REMOVE = f"{DOMAIN}_entity_remove_signal." "{}"

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -47,17 +47,13 @@ from . import (
 )
 from .const import (
     CONF_INSTANCE_CLIENTS,
-    CONF_ON_UNLOAD,
     CONF_PRIORITY,
-    CONF_ROOT_CLIENT,
     DEFAULT_ORIGIN,
     DEFAULT_PRIORITY,
     DOMAIN,
     NAME_SUFFIX_HYPERION_LIGHT,
     NAME_SUFFIX_HYPERION_PRIORITY_LIGHT,
     SIGNAL_ENTITY_REMOVE,
-    SIGNAL_INSTANCE_ADD,
-    SIGNAL_INSTANCE_REMOVE,
     TYPE_HYPERION_LIGHT,
     TYPE_HYPERION_PRIORITY_LIGHT,
 )
@@ -272,32 +268,7 @@ async def async_setup_entry(
                 ),
             )
 
-    # Note: When the YAML migration code is removed, this can be simplified by allowing
-    # instance_add(...) to be called directly via the signal in __init__.py without
-    # needing to be also called synchronously here.
-    for instance in entry_data[CONF_ROOT_CLIENT].instances:
-        instance_num = instance.get(const.KEY_INSTANCE)
-        if (
-            instance_num is not None
-            and instance_num in entry_data[CONF_INSTANCE_CLIENTS]
-        ):
-            instance_name = instance.get(const.KEY_FRIENDLY_NAME, DEFAULT_NAME)
-            instance_add(instance_num, instance_name)
-
-    hass.data[DOMAIN][config_entry.entry_id][CONF_ON_UNLOAD].extend(
-        [
-            async_dispatcher_connect(
-                hass,
-                SIGNAL_INSTANCE_ADD.format(config_entry.entry_id),
-                instance_add,
-            ),
-            async_dispatcher_connect(
-                hass,
-                SIGNAL_INSTANCE_REMOVE.format(config_entry.entry_id),
-                instance_remove,
-            ),
-        ]
-    )
+    listen_for_instance_updates(hass, config_entry, instance_add, instance_remove)
     return True
 
 

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -41,9 +41,9 @@ from homeassistant.helpers.typing import (
 import homeassistant.util.color as color_util
 
 from . import (
-    async_create_connect_hyperion_client,
     create_hyperion_client,
     get_hyperion_unique_id,
+    listen_for_instance_updates,
 )
 from .const import (
     CONF_INSTANCE_CLIENTS,

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -29,10 +29,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.entity_registry import (
-    async_entries_for_config_entry,
-    async_get_registry,
-)
+from homeassistant.helpers.entity_registry import async_get_registry
 from homeassistant.helpers.typing import (
     ConfigType,
     DiscoveryInfoType,

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -324,6 +324,14 @@ class HyperionPriorityLight(LightEntity):
 
         self._effect_list: List[str] = []
 
+        self._client_callbacks = {
+            f"{const.KEY_ADJUSTMENT}-{const.KEY_UPDATE}": self._update_adjustment,
+            f"{const.KEY_COMPONENTS}-{const.KEY_UPDATE}": self._update_components,
+            f"{const.KEY_EFFECTS}-{const.KEY_UPDATE}": self._update_effect_list,
+            f"{const.KEY_PRIORITIES}-{const.KEY_UPDATE}": self._update_priorities,
+            f"{const.KEY_CLIENT}-{const.KEY_UPDATE}": self._update_client,
+        }
+
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Whether or not the entity is enabled by default."""
@@ -622,18 +630,14 @@ class HyperionPriorityLight(LightEntity):
             )
         )
 
-        self._client.set_callbacks(
-            {
-                f"{const.KEY_ADJUSTMENT}-{const.KEY_UPDATE}": self._update_adjustment,
-                f"{const.KEY_COMPONENTS}-{const.KEY_UPDATE}": self._update_components,
-                f"{const.KEY_EFFECTS}-{const.KEY_UPDATE}": self._update_effect_list,
-                f"{const.KEY_PRIORITIES}-{const.KEY_UPDATE}": self._update_priorities,
-                f"{const.KEY_CLIENT}-{const.KEY_UPDATE}": self._update_client,
-            }
-        )
+        self._client.add_callbacks(self._client_callbacks)
 
         # Load initial state.
         self._update_full_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cleanup prior to hass removal."""
+        self._client.remove_callbacks(self._client_callbacks)
 
 
 class HyperionLight(HyperionPriorityLight):

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -1,0 +1,189 @@
+"""Switch platform for Hyperion."""
+
+from typing import Any, Callable, Dict, Optional
+
+from hyperion import client
+from hyperion.const import (
+    KEY_COMPONENT,
+    KEY_COMPONENTID_ALL,
+    KEY_COMPONENTID_BLACKBORDER,
+    KEY_COMPONENTID_BOBLIGHTSERVER,
+    KEY_COMPONENTID_FORWARDER,
+    KEY_COMPONENTID_GRABBER,
+    KEY_COMPONENTID_LEDDEVICE,
+    KEY_COMPONENTID_SMOOTHING,
+    KEY_COMPONENTID_V4L,
+    KEY_COMPONENTS,
+    KEY_COMPONENTSTATE,
+    KEY_ENABLED,
+    KEY_NAME,
+    KEY_STATE,
+    KEY_UPDATE,
+)
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import (
+    add_instances_from_root_client,
+    get_hyperion_unique_id,
+    listen_for_instance_updates,
+)
+from .const import (
+    CONF_INSTANCE_CLIENTS,
+    DOMAIN,
+    NAME_SUFFIX_HYPERION_COMPONENT_SWITCH,
+    SIGNAL_ENTITY_REMOVE,
+    TYPE_HYPERION_COMPONENT_SWITCH_BASE,
+)
+
+COMPONENT_TO_SWITCH_TYPE = {
+    component: f"{TYPE_HYPERION_COMPONENT_SWITCH_BASE}_{component.lower()}"
+    for component in [
+        KEY_COMPONENTID_ALL,
+        KEY_COMPONENTID_SMOOTHING,
+        KEY_COMPONENTID_BLACKBORDER,
+        KEY_COMPONENTID_FORWARDER,
+        KEY_COMPONENTID_BOBLIGHTSERVER,
+        KEY_COMPONENTID_GRABBER,
+        KEY_COMPONENTID_LEDDEVICE,
+        KEY_COMPONENTID_V4L,
+    ]
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities: Callable
+) -> bool:
+    """Set up a Hyperion platform from config entry."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    server_id = config_entry.unique_id
+
+    def instance_add(instance_num: int, instance_name: str) -> None:
+        """Add entities for a new Hyperion instance."""
+        assert server_id
+        switches = []
+        for component in COMPONENT_TO_SWITCH_TYPE:
+            switches.append(
+                HyperionComponentSwitch(
+                    get_hyperion_unique_id(
+                        server_id, instance_num, COMPONENT_TO_SWITCH_TYPE[component]
+                    ),
+                    f"{instance_name} {NAME_SUFFIX_HYPERION_COMPONENT_SWITCH} {component.capitalize()}",
+                    component,
+                    entry_data[CONF_INSTANCE_CLIENTS][instance_num],
+                ),
+            )
+        async_add_entities(switches)
+
+    def instance_remove(instance_num: int) -> None:
+        """Remove entities for an old Hyperion instance."""
+        assert server_id
+        for component in COMPONENT_TO_SWITCH_TYPE:
+            async_dispatcher_send(
+                hass,
+                SIGNAL_ENTITY_REMOVE.format(
+                    get_hyperion_unique_id(
+                        server_id, instance_num, COMPONENT_TO_SWITCH_TYPE[component]
+                    )
+                ),
+            )
+
+    add_instances_from_root_client(hass, config_entry, instance_add)
+    listen_for_instance_updates(hass, config_entry, instance_add, instance_remove)
+    return True
+
+
+class HyperionComponentSwitch(SwitchEntity):
+    """ComponentBinarySwitch switch class."""
+
+    def __init__(
+        self,
+        unique_id: str,
+        name: str,
+        component_name: str,
+        hyperion_client: client.HyperionClient,
+    ) -> None:
+        """Initialize the switch."""
+        self._unique_id = unique_id
+        self._name = name
+        self._component_name = component_name
+        self._client = hyperion_client
+        self._client_callbacks = {
+            f"{KEY_COMPONENTS}-{KEY_UPDATE}": self._update_components
+        }
+
+    @property
+    def should_poll(self) -> bool:
+        """Return whether or not this entity should be polled."""
+        return False
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Whether or not the entity is enabled by default."""
+        # These component controls are for advanced users and are disabled by default.
+        return False
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique id for this instance."""
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the switch is on."""
+        for component in self._client.components:
+            if component[KEY_NAME] == self._component_name:
+                return bool(component.setdefault(KEY_ENABLED, False))
+        return False
+
+    async def _async_send_set_component(self, value: bool) -> None:
+        await self._client.async_send_set_component(
+            **{
+                KEY_COMPONENTSTATE: {
+                    KEY_COMPONENT: self._component_name,
+                    KEY_STATE: value,
+                }
+            }
+        )
+
+    # pylint: disable=unused-argument
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the switch."""
+        await self._async_send_set_component(True)
+
+    # pylint: disable=unused-argument
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the switch."""
+        await self._async_send_set_component(False)
+
+    def _update_components(self, _: Optional[Dict[str, Any]] = None) -> None:
+        """Update Hyperion components."""
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks when entity added to hass."""
+        assert self.hass
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_ENTITY_REMOVE.format(self._unique_id),
+                self.async_remove,
+            )
+        )
+
+        self._client.add_callbacks(self._client_callbacks)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cleanup prior to hass removal."""
+        self._client.remove_callbacks(self._client_callbacks)

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -29,11 +29,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import (
-    add_instances_from_root_client,
-    get_hyperion_unique_id,
-    listen_for_instance_updates,
-)
+from . import get_hyperion_unique_id, listen_for_instance_updates
 from .const import (
     CONF_INSTANCE_CLIENTS,
     DOMAIN,
@@ -94,7 +90,6 @@ async def async_setup_entry(
                 ),
             )
 
-    add_instances_from_root_client(hass, config_entry, instance_add)
     listen_for_instance_updates(hass, config_entry, instance_add, instance_remove)
     return True
 
@@ -146,6 +141,11 @@ class HyperionComponentSwitch(SwitchEntity):
             if component[KEY_NAME] == self._component_name:
                 return bool(component.setdefault(KEY_ENABLED, False))
         return False
+
+    @property
+    def available(self) -> bool:
+        """Return server availability."""
+        return bool(self._client.has_loaded_state)
 
     async def _async_send_set_component(self, value: bool) -> None:
         await self._client.async_send_set_component(

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -23,6 +23,7 @@ from hyperion.const import (
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -80,6 +81,7 @@ async def async_setup_entry(
             f"{COMPONENT_TO_NAME.get(component, component.capitalize())}"
         )
 
+    @callback
     def instance_add(instance_num: int, instance_name: str) -> None:
         """Add entities for a new Hyperion instance."""
         assert server_id
@@ -95,6 +97,7 @@ async def async_setup_entry(
             )
         async_add_entities(switches)
 
+    @callback
     def instance_remove(instance_num: int) -> None:
         """Remove entities for an old Hyperion instance."""
         assert server_id
@@ -184,6 +187,7 @@ class HyperionComponentSwitch(SwitchEntity):
         """Turn off the switch."""
         await self._async_send_set_component(False)
 
+    @callback
     def _update_components(self, _: Optional[Dict[str, Any]] = None) -> None:
         """Update Hyperion components."""
         self.async_write_ha_state()

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -113,6 +113,7 @@ def create_mock_client() -> Mock:
         }
     )
 
+    mock_client.priorities = []
     mock_client.adjustment = None
     mock_client.effects = None
     mock_client.instances = [

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -29,7 +29,7 @@ TEST_YAML_ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_YAML_NAME}"
 TEST_ENTITY_ID_1 = "light.test_instance_1"
 TEST_ENTITY_ID_2 = "light.test_instance_2"
 TEST_ENTITY_ID_3 = "light.test_instance_3"
-TEST_PRIORITY_LIGHT_ENTITY_ID_1 = "light.test_instance_1_priority_light"
+TEST_PRIORITY_LIGHT_ENTITY_ID_1 = "light.test_instance_1_priority"
 TEST_TITLE = f"{TEST_HOST}:{TEST_PORT}"
 
 TEST_TOKEN = "sekr1t"
@@ -161,3 +161,12 @@ async def setup_test_config_entry(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
     return config_entry
+
+
+def call_registered_callback(
+    client: AsyncMock, key: str, *args: Any, **kwargs: Any
+) -> None:
+    """Call Hyperion entity callbacks that were registered with the client."""
+    for call in client.add_callbacks.call_args_list:
+        if key in call[0][0]:
+            call[0][0][key](*args, **kwargs)

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -29,6 +29,7 @@ TEST_YAML_ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_YAML_NAME}"
 TEST_ENTITY_ID_1 = "light.test_instance_1"
 TEST_ENTITY_ID_2 = "light.test_instance_2"
 TEST_ENTITY_ID_3 = "light.test_instance_3"
+TEST_PRIORITY_LIGHT_ENTITY_ID_1 = "light.test_instance_1_priority_light"
 TEST_TITLE = f"{TEST_HOST}:{TEST_PORT}"
 
 TEST_TOKEN = "sekr1t"

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from types import TracebackType
 from typing import Any, Dict, Optional, Type
-from unittest.mock import AsyncMock, Mock, patch  # type: ignore[attr-defined]
+from unittest.mock import AsyncMock, Mock, patch
 
 from hyperion import const
 
@@ -68,7 +68,7 @@ TEST_AUTH_NOT_REQUIRED_RESP = {
 _LOGGER = logging.getLogger(__name__)
 
 
-class AsyncContextManagerMock(Mock):  # type: ignore[misc]
+class AsyncContextManagerMock(Mock):
     """An async context manager mock for Hyperion."""
 
     async def __aenter__(self) -> Optional[AsyncContextManagerMock]:

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Any, Dict, Optional
-from unittest.mock import AsyncMock, patch  # type: ignore[attr-defined]
+from unittest.mock import AsyncMock, patch
 
 from hyperion import const
 
@@ -689,6 +689,7 @@ async def test_options(hass: HomeAssistantType) -> None:
             {ATTR_ENTITY_ID: TEST_ENTITY_ID_1},
             blocking=True,
         )
+        # pylint: disable=unsubscriptable-object
         assert client.async_send_set_color.call_args[1][CONF_PRIORITY] == new_priority
 
 

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -71,7 +71,7 @@ def _call_registered_callback(
     client: AsyncMock, key: str, *args: Any, **kwargs: Any
 ) -> None:
     """Call a Hyperion entity callback that was registered with the client."""
-    client.set_callbacks.call_args[0][0][key](*args, **kwargs)
+    client.add_callbacks.call_args[0][0][key](*args, **kwargs)
 
 
 async def _setup_entity_yaml(hass: HomeAssistantType, client: AsyncMock = None) -> None:

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -2,7 +2,7 @@
 import logging
 from types import MappingProxyType
 from typing import Any, Optional
-from unittest.mock import AsyncMock, call, patch  # type: ignore[attr-defined]
+from unittest.mock import AsyncMock, call, patch
 
 from hyperion import const
 
@@ -264,7 +264,7 @@ async def test_setup_config_entry_not_ready_load_state_fail(
 
 
 async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> None:
-    """Test dynamic changes in the omstamce configuration."""
+    """Test dynamic changes in the instance configuration."""
     registry = await async_get_registry(hass)
 
     config_entry = add_test_config_entry(hass)
@@ -291,11 +291,12 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
     instance_callback = master_client.set_callbacks.call_args[0][0][
         f"{const.KEY_INSTANCE}-{const.KEY_UPDATE}"
     ]
+
     with patch(
         "homeassistant.components.hyperion.client.HyperionClient",
         return_value=entity_client,
     ):
-        instance_callback(
+        await instance_callback(
             {
                 const.KEY_SUCCESS: True,
                 const.KEY_DATA: [
@@ -323,7 +324,7 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
         "homeassistant.components.hyperion.client.HyperionClient",
         return_value=entity_client,
     ):
-        instance_callback(
+        await instance_callback(
             {
                 const.KEY_SUCCESS: True,
                 const.KEY_DATA: [TEST_INSTANCE_2, TEST_INSTANCE_3],
@@ -343,7 +344,7 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
         "homeassistant.components.hyperion.client.HyperionClient",
         return_value=entity_client,
     ):
-        instance_callback(
+        await instance_callback(
             {
                 const.KEY_SUCCESS: True,
                 const.KEY_DATA: [
@@ -364,7 +365,7 @@ async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> 
         "homeassistant.components.hyperion.client.HyperionClient",
         return_value=entity_client,
     ):
-        instance_callback(
+        await instance_callback(
             {
                 const.KEY_SUCCESS: True,
                 const.KEY_DATA: [TEST_INSTANCE_1, TEST_INSTANCE_2, TEST_INSTANCE_3],

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -825,9 +825,12 @@ async def test_light_async_updates_from_hyperion_client(
     _call_registered_callback(client, "effects-update")
     entity_state = hass.states.get(TEST_ENTITY_ID_1)
     assert entity_state
-    assert entity_state.attributes["effect_list"] == [
-        effect[const.KEY_NAME] for effect in effects
-    ] + const.KEY_COMPONENTID_EXTERNAL_SOURCES + [hyperion_light.KEY_EFFECT_SOLID]
+    assert (
+        entity_state.attributes["effect_list"]
+        == [effect[const.KEY_NAME] for effect in effects]
+        + [hyperion_light.KEY_EFFECT_SOLID]
+        + const.KEY_COMPONENTID_EXTERNAL_SOURCES
+    )
 
     # Update connection status (e.g. disconnection).
 
@@ -1274,3 +1277,19 @@ async def test_priority_light_prior_color_preserved_after_black(
     assert entity_state
     assert entity_state.state == "on"
     assert entity_state.attributes["hs_color"] == hs_color
+
+
+async def test_priority_light_has_no_external_sources(hass: HomeAssistantType) -> None:
+    """Ensure a HyperionPriorityLight does not list external sources."""
+    client = create_mock_client()
+    client.priorities = []
+
+    with patch(
+        "homeassistant.components.hyperion.light.HyperionPriorityLight.entity_registry_enabled_default"
+    ) as enabled_by_default_mock:
+        enabled_by_default_mock.return_value = True
+        await setup_test_config_entry(hass, hyperion_client=client)
+
+    entity_state = hass.states.get(TEST_PRIORITY_LIGHT_ENTITY_ID_1)
+    assert entity_state
+    assert entity_state.attributes["effect_list"] == [hyperion_light.KEY_EFFECT_SOLID]

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -711,7 +711,7 @@ async def test_light_async_turn_off(hass: HomeAssistantType) -> None:
         }
     )
 
-    _call_registered_callback(client, "components-update")
+    call_registered_callback(client, "components-update")
     entity_state = hass.states.get(TEST_ENTITY_ID_1)
     assert entity_state
     assert entity_state.attributes["icon"] == hyperion_light.ICON_LIGHTBULB

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -819,12 +819,11 @@ async def test_light_async_updates_from_hyperion_client(
     call_registered_callback(client, "effects-update")
     entity_state = hass.states.get(TEST_ENTITY_ID_1)
     assert entity_state
-    assert (
-        entity_state.attributes["effect_list"]
-        == [effect[const.KEY_NAME] for effect in effects]
-        + [hyperion_light.KEY_EFFECT_SOLID]
-        + const.KEY_COMPONENTID_EXTERNAL_SOURCES
-    )
+    assert entity_state.attributes["effect_list"] == [
+        hyperion_light.KEY_EFFECT_SOLID
+    ] + const.KEY_COMPONENTID_EXTERNAL_SOURCES + [
+        effect[const.KEY_NAME] for effect in effects
+    ]
 
     # Update connection status (e.g. disconnection).
 

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -1,0 +1,134 @@
+"""Tests for the Hyperion integration."""
+import logging
+from unittest.mock import AsyncMock, call, patch
+
+from hyperion.const import (
+    KEY_COMPONENT,
+    KEY_COMPONENTID_ALL,
+    KEY_COMPONENTID_BLACKBORDER,
+    KEY_COMPONENTID_BOBLIGHTSERVER,
+    KEY_COMPONENTID_FORWARDER,
+    KEY_COMPONENTID_GRABBER,
+    KEY_COMPONENTID_LEDDEVICE,
+    KEY_COMPONENTID_SMOOTHING,
+    KEY_COMPONENTID_V4L,
+    KEY_COMPONENTSTATE,
+    KEY_STATE,
+)
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import call_registered_callback, create_mock_client, setup_test_config_entry
+
+TEST_COMPONENTS = [
+    {"enabled": True, "name": "ALL"},
+    {"enabled": True, "name": "SMOOTHING"},
+    {"enabled": True, "name": "BLACKBORDER"},
+    {"enabled": False, "name": "FORWARDER"},
+    {"enabled": False, "name": "BOBLIGHTSERVER"},
+    {"enabled": False, "name": "GRABBER"},
+    {"enabled": False, "name": "V4L"},
+    {"enabled": True, "name": "LEDDEVICE"},
+]
+
+_LOGGER = logging.getLogger(__name__)
+TEST_SWITCH_COMPONENT_BASE_ENTITY_ID = "switch.test_instance_1_component"
+TEST_SWITCH_COMPONENT_ALL_ENTITY_ID = f"{TEST_SWITCH_COMPONENT_BASE_ENTITY_ID}_all"
+
+
+async def test_switch_turn_on_off(hass: HomeAssistantType) -> None:
+    """Test turning the light on."""
+    client = create_mock_client()
+    client.async_send_set_component = AsyncMock(return_value=True)
+    client.components = TEST_COMPONENTS
+
+    # Setup component switch.
+    with patch(
+        "homeassistant.components.hyperion.switch.HyperionComponentSwitch.entity_registry_enabled_default"
+    ) as enabled_by_default_mock:
+        enabled_by_default_mock.return_value = True
+        await setup_test_config_entry(hass, hyperion_client=client)
+
+    # Verify switch is on (as per TEST_COMPONENTS above).
+    entity_state = hass.states.get(TEST_SWITCH_COMPONENT_ALL_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "on"
+
+    # Turn switch off.
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: TEST_SWITCH_COMPONENT_ALL_ENTITY_ID},
+        blocking=True,
+    )
+
+    # Verify correct parameters are passed to the library.
+    assert client.async_send_set_component.call_args == call(
+        **{KEY_COMPONENTSTATE: {KEY_COMPONENT: KEY_COMPONENTID_ALL, KEY_STATE: False}}
+    )
+
+    client.components[0] = {
+        "enabled": False,
+        "name": "ALL",
+    }
+    call_registered_callback(client, "components-update")
+
+    # Verify the switch turns off.
+    entity_state = hass.states.get(TEST_SWITCH_COMPONENT_ALL_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "off"
+
+    # Turn switch on.
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: TEST_SWITCH_COMPONENT_ALL_ENTITY_ID},
+        blocking=True,
+    )
+
+    # Verify correct parameters are passed to the library.
+    assert client.async_send_set_component.call_args == call(
+        **{KEY_COMPONENTSTATE: {KEY_COMPONENT: KEY_COMPONENTID_ALL, KEY_STATE: True}}
+    )
+
+    client.components[0] = {
+        "enabled": True,
+        "name": "ALL",
+    }
+    call_registered_callback(client, "components-update")
+
+    # Verify the switch turns on.
+    entity_state = hass.states.get(TEST_SWITCH_COMPONENT_ALL_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "on"
+
+
+async def test_switch_has_correct_entities(hass: HomeAssistantType) -> None:
+    """Test that the correct switch entities are created."""
+    client = create_mock_client()
+    client.components = TEST_COMPONENTS
+
+    # Setup component switch.
+    with patch(
+        "homeassistant.components.hyperion.switch.HyperionComponentSwitch.entity_registry_enabled_default"
+    ) as enabled_by_default_mock:
+        enabled_by_default_mock.return_value = True
+        await setup_test_config_entry(hass, hyperion_client=client)
+
+    entity_state = hass.states.get(TEST_SWITCH_COMPONENT_ALL_ENTITY_ID)
+
+    for component in (
+        KEY_COMPONENTID_ALL,
+        KEY_COMPONENTID_SMOOTHING,
+        KEY_COMPONENTID_BLACKBORDER,
+        KEY_COMPONENTID_FORWARDER,
+        KEY_COMPONENTID_BOBLIGHTSERVER,
+        KEY_COMPONENTID_GRABBER,
+        KEY_COMPONENTID_LEDDEVICE,
+        KEY_COMPONENTID_V4L,
+    ):
+        entity_id = f"{TEST_SWITCH_COMPONENT_BASE_ENTITY_ID}_{component.lower()}"
+        entity_state = hass.states.get(entity_id)
+        assert entity_state

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -16,9 +16,11 @@ from hyperion.const import (
     KEY_STATE,
 )
 
+from homeassistant.components.hyperion.const import COMPONENT_TO_NAME
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.util import slugify
 
 from . import call_registered_callback, create_mock_client, setup_test_config_entry
 
@@ -129,6 +131,10 @@ async def test_switch_has_correct_entities(hass: HomeAssistantType) -> None:
         KEY_COMPONENTID_LEDDEVICE,
         KEY_COMPONENTID_V4L,
     ):
-        entity_id = f"{TEST_SWITCH_COMPONENT_BASE_ENTITY_ID}_{component.lower()}"
+        entity_id = (
+            TEST_SWITCH_COMPONENT_BASE_ENTITY_ID
+            + "_"
+            + slugify(COMPONENT_TO_NAME[component])
+        )
         entity_state = hass.states.get(entity_id)
-        assert entity_state
+        assert entity_state, f"Couldn't find entity: {entity_id}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactors the Hyperion integration to support multiple entities and adds advanced disabled-by-default entity types: a "priority light" that acts upon a single Hyperion priority only (for improved interoperability), and several switches that map cleanly to parts of the Hyperion API for advanced users to include in automations.

This is the fix to the lengthy https://github.com/home-assistant/core/issues/41892 , where users complain that Hyperion for one source (HA) turns off Hyperion for other sources in cases where Hyperion is used by multiple distinct callers. After substantial debate, the agreement in that issue was to expose the underlying API parts as disabled-by-default entities, including a light entity that (controversially) turns off by setting a black color at a given Hyperion priority as opposed to an absolutely hard off as the default Hyperion entity does.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41892
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
