### PR TITLE
Use pure rgb and allow to set only brightness for fibaro

### DIFF
--- a/homeassistant/components/fibaro/light.py
+++ b/homeassistant/components/fibaro/light.py
@@ -137,7 +137,7 @@ class FibaroLight(FibaroDevice, LightEntity):
             )
 
             if self.state == "off":
-                self.set_level(int(self._brightness if self._brightness < 100 else 99))
+                self.set_level(min(int(self._brightness), 99))
             return
 
         if self._reset_color:
@@ -145,7 +145,7 @@ class FibaroLight(FibaroDevice, LightEntity):
             self.call_set_color(bri255, bri255, bri255, bri255)
 
         if self._supported_flags & SUPPORT_BRIGHTNESS:
-            self.set_level(int(self._brightness if self._brightness < 100 else 99))
+            self.set_level(min(int(self._brightness), 99))
             return
 
         # The simplest case is left for last. No dimming, just switch on

--- a/homeassistant/components/fibaro/light.py
+++ b/homeassistant/components/fibaro/light.py
@@ -118,13 +118,11 @@ class FibaroLight(FibaroDevice, LightEntity):
                 # We set it to the target brightness and turn it on
                 self._brightness = scaleto100(target_brightness)
 
-        if self._supported_flags & SUPPORT_COLOR:
-            if (
-                self._reset_color
-                and kwargs.get(ATTR_WHITE_VALUE) is None
-                and kwargs.get(ATTR_HS_COLOR) is None
-                and kwargs.get(ATTR_BRIGHTNESS) is None
-            ):
+        if self._supported_flags & SUPPORT_COLOR and (
+            kwargs.get(ATTR_WHITE_VALUE) is not None
+            or kwargs.get(ATTR_HS_COLOR) is not None
+        ):
+            if self._reset_color:
                 self._color = (100, 0)
 
             # Update based on parameters
@@ -132,14 +130,14 @@ class FibaroLight(FibaroDevice, LightEntity):
             self._color = kwargs.get(ATTR_HS_COLOR, self._color)
             rgb = color_util.color_hs_to_RGB(*self._color)
             self.call_set_color(
-                round(rgb[0] * self._brightness / 100.0),
-                round(rgb[1] * self._brightness / 100.0),
-                round(rgb[2] * self._brightness / 100.0),
-                round(self._white * self._brightness / 100.0),
+                round(rgb[0]),
+                round(rgb[1]),
+                round(rgb[2]),
+                round(self._white),
             )
 
             if self.state == "off":
-                self.set_level(int(self._brightness))
+                self.set_level(int(self._brightness if self._brightness < 100 else 99))
             return
 
         if self._reset_color:
@@ -147,7 +145,7 @@ class FibaroLight(FibaroDevice, LightEntity):
             self.call_set_color(bri255, bri255, bri255, bri255)
 
         if self._supported_flags & SUPPORT_BRIGHTNESS:
-            self.set_level(int(self._brightness))
+            self.set_level(int(self._brightness if self._brightness < 100 else 99))
             return
 
         # The simplest case is left for last. No dimming, just switch on
@@ -203,4 +201,4 @@ class FibaroLight(FibaroDevice, LightEntity):
             if rgbw_list[0] or rgbw_list[1] or rgbw_list[2]:
                 self._color = color_util.color_RGB_to_hs(*rgbw_list[:3])
             if (self._supported_flags & SUPPORT_WHITE_VALUE) and self.brightness != 0:
-                self._white = min(255, max(0, rgbw_list[3] * 100.0 / self._brightness))
+                self._white = min(255, max(0, rgbw_list[3]))


### PR DESCRIPTION
## Proposed change
I had four problems with current code.
  
1. When I only changed brightness via UI then it always slips into setColor and not into setValue. >> I've added check if white or RGB is present in kwargs for setColor.
2. RGBW colour is multiplied by brightness, which I don't fully understand why is that. And because of that, it was not possible to set colour with colour picker. >> I've removed the multiplication.
3. Brightness for setValue has not been accepted by fibaro rest API when value was 100. >> I've changed it to 99, which is accepted.
4. Similar to 2, but only for white when updating data. >> I've removed it.

Tested on fibaro rgbw controller 2 (fw 5.0) and HClite (fw 4.6).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
