### PR TITLE
Better wait for Z-Wave to be initialized

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -58,19 +58,24 @@ def register_node_in_dev_reg(
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Z-Wave JS from a config entry."""
     client = ZwaveClient(entry.data[CONF_URL], async_get_clientsession(hass))
+    connected = asyncio.Event()
     initialized = asyncio.Event()
     dev_reg = await device_registry.async_get_registry(hass)
 
     async def async_on_connect() -> None:
         """Handle websocket is (re)connected."""
         LOGGER.info("Connected to Zwave JS Server")
+        connected.set()
         if initialized.is_set():
             # update entity availability
             async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
 
+        initialized.clear()
+
     async def async_on_disconnect() -> None:
         """Handle websocket is disconnected."""
         LOGGER.info("Disconnected from Zwave JS Server")
+        connected.clear()
         async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
 
     async def async_on_initialized() -> None:
@@ -127,7 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     asyncio.create_task(client.connect())
     try:
         async with timeout(CONNECT_TIMEOUT):
-            await initialized.wait()
+            await connected.wait()
     except asyncio.TimeoutError as err:
         for unsub in unsubs:
             unsub()
@@ -151,6 +156,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 for component in PLATFORMS
             ]
         )
+
+        # Wait till we're initialized
+        LOGGER.info("Waiting for Z-Wave to be fully initialized")
+        await initialized.wait()
 
         # run discovery on all ready nodes
         for node in client.driver.controller.nodes.values():

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -66,22 +66,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Handle websocket is (re)connected."""
         LOGGER.info("Connected to Zwave JS Server")
         connected.set()
-        if initialized.is_set():
-            # update entity availability
-            async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
-
-        initialized.clear()
 
     async def async_on_disconnect() -> None:
         """Handle websocket is disconnected."""
         LOGGER.info("Disconnected from Zwave JS Server")
         connected.clear()
-        async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
+        if initialized.is_set():
+            initialized.clear()
+            # update entity availability
+            async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
 
     async def async_on_initialized() -> None:
         """Handle initial full state received."""
         LOGGER.info("Connection to Zwave JS Server initialized.")
         initialized.set()
+        # update entity availability
+        async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_connection_state")
 
     @callback
     def async_on_node_ready(node: ZwaveNode) -> None:

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1,6 +1,6 @@
 """Provide common Z-Wave JS fixtures."""
 import json
-from unittest.mock import DEFAULT, patch
+from unittest.mock import DEFAULT, Mock, patch
 
 import pytest
 from zwave_js_server.event import Event
@@ -97,16 +97,37 @@ def in_wall_smart_fan_control_state_fixture():
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state):
     """Mock a client."""
+
+    def mock_callback():
+        callbacks = []
+
+        def add_callback(cb):
+            callbacks.append(cb)
+            return DEFAULT
+
+        return callbacks, Mock(side_effect=add_callback)
+
     with patch(
         "homeassistant.components.zwave_js.ZwaveClient", autospec=True
     ) as client_class:
-        driver = Driver(client_class.return_value, controller_state)
-        version = VersionInfo.from_message(version_state)
-        client_class.return_value.driver = driver
-        client_class.return_value.version = version
-        client_class.return_value.ws_server_url = "ws://test:3000/zjs"
-        client_class.return_value.state = "connected"
-        yield client_class.return_value
+        client = client_class.return_value
+
+        connect_callback, client.register_on_connect = mock_callback()
+        initialized_callback, client.register_on_initialized = mock_callback()
+
+        async def connect():
+            for cb in connect_callback:
+                await cb()
+
+            for cb in initialized_callback:
+                await cb()
+
+        client.connect = Mock(side_effect=connect)
+        client.driver = Driver(client, controller_state)
+        client.version = VersionInfo.from_message(version_state)
+        client.ws_server_url = "ws://test:3000/zjs"
+        client.state = "connected"
+        yield client
 
 
 @pytest.fixture(name="multisensor_6")
@@ -190,14 +211,6 @@ async def integration_fixture(hass, client):
     """Set up the zwave_js integration."""
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)
-
-    def initialize_client(async_on_initialized):
-        """Init the client."""
-        hass.async_create_task(async_on_initialized())
-        return DEFAULT
-
-    client.register_on_initialized.side_effect = initialize_client
-
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1,6 +1,6 @@
 """Test the Z-Wave JS init module."""
 from copy import deepcopy
-from unittest.mock import DEFAULT, patch
+from unittest.mock import patch
 
 import pytest
 from zwave_js_server.model.node import Node
@@ -181,13 +181,6 @@ async def test_existing_node_not_ready(hass, client, multisensor_6, device_regis
     air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)
-
-    def initialize_client(async_on_initialized):
-        """Init the client."""
-        hass.async_create_task(async_on_initialized())
-        return DEFAULT
-
-    client.register_on_initialized.side_effect = initialize_client
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -51,9 +51,11 @@ async def test_home_assistant_stop(hass, client, integration):
     assert client.disconnect.call_count == 1
 
 
-async def test_on_connect_disconnect(hass, client, multisensor_6, integration):
+async def test_availability_reflect_connection_status(
+    hass, client, multisensor_6, integration
+):
     """Test we handle disconnect and reconnect."""
-    on_connect = client.register_on_connect.call_args[0][0]
+    on_initialized = client.register_on_initialized.call_args[0][0]
     on_disconnect = client.register_on_disconnect.call_args[0][0]
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
@@ -72,7 +74,7 @@ async def test_on_connect_disconnect(hass, client, multisensor_6, integration):
 
     client.connected = True
 
-    await on_connect()
+    await on_initialized()
     await hass.async_block_till_done()
 
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only wait 10 seconds for the connection to be established with Z-Wave JS server. Don't also expect the full server state in that time. 

~~Requires lib upgrade that includes https://github.com/home-assistant-libs/zwave-js-server-python/pull/67~~

CC @jcam @marcelveldt @MartinHjelmare 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
