### PR TITLE
Add BPUP (push updates) support to bond

### DIFF
--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -55,7 +55,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Bond."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     _discovered: dict = None
 

--- a/homeassistant/components/bond/const.py
+++ b/homeassistant/components/bond/const.py
@@ -5,3 +5,8 @@ BRIDGE_MAKE = "Olibra"
 DOMAIN = "bond"
 
 CONF_BOND_ID: str = "bond_id"
+
+
+HUB = "hub"
+BPUP_SUBS = "bpup_subs"
+BPUP_STOP = "bpup_stop"

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -1,14 +1,14 @@
 """Support for Bond covers."""
 from typing import Any, Callable, List, Optional
 
-from bond_api import Action, DeviceType
+from bond_api import Action, BPUPSubscriptions, DeviceType
 
 from homeassistant.components.cover import DEVICE_CLASS_SHADE, CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 
-from .const import DOMAIN
+from .const import BPUP_SUBS, DOMAIN, HUB
 from .entity import BondEntity
 from .utils import BondDevice, BondHub
 
@@ -19,10 +19,12 @@ async def async_setup_entry(
     async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:
     """Set up Bond cover devices."""
-    hub: BondHub = hass.data[DOMAIN][entry.entry_id]
+    data = hass.data[DOMAIN][entry.entry_id]
+    hub: BondHub = data[HUB]
+    bpup_subs: BPUPSubscriptions = data[BPUP_SUBS]
 
     covers = [
-        BondCover(hub, device)
+        BondCover(hub, device, bpup_subs)
         for device in hub.devices
         if device.type == DeviceType.MOTORIZED_SHADES
     ]
@@ -33,9 +35,9 @@ async def async_setup_entry(
 class BondCover(BondEntity, CoverEntity):
     """Representation of a Bond cover."""
 
-    def __init__(self, hub: BondHub, device: BondDevice):
+    def __init__(self, hub: BondHub, device: BondDevice, bpup_subs: BPUPSubscriptions):
         """Create HA entity representing Bond cover."""
-        super().__init__(hub, device)
+        super().__init__(hub, device, bpup_subs)
 
         self._closed: Optional[bool] = None
 

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -9,6 +9,7 @@ from aiohttp import ClientError
 from bond_api import BPUPSubscriptions
 
 from homeassistant.const import ATTR_NAME
+from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 
@@ -33,18 +34,18 @@ class BondEntity(Entity):
         """Initialize entity with API and device info."""
         self._hub = hub
         self._device = device
+        self._device_id = device.device_id
         self._sub_device = sub_device
         self._available = True
         self._bpup_subs = bpup_subs
-        self._cancel_updates = None
         self._update_lock = None
-        self._first_update = False
+        self._initialized = False
 
     @property
     def unique_id(self) -> Optional[str]:
         """Get unique ID for the entity."""
         hub_id = self._hub.bond_id
-        device_id = self._device.device_id
+        device_id = self._device_id
         sub_device_id: str = f"_{self._sub_device}" if self._sub_device else ""
         return f"{hub_id}_{device_id}{sub_device_id}"
 
@@ -64,7 +65,7 @@ class BondEntity(Entity):
         device_info = {
             ATTR_NAME: self.name,
             "manufacturer": self._hub.make,
-            "identifiers": {(DOMAIN, self._hub.bond_id, self._device.device_id)},
+            "identifiers": {(DOMAIN, self._hub.bond_id, self._device_id)},
             "via_device": (DOMAIN, self._hub.bond_id),
         }
         if not self._hub.is_bridge:
@@ -93,12 +94,11 @@ class BondEntity(Entity):
 
     async def async_update(self):
         """Fetch assumed state of the cover from the hub using API."""
-
         await self._async_update_from_api()
 
-    async def _async_update_if_bpup_not_alive(self, now):
+    async def _async_update_if_bpup_not_alive(self, *_):
         """Fetch via the API if BPUP is not alive."""
-        if self._bpup_subs.alive and self._first_update:
+        if self._bpup_subs.alive and self._initialized:
             return
 
         if self._update_lock.locked():
@@ -111,14 +111,12 @@ class BondEntity(Entity):
 
         async with self._update_lock:
             await self._async_update_from_api()
-
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
     async def _async_update_from_api(self):
         """Fetch via the API."""
         try:
-            state: dict = await self._hub.bond.device_state(self._device.device_id)
-            self._first_update = True
+            state: dict = await self._hub.bond.device_state(self._device_id)
         except (ClientError, AsyncIOTimeoutError, OSError) as error:
             if self._available:
                 _LOGGER.warning(
@@ -126,35 +124,42 @@ class BondEntity(Entity):
                 )
             self._available = False
         else:
-            _LOGGER.debug("Device state for %s is:\n%s", self.entity_id, state)
-            if not self._available:
-                _LOGGER.info("Entity %s has come back", self.entity_id)
-            self._available = True
-            self._apply_state(state)
+            self._async_state_callback(state)
 
     @abstractmethod
     def _apply_state(self, state: dict):
         raise NotImplementedError
 
-    def _bpup_callback(self, state):
-        """Process a BPUP state change."""
+    @callback
+    def _async_state_callback(self, state):
+        """Process a state change."""
+        self._initialized = True
+        if not self._available:
+            _LOGGER.info("Entity %s has come back", self.entity_id)
         self._available = True
+        _LOGGER.debug(
+            "Device state for %s (%s) is:\n%s", self.name, self.entity_id, state
+        )
         self._apply_state(state)
+
+    @callback
+    def _async_bpup_callback(self, state):
+        """Process a state change from BPUP."""
+        self._async_state_callback(state)
         self.async_write_ha_state()
 
     async def async_added_to_hass(self):
-        """Subscribe to BPUP."""
+        """Subscribe to BPUP and start polling."""
         await super().async_added_to_hass()
         self._update_lock = Lock()
-        self._bpup_subs.subscribe(self._device.device_id, self._bpup_callback)
-        self._cancel_updates = async_track_time_interval(
-            self.hass, self._async_update_if_bpup_not_alive, _FALLBACK_SCAN_INTERVAL
+        self._bpup_subs.subscribe(self._device_id, self._async_bpup_callback)
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass, self._async_update_if_bpup_not_alive, _FALLBACK_SCAN_INTERVAL
+            )
         )
 
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from BPUP data on remove."""
         await super().async_will_remove_from_hass()
-        self._bpup_subs.unsubscribe(self._device.device_id, self._bpup_callback)
-        if self._cancel_updates:
-            self._cancel_updates()
-            self._cancel_updates = None
+        self._bpup_subs.unsubscribe(self._device_id, self._async_bpup_callback)

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -1,6 +1,6 @@
 """An abstract class common to all Bond entities."""
 from abc import abstractmethod
-from asyncio import TimeoutError as AsyncIOTimeoutError
+from asyncio import Lock, TimeoutError as AsyncIOTimeoutError
 from datetime import timedelta
 import logging
 from typing import Any, Dict, Optional
@@ -37,6 +37,8 @@ class BondEntity(Entity):
         self._available = True
         self._bpup_subs = bpup_subs
         self._cancel_updates = None
+        self._update_lock = None
+        self._first_update = False
 
     @property
     def unique_id(self) -> Optional[str]:
@@ -91,19 +93,32 @@ class BondEntity(Entity):
 
     async def async_update(self):
         """Fetch assumed state of the cover from the hub using API."""
+
         await self._async_update_from_api()
 
     async def _async_update_if_bpup_not_alive(self, now):
         """Fetch via the API if BPUP is not alive."""
-        if self._bpup_subs.alive:
+        if self._bpup_subs.alive and self._first_update:
             return
-        await self._async_update_from_api()
+
+        if self._update_lock.locked():
+            _LOGGER.warning(
+                "Updating %s took longer than the scheduled update interval %s",
+                self.entity_id,
+                _FALLBACK_SCAN_INTERVAL,
+            )
+            return
+
+        async with self._update_lock:
+            await self._async_update_from_api()
+
         self.async_write_ha_state()
 
     async def _async_update_from_api(self):
         """Fetch via the API."""
         try:
             state: dict = await self._hub.bond.device_state(self._device.device_id)
+            self._first_update = True
         except (ClientError, AsyncIOTimeoutError, OSError) as error:
             if self._available:
                 _LOGGER.warning(
@@ -130,6 +145,7 @@ class BondEntity(Entity):
     async def async_added_to_hass(self):
         """Subscribe to BPUP."""
         await super().async_added_to_hass()
+        self._update_lock = Lock()
         self._bpup_subs.subscribe(self._device.device_id, self._bpup_callback)
         self._cancel_updates = async_track_time_interval(
             self.hass, self._async_update_if_bpup_not_alive, _FALLBACK_SCAN_INTERVAL

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -1,6 +1,7 @@
 """An abstract class common to all Bond entities."""
 from abc import abstractmethod
 from asyncio import TimeoutError as AsyncIOTimeoutError
+from datetime import timedelta
 import logging
 from typing import Any, Dict, Optional
 
@@ -9,11 +10,14 @@ from bond_api import BPUPSubscriptions
 
 from homeassistant.const import ATTR_NAME
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import DOMAIN
 from .utils import BondDevice, BondHub
 
 _LOGGER = logging.getLogger(__name__)
+
+_FALLBACK_SCAN_INTERVAL = timedelta(seconds=10)
 
 
 class BondEntity(Entity):
@@ -32,6 +36,7 @@ class BondEntity(Entity):
         self._sub_device = sub_device
         self._available = True
         self._bpup_subs = bpup_subs
+        self._cancel_updates = None
 
     @property
     def unique_id(self) -> Optional[str]:
@@ -45,6 +50,11 @@ class BondEntity(Entity):
     def name(self) -> Optional[str]:
         """Get entity name."""
         return self._device.name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
 
     @property
     def device_info(self) -> Optional[Dict[str, Any]]:
@@ -81,9 +91,17 @@ class BondEntity(Entity):
 
     async def async_update(self):
         """Fetch assumed state of the cover from the hub using API."""
+        await self._async_update_from_api()
+
+    async def _async_update_if_bpup_not_alive(self, now):
+        """Fetch via the API if BPUP is not alive."""
         if self._bpup_subs.alive:
             return
+        await self._async_update_from_api()
+        self.async_write_ha_state()
 
+    async def _async_update_from_api(self):
+        """Fetch via the API."""
         try:
             state: dict = await self._hub.bond.device_state(self._device.device_id)
         except (ClientError, AsyncIOTimeoutError, OSError) as error:
@@ -113,8 +131,14 @@ class BondEntity(Entity):
         """Subscribe to BPUP."""
         await super().async_added_to_hass()
         self._bpup_subs.subscribe(self._device.device_id, self._bpup_callback)
+        self._cancel_updates = async_track_time_interval(
+            self.hass, self._async_update_if_bpup_not_alive, _FALLBACK_SCAN_INTERVAL
+        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from BPUP data on remove."""
         await super().async_will_remove_from_hass()
         self._bpup_subs.unsubscribe(self._device.device_id, self._bpup_callback)
+        if self._cancel_updates:
+            self._cancel_updates()
+            self._cancel_updates = None

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from aiohttp import ClientError
+from bond_api import BPUPSubscriptions
 
 from homeassistant.const import ATTR_NAME
 from homeassistant.helpers.entity import Entity
@@ -19,13 +20,18 @@ class BondEntity(Entity):
     """Generic Bond entity encapsulating common features of any Bond controlled device."""
 
     def __init__(
-        self, hub: BondHub, device: BondDevice, sub_device: Optional[str] = None
+        self,
+        hub: BondHub,
+        device: BondDevice,
+        bpup_subs: BPUPSubscriptions,
+        sub_device: Optional[str] = None,
     ):
         """Initialize entity with API and device info."""
         self._hub = hub
         self._device = device
         self._sub_device = sub_device
         self._available = True
+        self._bpup_subs = bpup_subs
 
     @property
     def unique_id(self) -> Optional[str]:
@@ -75,6 +81,9 @@ class BondEntity(Entity):
 
     async def async_update(self):
         """Fetch assumed state of the cover from the hub using API."""
+        if self._bpup_subs.alive:
+            return
+
         try:
             state: dict = await self._hub.bond.device_state(self._device.device_id)
         except (ClientError, AsyncIOTimeoutError, OSError) as error:
@@ -93,3 +102,19 @@ class BondEntity(Entity):
     @abstractmethod
     def _apply_state(self, state: dict):
         raise NotImplementedError
+
+    def _bpup_callback(self, state):
+        """Process a BPUP state change."""
+        self._available = True
+        self._apply_state(state)
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Subscribe to BPUP."""
+        await super().async_added_to_hass()
+        self._bpup_subs.subscribe(self._device.device_id, self._bpup_callback)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from BPUP data on remove."""
+        await super().async_will_remove_from_hass()
+        self._bpup_subs.unsubscribe(self._device.device_id, self._bpup_callback)

--- a/homeassistant/components/bond/manifest.json
+++ b/homeassistant/components/bond/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bond",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bond",
-  "requirements": ["bond-api==0.1.8"],
+  "requirements": ["bond-api==0.1.9"],
   "zeroconf": ["_bond._tcp.local."],
   "codeowners": ["@prystupa"],
   "quality_scale": "platinum"

--- a/homeassistant/components/bond/switch.py
+++ b/homeassistant/components/bond/switch.py
@@ -1,14 +1,14 @@
 """Support for Bond generic devices."""
 from typing import Any, Callable, List, Optional
 
-from bond_api import Action, DeviceType
+from bond_api import Action, BPUPSubscriptions, DeviceType
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 
-from .const import DOMAIN
+from .const import BPUP_SUBS, DOMAIN, HUB
 from .entity import BondEntity
 from .utils import BondDevice, BondHub
 
@@ -19,10 +19,12 @@ async def async_setup_entry(
     async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:
     """Set up Bond generic devices."""
-    hub: BondHub = hass.data[DOMAIN][entry.entry_id]
+    data = hass.data[DOMAIN][entry.entry_id]
+    hub: BondHub = data[HUB]
+    bpup_subs: BPUPSubscriptions = data[BPUP_SUBS]
 
     switches = [
-        BondSwitch(hub, device)
+        BondSwitch(hub, device, bpup_subs)
         for device in hub.devices
         if DeviceType.is_generic(device.type)
     ]
@@ -33,9 +35,9 @@ async def async_setup_entry(
 class BondSwitch(BondEntity, SwitchEntity):
     """Representation of a Bond generic device."""
 
-    def __init__(self, hub: BondHub, device: BondDevice):
+    def __init__(self, hub: BondHub, device: BondDevice, bpup_subs: BPUPSubscriptions):
         """Create HA entity representing Bond generic device (switch)."""
-        super().__init__(hub, device)
+        super().__init__(hub, device, bpup_subs)
 
         self._power: Optional[bool] = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -367,7 +367,7 @@ blockchain==1.4.4
 # bme680==1.0.5
 
 # homeassistant.components.bond
-bond-api==0.1.8
+bond-api==0.1.9
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -201,7 +201,7 @@ blebox_uniapi==1.3.2
 blinkpy==0.16.4
 
 # homeassistant.components.bond
-bond-api==0.1.8
+bond-api==0.1.9
 
 # homeassistant.components.braviatv
 bravia-tv==1.0.8

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -3,7 +3,7 @@ from asyncio import TimeoutError as AsyncIOTimeoutError
 from contextlib import nullcontext
 from datetime import timedelta
 from typing import Any, Dict, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from homeassistant import core
 from homeassistant.components.bond.const import DOMAIN as BOND_DOMAIN
@@ -33,9 +33,11 @@ async def setup_bond_entity(
     """Set up Bond entity."""
     config_entry.add_to_hass(hass)
 
-    with patch_bond_version(enabled=patch_version), patch_bond_device_ids(
-        enabled=patch_device_ids
-    ), patch_setup_entry("cover", enabled=patch_platforms), patch_setup_entry(
+    with patch_start_bpup(), patch_bond_version(
+        enabled=patch_version
+    ), patch_bond_device_ids(enabled=patch_device_ids), patch_setup_entry(
+        "cover", enabled=patch_platforms
+    ), patch_setup_entry(
         "fan", enabled=patch_platforms
     ), patch_setup_entry(
         "light", enabled=patch_platforms
@@ -65,7 +67,7 @@ async def setup_platform(
     with patch("homeassistant.components.bond.PLATFORMS", [platform]):
         with patch_bond_version(return_value=bond_version), patch_bond_device_ids(
             return_value=[bond_device_id]
-        ), patch_bond_device(
+        ), patch_start_bpup(), patch_bond_device(
             return_value=discovered_device
         ), patch_bond_device_properties(
             return_value=props
@@ -115,6 +117,14 @@ def patch_bond_device(return_value=None):
     return patch(
         "homeassistant.components.bond.Bond.device",
         return_value=return_value,
+    )
+
+
+def patch_start_bpup():
+    """Patch start_bpup."""
+    return patch(
+        "homeassistant.components.bond.start_bpup",
+        return_value=MagicMock(),
     )
 
 

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -20,6 +20,7 @@ from .common import (
     patch_bond_device_state,
     patch_bond_version,
     patch_setup_entry,
+    patch_start_bpup,
     setup_bond_entity,
 )
 
@@ -141,7 +142,7 @@ async def test_old_identifiers_are_removed(hass: HomeAssistant):
             "target": "test-model",
             "fw_ver": "test-version",
         }
-    ), patch_bond_device_ids(
+    ), patch_start_bpup(), patch_bond_device_ids(
         return_value=["bond-device-id", "device_id"]
     ), patch_bond_device(
         return_value={


### PR DESCRIPTION
Changelog: https://github.com/prystupa/bond-api/compare/v0.1.8...v0.1.9

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Add BPUP (push updates) support to bond.

http://docs-local.appbond.com/#section/Bond-Push-UDP-Protocol-(BPUP)

Automatically falls back to polling if BPUP is no longer alive.

Updates are close to instant.  Demo is with the bond app open a Home Assistant exporting the fan to homekit.

Note that the examples use the new entity model which support > 3 speeds from https://github.com/home-assistant/core/pull/45407

Before:
![FhScKNa7qy](https://user-images.githubusercontent.com/663432/105793905-944c1000-5f4f-11eb-8653-f81aebe49473.gif)

After:
![m2fSMLYOuJ](https://user-images.githubusercontent.com/663432/105793893-901ff280-5f4f-11eb-8afa-84dda2054243.gif)

..and in the Home Assistant UI
![nT0vs9V8KW](https://user-images.githubusercontent.com/663432/105794827-6d8ed900-5f51-11eb-8d9b-95444347bb82.gif)




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16441

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
