### PR TITLE
Remove unwanted brightness check in zwave_js light

### DIFF
--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -240,9 +240,6 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             # Zwave multilevel switches use a range of [0, 99] to control brightness.
             zwave_brightness = byte_to_zwave_brightness(brightness)
 
-        if self.info.primary_value.value == zwave_brightness:
-            # no point in setting same brightness
-            return
         # set transition value before sending new brightness
         await self._async_set_transition_duration(transition)
         # setting a value requires setting targetValue

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -164,15 +164,14 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             await self._async_set_color("Red", red)
             await self._async_set_color("Green", green)
             await self._async_set_color("Blue", blue)
-        else:
-            # turn off rgb when setting white values
-            await self._async_set_color("Red", 0)
-            await self._async_set_color("Green", 0)
-            await self._async_set_color("Blue", 0)
 
         # Color temperature
         color_temp = kwargs.get(ATTR_COLOR_TEMP)
         if color_temp is not None and self._supports_color_temp:
+            # turn off rgb when setting white values
+            await self._async_set_color("Red", 0)
+            await self._async_set_color("Green", 0)
+            await self._async_set_color("Blue", 0)
             # Limit color temp to min/max values
             cold = max(
                 0,
@@ -192,6 +191,10 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         # White value
         white_value = kwargs.get(ATTR_WHITE_VALUE)
         if white_value is not None and self._supports_white_value:
+            # turn off rgb when setting white values
+            await self._async_set_color("Red", 0)
+            await self._async_set_color("Green", 0)
+            await self._async_set_color("Blue", 0)
             await self._async_set_color("Warm White", white_value)
 
         # set brightness

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -213,9 +213,6 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         # guard for unsupported command
         if cur_zwave_value is None:
             return
-        # no need to send same value
-        if cur_zwave_value.value == new_value:
-            return
         # actually set the new color value
         target_zwave_value = self.get_zwave_value(
             "targetColor",

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -92,7 +92,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 1
 
     client.async_send_command.reset_mock()
 
@@ -136,7 +136,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 4
+    assert len(client.async_send_command.call_args_list) == 5
     warm_args = client.async_send_command.call_args_list[0][0][0]  # warm white 0
     assert warm_args["command"] == "node.set_value"
     assert warm_args["nodeId"] == 39
@@ -147,7 +147,18 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert warm_args["valueId"]["property"] == "targetColor"
     assert warm_args["valueId"]["propertyName"] == "targetColor"
     assert warm_args["value"] == 0
-    red_args = client.async_send_command.call_args_list[1][0][0]  # red 255
+
+    cold_args = client.async_send_command.call_args_list[1][0][0]  # cold white 0
+    assert cold_args["command"] == "node.set_value"
+    assert cold_args["nodeId"] == 39
+    assert cold_args["valueId"]["commandClassName"] == "Color Switch"
+    assert cold_args["valueId"]["commandClass"] == 51
+    assert cold_args["valueId"]["endpoint"] == 0
+    assert cold_args["valueId"]["metadata"]["label"] == "Target value (Cold White)"
+    assert cold_args["valueId"]["property"] == "targetColor"
+    assert cold_args["valueId"]["propertyName"] == "targetColor"
+    assert cold_args["value"] == 0
+    red_args = client.async_send_command.call_args_list[2][0][0]  # red 255
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
     assert red_args["valueId"]["commandClassName"] == "Color Switch"
@@ -157,7 +168,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert red_args["valueId"]["property"] == "targetColor"
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 255
-    green_args = client.async_send_command.call_args_list[2][0][0]  # green 76
+    green_args = client.async_send_command.call_args_list[3][0][0]  # green 76
     assert green_args["command"] == "node.set_value"
     assert green_args["nodeId"] == 39
     assert green_args["valueId"]["commandClassName"] == "Color Switch"
@@ -167,7 +178,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert green_args["valueId"]["property"] == "targetColor"
     assert green_args["valueId"]["propertyName"] == "targetColor"
     assert green_args["value"] == 76
-    blue_args = client.async_send_command.call_args_list[3][0][0]  # blue 255
+    blue_args = client.async_send_command.call_args_list[4][0][0]  # blue 255
     assert blue_args["command"] == "node.set_value"
     assert blue_args["nodeId"] == 39
     assert blue_args["valueId"]["commandClassName"] == "Color Switch"
@@ -225,7 +236,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 5
 
     client.async_send_command.reset_mock()
 
@@ -343,7 +354,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 5
 
     client.async_send_command.reset_mock()
 


### PR DESCRIPTION
## Breaking change


## Proposed change
Do not assume that the value is accurate, always send brightness.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x Local tests pass. **Your PR cannot be merged unless tests pass**
- [x There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
