### PR TITLE
Resolve homekit cover adjustment slowness

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_state_change_event
 
-from .accessories import TYPES, HomeAccessory, debounce
+from .accessories import TYPES, HomeAccessory
 from .const import (
     ATTR_OBSTRUCTION_DETECTED,
     CHAR_CURRENT_DOOR_STATE,
@@ -233,7 +233,6 @@ class OpeningDeviceBase(HomeAccessory):
             return
         self.call_service(DOMAIN, SERVICE_STOP_COVER, {ATTR_ENTITY_ID: self.entity_id})
 
-    @debounce
     def set_tilt(self, value):
         """Set tilt to value if call came from HomeKit."""
         _LOGGER.info("%s: Set tilt to %d", self.entity_id, value)
@@ -284,7 +283,6 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
         )
         self.async_update_state(state)
 
-    @debounce
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
         _LOGGER.debug("%s: Set position to %d", self.entity_id, value)
@@ -360,7 +358,6 @@ class WindowCoveringBasic(OpeningDeviceBase, HomeAccessory):
         )
         self.async_update_state(state)
 
-    @debounce
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
         _LOGGER.debug("%s: Set position to %d", self.entity_id, value)

--- a/tests/components/homekit/common.py
+++ b/tests/components/homekit/common.py
@@ -1,15 +1,7 @@
 """Collection of fixtures and functions for the HomeKit tests."""
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 EMPTY_8_6_JPEG = b"empty_8_6"
-
-
-def patch_debounce():
-    """Return patch for debounce method."""
-    return patch(
-        "homeassistant.components.homekit.accessories.debounce",
-        lambda f: lambda *args, **kwargs: f(*args, **kwargs),
-    )
 
 
 def mock_turbo_jpeg(

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -2,7 +2,6 @@
 
 This includes tests for all mock object types.
 """
-from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,7 +10,6 @@ from homeassistant.components.homekit.accessories import (
     HomeAccessory,
     HomeBridge,
     HomeDriver,
-    debounce,
 )
 from homeassistant.components.homekit.const import (
     ATTR_DISPLAY_NAME,
@@ -45,41 +43,8 @@ from homeassistant.const import (
     __version__,
 )
 from homeassistant.helpers.event import TRACK_STATE_CHANGE_CALLBACKS
-import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed, async_mock_service
-
-
-async def test_debounce(hass):
-    """Test add_timeout decorator function."""
-
-    def demo_func(*args):
-        nonlocal arguments, counter
-        counter += 1
-        arguments = args
-
-    arguments = None
-    counter = 0
-    mock = Mock(hass=hass, debounce={})
-
-    debounce_demo = debounce(demo_func)
-    assert debounce_demo.__name__ == "demo_func"
-    now = dt_util.utcnow()
-
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
-        await hass.async_add_executor_job(debounce_demo, mock, "value")
-    async_fire_time_changed(hass, now + timedelta(seconds=3))
-    await hass.async_block_till_done()
-    assert counter == 1
-    assert len(arguments) == 2
-
-    with patch("homeassistant.util.dt.utcnow", return_value=now):
-        await hass.async_add_executor_job(debounce_demo, mock, "value")
-        await hass.async_add_executor_job(debounce_demo, mock, "value")
-
-    async_fire_time_changed(hass, now + timedelta(seconds=3))
-    await hass.async_block_till_done()
-    assert counter == 2
+from tests.common import async_mock_service
 
 
 async def test_accessory_cancels_track_state_change_on_stop(hass, hk_driver):

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -67,7 +67,6 @@ from homeassistant.util import json as json_util
 from .util import PATH_HOMEKIT, async_init_entry, async_init_integration
 
 from tests.common import MockConfigEntry, mock_device_registry, mock_registry
-from tests.components.homekit.common import patch_debounce
 
 IP_ADDRESS = "127.0.0.1"
 
@@ -87,14 +86,6 @@ def device_reg_fixture(hass):
 def entity_reg_fixture(hass):
     """Return an empty, loaded, registry."""
     return mock_registry(hass)
-
-
-@pytest.fixture(name="debounce_patcher", scope="module")
-def debounce_patcher_fixture():
-    """Patch debounce method."""
-    patcher = patch_debounce()
-    yield patcher.start()
-    patcher.stop()
 
 
 async def test_setup_min(hass, mock_zeroconf):
@@ -485,7 +476,7 @@ async def test_homekit_entity_glob_filter(hass, mock_zeroconf):
         mock_get_acc.reset_mock()
 
 
-async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
+async def test_homekit_start(hass, hk_driver, device_reg):
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
 
@@ -573,9 +564,7 @@ async def test_homekit_start(hass, hk_driver, device_reg, debounce_patcher):
     assert len(device_reg.devices) == 1
 
 
-async def test_homekit_start_with_a_broken_accessory(
-    hass, hk_driver, debounce_patcher, mock_zeroconf
-):
+async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, mock_zeroconf):
     """Test HomeKit start method."""
     pin = b"123-45-678"
     entry = MockConfigEntry(
@@ -754,7 +743,7 @@ async def test_homekit_too_many_accessories(hass, hk_driver, caplog, mock_zeroco
 
 
 async def test_homekit_finds_linked_batteries(
-    hass, hk_driver, debounce_patcher, device_reg, entity_reg, mock_zeroconf
+    hass, hk_driver, device_reg, entity_reg, mock_zeroconf
 ):
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
@@ -840,7 +829,7 @@ async def test_homekit_finds_linked_batteries(
 
 
 async def test_homekit_async_get_integration_fails(
-    hass, hk_driver, debounce_patcher, device_reg, entity_reg, mock_zeroconf
+    hass, hk_driver, device_reg, entity_reg, mock_zeroconf
 ):
     """Test that we continue if async_get_integration fails."""
     entry = await async_init_integration(hass)
@@ -1072,7 +1061,7 @@ def _write_data(path: str, data: Dict) -> None:
 
 
 async def test_homekit_ignored_missing_devices(
-    hass, hk_driver, debounce_patcher, device_reg, entity_reg, mock_zeroconf
+    hass, hk_driver, device_reg, entity_reg, mock_zeroconf
 ):
     """Test HomeKit handles a device in the entity registry but missing from the device registry."""
     entry = await async_init_integration(hass)
@@ -1153,7 +1142,7 @@ async def test_homekit_ignored_missing_devices(
 
 
 async def test_homekit_finds_linked_motion_sensors(
-    hass, hk_driver, debounce_patcher, device_reg, entity_reg, mock_zeroconf
+    hass, hk_driver, device_reg, entity_reg, mock_zeroconf
 ):
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
@@ -1228,7 +1217,7 @@ async def test_homekit_finds_linked_motion_sensors(
 
 
 async def test_homekit_finds_linked_humidity_sensors(
-    hass, hk_driver, debounce_patcher, device_reg, entity_reg, mock_zeroconf
+    hass, hk_driver, device_reg, entity_reg, mock_zeroconf
 ):
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
@@ -1376,9 +1365,7 @@ def _get_fixtures_base_path():
     return os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 
-async def test_homekit_start_in_accessory_mode(
-    hass, hk_driver, device_reg, debounce_patcher
-):
+async def test_homekit_start_in_accessory_mode(hass, hk_driver, device_reg):
     """Test HomeKit start method in accessory mode."""
     entry = await async_init_integration(hass)
 

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -1,10 +1,9 @@
 """Test different accessory types: Lights."""
-from collections import namedtuple
 
 from pyhap.const import HAP_REPR_AID, HAP_REPR_CHARS, HAP_REPR_IID, HAP_REPR_VALUE
-import pytest
 
 from homeassistant.components.homekit.const import ATTR_VALUE
+from homeassistant.components.homekit.type_lights import Light
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
@@ -28,29 +27,15 @@ from homeassistant.core import CoreState
 from homeassistant.helpers import entity_registry
 
 from tests.common import async_mock_service
-from tests.components.homekit.common import patch_debounce
 
 
-@pytest.fixture(scope="module")
-def cls():
-    """Patch debounce decorator during import of type_lights."""
-    patcher = patch_debounce()
-    patcher.start()
-    _import = __import__(
-        "homeassistant.components.homekit.type_lights", fromlist=["Light"]
-    )
-    patcher_tuple = namedtuple("Cls", ["light"])
-    yield patcher_tuple(light=_import.Light)
-    patcher.stop()
-
-
-async def test_light_basic(hass, hk_driver, cls, events):
+async def test_light_basic(hass, hk_driver, events):
     """Test light with char state."""
     entity_id = "light.demo"
 
     hass.states.async_set(entity_id, STATE_ON, {ATTR_SUPPORTED_FEATURES: 0})
     await hass.async_block_till_done()
-    acc = cls.light(hass, hk_driver, "Light", entity_id, 1, None)
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
     hk_driver.add_accessory(acc)
 
     assert acc.aid == 1
@@ -113,7 +98,7 @@ async def test_light_basic(hass, hk_driver, cls, events):
     assert events[-1].data[ATTR_VALUE] == "Set state to 0"
 
 
-async def test_light_brightness(hass, hk_driver, cls, events):
+async def test_light_brightness(hass, hk_driver, events):
     """Test light with brightness."""
     entity_id = "light.demo"
 
@@ -123,7 +108,7 @@ async def test_light_brightness(hass, hk_driver, cls, events):
         {ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 255},
     )
     await hass.async_block_till_done()
-    acc = cls.light(hass, hk_driver, "Light", entity_id, 1, None)
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
     hk_driver.add_accessory(acc)
 
     # Initial value can be anything but 0. If it is 0, it might cause HomeKit to set the
@@ -231,7 +216,7 @@ async def test_light_brightness(hass, hk_driver, cls, events):
     assert acc.char_brightness.value == 1
 
 
-async def test_light_color_temperature(hass, hk_driver, cls, events):
+async def test_light_color_temperature(hass, hk_driver, events):
     """Test light with color temperature."""
     entity_id = "light.demo"
 
@@ -241,7 +226,7 @@ async def test_light_color_temperature(hass, hk_driver, cls, events):
         {ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR_TEMP, ATTR_COLOR_TEMP: 190},
     )
     await hass.async_block_till_done()
-    acc = cls.light(hass, hk_driver, "Light", entity_id, 1, None)
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
     hk_driver.add_accessory(acc)
 
     assert acc.char_color_temperature.value == 190
@@ -278,7 +263,7 @@ async def test_light_color_temperature(hass, hk_driver, cls, events):
     assert events[-1].data[ATTR_VALUE] == "color temperature at 250"
 
 
-async def test_light_color_temperature_and_rgb_color(hass, hk_driver, cls, events):
+async def test_light_color_temperature_and_rgb_color(hass, hk_driver, events):
     """Test light with color temperature and rgb color not exposing temperature."""
     entity_id = "light.demo"
 
@@ -292,7 +277,7 @@ async def test_light_color_temperature_and_rgb_color(hass, hk_driver, cls, event
         },
     )
     await hass.async_block_till_done()
-    acc = cls.light(hass, hk_driver, "Light", entity_id, 2, None)
+    acc = Light(hass, hk_driver, "Light", entity_id, 2, None)
     assert acc.char_hue.value == 260
     assert acc.char_saturation.value == 90
 
@@ -313,7 +298,7 @@ async def test_light_color_temperature_and_rgb_color(hass, hk_driver, cls, event
     assert acc.char_saturation.value == 61
 
 
-async def test_light_rgb_color(hass, hk_driver, cls, events):
+async def test_light_rgb_color(hass, hk_driver, events):
     """Test light with rgb_color."""
     entity_id = "light.demo"
 
@@ -323,7 +308,7 @@ async def test_light_rgb_color(hass, hk_driver, cls, events):
         {ATTR_SUPPORTED_FEATURES: SUPPORT_COLOR, ATTR_HS_COLOR: (260, 90)},
     )
     await hass.async_block_till_done()
-    acc = cls.light(hass, hk_driver, "Light", entity_id, 1, None)
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
     hk_driver.add_accessory(acc)
 
     assert acc.char_hue.value == 260
@@ -365,7 +350,7 @@ async def test_light_rgb_color(hass, hk_driver, cls, events):
     assert events[-1].data[ATTR_VALUE] == "set color at (145, 75)"
 
 
-async def test_light_restore(hass, hk_driver, cls, events):
+async def test_light_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
@@ -385,20 +370,20 @@ async def test_light_restore(hass, hk_driver, cls, events):
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START, {})
     await hass.async_block_till_done()
 
-    acc = cls.light(hass, hk_driver, "Light", "light.simple", 1, None)
+    acc = Light(hass, hk_driver, "Light", "light.simple", 1, None)
     hk_driver.add_accessory(acc)
 
     assert acc.category == 5  # Lightbulb
     assert acc.chars == []
     assert acc.char_on.value == 0
 
-    acc = cls.light(hass, hk_driver, "Light", "light.all_info_set", 2, None)
+    acc = Light(hass, hk_driver, "Light", "light.all_info_set", 2, None)
     assert acc.category == 5  # Lightbulb
     assert acc.chars == ["Brightness"]
     assert acc.char_on.value == 0
 
 
-async def test_light_set_brightness_and_color(hass, hk_driver, cls, events):
+async def test_light_set_brightness_and_color(hass, hk_driver, events):
     """Test light with all chars in one go."""
     entity_id = "light.demo"
 
@@ -411,7 +396,7 @@ async def test_light_set_brightness_and_color(hass, hk_driver, cls, events):
         },
     )
     await hass.async_block_till_done()
-    acc = cls.light(hass, hk_driver, "Light", entity_id, 1, None)
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
     hk_driver.add_accessory(acc)
 
     # Initial value can be anything but 0. If it is 0, it might cause HomeKit to set the
@@ -474,7 +459,7 @@ async def test_light_set_brightness_and_color(hass, hk_driver, cls, events):
     )
 
 
-async def test_light_set_brightness_and_color_temp(hass, hk_driver, cls, events):
+async def test_light_set_brightness_and_color_temp(hass, hk_driver, events):
     """Test light with all chars in one go."""
     entity_id = "light.demo"
 
@@ -487,7 +472,7 @@ async def test_light_set_brightness_and_color_temp(hass, hk_driver, cls, events)
         },
     )
     await hass.async_block_till_done()
-    acc = cls.light(hass, hk_driver, "Light", entity_id, 1, None)
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
     hk_driver.add_accessory(acc)
 
     # Initial value can be anything but 0. If it is 0, it might cause HomeKit to set the


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Resolve homekit cover adjustment slowness

This is the last remaining debounce that was left in (was already removed from fans and lights for similar reasons).

HomeKit is much much faster due to optimizations under
the hood, so a debounce is no longer needed. This
solves the perceived unresponsiveness with homekit covers
which was especially apparent when the shades or blinds are local.

I finally got around to fixing this because homekit
is about to go fully async https://github.com/ikalchev/HAP-python/pull/301
which makes it even more responsive.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
