### PR TITLE
Ensure homekit never picks a port that another config entry uses

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -224,12 +224,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     port = conf[CONF_PORT]
     _LOGGER.debug("Begin setup HomeKit for %s", name)
 
-    # If the previous instance hasn't cleaned up yet
-    # we need to wait a bit
-    if not await hass.async_add_executor_job(port_is_available, port):
-        _LOGGER.warning("The local port %s is in use", port)
-        raise ConfigEntryNotReady
-
     if CONF_ENTRY_INDEX in conf and conf[CONF_ENTRY_INDEX] == 0:
         _LOGGER.debug("Migrating legacy HomeKit data for %s", name)
         hass.async_add_executor_job(
@@ -261,7 +255,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry.entry_id,
     )
     zeroconf_instance = await zeroconf.async_get_instance(hass)
-    await hass.async_add_executor_job(homekit.setup, zeroconf_instance)
+
+    # If the previous instance hasn't cleaned up yet
+    # we need to wait a bit
+    try:
+        await hass.async_add_executor_job(homekit.setup, zeroconf_instance)
+    except (OSError, AttributeError) as ex:
+        _LOGGER.warning(
+            "%s could not be setup because the local port %s is in use", name, port
+        )
+        raise ConfigEntryNotReady from ex
 
     undo_listener = entry.add_update_listener(_async_update_listener)
 

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -40,7 +40,7 @@ from .const import (
     VIDEO_CODEC_COPY,
 )
 from .const import DOMAIN  # pylint:disable=unused-import
-from .util import find_next_available_port
+from .util import async_find_next_available_port
 
 CONF_CAMERA_COPY = "camera_copy"
 CONF_INCLUDE_EXCLUDE_MODE = "include_exclude_mode"
@@ -162,7 +162,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return self.async_create_entry(title=self.entry_title, data=self.hk_data)
 
-        self.hk_data[CONF_PORT] = await self._async_available_port()
+        self.hk_data[CONF_PORT] = await async_find_next_available_port()
         self.hk_data[CONF_NAME] = self._async_available_name(
             self.hk_data[CONF_HOMEKIT_MODE]
         )
@@ -203,12 +203,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="port_name_in_use")
         return self.async_create_entry(
             title=f"{user_input[CONF_NAME]}:{user_input[CONF_PORT]}", data=user_input
-        )
-
-    async def _async_available_port(self):
-        """Return an available port the bridge."""
-        return await self.hass.async_add_executor_job(
-            find_next_available_port, DEFAULT_CONFIG_FLOW_PORT
         )
 
     @callback

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -162,7 +162,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return self.async_create_entry(title=self.entry_title, data=self.hk_data)
 
-        self.hk_data[CONF_PORT] = await async_find_next_available_port()
+        self.hk_data[CONF_PORT] = await async_find_next_available_port(
+            self.hass, DEFAULT_CONFIG_FLOW_PORT
+        )
         self.hk_data[CONF_NAME] = self._async_available_name(
             self.hk_data[CONF_HOMEKIT_MODE]
         )

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_setup_in_accessory_mode(hass):
     assert result2["step_id"] == "accessory_mode"
 
     with patch(
-        "homeassistant.components.homekit.config_flow.find_next_available_port",
+        "homeassistant.components.homekit.config_flow.async_find_next_available_port",
         return_value=12345,
     ):
         result3 = await hass.config_entries.flow.async_configure(
@@ -629,7 +629,7 @@ async def test_converting_bridge_to_accessory_mode(hass):
     assert result2["step_id"] == "bridge_mode"
 
     with patch(
-        "homeassistant.components.homekit.config_flow.find_next_available_port",
+        "homeassistant.components.homekit.config_flow.async_find_next_available_port",
         return_value=12345,
     ):
         result3 = await hass.config_entries.flow.async_configure(

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -49,7 +49,7 @@ async def test_setup_in_bridge_mode(hass):
     assert result2["step_id"] == "bridge_mode"
 
     with patch(
-        "homeassistant.components.homekit.config_flow.find_next_available_port",
+        "homeassistant.components.homekit.config_flow.async_find_next_available_port",
         return_value=12345,
     ):
         result3 = await hass.config_entries.flow.async_configure(

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1035,10 +1035,7 @@ async def test_raise_config_entry_not_ready(hass, mock_zeroconf):
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.homekit.port_is_available",
-        return_value=False,
-    ):
+    with patch(f"{PATH_HOMEKIT}.HomeKit.setup", side_effect=OSError):
         assert not await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -3,6 +3,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.homekit.const import (
+    BRIDGE_NAME,
     CONF_FEATURE,
     CONF_FEATURE_LIST,
     CONF_LINKED_BATTERY_SENSOR,
@@ -21,11 +22,11 @@ from homeassistant.components.homekit.const import (
     TYPE_VALVE,
 )
 from homeassistant.components.homekit.util import (
+    async_find_next_available_port,
     cleanup_name_for_homekit,
     convert_to_float,
     density_to_air_quality,
     dismiss_setup_message,
-    find_next_available_port,
     format_sw_version,
     port_is_available,
     show_setup_message,
@@ -43,6 +44,7 @@ from homeassistant.const import (
     ATTR_CODE,
     ATTR_SUPPORTED_FEATURES,
     CONF_NAME,
+    CONF_PORT,
     CONF_TYPE,
     STATE_UNKNOWN,
     TEMP_CELSIUS,
@@ -52,7 +54,7 @@ from homeassistant.core import State
 
 from .util import async_init_integration
 
-from tests.common import async_mock_service
+from tests.common import MockConfigEntry, async_mock_service
 
 
 def test_validate_entity_config():
@@ -251,10 +253,26 @@ async def test_dismiss_setup_msg(hass):
 
 async def test_port_is_available(hass):
     """Test we can get an available port and it is actually available."""
-    next_port = await hass.async_add_executor_job(
-        find_next_available_port, DEFAULT_CONFIG_FLOW_PORT
-    )
+    next_port = await async_find_next_available_port(hass, DEFAULT_CONFIG_FLOW_PORT)
+
     assert next_port
+
+    assert await hass.async_add_executor_job(port_is_available, next_port)
+
+
+async def test_port_is_available_skips_existing_entries(hass):
+    """Test we can get an available port and it is actually available."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: BRIDGE_NAME, CONF_PORT: DEFAULT_CONFIG_FLOW_PORT},
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    next_port = await async_find_next_available_port(hass, DEFAULT_CONFIG_FLOW_PORT)
+
+    assert next_port
+    assert next_port != DEFAULT_CONFIG_FLOW_PORT
 
     assert await hass.async_add_executor_job(port_is_available, next_port)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure homekit never picks a port that another config entry uses.

We were not checking other config entries when assigning a port, only that the port wasn't currently bound.  That usually is fine but if the bridge is offline or has a misconfiguration we could end up having two config entries that compete for the same port.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
