### PR TITLE
Avoid misuse sanitize_path, clarify docs

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -33,13 +33,33 @@ RE_SANITIZE_PATH = re.compile(r"(~|\.(\.)+)")
 
 
 def sanitize_filename(filename: str) -> str:
-    r"""Sanitize a filename by removing .. / and \\."""
-    return RE_SANITIZE_FILENAME.sub("", filename)
+    """Check if a filename is safe.
+
+    Only to be used to compare to original filename to check if changed.
+    If result changed, the given path is not safe and should not be used,
+    raise an error.
+
+    DEPRECATED.
+    """
+    # Backwards compatible fix for misuse of method
+    if RE_SANITIZE_FILENAME.sub("", filename) != filename:
+        return ""
+    return filename
 
 
 def sanitize_path(path: str) -> str:
-    """Sanitize a path by removing ~ and .."""
-    return RE_SANITIZE_PATH.sub("", path)
+    """Check if a path is safe.
+
+    Only to be used to compare to original path to check if changed.
+    If result changed, the given path is not safe and should not be used,
+    raise an error.
+
+    DEPRECATED.
+    """
+    # Backwards compatible fix for misuse of method
+    if RE_SANITIZE_PATH.sub("", path) != path:
+        return ""
+    return path
 
 
 def slugify(text: str, *, separator: str = "_") -> str:

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -11,17 +11,17 @@ import homeassistant.util.dt as dt_util
 def test_sanitize_filename():
     """Test sanitize_filename."""
     assert util.sanitize_filename("test") == "test"
-    assert util.sanitize_filename("/test") == "test"
-    assert util.sanitize_filename("..test") == "test"
-    assert util.sanitize_filename("\\test") == "test"
-    assert util.sanitize_filename("\\../test") == "test"
+    assert util.sanitize_filename("/test") == ""
+    assert util.sanitize_filename("..test") == ""
+    assert util.sanitize_filename("\\test") == ""
+    assert util.sanitize_filename("\\../test") == ""
 
 
 def test_sanitize_path():
     """Test sanitize_path."""
     assert util.sanitize_path("test/path") == "test/path"
-    assert util.sanitize_path("~test/path") == "test/path"
-    assert util.sanitize_path("~/../test/path") == "//test/path"
+    assert util.sanitize_path("~test/path") == ""
+    assert util.sanitize_path("~/../test/path") == ""
 
 
 def test_slugify():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sanitize_path should be used to compare against the source path and raise if it's different. This is how we use it inside Home Assistant too. To avoid misuse, now return an empty string so it can't be interpreted as a safe string.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
