### PR TITLE
Fix for radiotherm component stall

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -363,6 +363,7 @@ homeassistant/components/quantum_gateway/* @cisasteelersfan
 homeassistant/components/qvr_pro/* @oblogic7
 homeassistant/components/qwikswitch/* @kellerza
 homeassistant/components/rachio/* @bdraco
+homeassistant/components/radiotherm/* @vinnyfuria
 homeassistant/components/rainbird/* @konikvranik
 homeassistant/components/raincloud/* @vanstinator
 homeassistant/components/rainforest_eagle/* @gtdiehl @jcalbert

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -263,7 +263,6 @@ class RadioThermostat(ClimateEntity):
         # heating or cooling.
 
         try:
-
             # First time - get the name from the thermostat.  This is
             # normally set in the radio thermostat web app.
             if self._name is None:
@@ -274,6 +273,23 @@ class RadioThermostat(ClimateEntity):
 
             if self._is_model_ct80:
                 humiditydata = self.device.humidity["raw"]
+
+        except radiotherm.validate.RadiothermTstatError:
+            _LOGGER.warning(
+                "%s (%s) was busy (invalid value returned)",
+                self._name,
+                self.device.host,
+            )
+
+        except timeout:
+            _LOGGER.warning(
+                "Timeout waiting for response from %s (%s)",
+                self._name,
+                self.device.host,
+            )
+
+        else:
+            if self._is_model_ct80:
                 self._current_humidity = humiditydata
                 self._program_mode = data["program_mode"]
                 self._preset_mode = CODE_TO_PRESET_MODE[data["program_mode"]]
@@ -300,20 +316,6 @@ class RadioThermostat(ClimateEntity):
                     self._target_temperature = data["t_heat"]
             else:
                 self._current_operation = HVAC_MODE_OFF
-
-        except radiotherm.validate.RadiothermTstatError:
-            _LOGGER.warning(
-                "%s (%s) was busy (invalid value returned)",
-                self._name,
-                self.device.host,
-            )
-
-        except timeout:
-            _LOGGER.warning(
-                "Timeout waiting for response from %s (%s)",
-                self._name,
-                self.device.host,
-            )
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -262,89 +262,58 @@ class RadioThermostat(ClimateEntity):
         # thermostats tend to time out sometimes when they're actively
         # heating or cooling.
 
-        # First time - get the name from the thermostat.  This is
-        # normally set in the radio thermostat web app.
-        if self._name is None:
-            try:
-                self._name = self.device.name["raw"]
-            except radiotherm.validate.RadiothermTstatError:
-                _LOGGER.warning(
-                    "%s (%s) was busy (invalid value returned)",
-                    self._name,
-                    self.device.host,
-                )
-                return
-            except timeout:
-                _LOGGER.warning(
-                    "Timeout waiting for response from %s (%s)",
-                    self._name,
-                    self.device.host,
-                )
-                return
-
-        # Request the current state from the thermostat.
         try:
+
+            # First time - get the name from the thermostat.  This is
+            # normally set in the radio thermostat web app.
+            if self._name is None:
+                self._name = self.device.name["raw"]
+
+            # Request the current state from the thermostat.
             data = self.device.tstat["raw"]
+
+            if self._is_model_ct80:
+                humiditydata = self.device.humidity["raw"]
+                self._current_humidity = humiditydata
+                self._program_mode = data["program_mode"]
+                self._preset_mode = CODE_TO_PRESET_MODE[data["program_mode"]]
+
+            # Map thermostat values into various STATE_ flags.
+            self._current_temperature = data["temp"]
+            self._fmode = CODE_TO_FAN_MODE[data["fmode"]]
+            self._fstate = CODE_TO_FAN_STATE[data["fstate"]]
+            self._tmode = CODE_TO_TEMP_MODE[data["tmode"]]
+            self._tstate = CODE_TO_TEMP_STATE[data["tstate"]]
+
+            self._current_operation = self._tmode
+            if self._tmode == HVAC_MODE_COOL:
+                self._target_temperature = data["t_cool"]
+            elif self._tmode == HVAC_MODE_HEAT:
+                self._target_temperature = data["t_heat"]
+            elif self._tmode == HVAC_MODE_AUTO:
+                # This doesn't really work - tstate is only set if the HVAC is
+                # active. If it's idle, we don't know what to do with the target
+                # temperature.
+                if self._tstate == CURRENT_HVAC_COOL:
+                    self._target_temperature = data["t_cool"]
+                elif self._tstate == CURRENT_HVAC_HEAT:
+                    self._target_temperature = data["t_heat"]
+            else:
+                self._current_operation = HVAC_MODE_OFF
+
         except radiotherm.validate.RadiothermTstatError:
             _LOGGER.warning(
                 "%s (%s) was busy (invalid value returned)",
                 self._name,
                 self.device.host,
             )
-            return
+
         except timeout:
             _LOGGER.warning(
                 "Timeout waiting for response from %s (%s)",
                 self._name,
                 self.device.host,
             )
-            return
-
-        current_temp = data["temp"]
-
-        if self._is_model_ct80:
-            try:
-                humiditydata = self.device.humidity["raw"]
-            except radiotherm.validate.RadiothermTstatError:
-                _LOGGER.warning(
-                    "%s (%s) was busy (invalid value returned)",
-                    self._name,
-                    self.device.host,
-                )
-                return
-            except timeout:
-                _LOGGER.warning(
-                    "Timeout waiting for response from %s (%s)",
-                    self._name,
-                    self.device.host,
-                )
-                return
-            self._current_humidity = humiditydata
-            self._program_mode = data["program_mode"]
-            self._preset_mode = CODE_TO_PRESET_MODE[data["program_mode"]]
-
-        # Map thermostat values into various STATE_ flags.
-        self._current_temperature = current_temp
-        self._fmode = CODE_TO_FAN_MODE[data["fmode"]]
-        self._fstate = CODE_TO_FAN_STATE[data["fstate"]]
-        self._tmode = CODE_TO_TEMP_MODE[data["tmode"]]
-        self._tstate = CODE_TO_TEMP_STATE[data["tstate"]]
-
-        self._current_operation = self._tmode
-        if self._tmode == HVAC_MODE_COOL:
-            self._target_temperature = data["t_cool"]
-        elif self._tmode == HVAC_MODE_HEAT:
-            self._target_temperature = data["t_heat"]
-        elif self._tmode == HVAC_MODE_AUTO:
-            # This doesn't really work - tstate is only set if the HVAC is
-            # active. If it's idle, we don't know what to do with the target
-            # temperature.
-            if self._tstate == CURRENT_HVAC_COOL:
-                self._target_temperature = data["t_cool"]
-            elif self._tstate == CURRENT_HVAC_HEAT:
-                self._target_temperature = data["t_heat"]
-        else:
-            self._current_operation = HVAC_MODE_OFF
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -1,9 +1,9 @@
 """Support for Radio Thermostat wifi-enabled home thermostats."""
 import logging
+from socket import timeout
 
 import radiotherm
 import voluptuous as vol
-from socket import timeout
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
 from homeassistant.components.climate.const import (

--- a/homeassistant/components/radiotherm/manifest.json
+++ b/homeassistant/components/radiotherm/manifest.json
@@ -2,6 +2,6 @@
   "domain": "radiotherm",
   "name": "Radio Thermostat",
   "documentation": "https://www.home-assistant.io/integrations/radiotherm",
-  "requirements": ["radiotherm==2.0.0"],
+  "requirements": ["radiotherm==2.1.0"],
   "codeowners": []
 }

--- a/homeassistant/components/radiotherm/manifest.json
+++ b/homeassistant/components/radiotherm/manifest.json
@@ -3,5 +3,5 @@
   "name": "Radio Thermostat",
   "documentation": "https://www.home-assistant.io/integrations/radiotherm",
   "requirements": ["radiotherm==2.1.0"],
-  "codeowners": []
+  "codeowners": ["@vinnyfuria"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1913,7 +1913,7 @@ quantum-gateway==0.0.5
 rachiopy==1.0.3
 
 # homeassistant.components.radiotherm
-radiotherm==2.0.0
+radiotherm==2.1.0
 
 # homeassistant.components.raincloud
 raincloudy==0.0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes #25701. The radiotherm component will often stall. The root cause of this stall is the default, long timeout used when querying the device. This solution pulls in a more recent version of the radiotherm library which provides a default timeout on the device query. This PR then handles any timeout exceptions as they occur.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
# Filtrete 3M-50 Radio Thermastat
climate:
  - platform: radiotherm
    host:
      - 192.168.1.100
    hold_temp: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25701
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
