### PR TITLE
Add additional error handling for automation script run

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -31,12 +31,7 @@ from homeassistant.core import (
     callback,
     split_entity_id,
 )
-from homeassistant.exceptions import (
-    HomeAssistantError,
-    ServiceNotFound,
-    TemplateError,
-    Unauthorized,
-)
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition, extract_domain_configs, template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
@@ -409,7 +404,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             await self.action_script.async_run(
                 variables, trigger_context, started_action
             )
-        except (vol.Invalid, TemplateError, Unauthorized, ServiceNotFound) as err:
+        except (vol.Invalid, HomeAssistantError) as err:
             self._logger.error(
                 "Error while executing automation %s: %s",
                 self.entity_id,

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -31,7 +31,12 @@ from homeassistant.core import (
     callback,
     split_entity_id,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceNotFound,
+    TemplateError,
+    Unauthorized,
+)
 from homeassistant.helpers import condition, extract_domain_configs, template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
@@ -403,6 +408,12 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         try:
             await self.action_script.async_run(
                 variables, trigger_context, started_action
+            )
+        except (vol.Invalid, TemplateError, Unauthorized, ServiceNotFound) as err:
+            self._logger.error(
+                "Error while executing automation %s: %s",
+                self.entity_id,
+                err,
             )
         except Exception:  # pylint: disable=broad-except
             self._logger.exception("While executing automation %s", self.entity_id)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -291,6 +291,9 @@ class _ScriptRun:
         elif isinstance(exception, exceptions.ServiceNotFound):
             error_desc = "Service not found"
 
+        elif isinstance(exception, exceptions.HomeAssistantError):
+            error_desc = "Error"
+
         else:
             error_desc = "Unexpected error"
             level = _LOG_EXCEPTION

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -947,6 +947,7 @@ async def test_automation_with_error_in_script(hass, caplog):
     hass.bus.async_fire("test_event")
     await hass.async_block_till_done()
     assert "Service not found" in caplog.text
+    assert "Traceback" not in caplog.text
 
 
 async def test_automation_with_error_in_script_2(hass, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I've added additional error handling to the automation component. Previously, in cases where a script run fails, Home Assistant would log a traceback even for known errors.

This PR adds the exception classes already used by the script component.
https://github.com/home-assistant/core/blob/a1662b3bb90f55b1eeb2cc11c740c9f81364f334/homeassistant/helpers/script.py#L282-L296

Previous log message:
```
Logger: homeassistant.components.automation.time_open
Source: core.py:1395 
Integration: Automation (documentation, issues) 
First occurred: 5:17:09 PM (1 occurrences) 
Last logged: 5:17:09 PM

While executing automation automation.time_open
Traceback (most recent call last):
  File "/srv/homeassistant/venv/lib/python3.8/site-packages/homeassistant/components/automation/__init__.py", line 404, in async_trigger
    await self.action_script.async_run(
  File "/srv/homeassistant/venv/lib/python3.8/site-packages/homeassistant/helpers/script.py", line 1026, in async_run
    await asyncio.shield(run.async_run())
  File "/srv/homeassistant/venv/lib/python3.8/site-packages/homeassistant/helpers/script.py", line 242, in async_run
    await self._async_step(log_exceptions=False)
  File "/srv/homeassistant/venv/lib/python3.8/site-packages/homeassistant/helpers/script.py", line 250, in _async_step
    await getattr(
  File "/srv/homeassistant/venv/lib/python3.8/site-packages/homeassistant/helpers/script.py", line 457, in _async_call_service_step
    await service_task
  File "/srv/homeassistant/venv/lib/python3.8/site-packages/homeassistant/core.py", line 1395, in async_call
    raise ServiceNotFound(domain, service) from None
homeassistant.exceptions.ServiceNotFound: Unable to find service notify.slack_debug
```

Now:
```
Logger: homeassistant.components.automation.test_errors
Source: components/automation/__init__.py:413 
Integration: Automation (documentation, issues) 
First occurred: 6:18:59 PM (1 occurrences) 
Last logged: 6:18:59 PM

Error while executing automation automation.my_automation: Unable to find service notify.slack_debug
```

**Note:** the script component itself also logs an error
```
Logger: homeassistant.components.automation.test_errors
Source: helpers/script.py:1144 
Integration: Automation (documentation, issues) 
First occurred: 6:18:59 PM (1 occurrences) 
Last logged: 6:18:59 PM

My_Automation: Error executing script. Service not found for call_service at pos 1: Unable to find service notify.slack_debug
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
