### PR TITLE
Allow new UniFi flows to update existing entries if host and site match

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -40,7 +40,7 @@ from .const import (
 from .controller import get_controller
 from .errors import AuthenticationRequired, CannotConnect
 
-DEFAULT_PORT = 8443
+DEFAULT_PORT = 443
 DEFAULT_SITE_ID = "default"
 DEFAULT_VERIFY_SSL = False
 

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -38,7 +38,7 @@ from .const import (
     LOGGER,
 )
 from .controller import get_controller
-from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
+from .errors import AuthenticationRequired, CannotConnect
 
 DEFAULT_PORT = 8443
 DEFAULT_SITE_ID = "default"
@@ -76,7 +76,7 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
         """Initialize the UniFi flow."""
         self.config = {}
         self.sites = None
-        self.reauth_config_entry = {}
+        self.reauth_config_entry = None
         self.reauth_config = {}
         self.reauth_schema = {}
 
@@ -146,32 +146,40 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
         errors = {}
 
         if user_input is not None:
-            try:
-                self.config[CONF_SITE_ID] = user_input[CONF_SITE_ID]
-                data = {CONF_CONTROLLER: self.config}
 
-                if self.reauth_config_entry:
-                    self.hass.config_entries.async_update_entry(
-                        self.reauth_config_entry, data=data
-                    )
-                    await self.hass.config_entries.async_reload(
-                        self.reauth_config_entry.entry_id
-                    )
-                    return self.async_abort(reason="reauth_successful")
+            self.config[CONF_SITE_ID] = user_input[CONF_SITE_ID]
+            data = {CONF_CONTROLLER: self.config}
 
-                for entry in self._async_current_entries():
-                    controller = entry.data[CONF_CONTROLLER]
-                    if (
-                        controller[CONF_HOST] == self.config[CONF_HOST]
-                        and controller[CONF_SITE_ID] == self.config[CONF_SITE_ID]
-                    ):
-                        raise AlreadyConfigured
+            if self.reauth_config_entry:
+                self.hass.config_entries.async_update_entry(
+                    self.reauth_config_entry, data=data
+                )
+                await self.hass.config_entries.async_reload(
+                    self.reauth_config_entry.entry_id
+                )
+                return self.async_abort(reason="reauth_successful")
 
-                site_nice_name = self.sites[self.config[CONF_SITE_ID]]
-                return self.async_create_entry(title=site_nice_name, data=data)
+            for config_entry in self._async_current_entries():
+                controller_data = config_entry.data[CONF_CONTROLLER]
+                if (
+                    controller_data[CONF_HOST] != self.config[CONF_HOST]
+                    or controller_data[CONF_SITE_ID] != self.config[CONF_SITE_ID]
+                ):
+                    continue
 
-            except AlreadyConfigured:
-                return self.async_abort(reason="already_configured")
+                controller = self.hass.data.get(UNIFI_DOMAIN, {}).get(
+                    config_entry.entry_id
+                )
+
+                if controller and controller.available:
+                    return self.async_abort(reason="already_configured")
+
+                self.hass.config_entries.async_update_entry(config_entry, data=data)
+                await self.hass.config_entries.async_reload(config_entry.entry_id)
+                return self.async_abort(reason="configuration_updated")
+
+            site_nice_name = self.sites[self.config[CONF_SITE_ID]]
+            return self.async_create_entry(title=site_nice_name, data=data)
 
         if len(self.sites) == 1:
             return await self.async_step_site({CONF_SITE_ID: next(iter(self.sites))})

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -21,6 +21,7 @@
     },
     "abort": {
       "already_configured": "Controller site is already configured",
+      "configuration_updated": "Configuration updated.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -189,12 +189,9 @@ async def test_flow_works_multiple_sites(hass, aioclient_mock):
     assert result["data_schema"]({"site": "site2"})
 
 
-async def test_flow_fails_site_already_configured(hass, aioclient_mock):
-    """Test config flow."""
-    entry = MockConfigEntry(
-        domain=UNIFI_DOMAIN, data={"controller": {"host": "1.2.3.4", "site": "site_id"}}
-    )
-    entry.add_to_hass(hass)
+async def test_flow_raise_already_configured(hass, aioclient_mock):
+    """Test config flow aborts since a connected config entry already exists."""
+    await setup_unifi_integration(hass)
 
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN, context={"source": "user"}
@@ -233,6 +230,58 @@ async def test_flow_fails_site_already_configured(hass, aioclient_mock):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_flow_aborts_configuration_updated(hass, aioclient_mock):
+    """Test config flow aborts since a connected config entry already exists."""
+    entry = MockConfigEntry(
+        domain=UNIFI_DOMAIN, data={"controller": {"host": "1.2.3.4", "site": "office"}}
+    )
+    entry.add_to_hass(hass)
+
+    entry = MockConfigEntry(
+        domain=UNIFI_DOMAIN, data={"controller": {"host": "1.2.3.4", "site": "site_id"}}
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        UNIFI_DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    aioclient_mock.get("https://1.2.3.4:1234", status=302)
+
+    aioclient_mock.post(
+        "https://1.2.3.4:1234/api/login",
+        json={"data": "login successful", "meta": {"rc": "ok"}},
+        headers={"content-type": CONTENT_TYPE_JSON},
+    )
+
+    aioclient_mock.get(
+        "https://1.2.3.4:1234/api/self/sites",
+        json={
+            "data": [{"desc": "Site name", "name": "site_id", "role": "admin"}],
+            "meta": {"rc": "ok"},
+        },
+        headers={"content-type": CONTENT_TYPE_JSON},
+    )
+
+    with patch("homeassistant.components.unifi.async_setup_entry"):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "1.2.3.4",
+                CONF_USERNAME: "username",
+                CONF_PASSWORD: "password",
+                CONF_PORT: 1234,
+                CONF_VERIFY_SSL: True,
+            },
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "configuration_updated"
 
 
 async def test_flow_fails_user_credentials_faulty(hass, aioclient_mock):

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -97,7 +97,7 @@ async def test_flow_works(hass, aioclient_mock, mock_discovery):
         CONF_HOST: "unifi",
         CONF_USERNAME: "",
         CONF_PASSWORD: "",
-        CONF_PORT: 8443,
+        CONF_PORT: 443,
         CONF_VERIFY_SSL: False,
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow a user to update existing non-functional configuration
if the entry is in any state but connected to the controller
and If host and site already belong to an existing entry
it will update user, password and port

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45047
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
