### PR TITLE
Add override duration for genius hub switches

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -73,6 +73,17 @@ ATTR_DURATION = "duration"
 
 SVC_SET_ZONE_MODE = "set_zone_mode"
 SVC_SET_ZONE_OVERRIDE = "set_zone_override"
+SVC_SET_SWITCH_OVERRIDE = "set_switch_override"
+
+SET_SWITCH_OVERRIDE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Required(ATTR_DURATION): vol.All(
+            cv.time_period,
+            vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+        ),
+    }
+)
 
 SET_ZONE_MODE_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -78,7 +78,7 @@ SVC_SET_SWITCH_OVERRIDE = "set_switch_override"
 SET_SWITCH_OVERRIDE_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-        vol.Required(ATTR_DURATION): vol.All(
+        vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
             vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
         ),
@@ -162,6 +162,33 @@ def setup_service_functions(hass: HomeAssistantType, broker):
         }
 
         async_dispatcher_send(hass, DOMAIN, payload)
+
+    async def set_switch_override(call) -> None:
+        """Set the system mode."""
+        entity_id = call.data[ATTR_ENTITY_ID]
+
+        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry_entry = registry.async_get(entity_id)
+
+        if registry_entry is None or registry_entry.platform != DOMAIN:
+            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
+
+        if registry_entry.domain != "switch":
+            raise ValueError(f"'{entity_id}' is not an {DOMAIN} zone")
+
+        payload = {
+            "unique_id": registry_entry.unique_id,
+            "service": call.service,
+            "data": call.data,
+        }
+        async_dispatcher_send(hass, DOMAIN, payload)
+
+    hass.services.async_register(
+        DOMAIN,
+        SVC_SET_SWITCH_OVERRIDE,
+        set_switch_override,
+        schema=SET_SWITCH_OVERRIDE_SCHEMA,
+    )
 
     hass.services.async_register(
         DOMAIN, SVC_SET_ZONE_MODE, set_zone_mode, schema=SET_ZONE_MODE_SCHEMA

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -73,17 +73,6 @@ ATTR_DURATION = "duration"
 
 SVC_SET_ZONE_MODE = "set_zone_mode"
 SVC_SET_ZONE_OVERRIDE = "set_zone_override"
-SVC_SET_SWITCH_OVERRIDE = "set_switch_override"
-
-SET_SWITCH_OVERRIDE_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-        vol.Optional(ATTR_DURATION): vol.All(
-            cv.time_period,
-            vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
-        ),
-    }
-)
 
 SET_ZONE_MODE_SCHEMA = vol.Schema(
     {
@@ -162,33 +151,6 @@ def setup_service_functions(hass: HomeAssistantType, broker):
         }
 
         async_dispatcher_send(hass, DOMAIN, payload)
-
-    async def set_switch_override(call) -> None:
-        """Set the system mode."""
-        entity_id = call.data[ATTR_ENTITY_ID]
-
-        registry = await hass.helpers.entity_registry.async_get_registry()
-        registry_entry = registry.async_get(entity_id)
-
-        if registry_entry is None or registry_entry.platform != DOMAIN:
-            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
-
-        if registry_entry.domain != "switch":
-            raise ValueError(f"'{entity_id}' is not an {DOMAIN} zone")
-
-        payload = {
-            "unique_id": registry_entry.unique_id,
-            "service": call.service,
-            "data": call.data,
-        }
-        async_dispatcher_send(hass, DOMAIN, payload)
-
-    hass.services.async_register(
-        DOMAIN,
-        SVC_SET_SWITCH_OVERRIDE,
-        set_switch_override,
-        schema=SET_SWITCH_OVERRIDE_SCHEMA,
-    )
 
     hass.services.async_register(
         DOMAIN, SVC_SET_ZONE_MODE, set_zone_mode, schema=SET_ZONE_MODE_SCHEMA

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -26,3 +26,15 @@ set_zone_override:
       description: >-
         The duration of the override. Optional, default 1 hour, maximum 24 hours.
       example: '{"minutes": 135}'
+
+set_switch_override:
+  description: >-
+    Override the switches for a given duration.
+  fields:
+    entity_id:
+      description: The zone's entity_id.
+      example: switch.bathroom
+    duration:
+      description: >-
+        The duration of the override. Optional, default 1 hour, maximum 24 hours.
+      example: '{"minutes": 135}'

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -29,7 +29,7 @@ set_zone_override:
 
 set_switch_override:
   description: >-
-    Override switche for a given duration.
+    Override switch for a given duration.
   fields:
     entity_id:
       description: The zone's entity_id.

--- a/homeassistant/components/geniushub/services.yaml
+++ b/homeassistant/components/geniushub/services.yaml
@@ -29,11 +29,11 @@ set_zone_override:
 
 set_switch_override:
   description: >-
-    Override the switches for a given duration.
+    Override switche for a given duration.
   fields:
     entity_id:
       description: The zone's entity_id.
-      example: switch.bathroom
+      example: switch.study
     duration:
       description: >-
         The duration of the override. Optional, default 1 hour, maximum 24 hours.

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -1,17 +1,14 @@
 """Support for Genius Hub switch/outlet devices."""
-from homeassistant.components.switch import DEVICE_CLASS_OUTLET, SwitchEntity
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
-import voluptuous as vol
-from homeassistant.helpers import config_validation as cv
 from datetime import timedelta
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_send,
-)
 from typing import Optional
 
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-)
+import voluptuous as vol
+
+from homeassistant.components.switch import DEVICE_CLASS_OUTLET, SwitchEntity
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import (
     ATTR_DURATION,

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -35,33 +35,6 @@ async def async_setup_platform(
         ]
     )
 
-    async def set_switch_override(call) -> None:
-        """Set the system mode."""
-        entity_id = call.data[ATTR_ENTITY_ID]
-
-        registry = await hass.helpers.entity_registry.async_get_registry()
-        registry_entry = registry.async_get(entity_id)
-
-        if registry_entry is None or registry_entry.platform != DOMAIN:
-            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
-
-        if registry_entry.domain != "switch":
-            raise ValueError(f"'{entity_id}' is not an {DOMAIN} zone")
-
-        payload = {
-            "unique_id": registry_entry.unique_id,
-            "service": call.service,
-            "data": call.data,
-        }
-        async_dispatcher_send(hass, DOMAIN, payload)
-
-    hass.services.async_register(
-        DOMAIN,
-        SVC_SET_SWITCH_OVERRIDE,
-        set_switch_override,
-        schema=SET_SWITCH_OVERRIDE_SCHEMA,
-    )
-
 
 class GeniusSwitch(GeniusZone, SwitchEntity):
     """Representation of a Genius Hub switch."""

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -5,12 +5,7 @@ from typing import Optional
 from homeassistant.components.switch import DEVICE_CLASS_OUTLET, SwitchEntity
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from . import (
-    ATTR_DURATION,
-    DOMAIN,
-    SVC_SET_SWITCH_OVERRIDE,
-    GeniusZone,
-)
+from . import ATTR_DURATION, DOMAIN, SVC_SET_SWITCH_OVERRIDE, GeniusZone
 
 GH_ON_OFF_ZONE = "on / off"
 

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -2,11 +2,8 @@
 from datetime import timedelta
 from typing import Optional
 
-import voluptuous as vol
-
 from homeassistant.components.switch import DEVICE_CLASS_OUTLET, SwitchEntity
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -3,14 +3,11 @@ from datetime import timedelta
 from typing import Optional
 
 from homeassistant.components.switch import DEVICE_CLASS_OUTLET, SwitchEntity
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import (
     ATTR_DURATION,
     DOMAIN,
-    SET_SWITCH_OVERRIDE_SCHEMA,
     SVC_SET_SWITCH_OVERRIDE,
     GeniusZone,
 )

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -1,15 +1,11 @@
 """Support for Genius Hub switch/outlet devices."""
 from datetime import timedelta
-from typing import Optional
 
 import voluptuous as vol
 
 from homeassistant.components.switch import DEVICE_CLASS_OUTLET, SwitchEntity
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.service import verify_domain_control
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import ATTR_DURATION, DOMAIN, GeniusZone
@@ -46,39 +42,13 @@ async def async_setup_platform(
         ]
     )
 
-    setup_service_functions(hass, broker)
+    # Register custom services
+    platform = entity_platform.current_platform.get()
 
-
-@callback
-def setup_service_functions(hass: HomeAssistantType, broker):
-    """Set up the service functions."""
-
-    @verify_domain_control(hass, DOMAIN)
-    async def set_switch_override(call) -> None:
-        """Set the system mode."""
-        entity_id = call.data[ATTR_ENTITY_ID]
-
-        registry = await hass.helpers.entity_registry.async_get_registry()
-        registry_entry = registry.async_get(entity_id)
-
-        if registry_entry is None or registry_entry.platform != DOMAIN:
-            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
-
-        if registry_entry.domain != "switch":
-            raise ValueError(f"'{entity_id}' is not an {DOMAIN} zone")
-
-        payload = {
-            "unique_id": registry_entry.unique_id,
-            "service": call.service,
-            "data": call.data,
-        }
-        async_dispatcher_send(hass, DOMAIN, payload)
-
-    hass.services.async_register(
-        DOMAIN,
+    platform.async_register_entity_service(
         SVC_SET_SWITCH_OVERRIDE,
-        set_switch_override,
-        schema=SET_SWITCH_OVERRIDE_SCHEMA,
+        SET_SWITCH_OVERRIDE_SCHEMA,
+        "async_turn_on",
     )
 
 
@@ -89,23 +59,6 @@ class GeniusSwitch(GeniusZone, SwitchEntity):
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
         return DEVICE_CLASS_OUTLET
-
-    async def _refresh(self, payload: Optional[dict] = None) -> None:
-        """Process any signals."""
-        if payload is None:
-            self.async_schedule_update_ha_state(force_refresh=True)
-            return
-
-        if payload["unique_id"] != self._unique_id:
-            return
-
-        if payload["service"] == SVC_SET_SWITCH_OVERRIDE:
-            duration = payload["data"].get(ATTR_DURATION, timedelta(hours=1))
-
-            await self._zone.set_override(1, int(duration.total_seconds()))
-            return
-
-        raise TypeError(f"'{self.entity_id}' is not a geniushub switch")
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change
<!--
Add service 'geniushub.set_switch_override' to override the default duration of one hour.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR adds a new service to allow the duration of a switch to be changed. 
- This is a non-breaking change as it is adding a new service
- No changes are required to the configuration file

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
