### PR TITLE
Add significant change filtering to Google

### DIFF
--- a/homeassistant/components/google_assistant/report_state.py
+++ b/homeassistant/components/google_assistant/report_state.py
@@ -85,4 +85,5 @@ def async_enable_report_state(hass: HomeAssistant, google_config: AbstractConfig
 
     unsub = async_call_later(hass, INITIAL_REPORT_DELAY, inital_report)
 
+    # pylint: disable=unnecessary-lambda
     return lambda: unsub()

--- a/homeassistant/components/google_assistant/report_state.py
+++ b/homeassistant/components/google_assistant/report_state.py
@@ -4,7 +4,9 @@ import logging
 from homeassistant.const import MATCH_ALL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.significant_change import create_checker
 
+from .const import DOMAIN
 from .error import SmartHomeError
 from .helpers import AbstractConfig, GoogleEntity, async_get_entities
 
@@ -19,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 @callback
 def async_enable_report_state(hass: HomeAssistant, google_config: AbstractConfig):
     """Enable state reporting."""
+    checker = None
 
     async def async_entity_state_listener(changed_entity, old_state, new_state):
         if not hass.is_running:
@@ -35,24 +38,14 @@ def async_enable_report_state(hass: HomeAssistant, google_config: AbstractConfig
         if not entity.is_supported():
             return
 
+        if not checker.async_is_significant_change(new_state):
+            return
+
         try:
             entity_data = entity.query_serialize()
         except SmartHomeError as err:
             _LOGGER.debug("Not reporting state for %s: %s", changed_entity, err.code)
             return
-
-        if old_state:
-            old_entity = GoogleEntity(hass, google_config, old_state)
-
-            # Only report to Google if data that Google cares about has changed
-            try:
-                if entity_data == old_entity.query_serialize():
-                    return
-            except SmartHomeError:
-                # Happens if old state could not be serialized.
-                # In that case the data is different and should be
-                # reported.
-                pass
 
         _LOGGER.debug("Reporting state for %s: %s", changed_entity, entity_data)
 
@@ -62,10 +55,18 @@ def async_enable_report_state(hass: HomeAssistant, google_config: AbstractConfig
 
     async def inital_report(_now):
         """Report initially all states."""
+        nonlocal unsub, checker
         entities = {}
+
+        checker = await create_checker(hass, DOMAIN)
 
         for entity in async_get_entities(hass, google_config):
             if not entity.should_expose():
+                continue
+
+            # Tell our significant change checker that we're reporting
+            # So it knows with subsequent changes what was already reported.
+            if not checker.async_is_significant_change(entity.state):
                 continue
 
             try:
@@ -78,8 +79,10 @@ def async_enable_report_state(hass: HomeAssistant, google_config: AbstractConfig
 
         await google_config.async_report_state_all({"devices": {"states": entities}})
 
-    async_call_later(hass, INITIAL_REPORT_DELAY, inital_report)
+        unsub = hass.helpers.event.async_track_state_change(
+            MATCH_ALL, async_entity_state_listener
+        )
 
-    return hass.helpers.event.async_track_state_change(
-        MATCH_ALL, async_entity_state_listener
-    )
+    unsub = async_call_later(hass, INITIAL_REPORT_DELAY, inital_report)
+
+    return lambda: unsub()

--- a/homeassistant/components/sensor/significant_change.py
+++ b/homeassistant/components/sensor/significant_change.py
@@ -6,12 +6,13 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     TEMP_FAHRENHEIT,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 
 from . import DEVICE_CLASS_BATTERY, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE
 
 
-async def async_check_significant_change(
+@callback
+def async_check_significant_change(
     hass: HomeAssistant,
     old_state: str,
     old_attrs: dict,

--- a/homeassistant/components/switch/significant_change.py
+++ b/homeassistant/components/switch/significant_change.py
@@ -1,7 +1,6 @@
-"""Helper to test significant NEW_NAME state changes."""
+"""Helper to test significant Switch state changes."""
 from typing import Any, Optional
 
-from homeassistant.const import ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant, callback
 
 
@@ -15,9 +14,4 @@ def async_check_significant_change(
     **kwargs: Any,
 ) -> Optional[bool]:
     """Test if state significantly changed."""
-    device_class = new_attrs.get(ATTR_DEVICE_CLASS)
-
-    if device_class is None:
-        return None
-
-    return None
+    return old_state != new_state

--- a/tests/components/google_assistant/test_report_state.py
+++ b/tests/components/google_assistant/test_report_state.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.google_assistant import error, report_state
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from . import BASIC_CONFIG
@@ -11,6 +12,7 @@ from tests.common import async_fire_time_changed
 
 async def test_report_state(hass, caplog, legacy_patchable_time):
     """Test report state works."""
+    assert await async_setup_component(hass, "switch", {})
     hass.states.async_set("light.ceiling", "off")
     hass.states.async_set("switch.ac", "on")
 
@@ -44,14 +46,11 @@ async def test_report_state(hass, caplog, legacy_patchable_time):
         "devices": {"states": {"light.kitchen": {"on": True, "online": True}}}
     }
 
-    # Test that state changes that change something that Google doesn't care about
-    # do not trigger a state report.
+    # Test that only significant state changes are reported
     with patch.object(
         BASIC_CONFIG, "async_report_state_all", AsyncMock()
     ) as mock_report:
-        hass.states.async_set(
-            "light.kitchen", "on", {"irrelevant": "should_be_ignored"}
-        )
+        hass.states.async_set("switch.ac", "on", {"something": "else"})
         await hass.async_block_till_done()
 
     assert len(mock_report.mock_calls) == 0

--- a/tests/components/sensor/test_significant_change.py
+++ b/tests/components/sensor/test_significant_change.py
@@ -19,13 +19,13 @@ async def test_significant_change_temperature():
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
     }
-    assert not await async_check_significant_change(
+    assert not async_check_significant_change(
         None, "12", celsius_attrs, "12", celsius_attrs
     )
-    assert await async_check_significant_change(
+    assert async_check_significant_change(
         None, "12", celsius_attrs, "13", celsius_attrs
     )
-    assert not await async_check_significant_change(
+    assert not async_check_significant_change(
         None, "12.1", celsius_attrs, "12.2", celsius_attrs
     )
 
@@ -33,10 +33,10 @@ async def test_significant_change_temperature():
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT,
     }
-    assert await async_check_significant_change(
+    assert async_check_significant_change(
         None, "70", freedom_attrs, "74", freedom_attrs
     )
-    assert not await async_check_significant_change(
+    assert not async_check_significant_change(
         None, "70", freedom_attrs, "71", freedom_attrs
     )
 
@@ -46,8 +46,8 @@ async def test_significant_change_battery():
     attrs = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
     }
-    assert not await async_check_significant_change(None, "100", attrs, "100", attrs)
-    assert await async_check_significant_change(None, "100", attrs, "97", attrs)
+    assert not async_check_significant_change(None, "100", attrs, "100", attrs)
+    assert async_check_significant_change(None, "100", attrs, "97", attrs)
 
 
 async def test_significant_change_humidity():
@@ -55,5 +55,5 @@ async def test_significant_change_humidity():
     attrs = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
     }
-    assert not await async_check_significant_change(None, "100", attrs, "100", attrs)
-    assert await async_check_significant_change(None, "100", attrs, "97", attrs)
+    assert not async_check_significant_change(None, "100", attrs, "100", attrs)
+    assert async_check_significant_change(None, "100", attrs, "97", attrs)

--- a/tests/components/switch/test_significant_change.py
+++ b/tests/components/switch/test_significant_change.py
@@ -1,0 +1,12 @@
+"""Test the sensor significant change platform."""
+from homeassistant.components.switch.significant_change import (
+    async_check_significant_change,
+)
+
+
+async def test_significant_change():
+    """Detect Switch significant change."""
+    attrs = {}
+    assert not async_check_significant_change(None, "on", attrs, "on", attrs)
+    assert not async_check_significant_change(None, "off", attrs, "off", attrs)
+    assert async_check_significant_change(None, "on", attrs, "off", attrs)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds significant change filtering to Google. 

Also adds the switch significant change platform. 

Realized scaffolding accidentally marked the function as async, it should be callback. Fixed that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
