### PR TITLE
Improve MQTT JSON light to allow non-ambiguous states

### DIFF
--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -191,36 +191,39 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                 self._state = False
 
             if self._supported_features and SUPPORT_COLOR:
-                try:
-                    red = int(values["color"]["r"])
-                    green = int(values["color"]["g"])
-                    blue = int(values["color"]["b"])
+                if "color" in values and values["color"] is None:
+                    self._hs = None
+                else:
+                    try:
+                        red = int(values["color"]["r"])
+                        green = int(values["color"]["g"])
+                        blue = int(values["color"]["b"])
 
-                    self._hs = color_util.color_RGB_to_hs(red, green, blue)
-                except KeyError:
-                    pass
-                except ValueError:
-                    _LOGGER.warning("Invalid RGB color value received")
+                        self._hs = color_util.color_RGB_to_hs(red, green, blue)
+                    except KeyError:
+                        pass
+                    except ValueError:
+                        _LOGGER.warning("Invalid RGB color value received")
 
-                try:
-                    x_color = float(values["color"]["x"])
-                    y_color = float(values["color"]["y"])
+                    try:
+                        x_color = float(values["color"]["x"])
+                        y_color = float(values["color"]["y"])
 
-                    self._hs = color_util.color_xy_to_hs(x_color, y_color)
-                except KeyError:
-                    pass
-                except ValueError:
-                    _LOGGER.warning("Invalid XY color value received")
+                        self._hs = color_util.color_xy_to_hs(x_color, y_color)
+                    except KeyError:
+                        pass
+                    except ValueError:
+                        _LOGGER.warning("Invalid XY color value received")
 
-                try:
-                    hue = float(values["color"]["h"])
-                    saturation = float(values["color"]["s"])
+                    try:
+                        hue = float(values["color"]["h"])
+                        saturation = float(values["color"]["s"])
 
-                    self._hs = (hue, saturation)
-                except KeyError:
-                    pass
-                except ValueError:
-                    _LOGGER.warning("Invalid HS color value received")
+                        self._hs = (hue, saturation)
+                    except KeyError:
+                        pass
+                    except ValueError:
+                        _LOGGER.warning("Invalid HS color value received")
 
             if self._supported_features and SUPPORT_BRIGHTNESS:
                 try:
@@ -236,7 +239,10 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
 
             if self._supported_features and SUPPORT_COLOR_TEMP:
                 try:
-                    self._color_temp = int(values["color_temp"])
+                    if values["color_temp"] is None:
+                        self._color_temp = None
+                    else:
+                        self._color_temp = int(values["color_temp"])
                 except KeyError:
                     pass
                 except ValueError:
@@ -250,7 +256,10 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
 
             if self._supported_features and SUPPORT_WHITE_VALUE:
                 try:
-                    self._white_value = int(values["white_value"])
+                    if values["white_value"] is None:
+                        self._white_value = None
+                    else:
+                        self._white_value = int(values["white_value"])
                 except KeyError:
                     pass
                 except ValueError:

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -186,6 +186,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             pass
         except ValueError:
             _LOGGER.warning("Invalid RGB color value received")
+            return self._hs
 
         try:
             x_color = float(values["color"]["x"])
@@ -196,6 +197,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             pass
         except ValueError:
             _LOGGER.warning("Invalid XY color value received")
+            return self._hs
 
         try:
             hue = float(values["color"]["h"])
@@ -206,6 +208,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             pass
         except ValueError:
             _LOGGER.warning("Invalid HS color value received")
+            return self._hs
 
         return self._hs
 
@@ -224,8 +227,8 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             elif values["state"] == "OFF":
                 self._state = False
 
-            if self._supported_features and SUPPORT_COLOR:
-                if "color" in values and values["color"] is None:
+            if self._supported_features and SUPPORT_COLOR and "color" in values:
+                if values["color"] is None:
                     self._hs = None
                 else:
                     self._hs = self._parse_color(values)

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -295,10 +295,20 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("hs_color") == (180.0, 50.0)
 
+    async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "color":null}')
+
+    light_state = hass.states.get("light.test")
+    assert "hs_color" not in light_state.attributes
+
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "color_temp":155}')
 
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("color_temp") == 155
+
+    async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "color_temp":null}')
+
+    light_state = hass.states.get("light.test")
+    assert "color_temp" not in light_state.attributes
 
     async_fire_mqtt_message(
         hass, "test_light_rgb", '{"state":"ON", "effect":"colorloop"}'
@@ -311,6 +321,13 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
 
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("white_value") == 155
+
+    async_fire_mqtt_message(
+        hass, "test_light_rgb", '{"state":"ON", "white_value":null}'
+    )
+
+    light_state = hass.states.get("light.test")
+    assert "white_value" not in light_state.attributes
 
 
 async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -1014,6 +1014,18 @@ async def test_invalid_values(hass, mqtt_mock):
     assert state.attributes.get("white_value") == 255
     assert state.attributes.get("color_temp") == 100
 
+    # Empty color value
+    async_fire_mqtt_message(
+        hass,
+        "test_light_rgb",
+        '{"state":"ON",' '"color":{}}',
+    )
+
+    # Color should not have changed
+    state = hass.states.get("light.test")
+    assert state.state == STATE_ON
+    assert state.attributes.get("rgb_color") == (255, 255, 255)
+
     # Bad HS color values
     async_fire_mqtt_message(
         hass,

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -322,13 +322,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("white_value") == 155
 
-    async_fire_mqtt_message(
-        hass, "test_light_rgb", '{"state":"ON", "white_value":null}'
-    )
-
-    light_state = hass.states.get("light.test")
-    assert "white_value" not in light_state.attributes
-
 
 async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     """Test the sending of command in optimistic mode."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve MQTT JSON light to allow non-ambiguous states for lights which support both color and color temperature:
- This PR allows setting `color` and `color_temperature` to `null` in the JSON state message, which in turn will set `hs_color`, or `color_temperature` to `None` in the state machine, making the state non ambiguous.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #45145
- Fixes #45576

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
