### PR TITLE
Add an HTTP view to dump the Z-Wave JS state

### DIFF
--- a/homeassistant/components/http/data_validator.py
+++ b/homeassistant/components/http/data_validator.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 class RequestDataValidator:
     """Decorator that will validate the incoming data.
 
-    Takes in a voluptuous schema and adds 'post_data' as
+    Takes in a voluptuous schema and adds 'data' as
     keyword argument to the function call.
 
     Will return a 400 if no JSON provided or doesn't match schema.

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import device_registry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
+from .api import async_register_api
 from .const import (
     DATA_CLIENT,
     DATA_UNSUBSCRIBE,
@@ -22,7 +23,6 @@ from .const import (
     PLATFORMS,
 )
 from .discovery import async_discover_values
-from .websocket_api import async_register_api
 
 LOGGER = logging.getLogger(__name__)
 CONNECT_TIMEOUT = 10

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -309,6 +309,6 @@ class DumpView(HomeAssistantView):
             body="\n".join(json.dumps(msg) for msg in msgs) + "\n",
             headers={
                 hdrs.CONTENT_TYPE: "application/jsonl",
-                hdrs.CONTENT_DISPOSITION: 'attachment; filename="zwavejs_dump.jsonl"',
+                hdrs.CONTENT_DISPOSITION: 'attachment; filename="zwave_js_dump.jsonl"',
             },
         )

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -60,7 +60,7 @@ def websocket_network_status(
         },
         "controller": {
             "home_id": client.driver.controller.data["homeId"],
-            "nodes": list(client.driver.controller.nodes.keys()),
+            "nodes": list(client.driver.controller.nodes),
         },
     }
     connection.send_result(

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -60,7 +60,7 @@ def websocket_network_status(
         },
         "controller": {
             "home_id": client.driver.controller.data["homeId"],
-            "node_count": len(client.driver.controller.nodes),
+            "nodes": list(client.driver.controller.nodes.keys()),
         },
     }
     connection.send_result(

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2,7 +2,7 @@
 import json
 import logging
 
-from aiohttp import hdrs, http_exceptions, web
+from aiohttp import hdrs, web, web_exceptions
 import voluptuous as vol
 from zwave_js_server import dump
 from zwave_js_server.client import Client as ZwaveClient
@@ -299,9 +299,7 @@ class DumpView(HomeAssistantView):
         hass = request.app["hass"]
 
         if data["config_entry_id"] not in hass.data[DOMAIN]:
-            raise http_exceptions.HttpBadRequest(
-                f"Invalid config entry ID: {data['config_entry_id']}."
-            )
+            raise web_exceptions.HTTPBadRequest
 
         entry = hass.config_entries.async_get_entry(data["config_entry_id"])
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -299,7 +299,9 @@ class DumpView(HomeAssistantView):
         hass = request.app["hass"]
 
         if data["config_entry_id"] not in hass.data[DOMAIN]:
-            raise http_exceptions.HttpBadRequest
+            raise http_exceptions.HttpBadRequest(
+                f"Invalid config entry ID: {data['config_entry_id']}."
+            )
 
         entry = hass.config_entries.async_get_entry(data["config_entry_id"])
 

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -4,5 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
   "requirements": ["zwave-js-server-python==0.13.0"],
-  "codeowners": ["@home-assistant/z-wave"]
+  "codeowners": ["@home-assistant/z-wave"],
+  "dependencies": ["http", "websocket_api"]
 }

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -162,9 +162,7 @@ async def test_dump_view(integration, hass_client):
         "zwave_js_server.dump.dump_msgs",
         return_value=[{"hello": "world"}, {"second": "msg"}],
     ):
-        resp = await client.post(
-            "/api/zwave_js/dump", json={"config_entry_id": integration.entry_id}
-        )
+        resp = await client.get("/api/zwave_js/dump/integration.entry_id")
     assert resp.status == 200
     assert await resp.text() == '{"hello": "world"}\n{"second": "msg"}\n'
 
@@ -172,5 +170,5 @@ async def test_dump_view(integration, hass_client):
 async def test_dump_view_invalid_entry_id(integration, hass_client):
     """Test an invalid config entry id parameter."""
     client = await hass_client()
-    resp = await client.post("/api/zwave_js/dump", json={"config_entry_id": "INVALID"})
+    resp = await client.get("/api/zwave_js/dump/INVALID")
     assert resp.status == 400

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -162,7 +162,7 @@ async def test_dump_view(integration, hass_client):
         "zwave_js_server.dump.dump_msgs",
         return_value=[{"hello": "world"}, {"second": "msg"}],
     ):
-        resp = await client.get("/api/zwave_js/dump/integration.entry_id")
+        resp = await client.get(f"/api/zwave_js/dump/{integration.entry_id}")
     assert resp.status == 200
     assert await resp.text() == '{"hello": "world"}\n{"second": "msg"}\n'
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -8,7 +8,7 @@ from homeassistant.components.zwave_js.const import DOMAIN
 from homeassistant.helpers.device_registry import async_get_registry
 
 
-async def test_api(hass, integration, multisensor_6, hass_ws_client):
+async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     """Test the network and node status websocket commands."""
     entry = integration
     ws_client = await hass_ws_client(hass)

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -172,11 +172,5 @@ async def test_dump_view(integration, hass_client):
 async def test_dump_view_invalid_entry_id(integration, hass_client):
     """Test an invalid config entry id parameter."""
     client = await hass_client()
-    with patch(
-        "zwave_js_server.dump.dump_msgs",
-        return_value=[{"hello": "world"}, {"second": "msg"}],
-    ):
-        resp = await client.post(
-            "/api/zwave_js/dump", json={"config_entry_id": "INVALID"}
-        )
+    resp = await client.post("/api/zwave_js/dump", json={"config_entry_id": "INVALID"})
     assert resp.status == 400

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -167,3 +167,16 @@ async def test_dump_view(integration, hass_client):
         )
     assert resp.status == 200
     assert await resp.text() == '{"hello": "world"}\n{"second": "msg"}\n'
+
+
+async def test_dump_view_invalid_entry_id(integration, hass_client):
+    """Test an invalid config entry id parameter."""
+    client = await hass_client()
+    with patch(
+        "zwave_js_server.dump.dump_msgs",
+        return_value=[{"hello": "world"}, {"second": "msg"}],
+    ):
+        resp = await client.post(
+            "/api/zwave_js/dump", json={"config_entry_id": "INVALID"}
+        )
+    assert resp.status == 400


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds an HTTP view to download a dump of the Z-Wave JS server state. This will help people provide data for debugging.

Note, this is an HTTP POST endpoint that requires authentication and triggers a download. To make  this work in the frontend, create a form that has as URL a [signed path](https://github.com/home-assistant/frontend/blob/9ac777d687e438fcda3257677809102037caa926/src/data/auth.ts#L25-L28).

@bramkragten have we done an HTTP POST to download before, any code examples you can link?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
