### PR TITLE
Update homekit to use new fan entity model 

### DIFF
--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -1,5 +1,4 @@
 """Collection of useful functions for the HomeKit component."""
-from collections import OrderedDict, namedtuple
 import io
 import ipaddress
 import logging
@@ -11,7 +10,7 @@ import socket
 import pyqrcode
 import voluptuous as vol
 
-from homeassistant.components import binary_sensor, fan, media_player, sensor
+from homeassistant.components import binary_sensor, media_player, sensor
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_SUPPORTED_FEATURES,
@@ -308,56 +307,6 @@ def validate_media_player_features(state, feature_list):
         )
         return False
     return True
-
-
-SpeedRange = namedtuple("SpeedRange", ("start", "target"))
-SpeedRange.__doc__ += """ Maps Home Assistant speed \
-values to percentage based HomeKit speeds.
-start: Start of the range (inclusive).
-target: Percentage to use to determine HomeKit percentages \
-from HomeAssistant speed.
-"""
-
-
-class HomeKitSpeedMapping:
-    """Supports conversion between Home Assistant and HomeKit fan speeds."""
-
-    def __init__(self, speed_list):
-        """Initialize a new SpeedMapping object."""
-        if speed_list[0] != fan.SPEED_OFF:
-            _LOGGER.warning(
-                "%s does not contain the speed setting "
-                "%s as its first element. "
-                "Assuming that %s is equivalent to 'off'",
-                speed_list,
-                fan.SPEED_OFF,
-                speed_list[0],
-            )
-        self.speed_ranges = OrderedDict()
-        list_size = len(speed_list)
-        for index, speed in enumerate(speed_list):
-            # By dividing by list_size -1 the following
-            # desired attributes hold true:
-            # * index = 0 => 0%, equal to "off"
-            # * index = len(speed_list) - 1 => 100 %
-            # * all other indices are equally distributed
-            target = index * 100 / (list_size - 1)
-            start = index * 100 / list_size
-            self.speed_ranges[speed] = SpeedRange(start, target)
-
-    def speed_to_homekit(self, speed):
-        """Map Home Assistant speed state to HomeKit speed."""
-        if speed is None:
-            return None
-        speed_range = self.speed_ranges[speed]
-        return round(speed_range.target)
-
-    def speed_to_states(self, speed):
-        """Map HomeKit speed to Home Assistant speed state."""
-        for state, speed_range in reversed(self.speed_ranges.items()):
-            if speed_range.start <= speed:
-                return state
-        return list(self.speed_ranges)[0]
 
 
 def show_setup_message(hass, entry_id, bridge_name, pincode, uri):

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -1,6 +1,5 @@
 """Test different accessory types: Fans."""
 from collections import namedtuple
-from unittest.mock import Mock
 
 from pyhap.const import HAP_REPR_AID, HAP_REPR_CHARS, HAP_REPR_IID, HAP_REPR_VALUE
 import pytest
@@ -8,20 +7,15 @@ import pytest
 from homeassistant.components.fan import (
     ATTR_DIRECTION,
     ATTR_OSCILLATING,
-    ATTR_SPEED,
-    ATTR_SPEED_LIST,
+    ATTR_PERCENTAGE,
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
     DOMAIN,
-    SPEED_HIGH,
-    SPEED_LOW,
-    SPEED_OFF,
     SUPPORT_DIRECTION,
     SUPPORT_OSCILLATE,
     SUPPORT_SET_SPEED,
 )
 from homeassistant.components.homekit.const import ATTR_VALUE
-from homeassistant.components.homekit.util import HomeKitSpeedMapping
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
@@ -266,15 +260,13 @@ async def test_fan_oscillate(hass, hk_driver, cls, events):
 async def test_fan_speed(hass, hk_driver, cls, events):
     """Test fan with speed."""
     entity_id = "fan.demo"
-    speed_list = [SPEED_OFF, SPEED_LOW, SPEED_HIGH]
 
     hass.states.async_set(
         entity_id,
         STATE_ON,
         {
             ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED,
-            ATTR_SPEED: SPEED_OFF,
-            ATTR_SPEED_LIST: speed_list,
+            ATTR_PERCENTAGE: 0,
         },
     )
     await hass.async_block_till_done()
@@ -288,20 +280,12 @@ async def test_fan_speed(hass, hk_driver, cls, events):
     await acc.run_handler()
     await hass.async_block_till_done()
 
-    assert (
-        acc.speed_mapping.speed_ranges == HomeKitSpeedMapping(speed_list).speed_ranges
-    )
-
-    acc.speed_mapping.speed_to_homekit = Mock(return_value=42)
-    acc.speed_mapping.speed_to_states = Mock(return_value="ludicrous")
-
-    hass.states.async_set(entity_id, STATE_ON, {ATTR_SPEED: SPEED_HIGH})
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_PERCENTAGE: 100})
     await hass.async_block_till_done()
-    acc.speed_mapping.speed_to_homekit.assert_called_with(SPEED_HIGH)
-    assert acc.char_speed.value == 42
+    assert acc.char_speed.value == 100
 
     # Set from HomeKit
-    call_set_speed = async_mock_service(hass, DOMAIN, "set_speed")
+    call_set_percentage = async_mock_service(hass, DOMAIN, "set_percentage")
 
     char_speed_iid = acc.char_speed.to_HAP()[HAP_REPR_IID]
     char_active_iid = acc.char_active.to_HAP()[HAP_REPR_IID]
@@ -320,18 +304,17 @@ async def test_fan_speed(hass, hk_driver, cls, events):
     )
     await hass.async_add_executor_job(acc.char_speed.client_update_value, 42)
     await hass.async_block_till_done()
-    acc.speed_mapping.speed_to_states.assert_called_with(42)
     assert acc.char_speed.value == 42
     assert acc.char_active.value == 1
 
-    assert call_set_speed[0]
-    assert call_set_speed[0].data[ATTR_ENTITY_ID] == entity_id
-    assert call_set_speed[0].data[ATTR_SPEED] == "ludicrous"
+    assert call_set_percentage[0]
+    assert call_set_percentage[0].data[ATTR_ENTITY_ID] == entity_id
+    assert call_set_percentage[0].data[ATTR_PERCENTAGE] == 42
     assert len(events) == 1
-    assert events[-1].data[ATTR_VALUE] == "ludicrous"
+    assert events[-1].data[ATTR_VALUE] == 42
 
     # Verify speed is preserved from off to on
-    hass.states.async_set(entity_id, STATE_OFF, {ATTR_SPEED: SPEED_OFF})
+    hass.states.async_set(entity_id, STATE_OFF, {ATTR_PERCENTAGE: 42})
     await hass.async_block_till_done()
     assert acc.char_speed.value == 42
     assert acc.char_active.value == 0
@@ -356,7 +339,6 @@ async def test_fan_speed(hass, hk_driver, cls, events):
 async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     """Test fan with speed."""
     entity_id = "fan.demo"
-    speed_list = [SPEED_OFF, SPEED_LOW, SPEED_HIGH]
 
     hass.states.async_set(
         entity_id,
@@ -365,10 +347,9 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
             ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED
             | SUPPORT_OSCILLATE
             | SUPPORT_DIRECTION,
-            ATTR_SPEED: SPEED_OFF,
+            ATTR_PERCENTAGE: 0,
             ATTR_OSCILLATING: False,
             ATTR_DIRECTION: DIRECTION_FORWARD,
-            ATTR_SPEED_LIST: speed_list,
         },
     )
     await hass.async_block_till_done()
@@ -381,13 +362,6 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     await acc.run_handler()
     await hass.async_block_till_done()
 
-    assert (
-        acc.speed_mapping.speed_ranges == HomeKitSpeedMapping(speed_list).speed_ranges
-    )
-
-    acc.speed_mapping.speed_to_homekit = Mock(return_value=42)
-    acc.speed_mapping.speed_to_states = Mock(return_value="ludicrous")
-
     hass.states.async_set(
         entity_id,
         STATE_OFF,
@@ -395,17 +369,16 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
             ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED
             | SUPPORT_OSCILLATE
             | SUPPORT_DIRECTION,
-            ATTR_SPEED: SPEED_OFF,
+            ATTR_PERCENTAGE: 0,
             ATTR_OSCILLATING: False,
             ATTR_DIRECTION: DIRECTION_FORWARD,
-            ATTR_SPEED_LIST: speed_list,
         },
     )
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
     # Set from HomeKit
-    call_set_speed = async_mock_service(hass, DOMAIN, "set_speed")
+    call_set_percentage = async_mock_service(hass, DOMAIN, "set_percentage")
     call_oscillate = async_mock_service(hass, DOMAIN, "oscillate")
     call_set_direction = async_mock_service(hass, DOMAIN, "set_direction")
     call_turn_on = async_mock_service(hass, DOMAIN, "turn_on")
@@ -444,11 +417,10 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
         "mock_addr",
     )
     await hass.async_block_till_done()
-    acc.speed_mapping.speed_to_states.assert_called_with(42)
     assert not call_turn_on
-    assert call_set_speed[0]
-    assert call_set_speed[0].data[ATTR_ENTITY_ID] == entity_id
-    assert call_set_speed[0].data[ATTR_SPEED] == "ludicrous"
+    assert call_set_percentage[0]
+    assert call_set_percentage[0].data[ATTR_ENTITY_ID] == entity_id
+    assert call_set_percentage[0].data[ATTR_PERCENTAGE] == 42
     assert call_oscillate[0]
     assert call_oscillate[0].data[ATTR_ENTITY_ID] == entity_id
     assert call_oscillate[0].data[ATTR_OSCILLATING] is True
@@ -459,7 +431,7 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
 
     assert events[0].data[ATTR_VALUE] is True
     assert events[1].data[ATTR_VALUE] == DIRECTION_REVERSE
-    assert events[2].data[ATTR_VALUE] == "ludicrous"
+    assert events[2].data[ATTR_VALUE] == 42
 
     hass.states.async_set(
         entity_id,
@@ -468,10 +440,9 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
             ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED
             | SUPPORT_OSCILLATE
             | SUPPORT_DIRECTION,
-            ATTR_SPEED: SPEED_OFF,
+            ATTR_PERCENTAGE: 0,
             ATTR_OSCILLATING: False,
             ATTR_DIRECTION: DIRECTION_FORWARD,
-            ATTR_SPEED_LIST: speed_list,
         },
     )
     await hass.async_block_till_done()
@@ -506,11 +477,10 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     # Turn on should not be called if its already on
     # and we set a fan speed
     await hass.async_block_till_done()
-    acc.speed_mapping.speed_to_states.assert_called_with(42)
     assert len(events) == 6
-    assert call_set_speed[1]
-    assert call_set_speed[1].data[ATTR_ENTITY_ID] == entity_id
-    assert call_set_speed[1].data[ATTR_SPEED] == "ludicrous"
+    assert call_set_percentage[1]
+    assert call_set_percentage[1].data[ATTR_ENTITY_ID] == entity_id
+    assert call_set_percentage[1].data[ATTR_PERCENTAGE] == 42
     assert call_oscillate[1]
     assert call_oscillate[1].data[ATTR_ENTITY_ID] == entity_id
     assert call_oscillate[1].data[ATTR_OSCILLATING] is True
@@ -520,7 +490,7 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
 
     assert events[-3].data[ATTR_VALUE] is True
     assert events[-2].data[ATTR_VALUE] == DIRECTION_REVERSE
-    assert events[-1].data[ATTR_VALUE] == "ludicrous"
+    assert events[-1].data[ATTR_VALUE] == 42
 
     hk_driver.set_characteristics(
         {
@@ -554,7 +524,7 @@ async def test_fan_set_all_one_shot(hass, hk_driver, cls, events):
     assert len(events) == 7
     assert call_turn_off
     assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
-    assert len(call_set_speed) == 2
+    assert len(call_set_percentage) == 2
     assert len(call_oscillate) == 2
     assert len(call_set_direction) == 2
 

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -21,8 +21,6 @@ from homeassistant.components.homekit.const import (
     TYPE_VALVE,
 )
 from homeassistant.components.homekit.util import (
-    HomeKitSpeedMapping,
-    SpeedRange,
     cleanup_name_for_homekit,
     convert_to_float,
     density_to_air_quality,
@@ -249,63 +247,6 @@ async def test_dismiss_setup_msg(hass):
 
     assert call_dismiss_notification
     assert call_dismiss_notification[0].data[ATTR_NOTIFICATION_ID] == "entry_id"
-
-
-def test_homekit_speed_mapping():
-    """Test if the SpeedRanges from a speed_list are as expected."""
-    # A standard 2-speed fan
-    speed_mapping = HomeKitSpeedMapping(["off", "low", "high"])
-    assert speed_mapping.speed_ranges == {
-        "off": SpeedRange(0, 0),
-        "low": SpeedRange(100 / 3, 50),
-        "high": SpeedRange(200 / 3, 100),
-    }
-
-    # A standard 3-speed fan
-    speed_mapping = HomeKitSpeedMapping(["off", "low", "medium", "high"])
-    assert speed_mapping.speed_ranges == {
-        "off": SpeedRange(0, 0),
-        "low": SpeedRange(100 / 4, 100 / 3),
-        "medium": SpeedRange(200 / 4, 200 / 3),
-        "high": SpeedRange(300 / 4, 100),
-    }
-
-    # a Dyson-like fan with 10 speeds
-    speed_mapping = HomeKitSpeedMapping([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    assert speed_mapping.speed_ranges == {
-        0: SpeedRange(0, 0),
-        1: SpeedRange(10, 100 / 9),
-        2: SpeedRange(20, 200 / 9),
-        3: SpeedRange(30, 300 / 9),
-        4: SpeedRange(40, 400 / 9),
-        5: SpeedRange(50, 500 / 9),
-        6: SpeedRange(60, 600 / 9),
-        7: SpeedRange(70, 700 / 9),
-        8: SpeedRange(80, 800 / 9),
-        9: SpeedRange(90, 100),
-    }
-
-
-def test_speed_to_homekit():
-    """Test speed conversion from HA to Homekit."""
-    speed_mapping = HomeKitSpeedMapping(["off", "low", "high"])
-    assert speed_mapping.speed_to_homekit(None) is None
-    assert speed_mapping.speed_to_homekit("off") == 0
-    assert speed_mapping.speed_to_homekit("low") == 50
-    assert speed_mapping.speed_to_homekit("high") == 100
-
-
-def test_speed_to_states():
-    """Test speed conversion from Homekit to HA."""
-    speed_mapping = HomeKitSpeedMapping(["off", "low", "high"])
-    assert speed_mapping.speed_to_states(-1) == "off"
-    assert speed_mapping.speed_to_states(0) == "off"
-    assert speed_mapping.speed_to_states(33) == "off"
-    assert speed_mapping.speed_to_states(34) == "low"
-    assert speed_mapping.speed_to_states(50) == "low"
-    assert speed_mapping.speed_to_states(66) == "low"
-    assert speed_mapping.speed_to_states(67) == "high"
-    assert speed_mapping.speed_to_states(100) == "high"
 
 
 async def test_port_is_available(hass):


### PR DESCRIPTION
Requires https://github.com/home-assistant/core/pull/45407

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update homekit to use new fan entity model.

I'm using the `bond` app to change the speed. Its a bit slow because it uses polling.  At some point it would be good to switch the `bond` integration to use the `udp` protocol.

![FhScKNa7qy](https://user-images.githubusercontent.com/663432/105782513-50024500-5f3a-11eb-88e1-78bb258653ac.gif)

Since testing showed how slow bond is to updated, I added support for BPUP protocol in https://github.com/home-assistant/core/pull/45550


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
