### PR TITLE
Fix removing nodes in zwave_js integration

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -188,6 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "node added", lambda event: async_on_node_added(event["node"])
         )
         # listen for nodes being removed from the mesh
+        # NOTE: This will not remove nodes that were removed when HA was not running
         client.driver.controller.on(
             "node removed", lambda event: async_on_node_removed(event["node"])
         )

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -1,6 +1,7 @@
 """The Z-Wave JS integration."""
 import asyncio
 import logging
+from typing import Tuple
 
 from async_timeout import timeout
 from zwave_js_server.client import Client as ZwaveClient
@@ -37,6 +38,12 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 
 @callback
+def get_device_id(client: ZwaveClient, node: ZwaveNode) -> Tuple[str, str]:
+    """Get device registry identifier for Z-Wave node."""
+    return (DOMAIN, f"{client.driver.controller.home_id}-{node.node_id}")
+
+
+@callback
 def register_node_in_dev_reg(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -47,7 +54,7 @@ def register_node_in_dev_reg(
     """Register node in dev reg."""
     device = dev_reg.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, f"{client.driver.controller.home_id}-{node.node_id}")},
+        identifiers={get_device_id(client, node)},
         sw_version=node.firmware_version,
         name=node.name or node.device_config.description or f"Node {node.node_id}",
         model=node.device_config.label,
@@ -118,6 +125,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # some visual feedback that something is (in the process of) being added
         register_node_in_dev_reg(hass, entry, dev_reg, client, node)
 
+    @callback
+    def async_on_node_removed(node: ZwaveNode) -> None:
+        """Handle node removed event."""
+        # grab device in device registry attached to this node
+        dev_id = get_device_id(client, node)
+        device = dev_reg.async_get_device({dev_id})
+        # note: removal of entity registry is handled by core
+        dev_reg.async_remove_device(device.id)
+
     async def handle_ha_shutdown(event: Event) -> None:
         """Handle HA shutdown."""
         await client.disconnect()
@@ -170,6 +186,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # listen for new nodes being added to the mesh
         client.driver.controller.on(
             "node added", lambda event: async_on_node_added(event["node"])
+        )
+        # listen for nodes being removed from the mesh
+        client.driver.controller.on(
+            "node removed", lambda event: async_on_node_removed(event["node"])
         )
 
     hass.async_create_task(start_platforms())


### PR DESCRIPTION
## Breaking change

## Proposed change
We forgot to handle the "node removed" event.
This will cleanup the device (and it's entities) when a node removed event is fired by Z-Wave JS.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information

- This PR fixes or closes issue: fixes #45634 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
