### PR TITLE
Add zha event "updated_alarm_state" for security devices 

### DIFF
--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -124,8 +124,10 @@ class IASZoneChannel(ZigbeeChannel):
             )
             self.debug("Updated alarm state: %s", state)
             # generate zha_event
-            self.zha_send_event("updated_alarm_state",
-                {"zone_status": state, "comment": "detected" if state else "clear"})
+            self.zha_send_event(
+                "updated_alarm_state",
+                {"zone_status": state, "comment": "detected" if state else "clear"}
+            )
         elif command_id == 1:
             self.debug("Enroll requested")
             res = self._cluster.enroll_response(0, 0)

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -123,6 +123,9 @@ class IASZoneChannel(ZigbeeChannel):
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", 2, "zone_status", state
             )
             self.debug("Updated alarm state: %s", state)
+            # generate zha_event
+            self.zha_send_event("updated_alarm_state",
+                {"zone_status": state, "comment": "detected" if state else "clear"})
         elif command_id == 1:
             self.debug("Enroll requested")
             res = self._cluster.enroll_response(0, 0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
At the moment there are no zha_events at all if some security devices sends a signal (e. g. motion or door sensors) changing the state.
This PR proposes generation of such zha_event "updated_alarm_state" if zone state gets changed, for instance motion sensor notices a motion (detected) or resets its state (clear).
This allows to listen for such signal events in "HA/Developer Tools/Events" as well as in some pythonic enhancements.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Here is an example of events listening in "HA/Developer Tools/Events" after the patch gets applied:
<details><summary>excerpt with zha_event of a motion sensor (detected and clear signals)...</summary>

```
Event 112 fired 8:42 PM: ## ------  ias_zone stopped detecting motion -------
{
    "event_type": "zha_event",
    "data": {
        "device_ieee": "...", "unique_id": "...", "device_id": "...",
        "endpoint_id": 1, "cluster_id": 1280,
        "command": "updated_alarm_state",
        "args": {
            "zone_status": 0,
            "comment": "clear"
        }
    },
    "origin": "LOCAL",
    "time_fired": "2021-01-23T19:42:29.447584+00:00",
    "context": {"id": "...", "parent_id": null, "user_id": null}
}
Event 111 fired 8:41 PM: ## ------ ias_zone started detecting motion -------
{
    "event_type": "zha_event",
    "data": {
        "device_ieee": "...", "unique_id": "...", "device_id": "...",
        "endpoint_id": 1, "cluster_id": 1280,
        "command": "updated_alarm_state",
        "args": {
            "zone_status": 1,
            "comment": "detected"
        }
    },
    "origin": "LOCAL",
    "time_fired": "2021-01-23T19:41:29.472676+00:00",
    "context": {"id": "...", "parent_id": null, "user_id": null}
}
```
</details>

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass.
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
