### PR TITLE
Ignore errors if script is automation

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -274,6 +274,9 @@ class _ScriptRun:
         await self._stopped.wait()
 
     def _log_exception(self, exception):
+        if self._script.domain == "automation":  # don't use const: circular import
+            return
+
         action_type = cv.determine_script_action(self._action)
 
         error = str(exception)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the automation component."""
 import asyncio
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -946,7 +947,8 @@ async def test_automation_with_error_in_script(hass, caplog):
 
     hass.bus.async_fire("test_event")
     await hass.async_block_till_done()
-    assert "Service not found" in caplog.text
+    assert len([rec for rec in caplog.records if rec.levelno == logging.ERROR]) == 1
+    assert "Unable to find service" in caplog.text
     assert "Traceback" not in caplog.text
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up and dependent on #45613 
Don't log script error if script is part of automation.

**Previously**: Every error would have been logged twice, once from the automation and once from the script.

```
Logger: homeassistant.components.automation.test_errors
Source: components/automation/__init__.py:413 
Integration: Automation (documentation, issues) 
First occurred: 6:18:59 PM (1 occurrences) 
Last logged: 6:18:59 PM

Error while executing automation automation.my_automation: Unable to find service notify.slack_debug
```

```
Logger: homeassistant.components.automation.test_errors
Source: helpers/script.py:1144 
Integration: Automation (documentation, issues) 
First occurred: 6:18:59 PM (1 occurrences) 
Last logged: 6:18:59 PM

My_Automation: Error executing script. Service not found for call_service at pos 1: Unable to find service notify.slack_debug
```

**Now**: Only the first error will be shown.
(In case the automation calls a script as a service, two errors are logged -> due to different scopes)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
