### PR TITLE
Add zwave_js ZWavePropertyBinarySensory

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -74,6 +74,24 @@ DISCOVERY_SCHEMAS = [
         property={"currentMode", "locked"},
         type={"number", "boolean"},
     ),
+    # door lock door status
+    ZWaveDiscoverySchema(
+        platform="binary_sensor",
+        hint="property",
+        device_class_generic={"Entry Control"},
+        device_class_specific={
+            "Door Lock",
+            "Advanced Door Lock",
+            "Secure Keypad Door Lock",
+            "Secure Lockbox",
+        },
+        command_class={
+            CommandClass.LOCK,
+            CommandClass.DOOR_LOCK,
+        },
+        property={"doorStatus"},
+        type={"any"},
+    ),
     # climate
     ZWaveDiscoverySchema(
         platform="climate",

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -7,3 +7,6 @@ LOW_BATTERY_BINARY_SENSOR = "binary_sensor.multisensor_6_low_battery_level"
 ENABLED_LEGACY_BINARY_SENSOR = "binary_sensor.z_wave_door_window_sensor_any"
 DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
 NOTIFICATION_MOTION_BINARY_SENSOR = "binary_sensor.multisensor_6_motion_sensor_status"
+PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
+    "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
+)

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -68,6 +68,12 @@ def lock_schlage_be469_state_fixture():
     return json.loads(load_fixture("zwave_js/lock_schlage_be469_state.json"))
 
 
+@pytest.fixture(name="lock_august_asl03_state", scope="session")
+def lock_august_asl03_state_fixture():
+    """Load the August Pro lock node state fixture data."""
+    return json.loads(load_fixture("zwave_js/lock_august_asl03_state.json"))
+
+
 @pytest.fixture(name="climate_radio_thermostat_ct100_plus_state", scope="session")
 def climate_radio_thermostat_ct100_plus_state_fixture():
     """Load the climate radio thermostat ct100 plus node state fixture data."""
@@ -145,6 +151,14 @@ def bulb_6_multi_color_fixture(client, bulb_6_multi_color_state):
 def lock_schlage_be469_fixture(client, lock_schlage_be469_state):
     """Mock a schlage lock node."""
     node = Node(client, lock_schlage_be469_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="lock_august_pro")
+def lock_august_asl03_fixture(client, lock_august_asl03_state):
+    """Mock a August Pro lock node."""
+    node = Node(client, lock_august_asl03_state)
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -9,6 +9,7 @@ from .common import (
     ENABLED_LEGACY_BINARY_SENSOR,
     LOW_BATTERY_BINARY_SENSOR,
     NOTIFICATION_MOTION_BINARY_SENSOR,
+    PROPERTY_DOOR_STATUS_BINARY_SENSOR,
 )
 
 
@@ -84,3 +85,56 @@ async def test_notification_sensor(hass, multisensor_6, integration):
     assert state
     assert state.state == STATE_ON
     assert state.attributes["device_class"] == DEVICE_CLASS_MOTION
+
+
+async def test_property_sensor_door_status(hass, lock_august_pro, integration):
+    """Test property binary sensor with sensor mapping (doorStatus)."""
+    node = lock_august_pro
+
+    state = hass.states.get(PROPERTY_DOOR_STATUS_BINARY_SENSOR)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    # open door
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 6,
+            "args": {
+                "commandClassName": "Door Lock",
+                "commandClass": 98,
+                "endpoint": 0,
+                "property": "doorStatus",
+                "newValue": "open",
+                "prevValue": "closed",
+                "propertyName": "doorStatus",
+            },
+        },
+    )
+    node.receive_event(event)
+    state = hass.states.get(PROPERTY_DOOR_STATUS_BINARY_SENSOR)
+    assert state.state == STATE_ON
+
+    # close door
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 6,
+            "args": {
+                "commandClassName": "Door Lock",
+                "commandClass": 98,
+                "endpoint": 0,
+                "property": "doorStatus",
+                "newValue": "closed",
+                "prevValue": "open",
+                "propertyName": "doorStatus",
+            },
+        },
+    )
+    node.receive_event(event)
+    state = hass.states.get(PROPERTY_DOOR_STATUS_BINARY_SENSOR)
+    assert state.state == STATE_OFF

--- a/tests/fixtures/zwave_js/lock_august_asl03_state.json
+++ b/tests/fixtures/zwave_js/lock_august_asl03_state.json
@@ -1,0 +1,456 @@
+{
+    "nodeId": 6,
+    "index": 0,
+    "installerIcon": 768,
+    "userIcon": 768,
+    "status": 4,
+    "ready": true,
+    "deviceClass": {
+        "basic": "Routing Slave",
+        "generic": "Entry Control",
+        "specific": "Secure Keypad Door Lock",
+        "mandatorySupportedCCs": [
+            "Basic",
+            "Door Lock",
+            "User Code",
+            "Manufacturer Specific",
+            "Security",
+            "Version"
+        ],
+        "mandatoryControlCCs": []
+    },
+    "isListening": false,
+    "isFrequentListening": true,
+    "isRouting": true,
+    "maxBaudRate": 40000,
+    "isSecure": true,
+    "version": 4,
+    "isBeaming": true,
+    "manufacturerId": 831,
+    "productId": 1,
+    "productType": 1,
+    "firmwareVersion": "1.59",
+    "zwavePlusVersion": 1,
+    "nodeType": 0,
+    "roleType": 7,
+    "deviceConfig": {
+        "manufacturerId": 831,
+        "manufacturer": "August Smart Locks",
+        "label": "ASL-03",
+        "description": "August Smart Lock Pro 3rd Gen",
+        "devices": [
+            {
+                "productType": "0x0000",
+                "productId": "0x0594"
+            },
+            {
+                "productType": "0x0000",
+                "productId": "0xdf29"
+            },
+            {
+                "productType": "0x0001",
+                "productId": "0x0001"
+            }
+        ],
+        "firmwareVersion": {
+            "min": "0.0",
+            "max": "255.255"
+        }
+    },
+    "label": "ASL-03",
+    "neighbors": [
+        1,
+        7,
+        8,
+        9
+    ],
+    "interviewAttempts": 1,
+    "endpoints": [
+        {
+            "nodeId": 6,
+            "index": 0,
+            "installerIcon": 768,
+            "userIcon": 768
+        }
+    ],
+    "values": [
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "currentMode",
+            "propertyName": "currentMode",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 255,
+                "label": "Current lock mode",
+                "states": {
+                    "0": "Unsecured",
+                    "1": "UnsecuredWithTimeout",
+                    "16": "InsideUnsecured",
+                    "17": "InsideUnsecuredWithTimeout",
+                    "32": "OutsideUnsecured",
+                    "33": "OutsideUnsecuredWithTimeout",
+                    "254": "Unknown",
+                    "255": "Secured"
+                }
+            },
+            "value": 255
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "targetMode",
+            "propertyName": "targetMode",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 255,
+                "label": "Target lock mode",
+                "states": {
+                    "0": "Unsecured",
+                    "1": "UnsecuredWithTimeout",
+                    "16": "InsideUnsecured",
+                    "17": "InsideUnsecuredWithTimeout",
+                    "32": "OutsideUnsecured",
+                    "33": "OutsideUnsecuredWithTimeout",
+                    "254": "Unknown",
+                    "255": "Secured"
+                }
+            }
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "outsideHandlesCanOpenDoor",
+            "propertyName": "outsideHandlesCanOpenDoor",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Which outside handles can open the door (actual status)"
+            },
+            "value": [
+                false,
+                false,
+                false,
+                false
+            ]
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "insideHandlesCanOpenDoor",
+            "propertyName": "insideHandlesCanOpenDoor",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Which inside handles can open the door (actual status)"
+            },
+            "value": [
+                true,
+                false,
+                false,
+                false
+            ]
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "latchStatus",
+            "propertyName": "latchStatus",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "The current status of the latch"
+            },
+            "value": "open"
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "boltStatus",
+            "propertyName": "boltStatus",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "The current status of the bolt"
+            },
+            "value": "locked"
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "doorStatus",
+            "propertyName": "doorStatus",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "The current status of the door"
+            },
+            "value": "closed"
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "lockTimeout",
+            "propertyName": "lockTimeout",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Seconds until lock mode times out"
+            }
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "operationType",
+            "propertyName": "operationType",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 255,
+                "label": "Lock operation type",
+                "states": {
+                    "1": "Constant",
+                    "2": "Timed"
+                }
+            },
+            "value": 1
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "outsideHandlesCanOpenDoorConfiguration",
+            "propertyName": "outsideHandlesCanOpenDoorConfiguration",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": true,
+                "label": "Which outside handles can open the door (configuration)"
+            },
+            "value": [
+                false,
+                false,
+                false,
+                false
+            ]
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "insideHandlesCanOpenDoorConfiguration",
+            "propertyName": "insideHandlesCanOpenDoorConfiguration",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": true,
+                "label": "Which inside handles can open the door (configuration)"
+            },
+            "value": [
+                true,
+                false,
+                false,
+                false
+            ]
+        },
+        {
+            "commandClassName": "Door Lock",
+            "commandClass": 98,
+            "endpoint": 0,
+            "property": "lockTimeoutConfiguration",
+            "propertyName": "lockTimeoutConfiguration",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 65535,
+                "label": "Duration of timed mode in seconds"
+            }
+        },
+        {
+            "commandClassName": "Notification",
+            "commandClass": 113,
+            "endpoint": 0,
+            "property": "Access Control",
+            "propertyKey": "Lock state",
+            "propertyName": "Access Control",
+            "propertyKeyName": "Lock state",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 255,
+                "label": "Lock state",
+                "states": {
+                    "0": "idle",
+                    "11": "Lock jammed"
+                },
+                "ccSpecific": {
+                    "notificationType": 6
+                }
+            },
+            "value": 0
+        },
+        {
+            "commandClassName": "Manufacturer Specific",
+            "commandClass": 114,
+            "endpoint": 0,
+            "property": "manufacturerId",
+            "propertyName": "manufacturerId",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Manufacturer ID"
+            },
+            "value": 831
+        },
+        {
+            "commandClassName": "Manufacturer Specific",
+            "commandClass": 114,
+            "endpoint": 0,
+            "property": "productType",
+            "propertyName": "productType",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Product type"
+            },
+            "value": 1
+        },
+        {
+            "commandClassName": "Manufacturer Specific",
+            "commandClass": 114,
+            "endpoint": 0,
+            "property": "productId",
+            "propertyName": "productId",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Product ID"
+            },
+            "value": 1
+        },
+        {
+            "commandClassName": "Battery",
+            "commandClass": 128,
+            "endpoint": 0,
+            "property": "level",
+            "propertyName": "level",
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 100,
+                "unit": "%",
+                "label": "Battery level"
+            },
+            "value": 100
+        },
+        {
+            "commandClassName": "Battery",
+            "commandClass": 128,
+            "endpoint": 0,
+            "property": "isLow",
+            "propertyName": "isLow",
+            "metadata": {
+                "type": "boolean",
+                "readable": true,
+                "writeable": false,
+                "label": "Low battery level"
+            },
+            "value": false
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "libraryType",
+            "propertyName": "libraryType",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Library type"
+            },
+            "value": 3
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "protocolVersion",
+            "propertyName": "protocolVersion",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave protocol version"
+            },
+            "value": "4.61"
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "firmwareVersions",
+            "propertyName": "firmwareVersions",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip firmware versions"
+            },
+            "value": [
+                "1.59"
+            ]
+        },
+        {
+            "commandClassName": "Version",
+            "commandClass": 134,
+            "endpoint": 0,
+            "property": "hardwareVersion",
+            "propertyName": "hardwareVersion",
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip hardware version"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds ZWavePropertyBinarySensory to zwave_js/binary_sensor and one working example of `doorStatus`. This functionality is useful for z-wave entities such as the August Lock Pro that has a door open close sensor as part of the lock and that status gets reported as a property no the Lock command class.

This functionality adds the base for expandability for other such sensors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
