### PR TITLE
Add support for zwave_js lock services

### DIFF
--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -117,13 +117,11 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
         """Unlock the lock."""
         await self._set_lock_state(STATE_UNLOCKED)
 
-    @callback
     async def async_set_usercode(self, code_slot: int, usercode: str) -> None:
         """Set the usercode to index X on the lock."""
         await set_usercode(self.info.node, code_slot, usercode)
         LOGGER.debug("User code at slot %s set", code_slot)
 
-    @callback
     async def async_clear_usercode(self, code_slot: int) -> None:
         """Clear the usercode at index X on the lock."""
         await clear_usercode(self.info.node, code_slot)

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -2,19 +2,24 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import voluptuous as vol
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import (
+    ATTR_CODE_SLOT,
+    ATTR_USERCODE,
     LOCK_CMD_CLASS_TO_LOCKED_STATE_MAP,
     LOCK_CMD_CLASS_TO_PROPERTY_MAP,
     CommandClass,
     DoorLockMode,
 )
 from zwave_js_server.model.value import Value as ZwaveValue
+from zwave_js_server.util.lock import clear_usercode, set_usercode
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DATA_CLIENT, DATA_UNSUBSCRIBE, DOMAIN
@@ -33,6 +38,9 @@ STATE_TO_ZWAVE_MAP: Dict[int, Dict[str, Union[int, bool]]] = {
         STATE_LOCKED: True,
     },
 }
+
+SERVICE_SET_USERCODE = "set_usercode"
+SERVICE_CLEAR_USERCODE = "clear_usercode"
 
 
 async def async_setup_entry(
@@ -53,6 +61,26 @@ async def async_setup_entry(
         async_dispatcher_connect(
             hass, f"{DOMAIN}_{config_entry.entry_id}_add_{LOCK_DOMAIN}", async_add_lock
         )
+    )
+
+    platform = entity_platform.current_platform.get()
+    assert platform
+
+    platform.async_register_entity_service(  # type: ignore
+        SERVICE_SET_USERCODE,
+        {
+            vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
+            vol.Required(ATTR_USERCODE): cv.string,
+        },
+        "async_set_usercode",
+    )
+
+    platform.async_register_entity_service(  # type: ignore
+        SERVICE_CLEAR_USERCODE,
+        {
+            vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
+        },
+        "async_clear_usercode",
     )
 
 
@@ -88,3 +116,15 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
     async def async_unlock(self, **kwargs: Dict[str, Any]) -> None:
         """Unlock the lock."""
         await self._set_lock_state(STATE_UNLOCKED)
+
+    @callback
+    async def async_set_usercode(self, code_slot: int, usercode: str) -> None:
+        """Set the usercode to index X on the lock."""
+        await set_usercode(self.info.node, code_slot, usercode)
+        LOGGER.debug("User code at slot %s set", code_slot)
+
+    @callback
+    async def async_clear_usercode(self, code_slot: int) -> None:
+        """Clear the usercode at index X on the lock."""
+        await clear_usercode(self.info.node, code_slot)
+        LOGGER.debug("User code at slot %s cleared", code_slot)

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -39,8 +39,8 @@ STATE_TO_ZWAVE_MAP: Dict[int, Dict[str, Union[int, bool]]] = {
     },
 }
 
-SERVICE_SET_USERCODE = "set_usercode"
-SERVICE_CLEAR_USERCODE = "clear_usercode"
+SERVICE_SET_LOCK_USERCODE = "set_lock_usercode"
+SERVICE_CLEAR_LOCK_USERCODE = "clear_lock_usercode"
 
 
 async def async_setup_entry(
@@ -67,20 +67,20 @@ async def async_setup_entry(
     assert platform
 
     platform.async_register_entity_service(  # type: ignore
-        SERVICE_SET_USERCODE,
+        SERVICE_SET_LOCK_USERCODE,
         {
             vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
             vol.Required(ATTR_USERCODE): cv.string,
         },
-        "async_set_usercode",
+        "async_set_lock_usercode",
     )
 
     platform.async_register_entity_service(  # type: ignore
-        SERVICE_CLEAR_USERCODE,
+        SERVICE_CLEAR_LOCK_USERCODE,
         {
             vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
         },
-        "async_clear_usercode",
+        "async_clear_lock_usercode",
     )
 
 
@@ -117,12 +117,12 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
         """Unlock the lock."""
         await self._set_lock_state(STATE_UNLOCKED)
 
-    async def async_set_usercode(self, code_slot: int, usercode: str) -> None:
+    async def async_set_lock_usercode(self, code_slot: int, usercode: str) -> None:
         """Set the usercode to index X on the lock."""
         await set_usercode(self.info.node, code_slot, usercode)
         LOGGER.debug("User code at slot %s set", code_slot)
 
-    async def async_clear_usercode(self, code_slot: int) -> None:
+    async def async_clear_lock_usercode(self, code_slot: int) -> None:
         """Clear the usercode at index X on the lock."""
         await clear_usercode(self.info.node, code_slot)
         LOGGER.debug("User code at slot %s cleared", code_slot)

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -1,0 +1,24 @@
+# Describes the format for available Z-Wave services
+
+clear_usercode:
+  description: Clear a usercode from lock.
+  fields:
+    entity_id:
+      description: Lock entity_id.
+      example: lock.front_door_locked
+    code_slot:
+      description: Code slot to clear code from.
+      example: 1
+
+set_usercode:
+  description: Set a usercode to lock.
+  fields:
+    entity_id:
+      description: Lock entity_id.
+      example: lock.front_door_locked
+    code_slot:
+      description: Code slot to set the code.
+      example: 1
+    usercode:
+      description: Code to set.
+      example: 1234

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -1,6 +1,6 @@
 # Describes the format for available Z-Wave services
 
-clear_usercode:
+clear_lock_usercode:
   description: Clear a usercode from lock.
   fields:
     entity_id:
@@ -10,7 +10,7 @@ clear_usercode:
       description: Code slot to clear code from.
       example: 1
 
-set_usercode:
+set_lock_usercode:
   description: Set a usercode to lock.
   fields:
     entity_id:

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -9,8 +9,8 @@ from homeassistant.components.lock import (
 )
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.components.zwave_js.lock import (
-    SERVICE_CLEAR_USERCODE,
-    SERVICE_SET_USERCODE,
+    SERVICE_CLEAR_LOCK_USERCODE,
+    SERVICE_SET_LOCK_USERCODE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_LOCKED, STATE_UNLOCKED
 
@@ -134,7 +134,7 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     # Test set usercode service
     await hass.services.async_call(
         ZWAVE_JS_DOMAIN,
-        SERVICE_SET_USERCODE,
+        SERVICE_SET_LOCK_USERCODE,
         {
             ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY,
             ATTR_CODE_SLOT: 1,
@@ -172,7 +172,7 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     # Test clear usercode
     await hass.services.async_call(
         ZWAVE_JS_DOMAIN,
-        SERVICE_CLEAR_USERCODE,
+        SERVICE_CLEAR_LOCK_USERCODE,
         {ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY, ATTR_CODE_SLOT: 1},
         blocking=True,
     )

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -1,10 +1,16 @@
 """Test the Z-Wave JS lock platform."""
+from zwave_js_server.const import ATTR_CODE_SLOT, ATTR_USERCODE
 from zwave_js_server.event import Event
 
 from homeassistant.components.lock import (
     DOMAIN as LOCK_DOMAIN,
     SERVICE_LOCK,
     SERVICE_UNLOCK,
+)
+from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
+from homeassistant.components.zwave_js.lock import (
+    SERVICE_CLEAR_USERCODE,
+    SERVICE_SET_USERCODE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_LOCKED, STATE_UNLOCKED
 
@@ -120,5 +126,80 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
                 "255": "Secured",
             },
         },
+    }
+    assert args["value"] == 0
+
+    client.async_send_command.reset_mock()
+
+    # Test set usercode service
+    await hass.services.async_call(
+        ZWAVE_JS_DOMAIN,
+        SERVICE_SET_USERCODE,
+        {
+            ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY,
+            ATTR_CODE_SLOT: 1,
+            ATTR_USERCODE: "1234",
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 20
+    assert args["valueId"] == {
+        "commandClassName": "User Code",
+        "commandClass": 99,
+        "endpoint": 0,
+        "property": "userCode",
+        "propertyName": "userCode",
+        "propertyKey": 1,
+        "propertyKeyName": "1",
+        "metadata": {
+            "type": "string",
+            "readable": True,
+            "writeable": True,
+            "minLength": 4,
+            "maxLength": 10,
+            "label": "User Code (1)",
+        },
+        "value": "**********",
+    }
+    assert args["value"] == "1234"
+
+    client.async_send_command.reset_mock()
+
+    # Test clear usercode
+    await hass.services.async_call(
+        ZWAVE_JS_DOMAIN,
+        SERVICE_CLEAR_USERCODE,
+        {ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY, ATTR_CODE_SLOT: 1},
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 20
+    assert args["valueId"] == {
+        "commandClassName": "User Code",
+        "commandClass": 99,
+        "endpoint": 0,
+        "property": "userIdStatus",
+        "propertyName": "userIdStatus",
+        "propertyKey": 1,
+        "propertyKeyName": "1",
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "label": "User ID status (1)",
+            "states": {
+                "0": "Available",
+                "1": "Enabled",
+                "2": "Disabled",
+            },
+        },
+        "value": 1,
     }
     assert args["value"] == 0


### PR DESCRIPTION
## Proposed change
This PR adds `set_usercode` and `clear_usercode` services to the `zwave_js` integration


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16286

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
