### PR TITLE
Fix mqtt check in ozw

### DIFF
--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -97,7 +97,11 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         This is the entry point for the logic that is needed
         when this integration will depend on the MQTT integration.
         """
-        if "mqtt" not in self.hass.config.components:
+        mqtt_entries = self.hass.config_entries.async_entries("mqtt")
+        if (
+            not mqtt_entries
+            or mqtt_entries[0].state != config_entries.ENTRY_STATE_LOADED
+        ):
             return self.async_abort(reason="mqtt_required")
         return self._async_create_entry_from_vars()
 

--- a/tests/components/ozw/common.py
+++ b/tests/components/ozw/common.py
@@ -10,7 +10,8 @@ from tests.common import MockConfigEntry
 
 async def setup_ozw(hass, entry=None, fixture=None):
     """Set up OZW and load a dump."""
-    hass.config.components.add("mqtt")
+    mqtt_entry = MockConfigEntry(domain="mqtt", state=config_entries.ENTRY_STATE_LOADED)
+    mqtt_entry.add_to_hass(hass)
 
     if entry is None:
         entry = MockConfigEntry(

--- a/tests/components/ozw/conftest.py
+++ b/tests/components/ozw/conftest.py
@@ -4,9 +4,11 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.config_entries import ENTRY_STATE_LOADED
+
 from .common import MQTTMessage
 
-from tests.common import load_fixture
+from tests.common import MockConfigEntry, load_fixture
 from tests.components.light.conftest import mock_light_profiles  # noqa
 
 
@@ -268,3 +270,11 @@ def mock_get_addon_discovery_info():
         "homeassistant.components.hassio.async_get_addon_discovery_info"
     ) as get_addon_discovery_info:
         yield get_addon_discovery_info
+
+
+@pytest.fixture(name="mqtt")
+async def mock_mqtt_fixture(hass):
+    """Mock the MQTT integration."""
+    mqtt_entry = MockConfigEntry(domain="mqtt", state=ENTRY_STATE_LOADED)
+    mqtt_entry.add_to_hass(hass)
+    return mqtt_entry

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -79,9 +79,8 @@ def mock_start_addon():
         yield start_addon
 
 
-async def test_user_not_supervisor_create_entry(hass):
+async def test_user_not_supervisor_create_entry(hass, mqtt):
     """Test the user step creates an entry not on Supervisor."""
-    hass.config.components.add("mqtt")
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
@@ -128,9 +127,8 @@ async def test_one_instance_allowed(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_not_addon(hass, supervisor):
+async def test_not_addon(hass, supervisor, mqtt):
     """Test opting out of add-on on Supervisor."""
-    hass.config.components.add("mqtt")
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/ozw/test_init.py
+++ b/tests/components/ozw/test_init.py
@@ -37,6 +37,26 @@ async def test_setup_entry_without_mqtt(hass):
     assert not await hass.config_entries.async_setup(entry.entry_id)
 
 
+async def test_publish_without_mqtt(hass, caplog):
+    """Test publish without mqtt integration setup."""
+    with patch("homeassistant.components.ozw.OZWOptions") as ozw_options:
+        await setup_ozw(hass)
+
+        send_message = ozw_options.call_args[1]["send_message"]
+
+        mqtt_entries = hass.config_entries.async_entries("mqtt")
+        mqtt_entry = mqtt_entries[0]
+        await hass.config_entries.async_remove(mqtt_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert not hass.config_entries.async_entries("mqtt")
+
+        # Sending a message should not error with the MQTT integration not set up.
+        send_message("test_topic", "test_payload")
+
+    assert "MQTT integration is not set up" in caplog.text
+
+
 async def test_unload_entry(hass, generic_data, switch_msg, caplog):
     """Test unload the config entry."""
     entry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The OpenZWave integration requires the MQTT integration in some setups.
- We used an outdated way to check if MQTT is setup.
- Fix this by using the config entries api to check if the MQTT integration is loaded.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
