### PR TITLE
Add significant change support to binary_sensor

### DIFF
--- a/homeassistant/components/binary_sensor/significant_change.py
+++ b/homeassistant/components/binary_sensor/significant_change.py
@@ -1,7 +1,6 @@
 """Helper to test significant Binary Sensor state changes."""
 from typing import Any, Optional
 
-from homeassistant.const import ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant, callback
 
 
@@ -15,11 +14,6 @@ def async_check_significant_change(
     **kwargs: Any,
 ) -> Optional[bool]:
     """Test if state significantly changed."""
-    device_class = new_attrs.get(ATTR_DEVICE_CLASS)
-
-    if device_class is None:
-        return None
-
     if old_state != new_state:
         return True
 

--- a/homeassistant/components/binary_sensor/significant_change.py
+++ b/homeassistant/components/binary_sensor/significant_change.py
@@ -1,0 +1,26 @@
+"""Helper to test significant Binary Sensor state changes."""
+from typing import Any, Optional
+
+from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.core import HomeAssistant, callback
+
+
+@callback
+def async_check_significant_change(
+    hass: HomeAssistant,
+    old_state: str,
+    old_attrs: dict,
+    new_state: str,
+    new_attrs: dict,
+    **kwargs: Any,
+) -> Optional[bool]:
+    """Test if state significantly changed."""
+    device_class = new_attrs.get(ATTR_DEVICE_CLASS)
+
+    if device_class is None:
+        return None
+
+    if old_state != new_state:
+        return True
+
+    return False

--- a/homeassistant/components/binary_sensor/translations/en.json
+++ b/homeassistant/components/binary_sensor/translations/en.json
@@ -159,8 +159,8 @@
             "on": "Plugged in"
         },
         "presence": {
-            "off": "Away",
-            "on": "Home"
+            "off": "[%key:common::state::not_home%]",
+            "on": "[%key:common::state::home%]"
         },
         "problem": {
             "off": "OK",

--- a/tests/components/binary_sensor/test_significant_change.py
+++ b/tests/components/binary_sensor/test_significant_change.py
@@ -1,0 +1,11 @@
+"""Test the Binary Sensor significant change platform."""
+from homeassistant.components.binary_sensor.significant_change import (
+    async_check_significant_change,
+)
+
+
+async def test_significant_change():
+    """Detect Binary Sensor significant changes."""
+    attrs = {}
+    assert not async_check_significant_change(None, "on", attrs, "on", attrs)
+    assert async_check_significant_change(None, "on", attrs, "off", attrs)

--- a/tests/components/binary_sensor/test_significant_change.py
+++ b/tests/components/binary_sensor/test_significant_change.py
@@ -6,6 +6,13 @@ from homeassistant.components.binary_sensor.significant_change import (
 
 async def test_significant_change():
     """Detect Binary Sensor significant changes."""
-    attrs = {}
-    assert not async_check_significant_change(None, "on", attrs, "on", attrs)
-    assert async_check_significant_change(None, "on", attrs, "off", attrs)
+    old_attrs = {}
+    new_attrs = {"a": 1}
+
+    assert not async_check_significant_change(None, "on", old_attrs, "on", old_attrs)
+    assert (
+        async_check_significant_change(None, "on", old_attrs, "off", old_attrs) is True
+    )
+    assert (
+        async_check_significant_change(None, "on", old_attrs, "on", new_attrs) is False
+    )

--- a/tests/components/binary_sensor/test_significant_change.py
+++ b/tests/components/binary_sensor/test_significant_change.py
@@ -9,7 +9,9 @@ async def test_significant_change():
     old_attrs = {}
     new_attrs = {"a": 1}
 
-    assert not async_check_significant_change(None, "on", old_attrs, "on", old_attrs)
+    assert (
+        async_check_significant_change(None, "on", old_attrs, "on", old_attrs) is False
+    )
     assert (
         async_check_significant_change(None, "on", old_attrs, "off", old_attrs) is True
     )

--- a/tests/components/binary_sensor/test_significant_change.py
+++ b/tests/components/binary_sensor/test_significant_change.py
@@ -13,8 +13,8 @@ async def test_significant_change():
         async_check_significant_change(None, "on", old_attrs, "on", old_attrs) is False
     )
     assert (
-        async_check_significant_change(None, "on", old_attrs, "off", old_attrs) is True
+        async_check_significant_change(None, "on", old_attrs, "on", new_attrs) is False
     )
     assert (
-        async_check_significant_change(None, "on", old_attrs, "on", new_attrs) is False
+        async_check_significant_change(None, "on", old_attrs, "off", old_attrs) is True
     )

--- a/tests/components/binary_sensor/test_significant_change.py
+++ b/tests/components/binary_sensor/test_significant_change.py
@@ -6,8 +6,8 @@ from homeassistant.components.binary_sensor.significant_change import (
 
 async def test_significant_change():
     """Detect Binary Sensor significant changes."""
-    old_attrs = {}
-    new_attrs = {"a": 1}
+    old_attrs = {"attr_1": "value_1"}
+    new_attrs = {"attr_1": "value_2"}
 
     assert (
         async_check_significant_change(None, "on", old_attrs, "on", old_attrs) is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for the `significant_change` platform within the `binary_sensor` component. It starts out nice and simple (there's only a significant change when the state value changes), but I'm open to other thoughts!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes https://github.com/home-assistant/core/issues/45647
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
