### PR TITLE
Add reauthentication flow to fritzbox integration

### DIFF
--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -85,7 +85,7 @@ async def async_setup_entry(hass, entry):
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": SOURCE_REAUTH},
-                data=entry.data,
+                data=entry,
             )
         )
         return False

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -2,9 +2,10 @@
 import asyncio
 import socket
 
-from pyfritzhome import Fritzhome
+from pyfritzhome import Fritzhome, LoginError
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH
 from homeassistant.const import (
     CONF_DEVICES,
     CONF_HOST,
@@ -62,7 +63,7 @@ async def async_setup(hass, config):
         for entry_config in config[DOMAIN][CONF_DEVICES]:
             hass.async_create_task(
                 hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": "import"}, data=entry_config
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry_config
                 )
             )
 
@@ -76,7 +77,18 @@ async def async_setup_entry(hass, entry):
         user=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
     )
-    await hass.async_add_executor_job(fritz.login)
+
+    try:
+        await hass.async_add_executor_job(fritz.login)
+    except LoginError:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_REAUTH},
+                data=entry.data,
+            )
+        )
+        return False
 
     hass.data.setdefault(DOMAIN, {CONF_CONNECTIONS: {}, CONF_DEVICES: set()})
     hass.data[DOMAIN][CONF_CONNECTIONS][entry.entry_id] = fritz

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -47,6 +47,7 @@ class FritzboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize flow."""
+        self._entry = None
         self._host = None
         self._name = None
         self._password = None
@@ -63,17 +64,16 @@ class FritzboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _update_entry(self):
-        for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data[CONF_HOST] == self._host:
-                self.hass.config_entries.async_update_entry(
-                    entry,
-                    data={
-                        CONF_HOST: self._host,
-                        CONF_PASSWORD: self._password,
-                        CONF_USERNAME: self._username,
-                    },
-                )
-                await self.hass.config_entries.async_reload(entry.entry_id)
+        if self._entry is not None:
+            self.hass.config_entries.async_update_entry(
+                self._entry,
+                data={
+                    CONF_HOST: self._host,
+                    CONF_PASSWORD: self._password,
+                    CONF_USERNAME: self._username,
+                },
+            )
+            await self.hass.config_entries.async_reload(self._entry.entry_id)
 
     def _try_connect(self):
         """Try to connect and check auth."""
@@ -174,11 +174,12 @@ class FritzboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_reauth(self, config):
+    async def async_step_reauth(self, entry):
         """Trigger a reauthentication flow."""
-        self._host = config[CONF_HOST]
-        self._name = config[CONF_HOST]
-        self._username = config[CONF_USERNAME]
+        self._entry = entry
+        self._host = entry.data[CONF_HOST]
+        self._name = entry.data[CONF_HOST]
+        self._username = entry.data[CONF_USERNAME]
 
         return await self.async_step_reauth_confirm()
 

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -64,16 +64,15 @@ class FritzboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _update_entry(self):
-        if self._entry is not None:
-            self.hass.config_entries.async_update_entry(
-                self._entry,
-                data={
-                    CONF_HOST: self._host,
-                    CONF_PASSWORD: self._password,
-                    CONF_USERNAME: self._username,
-                },
-            )
-            await self.hass.config_entries.async_reload(self._entry.entry_id)
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            data={
+                CONF_HOST: self._host,
+                CONF_PASSWORD: self._password,
+                CONF_USERNAME: self._username,
+            },
+        )
+        await self.hass.config_entries.async_reload(self._entry.entry_id)
 
     def _try_connect(self):
         """Try to connect and check auth."""

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -16,13 +16,21 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reauth_confirm": {
+        "description": "Update your login information for {name}.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "abort": {
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-      "not_supported": "Connected to AVM FRITZ!Box but it's unable to control Smart Home devices."
+      "not_supported": "Connected to AVM FRITZ!Box but it's unable to control Smart Home devices.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -12,10 +12,18 @@ from homeassistant.components.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_UDN,
 )
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import MOCK_CONFIG
+
+from tests.common import MockConfigEntry
 
 MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
 MOCK_SSDP_DATA = {
@@ -35,15 +43,15 @@ def fritz_fixture() -> Mock:
 async def test_user(hass: HomeAssistantType, fritz: Mock):
     """Test starting a flow by user."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}
+        DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_USER_DATA
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "fake_host"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
@@ -56,9 +64,9 @@ async def test_user_auth_failed(hass: HomeAssistantType, fritz: Mock):
     fritz().login.side_effect = [LoginError("Boom"), mock.DEFAULT]
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -68,25 +76,76 @@ async def test_user_not_successful(hass: HomeAssistantType, fritz: Mock):
     fritz().login.side_effect = OSError("Boom")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "no_devices_found"
 
 
 async def test_user_already_configured(hass: HomeAssistantType, fritz: Mock):
     """Test starting a flow by user when already configured."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert not result["result"].unique_id
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_reauth_success(hass: HomeAssistantType, fritz: Mock):
+    """Test starting a reauthentication flow."""
+    mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    mock_config.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config.data
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: "other_fake_user",
+            CONF_PASSWORD: "other_fake_password",
+        },
+    )
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config.data[CONF_USERNAME] == "other_fake_user"
+    assert mock_config.data[CONF_PASSWORD] == "other_fake_password"
+
+
+async def test_reauth_auth_failed(hass: HomeAssistantType, fritz: Mock):
+    """Test starting a reauthentication flow with authentication failure."""
+    fritz().login.side_effect = LoginError("Boom")
+
+    mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    mock_config.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config.data
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: "other_fake_user",
+            CONF_PASSWORD: "other_fake_password",
+        },
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"]["base"] == "invalid_auth"
 
 
 async def test_import(hass: HomeAssistantType, fritz: Mock):
@@ -94,7 +153,7 @@ async def test_import(hass: HomeAssistantType, fritz: Mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "import"}, data=MOCK_USER_DATA
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "fake_host"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
@@ -105,16 +164,16 @@ async def test_import(hass: HomeAssistantType, fritz: Mock):
 async def test_ssdp(hass: HomeAssistantType, fritz: Mock):
     """Test starting a flow from discovery."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_PASSWORD: "fake_pass", CONF_USERNAME: "fake_user"},
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "fake_name"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
@@ -127,16 +186,16 @@ async def test_ssdp_no_friendly_name(hass: HomeAssistantType, fritz: Mock):
     MOCK_NO_NAME = MOCK_SSDP_DATA.copy()
     del MOCK_NO_NAME[ATTR_UPNP_FRIENDLY_NAME]
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_NO_NAME
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_NO_NAME
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_PASSWORD: "fake_pass", CONF_USERNAME: "fake_user"},
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "fake_host"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
@@ -149,9 +208,9 @@ async def test_ssdp_auth_failed(hass: HomeAssistantType, fritz: Mock):
     fritz().login.side_effect = LoginError("Boom")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
     assert result["errors"] == {}
 
@@ -159,7 +218,7 @@ async def test_ssdp_auth_failed(hass: HomeAssistantType, fritz: Mock):
         result["flow_id"],
         user_input={CONF_PASSWORD: "whatever", CONF_USERNAME: "whatever"},
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -169,16 +228,16 @@ async def test_ssdp_not_successful(hass: HomeAssistantType, fritz: Mock):
     fritz().login.side_effect = OSError("Boom")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_PASSWORD: "whatever", CONF_USERNAME: "whatever"},
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "no_devices_found"
 
 
@@ -187,62 +246,62 @@ async def test_ssdp_not_supported(hass: HomeAssistantType, fritz: Mock):
     fritz().get_device_elements.side_effect = HTTPError("Boom")
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_PASSWORD: "whatever", CONF_USERNAME: "whatever"},
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "not_supported"
 
 
 async def test_ssdp_already_in_progress_unique_id(hass: HomeAssistantType, fritz: Mock):
     """Test starting a flow from discovery twice."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_in_progress"
 
 
 async def test_ssdp_already_in_progress_host(hass: HomeAssistantType, fritz: Mock):
     """Test starting a flow from discovery twice."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result["type"] == "form"
+    assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
 
     MOCK_NO_UNIQUE_ID = MOCK_SSDP_DATA.copy()
     del MOCK_NO_UNIQUE_ID[ATTR_UPNP_UDN]
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_NO_UNIQUE_ID
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_NO_UNIQUE_ID
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_in_progress"
 
 
 async def test_ssdp_already_configured(hass: HomeAssistantType, fritz: Mock):
     """Test starting a flow from discovery when already configured."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "user"}, data=MOCK_USER_DATA
+        DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA
     )
-    assert result["type"] == "create_entry"
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert not result["result"].unique_id
 
     result2 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "ssdp"}, data=MOCK_SSDP_DATA
+        DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
     )
-    assert result2["type"] == "abort"
+    assert result2["type"] == RESULT_TYPE_ABORT
     assert result2["reason"] == "already_configured"
     assert result["result"].unique_id == "only-a-test"

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -103,7 +103,7 @@ async def test_reauth_success(hass: HomeAssistantType, fritz: Mock):
     mock_config.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config.data
+        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config
     )
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "reauth_confirm"
@@ -130,7 +130,7 @@ async def test_reauth_auth_failed(hass: HomeAssistantType, fritz: Mock):
     mock_config.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config.data
+        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config
     )
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "reauth_confirm"
@@ -156,7 +156,7 @@ async def test_reauth_not_successful(hass: HomeAssistantType, fritz: Mock):
     mock_config.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config.data
+        DOMAIN, context={"source": SOURCE_REAUTH}, data=mock_config
     )
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "reauth_confirm"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements and adds the reauthentication flow for the `fritzbox` (AVM FRITZ!SmartHome) integration.
In case an entry fails with `LoginError` the reauth flow is started.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45497
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
