### PR TITLE
Disconnect Hyperion client in error conditions

### DIFF
--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -133,11 +133,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
         and token is None
     ):
+        await hyperion_client.async_client_disconnect()
         await _create_reauth_flow(hass, config_entry)
         return False
 
     # Client login doesn't work? => Reauth.
     if not await hyperion_client.async_client_login():
+        await hyperion_client.async_client_disconnect()
         await _create_reauth_flow(hass, config_entry)
         return False
 
@@ -146,6 +148,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         not await hyperion_client.async_client_switch_instance()
         or not client.ServerInfoResponseOK(await hyperion_client.async_get_serverinfo())
     ):
+        await hyperion_client.async_client_disconnect()
         raise ConfigEntryNotReady
 
     hyperion_client.set_callbacks(

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -37,7 +37,11 @@ from homeassistant.helpers.typing import (
 )
 import homeassistant.util.color as color_util
 
-from . import async_create_connect_hyperion_client, get_hyperion_unique_id
+from . import (
+    async_create_connect_hyperion_client,
+    create_hyperion_client,
+    get_hyperion_unique_id,
+)
 from .const import (
     CONF_ON_UNLOAD,
     CONF_PRIORITY,
@@ -132,12 +136,12 @@ async def async_setup_platform(
 
     # First, connect to the server and get the server id (which will be unique_id on a config_entry
     # if there is one).
-    hyperion_client = await async_create_connect_hyperion_client(host, port)
-    if not hyperion_client:
-        raise PlatformNotReady
-    hyperion_id = await hyperion_client.async_sysinfo_id()
-    if not hyperion_id:
-        raise PlatformNotReady
+    async with create_hyperion_client(host, port) as hyperion_client:
+        if not hyperion_client:
+            raise PlatformNotReady
+        hyperion_id = await hyperion_client.async_sysinfo_id()
+        if not hyperion_id:
+            raise PlatformNotReady
 
     future_unique_id = get_hyperion_unique_id(
         hyperion_id, instance, TYPE_HYPERION_LIGHT

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -105,6 +105,7 @@ async def test_setup_yaml_already_converted(hass: HomeAssistantType) -> None:
     add_test_config_entry(hass)
     client = create_mock_client()
     await _setup_entity_yaml(hass, client=client)
+    assert client.async_client_disconnect.called
 
     # Setup should be skipped for the YAML config as there is a pre-existing config
     # entry.
@@ -127,6 +128,7 @@ async def test_setup_yaml_old_style_unique_id(hass: HomeAssistantType) -> None:
 
     client = create_mock_client()
     await _setup_entity_yaml(hass, client=client)
+    assert client.async_client_disconnect.called
 
     # The entity should have been created with the same entity_id.
     assert hass.states.get(TEST_YAML_ENTITY_ID) is not None
@@ -166,6 +168,7 @@ async def test_setup_yaml_new_style_unique_id_wo_config(
 
     client = create_mock_client()
     await _setup_entity_yaml(hass, client=client)
+    assert client.async_client_disconnect.called
 
     # The entity should have been created with the same entity_id.
     assert hass.states.get(entity_id_to_preserve) is not None
@@ -189,6 +192,7 @@ async def test_setup_yaml_no_registry_entity(hass: HomeAssistantType) -> None:
     # Add a pre-existing config entry.
     client = create_mock_client()
     await _setup_entity_yaml(hass, client=client)
+    assert client.async_client_disconnect.called
 
     # The entity should have been created with the same entity_id.
     assert hass.states.get(TEST_YAML_ENTITY_ID) is not None
@@ -210,6 +214,7 @@ async def test_setup_yaml_not_ready(hass: HomeAssistantType) -> None:
     client = create_mock_client()
     client.async_client_connect = AsyncMock(return_value=False)
     await _setup_entity_yaml(hass, client=client)
+    assert client.async_client_disconnect.called
     assert hass.states.get(TEST_YAML_ENTITY_ID) is None
 
 
@@ -236,6 +241,7 @@ async def test_setup_config_entry_not_ready_switch_instance_fail(
     client = create_mock_client()
     client.async_client_switch_instance = AsyncMock(return_value=False)
     await setup_test_config_entry(hass, hyperion_client=client)
+    assert client.async_client_disconnect.called
     assert hass.states.get(TEST_ENTITY_ID_1) is None
 
 
@@ -252,6 +258,7 @@ async def test_setup_config_entry_not_ready_load_state_fail(
     )
 
     await setup_test_config_entry(hass, hyperion_client=client)
+    assert client.async_client_disconnect.called
     assert hass.states.get(TEST_ENTITY_ID_1) is None
 
 
@@ -802,6 +809,7 @@ async def test_setup_entry_no_token_reauth(hass: HomeAssistantType) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ), patch.object(hass.config_entries.flow, "async_init") as mock_flow_init:
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        assert client.async_client_disconnect.called
         mock_flow_init.assert_called_once_with(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_REAUTH},
@@ -825,6 +833,7 @@ async def test_setup_entry_bad_token_reauth(hass: HomeAssistantType) -> None:
         "homeassistant.components.hyperion.client.HyperionClient", return_value=client
     ), patch.object(hass.config_entries.flow, "async_init") as mock_flow_init:
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        assert client.async_client_disconnect.called
         mock_flow_init.assert_called_once_with(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_REAUTH},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Small cleanup to always disconnect a connected hyperion-py client, otherwise a useless error message is logged regarding a maintenance async task being destroyed whilst pending.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/dermotduffy/hyperion-py/issues/4
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
