### PR TITLE
Remove YAML support from Hyperion integration

### DIFF
--- a/homeassistant/components/hyperion/__init__.py
+++ b/homeassistant/components/hyperion/__init__.py
@@ -278,10 +278,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         }
     )
 
-    # Must only listen for option updates after the setup is complete, as otherwise
-    # the YAML->ConfigEntry migration code triggers an options update, which causes a
-    # reload -- which clashes with the initial load (causing entity_id / unique_id
-    # clashes).
     async def setup_then_listen() -> None:
         await asyncio.gather(
             *[

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -140,14 +140,6 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
             return await self.async_step_auth()
         return await self.async_step_confirm()
 
-    async def async_step_import(self, import_data: ConfigType) -> Dict[str, Any]:
-        """Handle a flow initiated by a YAML config import."""
-        self._data.update(import_data)
-        async with self._create_client(raw_connection=True) as hyperion_client:
-            if not hyperion_client:
-                return self.async_abort(reason="cannot_connect")
-            return await self._advance_to_auth_step_if_necessary(hyperion_client)
-
     async def async_step_reauth(
         self,
         config_data: ConfigType,

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, Mock, patch
 from hyperion import const
 
 from homeassistant.components.hyperion.const import CONF_PRIORITY, DOMAIN
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.typing import HomeAssistantType
@@ -24,8 +23,6 @@ TEST_ID = "default"
 TEST_SYSINFO_ID = "f9aab089-f85a-55cf-b7c1-222a72faebe9"
 TEST_SYSINFO_VERSION = "2.0.0-alpha.8"
 TEST_PRIORITY = 180
-TEST_YAML_NAME = f"{TEST_HOST}_{TEST_PORT}_{TEST_INSTANCE}"
-TEST_YAML_ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_YAML_NAME}"
 TEST_ENTITY_ID_1 = "light.test_instance_1"
 TEST_ENTITY_ID_2 = "light.test_instance_2"
 TEST_ENTITY_ID_3 = "light.test_instance_3"

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -14,12 +14,7 @@ from homeassistant.components.hyperion.const import (
     DOMAIN,
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.config_entries import (
-    SOURCE_IMPORT,
-    SOURCE_REAUTH,
-    SOURCE_SSDP,
-    SOURCE_USER,
-)
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_HOST,
@@ -604,56 +599,6 @@ async def test_ssdp_abort_duplicates(hass: HomeAssistantType) -> None:
     assert result_1["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result_2["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result_2["reason"] == "already_in_progress"
-
-
-async def test_import_success(hass: HomeAssistantType) -> None:
-    """Check an import flow from the old-style YAML."""
-
-    client = create_mock_client()
-    with patch(
-        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
-    ):
-        result = await _init_flow(
-            hass,
-            source=SOURCE_IMPORT,
-            data={
-                CONF_HOST: TEST_HOST,
-                CONF_PORT: TEST_PORT,
-            },
-        )
-        await hass.async_block_till_done()
-
-    # No human interaction should be required.
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["handler"] == DOMAIN
-    assert result["title"] == TEST_TITLE
-    assert result["data"] == {
-        CONF_HOST: TEST_HOST,
-        CONF_PORT: TEST_PORT,
-    }
-
-
-async def test_import_cannot_connect(hass: HomeAssistantType) -> None:
-    """Check an import flow that cannot connect."""
-
-    client = create_mock_client()
-    client.async_client_connect = AsyncMock(return_value=False)
-
-    with patch(
-        "homeassistant.components.hyperion.client.HyperionClient", return_value=client
-    ):
-        result = await _init_flow(
-            hass,
-            source=SOURCE_IMPORT,
-            data={
-                CONF_HOST: TEST_HOST,
-                CONF_PORT: TEST_PORT,
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "cannot_connect"
 
 
 async def test_options(hass: HomeAssistantType) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Remove support for Hyperion YAML configuration. Hyperion was converted to a config flow and the YAML options marked deprecated on November 30th 2020 (https://github.com/home-assistant/core/pull/43673/files#).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Note: It's a little hard to track what is counted as a release given the recent changes, but by ~any measure at least 2 have gone by.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/43673
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
