### PR TITLE
Fix home connect lights setting color

### DIFF
--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -98,9 +98,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                     True,
                 )
             except HomeConnectError as err:
-                _LOGGER.error(
-                    "Error while trying to turn on ambient light: %s", err
-                )
+                _LOGGER.error("Error while trying to turn on ambient light: %s", err)
             if ATTR_BRIGHTNESS in kwargs or ATTR_HS_COLOR in kwargs:
                 try:
                     await self.hass.async_add_executor_job(

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -89,7 +89,18 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Switch the light on, change brightness, change color."""
-        if self._ambient:
+        if self._ambient
+            _LOGGER.debug("Switching ambient light on for: %s", self.name)
+            try:
+                await self.hass.async_add_executor_job(
+                    self.device.appliance.set_setting,
+                    self._key,
+                    True,
+                    )
+            except HomeConnectError as err:
+                _LOGGER.error(
+                    "Error while trying to turn on ambient light: %s", err
+                    )
             if ATTR_BRIGHTNESS in kwargs or ATTR_HS_COLOR in kwargs:
                 try:
                     await self.hass.async_add_executor_job(
@@ -119,18 +130,6 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                             _LOGGER.error(
                                 "Error while trying setting the color: %s", err
                             )
-            else:
-                _LOGGER.debug("Switching ambient light on for: %s", self.name)
-                try:
-                    await self.hass.async_add_executor_job(
-                        self.device.appliance.set_setting,
-                        self._key,
-                        True,
-                    )
-                except HomeConnectError as err:
-                    _LOGGER.error(
-                        "Error while trying to turn on ambient light: %s", err
-                    )
 
         elif ATTR_BRIGHTNESS in kwargs:
             _LOGGER.debug("Changing brightness for: %s", self.name)

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -96,11 +96,11 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                     self.device.appliance.set_setting,
                     self._key,
                     True,
-                    )
+                )
             except HomeConnectError as err:
                 _LOGGER.error(
                     "Error while trying to turn on ambient light: %s", err
-                    )
+                )
             if ATTR_BRIGHTNESS in kwargs or ATTR_HS_COLOR in kwargs:
                 try:
                     await self.hass.async_add_executor_job(

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -99,6 +99,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 )
             except HomeConnectError as err:
                 _LOGGER.error("Error while trying to turn on ambient light: %s", err)
+                return
             if ATTR_BRIGHTNESS in kwargs or ATTR_HS_COLOR in kwargs:
                 try:
                     await self.hass.async_add_executor_job(

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -89,7 +89,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Switch the light on, change brightness, change color."""
-        if self._ambient
+        if self._ambient:
             _LOGGER.debug("Switching ambient light on for: %s", self.name)
             try:
                 await self.hass.async_add_executor_job(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When trying to turn on an Home Connect ambient light with a specific color, the following error appears  in the logs:

```
2021-01-20 23:11:49 ERROR (MainThread) [homeassistant.components.home_connect.light] Error while trying selecting customcolor: {'key': 'SDK.Error.InvalidSettingState', 'description': 'BSH.Common.Setting.AmbientLightColor currently not available or writable'}
2021-01-20 23:11:49 ERROR (MainThread) [homeassistant.components.home_connect.light] Error while trying setting the color: {'key': 'SDK.Error.InvalidSettingState', 'description': 'BSH.Common.Setting.AmbientLightCustomColor currently not available or writable'}
```
The Home Connect API requires that the light is turned on before the color can be set.
This fix changes the turn on method to always turn on the light before setting the color.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
home_connect:
  client_id: !secret home_connect_client_id
  client_secret: !secret home_connect_client_secret
```

## Additional information

Related #45015
PR of this feature: #44091 by @Sjack-Sch

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
