### PR TITLE
Fix Homematic transition function on light devices with multiple channels

### DIFF
--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -9,6 +9,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT,
+    SUPPORT_TRANSITION,
     LightEntity,
 )
 
@@ -53,7 +54,8 @@ class HMLight(HMDevice, LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        features = SUPPORT_BRIGHTNESS
+        features = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+
         if "COLOR" in self._hmdevice.WRITENODE:
             features |= SUPPORT_COLOR
         if "PROGRAM" in self._hmdevice.WRITENODE:
@@ -95,7 +97,7 @@ class HMLight(HMDevice, LightEntity):
     def turn_on(self, **kwargs):
         """Turn the light on and/or change color or color effect settings."""
         if ATTR_TRANSITION in kwargs:
-            self._hmdevice.setValue("RAMP_TIME", kwargs[ATTR_TRANSITION])
+            self._hmdevice.setValue("RAMP_TIME", kwargs[ATTR_TRANSITION], self._channel)
 
         if ATTR_BRIGHTNESS in kwargs and self._state == "LEVEL":
             percent_bright = float(kwargs[ATTR_BRIGHTNESS]) / 255
@@ -123,6 +125,9 @@ class HMLight(HMDevice, LightEntity):
 
     def turn_off(self, **kwargs):
         """Turn the light off."""
+        if ATTR_TRANSITION in kwargs:
+            self._hmdevice.setValue("RAMP_TIME", kwargs[ATTR_TRANSITION], self._channel)
+            
         self._hmdevice.off(self._channel)
 
     def _init_data_struct(self):

--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -127,7 +127,7 @@ class HMLight(HMDevice, LightEntity):
         """Turn the light off."""
         if ATTR_TRANSITION in kwargs:
             self._hmdevice.setValue("RAMP_TIME", kwargs[ATTR_TRANSITION], self._channel)
-            
+
         self._hmdevice.off(self._channel)
 
     def _init_data_struct(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Transition function on homematic light devices with multiple channels

Transitions are currently not working on devices with multiple channels. This fixes this in light_on and also adds transition functionality to light_off


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This is my first pull request here, please highlight any mistakes I might have made.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
