### PR TITLE
Use new fixtures in devolo Home Control tests

### DIFF
--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the devolo_home_control config flow."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.devolo_home_control.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -24,9 +26,6 @@ async def test_form(hass):
         "homeassistant.components.devolo_home_control.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
-        "homeassistant.components.devolo_home_control.config_flow.Mydevolo.credentials_valid",
-        return_value=True,
-    ), patch(
         "homeassistant.components.devolo_home_control.config_flow.Mydevolo.uuid",
         return_value="123456",
     ):
@@ -48,6 +47,7 @@ async def test_form(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.credentials_invalid
 async def test_form_invalid_credentials(hass):
     """Test if we get the error message on invalid credentials."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -57,16 +57,12 @@ async def test_form_invalid_credentials(hass):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.devolo_home_control.config_flow.Mydevolo.credentials_valid",
-        return_value=False,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"username": "test-username", "password": "test-password"},
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"username": "test-username", "password": "test-password"},
+    )
 
-        assert result["errors"] == {"base": "invalid_auth"}
+    assert result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_form_already_configured(hass):
@@ -74,9 +70,6 @@ async def test_form_already_configured(hass):
     with patch(
         "homeassistant.components.devolo_home_control.config_flow.Mydevolo.uuid",
         return_value="123456",
-    ), patch(
-        "homeassistant.components.devolo_home_control.config_flow.Mydevolo.credentials_valid",
-        return_value=True,
     ):
         MockConfigEntry(domain=DOMAIN, unique_id="123456", data={}).add_to_hass(hass)
         result = await hass.config_entries.flow.async_init(
@@ -103,9 +96,6 @@ async def test_form_advanced_options(hass):
         "homeassistant.components.devolo_home_control.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
-        "homeassistant.components.devolo_home_control.config_flow.Mydevolo.credentials_valid",
-        return_value=True,
-    ), patch(
         "homeassistant.components.devolo_home_control.config_flow.Mydevolo.uuid",
         return_value="123456",
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With #42527 we introduced fixtures that can be used to save a few lines in the existing config flow tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
