### PR TITLE
Don't parse previous messages when UniFi connection state change to available

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -177,6 +177,7 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         """Call when controller connection state change."""
         self.async_update_callback(controller_state_change=True)
 
+    # pylint: disable=arguments-differ
     @callback
     def async_update_callback(self, controller_state_change: bool = False) -> None:
         """Update the clients state."""
@@ -326,6 +327,7 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         """Call when controller connection state change."""
         self.async_update_callback(controller_state_change=True)
 
+    # pylint: disable=arguments-differ
     @callback
     def async_update_callback(self, controller_state_change: bool = False) -> None:
         """Update the devices' state."""

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -144,8 +144,8 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         super().__init__(client, controller)
 
         self.heartbeat_check = False
-        self.schedule_update = False
         self._is_connected = False
+
         if client.last_seen:
             self._is_connected = (
                 self.is_wired == client.is_wired
@@ -153,8 +153,8 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
                 - dt_util.utc_from_timestamp(float(client.last_seen))
                 < controller.option_detection_time
             )
-            if self._is_connected:
-                self.schedule_update = True
+
+        self.schedule_update = self._is_connected
 
     async def async_added_to_hass(self) -> None:
         """Watch object when added."""
@@ -173,10 +173,22 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         await super().async_will_remove_from_hass()
 
     @callback
-    def async_update_callback(self) -> None:
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_update_callback(controller_state_change=True)
+
+    @callback
+    def async_update_callback(self, controller_state_change: bool = False) -> None:
         """Update the clients state."""
 
-        if self.client.last_updated == SOURCE_EVENT:
+        if controller_state_change:
+            if self.controller.available:
+                self.schedule_update = True
+
+            else:
+                self.controller.async_heartbeat(self.unique_id)
+
+        elif self.client.last_updated == SOURCE_EVENT:
             if (self.is_wired and self.client.event.event in WIRED_CONNECTION) or (
                 not self.is_wired and self.client.event.event in WIRELESS_CONNECTION
             ):
@@ -291,6 +303,7 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
 
         self.device = self._item
         self._is_connected = device.state == 1
+        self.schedule_update = False
 
     async def async_added_to_hass(self) -> None:
         """Watch object when added."""
@@ -309,15 +322,25 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         await super().async_will_remove_from_hass()
 
     @callback
-    def async_update_callback(self):
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_update_callback(controller_state_change=True)
+
+    @callback
+    def async_update_callback(self, controller_state_change: bool = False) -> None:
         """Update the devices' state."""
 
-        if self.device.last_updated == SOURCE_DATA:
+        if controller_state_change:
+            if self.controller.available:
+                if self._is_connected:
+                    self.schedule_update = True
+
+            else:
+                self.controller.async_heartbeat(self.unique_id)
+
+        elif self.device.last_updated == SOURCE_DATA:
             self._is_connected = True
-            self.controller.async_heartbeat(
-                self.unique_id,
-                dt_util.utcnow() + timedelta(seconds=self.device.next_interval + 60),
-            )
+            self.schedule_update = True
 
         elif (
             self.device.last_updated == SOURCE_EVENT
@@ -325,6 +348,13 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         ):
             self.hass.async_create_task(self.async_update_device_registry())
             return
+
+        if self.schedule_update:
+            self.schedule_update = False
+            self.controller.async_heartbeat(
+                self.unique_id,
+                dt_util.utcnow() + timedelta(seconds=self.device.next_interval + 60),
+            )
 
         super().async_update_callback()
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -178,7 +178,9 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         self.async_update_callback(controller_state_change=True)
 
     @callback
-    def async_update_callback(self, controller_state_change: bool = False) -> None:
+    def async_update_callback(
+        self, controller_state_change: bool = False
+    ) -> None:  # pylint: disable=arguments-differ
         """Update the clients state."""
 
         if controller_state_change:
@@ -327,7 +329,9 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         self.async_update_callback(controller_state_change=True)
 
     @callback
-    def async_update_callback(self, controller_state_change: bool = False) -> None:
+    def async_update_callback(
+        self, controller_state_change: bool = False
+    ) -> None:  # pylint: disable=arguments-differ
         """Update the devices' state."""
 
         if controller_state_change:

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -178,9 +178,7 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         self.async_update_callback(controller_state_change=True)
 
     @callback
-    def async_update_callback(
-        self, controller_state_change: bool = False
-    ) -> None:  # pylint: disable=arguments-differ
+    def async_update_callback(self, controller_state_change: bool = False) -> None:
         """Update the clients state."""
 
         if controller_state_change:
@@ -329,9 +327,7 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         self.async_update_callback(controller_state_change=True)
 
     @callback
-    def async_update_callback(
-        self, controller_state_change: bool = False
-    ) -> None:  # pylint: disable=arguments-differ
+    def async_update_callback(self, controller_state_change: bool = False) -> None:
         """Update the devices' state."""
 
         if controller_state_change:

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -281,7 +281,7 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
         self._is_blocked = client.blocked
 
     @callback
-    def async_update_callback(self) -> None:
+    def async_update_callback(self, **kwargs) -> None:
         """Update the clients state."""
         if self.client.last_updated == SOURCE_EVENT:
 

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -281,7 +281,7 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
         self._is_blocked = client.blocked
 
     @callback
-    def async_update_callback(self, **kwargs) -> None:
+    def async_update_callback(self) -> None:
         """Update the clients state."""
         if self.client.last_updated == SOURCE_EVENT:
 

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -63,7 +63,7 @@ class UniFiBase(Entity):
         self.async_update_callback()
 
     @callback
-    def async_update_callback(self, **kwargs) -> None:
+    def async_update_callback(self) -> None:
         """Update the entity's state."""
         _LOGGER.debug(
             "Updating %s entity %s (%s)",

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -64,10 +64,7 @@ class UniFiBase(Entity):
 
     @callback
     def async_update_callback(self) -> None:
-        """Update the entity's state.
-
-        Optional input to tell call is made because of controller state changed.
-        """
+        """Update the entity's state."""
         _LOGGER.debug(
             "Updating %s entity %s (%s)",
             self.TYPE,

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -63,7 +63,7 @@ class UniFiBase(Entity):
         self.async_update_callback()
 
     @callback
-    def async_update_callback(self) -> None:
+    def async_update_callback(self, **kwargs) -> None:
         """Update the entity's state."""
         _LOGGER.debug(
             "Updating %s entity %s (%s)",

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -39,7 +39,7 @@ class UniFiBase(Entity):
             self.key,
         )
         for signal, method in (
-            (self.controller.signal_reachable, self.async_update_callback),
+            (self.controller.signal_reachable, self.async_signal_reachable_callback),
             (self.controller.signal_options_update, self.options_updated),
             (self.controller.signal_remove, self.remove_item),
         ):
@@ -58,8 +58,16 @@ class UniFiBase(Entity):
         self.controller.entities[self.DOMAIN][self.TYPE].remove(self.key)
 
     @callback
+    def async_signal_reachable_callback(self) -> None:
+        """Call when controller connection state change."""
+        self.async_update_callback()
+
+    @callback
     def async_update_callback(self) -> None:
-        """Update the entity's state."""
+        """Update the entity's state.
+
+        Optional input to tell call is made because of controller state changed.
+        """
         _LOGGER.debug(
             "Updating %s entity %s (%s)",
             self.TYPE,

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -376,6 +376,12 @@ async def test_controller_state_change(hass):
     )
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
 
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1.state == "not_home"
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1.state == "home"
+
     # Controller unavailable
     controller.async_unifi_signalling_callback(
         SIGNAL_CONNECTION_STATE, STATE_DISCONNECTED
@@ -393,7 +399,7 @@ async def test_controller_state_change(hass):
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
-    assert client_1.state == "home"
+    assert client_1.state == "not_home"
 
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1.state == "home"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When controller connection state change it signals all entities to update state. When reconnecting the signalling would lead all entities to be marked as "home" even though it should keep its previous _is_connected state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40983
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
