### PR TITLE
Change update interval tests in AccuWeather integration

### DIFF
--- a/tests/components/accuweather/test_init.py
+++ b/tests/components/accuweather/test_init.py
@@ -1,18 +1,20 @@
 """Test init of AccuWeather integration."""
 from datetime import timedelta
+import json
 from unittest.mock import patch
 
 from accuweather import ApiError
 
-from homeassistant.components.accuweather.const import COORDINATOR, DOMAIN
+from homeassistant.components.accuweather.const import DOMAIN
 from homeassistant.config_entries import (
     ENTRY_STATE_LOADED,
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_RETRY,
 )
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.util.dt import utcnow
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 from tests.components.accuweather import init_integration
 
 
@@ -65,19 +67,45 @@ async def test_unload_entry(hass):
 
 async def test_update_interval(hass):
     """Test correct update interval."""
-    entry = await init_integration(hass)
+    await init_integration(hass)
 
-    assert entry.state == ENTRY_STATE_LOADED
-    assert hass.data[DOMAIN][entry.entry_id][COORDINATOR].update_interval == timedelta(
-        minutes=40
-    )
+    current = json.loads(load_fixture("accuweather/current_conditions_data.json"))
+    future = utcnow() + timedelta(minutes=40)
+
+    with patch(
+        "homeassistant.components.accuweather.AccuWeather.async_get_current_conditions",
+        return_value=current,
+    ) as mock_current:
+
+        assert mock_current.call_count == 0
+
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        assert mock_current.call_count == 1
 
 
 async def test_update_interval_forecast(hass):
     """Test correct update interval when forecast is True."""
-    entry = await init_integration(hass, forecast=True)
+    await init_integration(hass, forecast=True)
 
-    assert entry.state == ENTRY_STATE_LOADED
-    assert hass.data[DOMAIN][entry.entry_id][COORDINATOR].update_interval == timedelta(
-        minutes=80
-    )
+    current = json.loads(load_fixture("accuweather/current_conditions_data.json"))
+    forecast = json.loads(load_fixture("accuweather/forecast_data.json"))
+    future = utcnow() + timedelta(minutes=80)
+
+    with patch(
+        "homeassistant.components.accuweather.AccuWeather.async_get_current_conditions",
+        return_value=current,
+    ) as mock_current, patch(
+        "homeassistant.components.accuweather.AccuWeather.async_get_forecast",
+        return_value=forecast,
+    ) as mock_forecast:
+
+        assert mock_current.call_count == 0
+        assert mock_forecast.call_count == 0
+
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        assert mock_current.call_count == 1
+        assert mock_forecast.call_count == 1

--- a/tests/components/accuweather/test_init.py
+++ b/tests/components/accuweather/test_init.py
@@ -67,7 +67,9 @@ async def test_unload_entry(hass):
 
 async def test_update_interval(hass):
     """Test correct update interval."""
-    await init_integration(hass)
+    entry = await init_integration(hass)
+
+    assert entry.state == ENTRY_STATE_LOADED
 
     current = json.loads(load_fixture("accuweather/current_conditions_data.json"))
     future = utcnow() + timedelta(minutes=40)
@@ -87,7 +89,9 @@ async def test_update_interval(hass):
 
 async def test_update_interval_forecast(hass):
     """Test correct update interval when forecast is True."""
-    await init_integration(hass, forecast=True)
+    entry = await init_integration(hass, forecast=True)
+
+    assert entry.state == ENTRY_STATE_LOADED
 
     current = json.loads(load_fixture("accuweather/current_conditions_data.json"))
     forecast = json.loads(load_fixture("accuweather/forecast_data.json"))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes `update_interval` tests as suggested here https://github.com/home-assistant/core/pull/44984#discussion_r561367569

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
