### PR TITLE
Add better message to deCONZ event logbook when information is available

### DIFF
--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -8,7 +8,107 @@ from homeassistant.helpers.event import Event
 
 from .const import DOMAIN as DECONZ_DOMAIN
 from .deconz_event import CONF_DECONZ_EVENT, DeconzEvent
-from .device_trigger import _get_deconz_event_from_device_id
+from .device_trigger import (
+    CONF_BOTH_BUTTONS,
+    CONF_BOTTOM_BUTTONS,
+    CONF_BUTTON_1,
+    CONF_BUTTON_2,
+    CONF_BUTTON_3,
+    CONF_BUTTON_4,
+    CONF_CLOSE,
+    CONF_DIM_DOWN,
+    CONF_DIM_UP,
+    CONF_DOUBLE_PRESS,
+    CONF_DOUBLE_TAP,
+    CONF_LEFT,
+    CONF_LONG_PRESS,
+    CONF_LONG_RELEASE,
+    CONF_MOVE,
+    CONF_OPEN,
+    CONF_QUADRUPLE_PRESS,
+    CONF_QUINTUPLE_PRESS,
+    CONF_RIGHT,
+    CONF_ROTATE_FROM_SIDE_1,
+    CONF_ROTATE_FROM_SIDE_2,
+    CONF_ROTATE_FROM_SIDE_3,
+    CONF_ROTATE_FROM_SIDE_4,
+    CONF_ROTATE_FROM_SIDE_5,
+    CONF_ROTATE_FROM_SIDE_6,
+    CONF_ROTATED,
+    CONF_ROTATED_FAST,
+    CONF_ROTATION_STOPPED,
+    CONF_SHAKE,
+    CONF_SHORT_PRESS,
+    CONF_SHORT_RELEASE,
+    CONF_SIDE_1,
+    CONF_SIDE_2,
+    CONF_SIDE_3,
+    CONF_SIDE_4,
+    CONF_SIDE_5,
+    CONF_SIDE_6,
+    CONF_TOP_BUTTONS,
+    CONF_TRIPLE_PRESS,
+    CONF_TURN_OFF,
+    CONF_TURN_ON,
+    REMOTES,
+    _get_deconz_event_from_device_id,
+)
+
+ACTIONS = {
+    CONF_SHORT_PRESS: "Short press",
+    CONF_SHORT_RELEASE: "Short release",
+    CONF_LONG_PRESS: "Long press",
+    CONF_LONG_RELEASE: "Long release",
+    CONF_DOUBLE_PRESS: "Double press",
+    CONF_TRIPLE_PRESS: "Triple press",
+    CONF_QUADRUPLE_PRESS: "Quadruple press",
+    CONF_QUINTUPLE_PRESS: "Quintuple press",
+    CONF_ROTATED: "Rotated",
+    CONF_ROTATED_FAST: "Rotated fast",
+    CONF_ROTATION_STOPPED: "Rotated stopped",
+    CONF_MOVE: "Move",
+    CONF_DOUBLE_TAP: "Double tap",
+    CONF_SHAKE: "Shake",
+    CONF_ROTATE_FROM_SIDE_1: "Rotate from side 1",
+    CONF_ROTATE_FROM_SIDE_2: "Rotate from side 2",
+    CONF_ROTATE_FROM_SIDE_3: "Rotate from side 3",
+    CONF_ROTATE_FROM_SIDE_4: "Rotate from side 4",
+    CONF_ROTATE_FROM_SIDE_5: "Rotate from side 5",
+    CONF_ROTATE_FROM_SIDE_6: "Rotate from side 6",
+}
+
+INTERFACES = {
+    CONF_TURN_ON: "Turn on",
+    CONF_TURN_OFF: "Turn off",
+    CONF_DIM_UP: "Dim up",
+    CONF_DIM_DOWN: "Dim down",
+    CONF_LEFT: "Left",
+    CONF_RIGHT: "Right",
+    CONF_OPEN: "Open",
+    CONF_CLOSE: "Close",
+    CONF_BOTH_BUTTONS: "Both buttons",
+    CONF_TOP_BUTTONS: "Top buttons",
+    CONF_BOTTOM_BUTTONS: "Bottom buttons",
+    CONF_BUTTON_1: "Button 1",
+    CONF_BUTTON_2: "Button 2",
+    CONF_BUTTON_3: "Button 3",
+    CONF_BUTTON_4: "Button 4",
+    CONF_SIDE_1: "Side 1",
+    CONF_SIDE_2: "Side 2",
+    CONF_SIDE_3: "Side 3",
+    CONF_SIDE_4: "Side 4",
+    CONF_SIDE_5: "Side 5",
+    CONF_SIDE_6: "Side 6",
+}
+
+
+def _get_device_event_description(modelid: str, event: str) -> tuple:
+    """Get device event description."""
+    device_event_descriptions: dict = REMOTES[modelid]
+
+    for k, v in device_event_descriptions.items():
+        if event == v[CONF_EVENT]:
+            return k
 
 
 @callback
@@ -25,9 +125,19 @@ def async_describe_events(
             hass, event.data[ATTR_DEVICE_ID]
         )
 
+        if deconz_event.device.modelid not in REMOTES:
+            return {
+                "name": f"{deconz_event.device.name}",
+                "message": f"fired event '{event.data[CONF_EVENT]}'.",
+            }
+
+        action, interface = _get_device_event_description(
+            deconz_event.device.modelid, event.data[CONF_EVENT]
+        )
+
         return {
             "name": f"{deconz_event.device.name}",
-            "message": f"fired event '{event.data[CONF_EVENT]}'.",
+            "message": f"'{ACTIONS[action]}' event for '{INTERFACES[interface]}' was fired.",
         }
 
     async_describe_event(DECONZ_DOMAIN, CONF_DECONZ_EVENT, async_describe_deconz_event)

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -106,9 +106,9 @@ def _get_device_event_description(modelid: str, event: str) -> tuple:
     """Get device event description."""
     device_event_descriptions: dict = REMOTES[modelid]
 
-    for k, v in device_event_descriptions.items():
-        if event == v[CONF_EVENT]:
-            return k
+    for event_type_tuple, event_dict in device_event_descriptions.items():
+        if event == event_dict[CONF_EVENT]:
+            return event_type_tuple
 
 
 @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve logbook message when information is available.

<img width="522" alt="Screenshot 2021-01-25 at 22 50 36" src="https://user-images.githubusercontent.com/24575746/105770640-c7969b00-5f5f-11eb-9fb6-357648d1055a.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
