### PR TITLE
Homeconnect remote states

### DIFF
--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import (
     BSH_ACTIVE_PROGRAM,
+    BSH_OPERATION_STATE,
     BSH_POWER_OFF,
     BSH_POWER_STANDBY,
     SIGNAL_UPDATE_ENTITIES,
@@ -156,6 +157,25 @@ class DeviceWithPrograms(HomeConnectDevice):
         ]
 
 
+class DeviceWithOpState(HomeConnectDevice):
+    """Device that has an operation state sensor."""
+
+    def get_opstate_sensor(self):
+        """Get a dictionary with info about operation state sensor."""
+
+        return [
+            {
+                "device": self,
+                "desc": "Operation State",
+                "unit": None,
+                "key": BSH_OPERATION_STATE,
+                "icon": "mdi:state-machine",
+                "device_class": None,
+                "sign": 1,
+            }
+        ]
+
+
 class DeviceWithDoor(HomeConnectDevice):
     """Device that has a door sensor."""
 
@@ -206,7 +226,11 @@ class DeviceWithRemoteStart(HomeConnectDevice):
 
 
 class Dryer(
-    DeviceWithDoor, DeviceWithPrograms, DeviceWithRemoteControl, DeviceWithRemoteStart
+    DeviceWithDoor,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
 ):
     """Dryer class."""
 
@@ -234,18 +258,20 @@ class Dryer(
         door_entity = self.get_door_entity()
         remote_control = self.get_remote_control()
         remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
             "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
 class Dishwasher(
     DeviceWithDoor,
     DeviceWithAmbientLight,
+    DeviceWithOpState,
     DeviceWithPrograms,
     DeviceWithRemoteControl,
     DeviceWithRemoteStart,
@@ -282,17 +308,22 @@ class Dishwasher(
         door_entity = self.get_door_entity()
         remote_control = self.get_remote_control()
         remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
             "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
 class Oven(
-    DeviceWithDoor, DeviceWithPrograms, DeviceWithRemoteControl, DeviceWithRemoteStart
+    DeviceWithDoor,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
 ):
     """Oven class."""
 
@@ -311,17 +342,22 @@ class Oven(
         door_entity = self.get_door_entity()
         remote_control = self.get_remote_control()
         remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
             "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
 class Washer(
-    DeviceWithDoor, DeviceWithPrograms, DeviceWithRemoteControl, DeviceWithRemoteStart
+    DeviceWithDoor,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
 ):
     """Washer class."""
 
@@ -354,16 +390,17 @@ class Washer(
         door_entity = self.get_door_entity()
         remote_control = self.get_remote_control()
         remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
             "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
-class CoffeeMaker(DeviceWithPrograms, DeviceWithRemoteStart):
+class CoffeeMaker(DeviceWithOpState, DeviceWithPrograms, DeviceWithRemoteStart):
     """Coffee maker class."""
 
     PROGRAMS = [
@@ -388,18 +425,20 @@ class CoffeeMaker(DeviceWithPrograms, DeviceWithRemoteStart):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
             "binary_sensor": [remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
 class Hood(
     DeviceWithLight,
     DeviceWithAmbientLight,
+    DeviceWithOpState,
     DeviceWithPrograms,
     DeviceWithRemoteControl,
     DeviceWithRemoteStart,
@@ -418,12 +457,13 @@ class Hood(
         remote_start = self.get_remote_start()
         light_entity = self.get_light_entity()
         ambientlight_entity = self.get_ambientlight_entity()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
             "binary_sensor": [remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
             "light": [light_entity, ambientlight_entity],
         }
 
@@ -437,7 +477,7 @@ class FridgeFreezer(DeviceWithDoor):
         return {"binary_sensor": [door_entity]}
 
 
-class Hob(DeviceWithPrograms, DeviceWithRemoteControl):
+class Hob(DeviceWithOpState, DeviceWithPrograms, DeviceWithRemoteControl):
     """Hob class."""
 
     PROGRAMS = [{"name": "Cooking.Hob.Program.PowerLevelMode"}]
@@ -445,10 +485,11 @@ class Hob(DeviceWithPrograms, DeviceWithRemoteControl):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         remote_control = self.get_remote_control()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
             "binary_sensor": [remote_control],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }

--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -164,6 +164,7 @@ class DeviceWithDoor(HomeConnectDevice):
         return {
             "device": self,
             "desc": "Door",
+            "sensor_type": "door",
             "device_class": "door",
         }
 
@@ -173,11 +174,7 @@ class DeviceWithLight(HomeConnectDevice):
 
     def get_light_entity(self):
         """Get a dictionary with info about the lighting."""
-        return {
-            "device": self,
-            "desc": "Light",
-            "ambient": None,
-        }
+        return {"device": self, "desc": "Light", "ambient": None}
 
 
 class DeviceWithAmbientLight(HomeConnectDevice):
@@ -185,14 +182,32 @@ class DeviceWithAmbientLight(HomeConnectDevice):
 
     def get_ambientlight_entity(self):
         """Get a dictionary with info about the ambient lighting."""
+        return {"device": self, "desc": "AmbientLight", "ambient": True}
+
+
+class DeviceWithRemoteControl(HomeConnectDevice):
+    """Device that has Remote Control binary sensor."""
+
+    def get_remote_control(self):
+        """Get a dictionary with info about the remote control sensor."""
         return {
             "device": self,
-            "desc": "AmbientLight",
-            "ambient": True,
+            "desc": "Remote Control",
+            "sensor_type": "remote_control",
         }
 
 
-class Dryer(DeviceWithDoor, DeviceWithPrograms):
+class DeviceWithRemoteStart(HomeConnectDevice):
+    """Device that has a Remote Start binary sensor."""
+
+    def get_remote_start(self):
+        """Get a dictionary with info about the remote start sensor."""
+        return {"device": self, "desc": "Remote Start", "sensor_type": "remote_start"}
+
+
+class Dryer(
+    DeviceWithDoor, DeviceWithPrograms, DeviceWithRemoteControl, DeviceWithRemoteStart
+):
     """Dryer class."""
 
     PROGRAMS = [
@@ -217,16 +232,24 @@ class Dryer(DeviceWithDoor, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
             "sensor": program_sensors,
         }
 
 
-class Dishwasher(DeviceWithDoor, DeviceWithAmbientLight, DeviceWithPrograms):
+class Dishwasher(
+    DeviceWithDoor,
+    DeviceWithAmbientLight,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
     """Dishwasher class."""
 
     PROGRAMS = [
@@ -257,16 +280,20 @@ class Dishwasher(DeviceWithDoor, DeviceWithAmbientLight, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
             "sensor": program_sensors,
         }
 
 
-class Oven(DeviceWithDoor, DeviceWithPrograms):
+class Oven(
+    DeviceWithDoor, DeviceWithPrograms, DeviceWithRemoteControl, DeviceWithRemoteStart
+):
     """Oven class."""
 
     PROGRAMS = [
@@ -282,16 +309,20 @@ class Oven(DeviceWithDoor, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
             "sensor": program_sensors,
         }
 
 
-class Washer(DeviceWithDoor, DeviceWithPrograms):
+class Washer(
+    DeviceWithDoor, DeviceWithPrograms, DeviceWithRemoteControl, DeviceWithRemoteStart
+):
     """Washer class."""
 
     PROGRAMS = [
@@ -321,16 +352,18 @@ class Washer(DeviceWithDoor, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
             "sensor": program_sensors,
         }
 
 
-class CoffeeMaker(DeviceWithPrograms):
+class CoffeeMaker(DeviceWithPrograms, DeviceWithRemoteStart):
     """Coffee maker class."""
 
     PROGRAMS = [
@@ -354,12 +387,23 @@ class CoffeeMaker(DeviceWithPrograms):
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
+        remote_start = self.get_remote_start()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
-        return {"switch": program_switches, "sensor": program_sensors}
+        return {
+            "binary_sensor": [remote_start],
+            "switch": program_switches,
+            "sensor": program_sensors,
+        }
 
 
-class Hood(DeviceWithLight, DeviceWithAmbientLight, DeviceWithPrograms):
+class Hood(
+    DeviceWithLight,
+    DeviceWithAmbientLight,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
     """Hood class."""
 
     PROGRAMS = [
@@ -370,11 +414,14 @@ class Hood(DeviceWithLight, DeviceWithAmbientLight, DeviceWithPrograms):
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
         light_entity = self.get_light_entity()
         ambientlight_entity = self.get_ambientlight_entity()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
+            "binary_sensor": [remote_control, remote_start],
             "switch": program_switches,
             "sensor": program_sensors,
             "light": [light_entity, ambientlight_entity],
@@ -390,13 +437,18 @@ class FridgeFreezer(DeviceWithDoor):
         return {"binary_sensor": [door_entity]}
 
 
-class Hob(DeviceWithPrograms):
+class Hob(DeviceWithPrograms, DeviceWithRemoteControl):
     """Hob class."""
 
     PROGRAMS = [{"name": "Cooking.Hob.Program.PowerLevelMode"}]
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
+        remote_control = self.get_remote_control()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
-        return {"switch": program_switches, "sensor": program_sensors}
+        return {
+            "binary_sensor": [remote_control],
+            "switch": program_switches,
+            "sensor": program_sensors,
+        }

--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -161,7 +161,7 @@ class DeviceWithOpState(HomeConnectDevice):
     """Device that has an operation state sensor."""
 
     def get_opstate_sensor(self):
-        """Get a dictionary with info about operation state sensor."""
+        """Get a list with info about operation state sensors."""
 
         return [
             {

--- a/homeassistant/components/home_connect/binary_sensor.py
+++ b/homeassistant/components/home_connect/binary_sensor.py
@@ -3,7 +3,12 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
-from .const import BSH_DOOR_STATE, DOMAIN
+from .const import (
+    BSH_DOOR_STATE,
+    BSH_REMOTE_CONTROL_ACTIVATION_STATE,
+    BSH_REMOTE_START_ALLOWANCE_STATE,
+    DOMAIN,
+)
 from .entity import HomeConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,11 +31,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
     """Binary sensor for Home Connect."""
 
-    def __init__(self, device, desc, device_class):
+    def __init__(self, device, desc, sensor_type, device_class=None):
         """Initialize the entity."""
         super().__init__(device, desc)
-        self._device_class = device_class
         self._state = None
+        self._device_class = device_class
+        self._type = sensor_type
+        if self._type == "door":
+            self._update_key = BSH_DOOR_STATE
+            self._false_value_list = [
+                "BSH.Common.EnumType.DoorState.Closed",
+                "BSH.Common.EnumType.DoorState.Locked",
+            ]
+            self._true_value_list = ["BSH.Common.EnumType.DoorState.Open"]
+        elif self._type == "remote_control":
+            self._update_key = BSH_REMOTE_CONTROL_ACTIVATION_STATE
+            self._false_value_list = [False]
+            self._true_value_list = [True]
+        elif self._type == "remote_start":
+            self._update_key = BSH_REMOTE_START_ALLOWANCE_STATE
+            self._false_value_list = [False]
+            self._true_value_list = [True]
 
     @property
     def is_on(self):
@@ -44,20 +65,19 @@ class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
 
     async def async_update(self):
         """Update the binary sensor's status."""
-        state = self.device.appliance.status.get(BSH_DOOR_STATE, {})
+        state = self.device.appliance.status.get(self._update_key, {})
         if not state:
             self._state = None
-        elif state.get("value") in [
-            "BSH.Common.EnumType.DoorState.Closed",
-            "BSH.Common.EnumType.DoorState.Locked",
-        ]:
+        elif state.get("value") in self._false_value_list:
             self._state = False
-        elif state.get("value") == "BSH.Common.EnumType.DoorState.Open":
+        elif state.get("value") in self._true_value_list:
             self._state = True
         else:
-            _LOGGER.warning("Unexpected value for HomeConnect door state: %s", state)
+            _LOGGER.warning(
+                f"Unexpected value for HomeConnect {self._type} state: {state}"
+            )
             self._state = None
-        _LOGGER.debug("Updated, new state: %s", self._state)
+        _LOGGER.debug(f"Updated, new state: {self._state}")
 
     @property
     def device_class(self):

--- a/homeassistant/components/home_connect/binary_sensor.py
+++ b/homeassistant/components/home_connect/binary_sensor.py
@@ -74,10 +74,10 @@ class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
             self._state = True
         else:
             _LOGGER.warning(
-                f"Unexpected value for HomeConnect {self._type} state: {state}"
+                "Unexpected value for HomeConnect %s state: %s", self._type, state
             )
             self._state = None
-        _LOGGER.debug(f"Updated, new state: {self._state}")
+        _LOGGER.debug("Updated, new state: %s", self._state)
 
     @property
     def device_class(self):

--- a/homeassistant/components/home_connect/binary_sensor.py
+++ b/homeassistant/components/home_connect/binary_sensor.py
@@ -39,10 +39,10 @@ class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
         self._type = sensor_type
         if self._type == "door":
             self._update_key = BSH_DOOR_STATE
-            self._false_value_list = [
+            self._false_value_list = (
                 "BSH.Common.EnumType.DoorState.Closed",
                 "BSH.Common.EnumType.DoorState.Locked",
-            ]
+            )
             self._true_value_list = ["BSH.Common.EnumType.DoorState.Open"]
         elif self._type == "remote_control":
             self._update_key = BSH_REMOTE_CONTROL_ACTIVATION_STATE

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -11,6 +11,8 @@ BSH_POWER_OFF = "BSH.Common.EnumType.PowerState.Off"
 BSH_POWER_STANDBY = "BSH.Common.EnumType.PowerState.Standby"
 BSH_ACTIVE_PROGRAM = "BSH.Common.Root.ActiveProgram"
 BSH_OPERATION_STATE = "BSH.Common.Status.OperationState"
+BSH_REMOTE_CONTROL_ACTIVATION_STATE = "BSH.Common.Status.RemoteControlActive"
+BSH_REMOTE_START_ALLOWANCE_STATE = "BSH.Common.Status.RemoteControlStartAllowed"
 
 COOKING_LIGHTING = "Cooking.Common.Setting.Lighting"
 COOKING_LIGHTING_BRIGHTNESS = "Cooking.Common.Setting.LightingBrightness"

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.const import DEVICE_CLASS_TIMESTAMP
 import homeassistant.util.dt as dt_util
 
-from .const import DOMAIN
+from .const import BSH_OPERATION_STATE, DOMAIN
 from .entity import HomeConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class HomeConnectSensor(HomeConnectEntity):
         return self._state is not None
 
     async def async_update(self):
-        """Update the sensos status."""
+        """Update the sensor's status."""
         status = self.device.appliance.status
         if self._key not in status:
             self._state = None
@@ -74,6 +74,11 @@ class HomeConnectSensor(HomeConnectEntity):
                     ).isoformat()
             else:
                 self._state = status[self._key].get("value")
+                if self._key == BSH_OPERATION_STATE:
+                    # Value comes back as an enum, we only really care about the
+                    # last part, so split it off
+                    # https://developer.home-connect.com/docs/status/operation_state
+                    self._state = self._state.split(".")[-1]
         _LOGGER.debug("Updated, new state: %s", self._state)
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds binary sensors for Remote Control Activation State and Remote Start Allowance State, which are either on or off.
It also adds a sensor for Operation State which has a number of different state values depending on what type of machine we are dealing with and what the machine is doing (links to developer documentation below)
These changes pave the way for automation of the devices. For example once my dishwasher has remote start and remote control on, and it is in "Ready" Operation State, I can trigger an automation to tell me the next cheapest time period (Time of Use electricity tariff) to run it in - as a follow on from this, I hope to add the ability to program the delayed start automatically in the future.

Home Connect developer docs:
[Remote Control Activation State](https://developer.home-connect.com/docs/api/status/remotecontrolactivationstate)
[Remote Start Allowance State](https://developer.home-connect.com/docs/api/status/remotestartallowancestate)
[Operation State](https://developer.home-connect.com/docs/status/operation_state)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38228 (already closed as it was stale but has background to this)
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
