### PR TITLE
Support templating MQTT triggers

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -465,6 +465,16 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         def log_cb(level, msg, **kwargs):
             self._logger.log(level, "%s %s", msg, self._name, **kwargs)
 
+        variables = None
+        if self._variables:
+            try:
+                variables = self._variables.async_render(
+                    cast(HomeAssistant, self.hass), None
+                )
+            except template.TemplateError as err:
+                self._logger.error("Error rendering variables: %s", err)
+                return None
+
         return await async_initialize_triggers(
             cast(HomeAssistant, self.hass),
             self._trigger_config,
@@ -473,6 +483,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             self._name,
             log_cb,
             home_assistant_start,
+            variables,
         )
 
     @property

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -564,6 +564,18 @@ async def _async_process_config(
             else:
                 cond_func = None
 
+            # Add trigger variables to variables
+            variables = None
+            if CONF_TRIGGER_VARIABLES in config_block:
+                variables = ScriptVariables(
+                    dict(config_block[CONF_TRIGGER_VARIABLES].as_dict())
+                )
+            if CONF_VARIABLES in config_block:
+                if variables:
+                    variables.variables.update(config_block[CONF_VARIABLES].as_dict())
+                else:
+                    variables = config_block[CONF_VARIABLES]
+
             entity = AutomationEntity(
                 automation_id,
                 name,
@@ -571,7 +583,7 @@ async def _async_process_config(
                 cond_func,
                 action_script,
                 initial_state,
-                config_block.get(CONF_VARIABLES),
+                variables,
                 config_block.get(CONF_TRIGGER_VARIABLES),
             )
 

--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_HIDE_ENTITY,
     CONF_INITIAL_STATE,
     CONF_TRIGGER,
+    CONF_TRIGGER_VARIABLES,
     DOMAIN,
 )
 from .helpers import async_get_blueprints
@@ -44,6 +45,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.Required(CONF_TRIGGER): cv.TRIGGER_SCHEMA,
             vol.Optional(CONF_CONDITION): _CONDITION_SCHEMA,
             vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
+            vol.Optional(CONF_TRIGGER_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
             vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
         },
         script.SCRIPT_MODE_SINGLE,

--- a/homeassistant/components/automation/const.py
+++ b/homeassistant/components/automation/const.py
@@ -4,6 +4,7 @@ import logging
 CONF_CONDITION = "condition"
 CONF_ACTION = "action"
 CONF_TRIGGER = "trigger"
+CONF_TRIGGER_VARIABLES = "trigger_variables"
 DOMAIN = "automation"
 
 CONF_DESCRIPTION = "description"

--- a/homeassistant/components/mqtt/device_trigger.py
+++ b/homeassistant/components/mqtt/device_trigger.py
@@ -89,12 +89,14 @@ class TriggerInstance:
     async def async_attach_trigger(self):
         """Attach MQTT trigger."""
         mqtt_config = {
+            mqtt_trigger.CONF_PLATFORM: mqtt.DOMAIN,
             mqtt_trigger.CONF_TOPIC: self.trigger.topic,
             mqtt_trigger.CONF_ENCODING: DEFAULT_ENCODING,
             mqtt_trigger.CONF_QOS: self.trigger.qos,
         }
         if self.trigger.payload:
             mqtt_config[CONF_PAYLOAD] = self.trigger.payload
+        mqtt_config = mqtt_trigger.TRIGGER_SCHEMA(mqtt_config)
 
         if self.remove:
             self.remove()

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -37,7 +37,9 @@ async def async_attach_trigger(hass, config, action, automation_info):
     encoding = config[CONF_ENCODING] or None
     qos = config[CONF_QOS]
     job = HassJob(action)
-    variables = automation_info["variables"]
+    variables = None
+    if automation_info:
+        variables = automation_info.get("variables")
 
     if payload:
         template.attach(hass, payload)

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -1,5 +1,6 @@
 """Offer MQTT listening automation rules."""
 import json
+import logging
 
 import voluptuous as vol
 
@@ -28,6 +29,8 @@ TRIGGER_SCHEMA = vol.Schema(
         ),
     }
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_attach_trigger(hass, config, action, automation_info):
@@ -67,6 +70,10 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 pass
 
             hass.async_run_hass_job(job, {"trigger": data})
+
+    _LOGGER.debug(
+        "Attaching MQTT trigger for topic: '%s', payload: '%s'", topic, payload
+    )
 
     remove = await mqtt.async_subscribe(
         hass, topic, mqtt_automation_listener, encoding=encoding, qos=qos

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -4,7 +4,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.const import CONF_PAYLOAD
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, template
 
 from .const import (
     ATTR_PAYLOAD,
@@ -59,6 +59,14 @@ def valid_subscribe_topic(value: Any) -> str:
             )
 
     return value
+
+
+def valid_subscribe_topic_template(value: Any) -> Any:
+    """Validate either a jinja2 template or a valid MQTT subscription topic."""
+    if template.is_template_string(value):
+        return cv.template(value)
+
+    return valid_subscribe_topic(value)
 
 
 def valid_publish_topic(value: Any) -> str:

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -61,12 +61,14 @@ def valid_subscribe_topic(value: Any) -> str:
     return value
 
 
-def valid_subscribe_topic_template(value: Any) -> Any:
+def valid_subscribe_topic_template(value: Any) -> template.Template:
     """Validate either a jinja2 template or a valid MQTT subscription topic."""
-    if template.is_template_string(value):
-        return cv.template(value)
+    tpl = template.Template(value)
 
-    return valid_subscribe_topic(value)
+    if tpl.is_static:
+        valid_subscribe_topic(value)
+
+    return tpl
 
 
 def valid_publish_topic(value: Any) -> str:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -570,7 +570,7 @@ def dynamic_template(value: Optional[Any]) -> template_helper.Template:
     if isinstance(value, (list, dict, template_helper.Template)):
         raise vol.Invalid("template value should be a string")
     if not template_helper.is_template_string(str(value)):
-        raise vol.Invalid("template value does not contain a dynmamic template")
+        raise vol.Invalid("template value does not contain a dynamic template")
 
     template_value = template_helper.Template(str(value))  # type: ignore
     try:

--- a/homeassistant/helpers/script_variables.py
+++ b/homeassistant/helpers/script_variables.py
@@ -21,6 +21,7 @@ class ScriptVariables:
         run_variables: Optional[Mapping[str, Any]],
         *,
         render_as_defaults: bool = True,
+        limited: bool = False,
     ) -> Dict[str, Any]:
         """Render script variables.
 
@@ -55,7 +56,9 @@ class ScriptVariables:
             if render_as_defaults and key in rendered_variables:
                 continue
 
-            rendered_variables[key] = template.render_complex(value, rendered_variables)
+            rendered_variables[key] = template.render_complex(
+                value, rendered_variables, limited
+            )
 
         return rendered_variables
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1383,10 +1383,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
                 "now",
             ]
             hass_filters = ["closest", "expand"]
-            for g in hass_globals:
-                self.globals[g] = unsupported(g)
-            for f in hass_filters:
-                self.filters[f] = unsupported(f)
+            for glob in hass_globals:
+                self.globals[glob] = unsupported(glob)
+            for filt in hass_filters:
+                self.filters[filt] = unsupported(filt)
             return
 
         # We mark these as a context functions to ensure they get

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -322,7 +322,10 @@ class Template:
         limited: bool = False,
         **kwargs: Any,
     ) -> Any:
-        """Render given template."""
+        """Render given template.
+
+        If limited is True, the template is not allowed to access any function or filter depending on hass or the state machine.
+        """
         if self.is_static:
             if self.hass.config.legacy_templates or not parse_result:
                 return self.template
@@ -344,6 +347,8 @@ class Template:
         """Render given template.
 
         This method must be run in the event loop.
+
+        If limited is True, the template is not allowed to access any function or filter depending on hass or the state machine.
         """
         if self.is_static:
             if self.hass.config.legacy_templates or not parse_result:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -84,7 +84,9 @@ def attach(hass: HomeAssistantType, obj: Any) -> None:
         obj.hass = hass
 
 
-def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
+def render_complex(
+    value: Any, variables: TemplateVarsType = None, limited: bool = False
+) -> Any:
     """Recursive template creator helper function."""
     if isinstance(value, list):
         return [render_complex(item, variables) for item in value]
@@ -94,7 +96,7 @@ def render_complex(value: Any, variables: TemplateVarsType = None) -> Any:
             for key, item in value.items()
         }
     if isinstance(value, Template):
-        return value.async_render(variables)
+        return value.async_render(variables, limited=limited)
 
     return value
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1363,10 +1363,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
             def unsupported(name):
                 def warn_unsupported(*args, **kwargs):
-                    _LOGGER.warning(
-                        "Use of '%s' is not supported in limited templates", name
+                    raise TemplateError(
+                        f"Use of '{name}' is not supported in limited templates"
                     )
-                    return ""
 
                 return warn_unsupported
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import CALLBACK_TYPE, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.loader import IntegrationNotFound, async_get_integration
 
@@ -79,7 +80,9 @@ async def async_initialize_triggers(
     removes = []
 
     for result in attach_results:
-        if isinstance(result, Exception):
+        if isinstance(result, HomeAssistantError):
+            log_cb(logging.ERROR, f"Got error '{result}' when setting up triggers for")
+        elif isinstance(result, Exception):
             log_cb(logging.ERROR, "Error setting up trigger", exc_info=result)
         elif result is None:
             log_cb(

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1234,6 +1234,94 @@ async def test_automation_variables(hass, caplog):
     assert len(calls) == 3
 
 
+async def test_automation_trigger_variables(hass, caplog):
+    """Test automation trigger variables."""
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "variables": {
+                        "event_type": "{{ trigger.event.event_type }}",
+                    },
+                    "trigger_variables": {
+                        "test_var": "defined_in_config",
+                    },
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "value": "{{ test_var }}",
+                            "event_type": "{{ event_type }}",
+                        },
+                    },
+                },
+                {
+                    "variables": {
+                        "event_type": "{{ trigger.event.event_type }}",
+                        "test_var": "overridden_in_config",
+                    },
+                    "trigger_variables": {
+                        "test_var": "defined_in_config",
+                    },
+                    "trigger": {"platform": "event", "event_type": "test_event_2"},
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "value": "{{ test_var }}",
+                            "event_type": "{{ event_type }}",
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["value"] == "defined_in_config"
+    assert calls[0].data["event_type"] == "test_event"
+
+    hass.bus.async_fire("test_event_2")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["value"] == "overridden_in_config"
+    assert calls[1].data["event_type"] == "test_event_2"
+
+    assert "Error rendering variables" not in caplog.text
+
+
+async def test_automation_bad_trigger_variables(hass, caplog):
+    """Test automation trigger variables accessing hass is rejected."""
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger_variables": {
+                        "test_var": "{{ states('foo.bar') }}",
+                    },
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "action": {
+                        "service": "test.automation",
+                    },
+                },
+            ]
+        },
+    )
+    hass.bus.async_fire("test_event")
+    assert "Use of 'states' is not supported in limited templates" in caplog.text
+
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
 async def test_blueprint_automation(hass, calls):
     """Test blueprint automation."""
     assert await async_setup_component(

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -81,6 +81,58 @@ async def test_if_fires_on_topic_and_payload_match(hass, calls):
     assert len(calls) == 1
 
 
+async def test_if_fires_on_templated_topic_and_payload_match(hass, calls):
+    """Test if message is fired on templated topic and payload match."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "mqtt",
+                    "topic": "test-topic-{{ sqrt(16)|round }}",
+                    "payload": '{{ "foo"|regex_replace("foo", "bar") }}',
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    async_fire_mqtt_message(hass, "test-topic-", "foo")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    async_fire_mqtt_message(hass, "test-topic-4", "foo")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    async_fire_mqtt_message(hass, "test-topic-4", "bar")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_non_allowed_templates(hass, calls, caplog):
+    """Test non allowed function in template."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "mqtt",
+                    "topic": "test-topic-{{ states() }}",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    assert (
+        "Got error 'TemplateError: str: Use of 'states' is not supported in limited templates' when setting up triggers"
+        in caplog.text
+    )
+
+
 async def test_if_not_fires_on_topic_but_no_payload_match(hass, calls):
     """Test if message is not fired on topic but no payload."""
     assert await async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support templating MQTT triggers

The main driver is to allow blueprint inputs to define an MQTT topic or payload to trigger on.

Introduce limited templates which don't have any access to the state dependent template filters and functions such as `states` etc.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example automation:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Example where MQTT trigger's topic is templated.
```yaml
trigger_variables:
  page: !input page
  object: !input object
  target_entity: !input target_entity
  haspentity: !input plate
  node: {{ haspentity.split(".")[1].split("_touch")[0] }}
  state_topic: '{{ "hasp/" ~ node ~ "/state/p" ~ page ~ "b" ~ object ~ "" }}'
trigger:
  - platform: mqtt
    topic: '{{ state_topic }}'
  - platform: state
    entity_id: !input target_entity
    attribute: brightness
  - platform: state
    entity_id: !input plate
    attribute: status
    from:
    to: 'available'
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16455

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
