### PR TITLE
Use shared httpx client in gogogate2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -179,7 +179,7 @@ homeassistant/components/gios/* @bieniu
 homeassistant/components/gitter/* @fabaff
 homeassistant/components/glances/* @fabaff @engrbm87
 homeassistant/components/goalzero/* @tkdrob
-homeassistant/components/gogogate2/* @vangorra
+homeassistant/components/gogogate2/* @vangorra @bdraco
 homeassistant/components/google_assistant/* @home-assistant/cloud
 homeassistant/components/google_cloud/* @lufton
 homeassistant/components/gpsd/* @fabaff

--- a/homeassistant/components/gogogate2/common.py
+++ b/homeassistant/components/gogogate2/common.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -112,7 +113,7 @@ def get_data_update_coordinator(
     config_entry_data = hass.data[DOMAIN][config_entry.entry_id]
 
     if DATA_UPDATE_COORDINATOR not in config_entry_data:
-        api = get_api(config_entry.data)
+        api = get_api(hass, config_entry.data)
 
         async def async_update_data():
             try:
@@ -148,7 +149,7 @@ def sensor_unique_id(
     return f"{config_entry.unique_id}_{door.door_id}_{sensor_type}"
 
 
-def get_api(config_data: dict) -> AbstractGateApi:
+def get_api(hass: HomeAssistant, config_data: dict) -> AbstractGateApi:
     """Get an api object for config data."""
     gate_class = GogoGate2Api
 
@@ -159,4 +160,5 @@ def get_api(config_data: dict) -> AbstractGateApi:
         config_data[CONF_IP_ADDRESS],
         config_data[CONF_USERNAME],
         config_data[CONF_PASSWORD],
+        httpx_async_client=get_async_client(hass),
     )

--- a/homeassistant/components/gogogate2/common.py
+++ b/homeassistant/components/gogogate2/common.py
@@ -6,8 +6,8 @@ from datetime import timedelta
 import logging
 from typing import Callable, NamedTuple
 
-from gogogate2_api import AbstractGateApi, GogoGate2Api, ISmartGateApi
-from gogogate2_api.common import AbstractDoor, get_door_by_id
+from ismartgate import AbstractGateApi, GogoGate2Api, ISmartGateApi
+from ismartgate.common import AbstractDoor, get_door_by_id
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/homeassistant/components/gogogate2/config_flow.py
+++ b/homeassistant/components/gogogate2/config_flow.py
@@ -2,8 +2,8 @@
 import dataclasses
 import re
 
-from gogogate2_api.common import AbstractInfoResponse, ApiError
-from gogogate2_api.const import GogoGate2ApiErrorCode, ISmartGateApiErrorCode
+from ismartgate.common import AbstractInfoResponse, ApiError
+from ismartgate.const import GogoGate2ApiErrorCode, ISmartGateApiErrorCode
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigFlow

--- a/homeassistant/components/gogogate2/config_flow.py
+++ b/homeassistant/components/gogogate2/config_flow.py
@@ -55,7 +55,7 @@ class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input:
-            api = get_api(user_input)
+            api = get_api(self.hass, user_input)
             try:
                 data: AbstractInfoResponse = await api.async_info()
                 data_dict = dataclasses.asdict(data)

--- a/homeassistant/components/gogogate2/cover.py
+++ b/homeassistant/components/gogogate2/cover.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from gogogate2_api.common import AbstractDoor, DoorStatus, get_configured_doors
+from ismartgate.common import AbstractDoor, DoorStatus, get_configured_doors
 
 from homeassistant.components.cover import (
     DEVICE_CLASS_GARAGE,

--- a/homeassistant/components/gogogate2/manifest.json
+++ b/homeassistant/components/gogogate2/manifest.json
@@ -3,8 +3,8 @@
   "name": "Gogogate2 and iSmartGate",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gogogate2",
-  "requirements": ["gogogate2-api==3.0.0"],
-  "codeowners": ["@vangorra"],
+  "requirements": ["ismartgate==4.0.0"],
+  "codeowners": ["@vangorra", "@bdraco"],
   "homekit": {
     "models": ["iSmartGate"]
   },

--- a/homeassistant/components/gogogate2/sensor.py
+++ b/homeassistant/components/gogogate2/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from itertools import chain
 
-from gogogate2_api.common import AbstractDoor, get_configured_doors
+from ismartgate.common import AbstractDoor, get_configured_doors
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -671,9 +671,6 @@ gntp==1.0.3
 # homeassistant.components.goalzero
 goalzero==0.1.7
 
-# homeassistant.components.gogogate2
-gogogate2-api==3.0.0
-
 # homeassistant.components.google
 google-api-python-client==1.6.4
 
@@ -832,6 +829,9 @@ influxdb==5.2.3
 
 # homeassistant.components.iperf3
 iperf3==0.1.11
+
+# homeassistant.components.gogogate2
+ismartgate==4.0.0
 
 # homeassistant.components.rest
 jsonpath==0.82

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -368,9 +368,6 @@ glances_api==0.2.0
 # homeassistant.components.goalzero
 goalzero==0.1.7
 
-# homeassistant.components.gogogate2
-gogogate2-api==3.0.0
-
 # homeassistant.components.google
 google-api-python-client==1.6.4
 
@@ -461,6 +458,9 @@ influxdb-client==1.14.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.3
+
+# homeassistant.components.gogogate2
+ismartgate==4.0.0
 
 # homeassistant.components.rest
 jsonpath==0.82

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -1,9 +1,9 @@
 """Tests for the GogoGate2 component."""
 from unittest.mock import MagicMock, patch
 
-from gogogate2_api import GogoGate2Api
-from gogogate2_api.common import ApiError
-from gogogate2_api.const import GogoGate2ApiErrorCode
+from ismartgate import GogoGate2Api
+from ismartgate.common import ApiError
+from ismartgate.const import GogoGate2ApiErrorCode
 
 from homeassistant import config_entries, setup
 from homeassistant.components.gogogate2.const import (

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -2,8 +2,8 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from gogogate2_api import GogoGate2Api, ISmartGateApi
-from gogogate2_api.common import (
+from ismartgate import GogoGate2Api, ISmartGateApi
+from ismartgate.common import (
     ApiError,
     DoorMode,
     DoorStatus,

--- a/tests/components/gogogate2/test_init.py
+++ b/tests/components/gogogate2/test_init.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest.mock import MagicMock, patch
 
-from gogogate2_api import GogoGate2Api
+from ismartgate import GogoGate2Api
 import pytest
 
 from homeassistant.components.gogogate2 import DEVICE_TYPE_GOGOGATE2, async_setup_entry

--- a/tests/components/gogogate2/test_sensor.py
+++ b/tests/components/gogogate2/test_sensor.py
@@ -2,8 +2,8 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from gogogate2_api import GogoGate2Api, ISmartGateApi
-from gogogate2_api.common import (
+from ismartgate import GogoGate2Api, ISmartGateApi
+from ismartgate.common import (
     DoorMode,
     DoorStatus,
     GogoGate2ActivateResponse,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use shared httpx client in gogogate2

Get the integration closer to `platinum` by using the shared httpx (https://github.com/home-assistant/developers.home-assistant/pull/778)
https://developers.home-assistant.io/docs/integration_quality_scale_index/#platinum-

I ended up forking the pypi since PRs went stale since Jan. The only changes are: ( https://github.com/vangorra/python_gogogate2_api/pull/26 &  https://github.com/vangorra/python_gogogate2_api/pull/25)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
