### PR TITLE
Add version to hassfest for custom integrations

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,6 +13,7 @@ pre-commit==2.9.3
 pylint==2.6.0
 astroid==2.4.2
 pipdeptree==1.0.0
+awesomeversion==21.1.3
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.10.1

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -183,7 +183,7 @@ def print_integrations_status(config, integrations, *, show_fixable_errors=True)
         print(f"Integration {integration.domain}{extra}:")
         for error in integration.errors:
             if show_fixable_errors or not error.fixable:
-                print("*", error)
+                print("*", "[ERROR]", error)
         for warning in integration.warnings:
             print("*", "[WARNING]", warning)
         print()

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -54,7 +54,7 @@ def verify_uppercase(value: str):
 def verify_version(value: str):
     """Verify the version."""
     version = AwesomeVersion(value)
-    if version.strategy in [
+    if version.strategy not in [
         AwesomeVersionStrategy.CALVER,
         AwesomeVersionStrategy.SEMVER,
         AwesomeVersionStrategy.SIMPLEVER,

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -54,7 +54,12 @@ def verify_uppercase(value: str):
 def verify_version(value: str):
     """Verify the version."""
     version = AwesomeVersion(value)
-    if version.strategy == AwesomeVersionStrategy.UNKNOWN:
+    if version.strategy in [
+        AwesomeVersionStrategy.CALVER,
+        AwesomeVersionStrategy.SEMVER,
+        AwesomeVersionStrategy.SIMPLEVER,
+        AwesomeVersionStrategy.BUILDVER,
+    ]:
         raise vol.Invalid(
             f"'{version}' is not a valid version. This will cause a future version of Home Assistant to block this integration.",
         )
@@ -122,7 +127,7 @@ def validate_version(integration: Integration):
     if not integration.manifest.get("version"):
         integration.add_warning(
             "manifest",
-            "No 'version' key in the manifest file, this will block the integration from be loaded in future versions of Home Assistant",
+            "No 'version' key in the manifest file. This will cause a future version of Home Assistant to block this integration.",
         )
         return
 

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -56,7 +56,7 @@ def verify_version(value: str):
     version = AwesomeVersion(value)
     if version.strategy == AwesomeVersionStrategy.UNKNOWN:
         raise vol.Invalid(
-            f"'{version}' is not a valid version, this will block the integration from be loaded in future versions of Home Assistant",
+            f"'{version}' is not a valid version. This will cause a future version of Home Assistant to block this integration.",
         )
     return value
 

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -77,7 +77,7 @@ class Integration:
     @property
     def core(self) -> bool:
         """Core integration."""
-        return "homeassistant/components" in self.path.as_posix()
+        return self.path.as_posix().startswith("homeassistant/components")
 
     @property
     def disabled(self) -> Optional[str]:

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -75,6 +75,11 @@ class Integration:
         return self.path.name
 
     @property
+    def core(self) -> bool:
+        """Core integration."""
+        return "homeassistant/components" in self.path.as_posix()
+
+    @property
     def disabled(self) -> Optional[str]:
         """List of disabled."""
         return self.manifest.get("disabled")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Adds a  `core` property to the integration model.
- Adds an optional `version` to the validation schema.
- Adds a new validate version function to make sure custom integrations have a version we can compare against with [AwesomeVersion](https://github.com/ludeeus/awesomeversion).
	 - For now, this is just a warning.
- Adds a "[ERROR]" prefix for error messages, this is needed for planned enhancement to the hassfest action.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/developers.home-assistant/pull/780

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
