### PR TITLE
Changes to filename and path validation

### DIFF
--- a/homeassistant/components/downloader/__init__.py
+++ b/homeassistant/components/downloader/__init__.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant.const import HTTP_OK
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import raise_if_invalid_filename
+from homeassistant.util import raise_if_invalid_filename, raise_if_invalid_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +70,8 @@ def setup(hass, config):
 
                 overwrite = service.data.get(ATTR_OVERWRITE)
 
-                raise_if_invalid_filename(subdir)
+                # Check the path
+                raise_if_invalid_path(subdir)
 
                 final_path = None
 
@@ -100,7 +101,7 @@ def setup(hass, config):
                     if not filename:
                         filename = "ha_download"
 
-                    # Remove stuff to ruin paths
+                    # Check the filename
                     raise_if_invalid_filename(filename)
 
                     # Do we want to download to subdir, create if needed

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -46,7 +46,7 @@ YAML_DASHBOARD_SCHEMA = vol.Schema(
     {
         **DASHBOARD_BASE_CREATE_FIELDS,
         vol.Required(CONF_MODE): MODE_YAML,
-        vol.Required(CONF_FILENAME): vol.All(cv.string, cv.path),
+        vol.Required(CONF_FILENAME): cv.path,
     }
 )
 

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -12,7 +12,6 @@ from homeassistant.helpers import collection, config_validation as cv
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType, ServiceCallType
 from homeassistant.loader import async_get_integration
-from homeassistant.util import sanitize_path
 
 from . import dashboard, resources, websocket
 from .const import (
@@ -47,7 +46,7 @@ YAML_DASHBOARD_SCHEMA = vol.Schema(
     {
         **DASHBOARD_BASE_CREATE_FIELDS,
         vol.Required(CONF_MODE): MODE_YAML,
-        vol.Required(CONF_FILENAME): vol.All(cv.string, sanitize_path),
+        vol.Required(CONF_FILENAME): vol.All(cv.string, cv.path),
     }
 )
 

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -10,7 +10,7 @@ from homeassistant.components.media_player.const import MEDIA_CLASS_DIRECTORY
 from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.components.media_source.error import Unresolvable
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.util import sanitize_path
+from homeassistant.util import raise_if_invalid_filename
 
 from .const import DOMAIN, MEDIA_CLASS_MAP, MEDIA_MIME_TYPES
 from .models import BrowseMediaSource, MediaSource, MediaSourceItem, PlayMedia
@@ -50,7 +50,9 @@ class LocalSource(MediaSource):
         if source_dir_id not in self.hass.config.media_dirs:
             raise Unresolvable("Unknown source directory.")
 
-        if location != sanitize_path(location):
+        try:
+            raise_if_invalid_filename(location)
+        except ValueError:
             raise Unresolvable("Invalid path.")
 
         return source_dir_id, location
@@ -189,7 +191,9 @@ class LocalMediaView(HomeAssistantView):
         self, request: web.Request, source_dir_id: str, location: str
     ) -> web.FileResponse:
         """Start a GET request."""
-        if location != sanitize_path(location):
+        try:
+            raise_if_invalid_filename(location)
+        except ValueError:
             raise web.HTTPNotFound()
 
         if source_dir_id not in self.hass.config.media_dirs:

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -194,7 +194,7 @@ class LocalMediaView(HomeAssistantView):
         try:
             raise_if_invalid_filename(location)
         except ValueError as err:
-            raise web.HTTPNotFound() from err
+            raise web.HTTPBadRequest() from err
 
         if source_dir_id not in self.hass.config.media_dirs:
             raise web.HTTPNotFound()

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -52,8 +52,8 @@ class LocalSource(MediaSource):
 
         try:
             raise_if_invalid_filename(location)
-        except ValueError:
-            raise Unresolvable("Invalid path.")
+        except ValueError as err:
+            raise Unresolvable("Invalid path.") from err
 
         return source_dir_id, location
 
@@ -193,8 +193,8 @@ class LocalMediaView(HomeAssistantView):
         """Start a GET request."""
         try:
             raise_if_invalid_filename(location)
-        except ValueError:
-            raise web.HTTPNotFound()
+        except ValueError as err:
+            raise web.HTTPNotFound() from err
 
         if source_dir_id not in self.hass.config.media_dirs:
             raise web.HTTPNotFound()

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.const import SERVICE_RELOAD
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.loader import bind_hass
-from homeassistant.util import sanitize_filename
+from homeassistant.util import raise_if_invalid_filename
 import homeassistant.util.dt as dt_util
 from homeassistant.util.yaml.loader import load_yaml
 
@@ -135,7 +135,8 @@ def discover_scripts(hass):
 def execute_script(hass, name, data=None):
     """Execute a script."""
     filename = f"{name}.py"
-    with open(hass.config.path(FOLDER, sanitize_filename(filename))) as fil:
+    raise_if_invalid_filename(filename)
+    with open(hass.config.path(FOLDER, filename)) as fil:
         source = fil.read()
     execute(hass, filename, source, data)
 

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -105,7 +105,10 @@ def discover_scripts(hass):
 
     def python_script_service_handler(call):
         """Handle python script service calls."""
-        execute_script(hass, call.service, call.data)
+        try:
+            execute_script(hass, call.service, call.data)
+        except ValueError:
+            _LOGGER.error("Invalid path")
 
     existing = hass.services.services.get(DOMAIN, {}).keys()
     for existing_service in existing:

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -105,10 +105,7 @@ def discover_scripts(hass):
 
     def python_script_service_handler(call):
         """Handle python script service calls."""
-        try:
-            execute_script(hass, call.service, call.data)
-        except ValueError:
-            _LOGGER.error("Invalid path")
+        execute_script(hass, call.service, call.data)
 
     existing = hass.services.services.get(DOMAIN, {}).keys()
     for existing_service in existing:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -120,8 +120,8 @@ def path(value: Any) -> str:
 
     try:
         raise_if_invalid_path(value)
-    except ValueError:
-        raise vol.Invalid("Invalid path")
+    except ValueError as err:
+        raise vol.Invalid("Invalid path") from err
 
     return value
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -87,7 +87,7 @@ from homeassistant.helpers import (
     template as template_helper,
 )
 from homeassistant.helpers.logging import KeywordStyleAdapter
-from homeassistant.util import sanitize_path, slugify as util_slugify
+from homeassistant.util import raise_if_invalid_path, slugify as util_slugify
 import homeassistant.util.dt as dt_util
 
 # pylint: disable=invalid-name
@@ -118,7 +118,9 @@ def path(value: Any) -> str:
     if not isinstance(value, str):
         raise vol.Invalid("Expected a string")
 
-    if sanitize_path(value) != value:
+    try:
+        raise_if_invalid_path(value)
+    except ValueError:
         raise vol.Invalid("Invalid path")
 
     return value

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -73,3 +73,19 @@ def get_deprecated(
         )
         return config.get(old_name)
     return config.get(new_name, default)
+
+
+def deprecated_function(replacement: str):
+    def deprecated_decorator(func):
+        def deprecated_func(*args, **kwargs):
+            logger = logging.getLogger(func.__module__)
+            logger.warning(
+                "%s is a deprecated function. Use %s instead",
+                func.__name__,
+                replacement,
+            )
+            return func(*args, **kwargs)
+
+        return deprecated_func
+
+    return deprecated_decorator

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -1,7 +1,7 @@
 """Deprecation helpers for Home Assistant."""
+import functools
 import inspect
 import logging
-import functools
 from typing import Any, Callable, Dict, Optional
 
 

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -1,6 +1,7 @@
 """Deprecation helpers for Home Assistant."""
 import inspect
 import logging
+import functools
 from typing import Any, Callable, Dict, Optional
 
 
@@ -77,6 +78,7 @@ def get_deprecated(
 
 def deprecated_function(replacement: str):
     def deprecated_decorator(func):
+        @functools.wraps(func)
         def deprecated_func(*args, **kwargs):
             logger = logging.getLogger(func.__module__)
             logger.warning(

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -83,7 +83,7 @@ def deprecated_function(replacement: str) -> Callable[..., Callable]:
         """Decorate function as deprecated."""
 
         @functools.wraps(func)
-        def deprecated_func(*args, **kwargs) -> Any:
+        def deprecated_func(*args: tuple, **kwargs: Dict[str, Any]) -> Any:
             """Wrap for the original function."""
             logger = logging.getLogger(func.__module__)
             logger.warning(

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -77,9 +77,14 @@ def get_deprecated(
 
 
 def deprecated_function(replacement: str):
+    """Mark function as deprecated and provide a replacement function to be used instead."""
+
     def deprecated_decorator(func):
+        """Decorate function as deprecated."""
+
         @functools.wraps(func)
         def deprecated_func(*args, **kwargs):
+            """Wrap for the original function."""
             logger = logging.getLogger(func.__module__)
             logger.warning(
                 "%s is a deprecated function. Use %s instead",

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -76,7 +76,7 @@ def get_deprecated(
     return config.get(new_name, default)
 
 
-def deprecated_function(replacement: str):
+def deprecated_function(replacement: str) -> Callable[..., Callable]:
     """Mark function as deprecated and provide a replacement function to be used instead."""
 
     def deprecated_decorator(func):

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -79,11 +79,11 @@ def get_deprecated(
 def deprecated_function(replacement: str) -> Callable[..., Callable]:
     """Mark function as deprecated and provide a replacement function to be used instead."""
 
-    def deprecated_decorator(func):
+    def deprecated_decorator(func: Callable) -> Callable:
         """Decorate function as deprecated."""
 
         @functools.wraps(func)
-        def deprecated_func(*args, **kwargs):
+        def deprecated_func(*args, **kwargs) -> Any:
             """Wrap for the original function."""
             logger = logging.getLogger(func.__module__)
             logger.warning(

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -22,8 +22,8 @@ from typing import (
 
 import slugify as unicode_slug
 
-from .dt import as_local, utcnow
 from ..helpers.deprecation import deprecated_function
+from .dt import as_local, utcnow
 
 T = TypeVar("T")
 U = TypeVar("U")  # pylint: disable=invalid-name

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -23,6 +23,7 @@ from typing import (
 import slugify as unicode_slug
 
 from .dt import as_local, utcnow
+from ..helpers.deprecation import deprecated_function
 
 T = TypeVar("T")
 U = TypeVar("U")  # pylint: disable=invalid-name
@@ -32,6 +33,27 @@ RE_SANITIZE_FILENAME = re.compile(r"(~|\.\.|/|\\)")
 RE_SANITIZE_PATH = re.compile(r"(~|\.(\.)+)")
 
 
+def raise_if_invalid_filename(filename: str) -> None:
+    """
+    Check if a filename is valid.
+
+    Raises a ValueError if the filename is invalid.
+    """
+    if RE_SANITIZE_FILENAME.sub("", filename) != filename:
+        raise ValueError(f"{filename} is not a safe filename")
+
+
+def raise_if_invalid_path(path: str) -> None:
+    """
+    Check if a path is valid.
+
+    Raises a ValueError if the path is invalid.
+    """
+    if RE_SANITIZE_PATH.sub("", path) != path:
+        raise ValueError(f"{path} is not a safe path")
+
+
+@deprecated_function(replacement="raise_if_invalid_filename")
 def sanitize_filename(filename: str) -> str:
     """Check if a filename is safe.
 
@@ -47,6 +69,7 @@ def sanitize_filename(filename: str) -> str:
     return filename
 
 
+@deprecated_function(replacement="raise_if_invalid_path")
 def sanitize_path(path: str) -> str:
     """Check if a path is safe.
 

--- a/tests/components/media_source/test_local_source.py
+++ b/tests/components/media_source/test_local_source.py
@@ -23,7 +23,7 @@ async def test_async_browse_media(hass):
         await media_source.async_browse_media(
             hass, f"{const.URI_SCHEME}{const.DOMAIN}/local/test/not/exist"
         )
-    assert str(excinfo.value) == "Path does not exist."
+    assert str(excinfo.value) == "Invalid path."
 
     # Test browse file
     with pytest.raises(media_source.BrowseError) as excinfo:

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -1,7 +1,11 @@
 """Test deprecation helpers."""
 from unittest.mock import MagicMock, patch
 
-from homeassistant.helpers.deprecation import deprecated_substitute, get_deprecated
+from homeassistant.helpers.deprecation import (
+    deprecated_substitute,
+    get_deprecated,
+    deprecated_function,
+)
 
 
 class MockBaseClass:
@@ -78,3 +82,21 @@ def test_config_get_deprecated_new(mock_get_logger):
     config = {"new_name": True}
     assert get_deprecated(config, "new_name", "old_name") is True
     assert not mock_logger.warning.called
+
+
+@patch("logging.getLogger")
+def test_deprecated_function(mock_get_logger):
+    """Test deprecated_function decorator."""
+    mock_logger = MagicMock()
+    mock_get_logger.return_value = mock_logger
+
+    @deprecated_function("new_function")
+    def mock_deprecated_function():
+        pass
+
+    mock_deprecated_function()
+    mock_logger.warning.assert_called_with(
+        "%s is a deprecated function. Use %s instead",
+        "mock_deprecated_function",
+        "new_function",
+    )

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -84,19 +84,15 @@ def test_config_get_deprecated_new(mock_get_logger):
     assert not mock_logger.warning.called
 
 
-@patch("logging.getLogger")
-def test_deprecated_function(mock_get_logger):
+def test_deprecated_function(caplog):
     """Test deprecated_function decorator."""
-    mock_logger = MagicMock()
-    mock_get_logger.return_value = mock_logger
 
     @deprecated_function("new_function")
     def mock_deprecated_function():
         pass
 
     mock_deprecated_function()
-    mock_logger.warning.assert_called_with(
-        "%s is a deprecated function. Use %s instead",
-        "mock_deprecated_function",
-        "new_function",
+    assert (
+        "mock_deprecated_function is a deprecated function. Use new_function instead"
+        == caplog.text
     )

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -2,9 +2,9 @@
 from unittest.mock import MagicMock, patch
 
 from homeassistant.helpers.deprecation import (
+    deprecated_function,
     deprecated_substitute,
     get_deprecated,
-    deprecated_function,
 )
 
 

--- a/tests/helpers/test_deprecation.py
+++ b/tests/helpers/test_deprecation.py
@@ -94,5 +94,5 @@ def test_deprecated_function(caplog):
     mock_deprecated_function()
     assert (
         "mock_deprecated_function is a deprecated function. Use new_function instead"
-        == caplog.text
+        in caplog.text
     )

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -24,6 +24,34 @@ def test_sanitize_path():
     assert util.sanitize_path("~/../test/path") == ""
 
 
+def test_raise_if_invalid_filename():
+    """Test raise_if_invalid_filename."""
+    assert util.raise_if_invalid_filename("test") is None
+
+    with pytest.raises(ValueError):
+        util.raise_if_invalid_filename("/test")
+
+    with pytest.raises(ValueError):
+        util.raise_if_invalid_filename("..test")
+
+    with pytest.raises(ValueError):
+        util.raise_if_invalid_filename("\\test")
+
+    with pytest.raises(ValueError):
+        util.raise_if_invalid_filename("\\../test")
+
+
+def test_raise_if_invalid_path():
+    """Test raise_if_invalid_path."""
+    assert util.raise_if_invalid_path("test/path") is None
+
+    with pytest.raises(ValueError):
+        assert util.raise_if_invalid_path("~test/path")
+
+    with pytest.raises(ValueError):
+        assert util.raise_if_invalid_path("~/../test/path")
+
+
 def test_slugify():
     """Test slugify."""
     assert util.slugify("T-!@#$!#@$!$est") == "t_est"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

`homeassistant.util.sanitize_filename` and `homeassistant.util.sanitize_path` are  deprecated and will now print a warning if used. `homeassistant.util.raise_if_invalid_filename` and `homeassistant.util.raise_if_invalid_path` should be used instead.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Adds deprecation warning to deprecated sanitize functions
- Adds replacement functions for the deprecated functions
- Adds a `deprecated_function` decorator
- Fixes incorrect usage of filename/path sanitization in the `lovelace`, `python_script` and `downloader` integrations


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
