### PR TITLE
Use hostname for deconz integration when deconz addon is being used

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -227,6 +227,8 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.bridge_id = normalize_bridge_id(discovery_info[CONF_SERIAL])
         await self.async_set_unique_id(self.bridge_id)
 
+        discovery_info[CONF_HOST] = "core-deconz"
+
         self._abort_if_unique_id_configured(
             updates={
                 CONF_HOST: discovery_info[CONF_HOST],

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -535,7 +535,7 @@ async def test_flow_hassio_discovery(hass):
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["result"].data == {
-        CONF_HOST: "mock-deconz",
+        CONF_HOST: "core-deconz",
         CONF_PORT: 80,
         CONF_API_KEY: API_KEY,
     }
@@ -565,7 +565,7 @@ async def test_hassio_discovery_update_configuration(hass):
 
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
-    assert config_entry.data[CONF_HOST] == "2.3.4.5"
+    assert config_entry.data[CONF_HOST] == "core-deconz"
     assert config_entry.data[CONF_PORT] == 8080
     assert config_entry.data[CONF_API_KEY] == "updated"
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
## Proposed change
`deconz` hassio discovery grabs the IP of the Docker container for the add-on upon discovery. In theory I suppose the way the discovery is written, the IP should always get updated when it changes, but in a practical sense that has not been my experience - my `deconz` config entry got stuck in a state where it could not be connected to until I manually changed the config entry in storage to point to the host name. I tried searching on Discord for `Error connecting to deCONZ gateway` and it was clear from the results that I am not the first person to run into this.

This change always uses the addon's hostname when setting up the add-on. Because this is done during discovery, this should eventually silently fix existing config entries.

Existing tests are already validating that this is working (once they were fixed)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
