### PR TITLE
Update zha to use new fan entity model

### DIFF
--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -7,11 +7,9 @@ from zigpy.exceptions import ZigbeeException
 import zigpy.zcl.clusters.hvac as hvac
 
 from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
     DOMAIN,
-    SPEED_HIGH,
-    SPEED_LOW,
-    SPEED_MEDIUM,
-    SPEED_OFF,
     SUPPORT_SET_SPEED,
     FanEntity,
 )
@@ -37,26 +35,20 @@ from .entity import ZhaEntity, ZhaGroupEntity
 # Additional speeds in zigbee's ZCL
 # Spec is unclear as to what this value means. On King Of Fans HBUniversal
 # receiver, this means Very High.
-SPEED_ON = "on"
+PRESET_MODE_ON = "on"
 # The fan speed is self-regulated
-SPEED_AUTO = "auto"
+PRESET_MODE_AUTO = "auto"
 # When the heated/cooled space is occupied, the fan is always on
-SPEED_SMART = "smart"
-
-SPEED_LIST = [
-    SPEED_OFF,
-    SPEED_LOW,
-    SPEED_MEDIUM,
-    SPEED_HIGH,
-    SPEED_ON,
-    SPEED_AUTO,
-    SPEED_SMART,
-]
+PRESET_MODE_SMART = "smart"
 
 SPEED_RANGE = (1, 3)  # off is not included
-PRESET_MODES_TO_NAME = {5: SPEED_AUTO, 6: SPEED_SMART}
+PRESET_MODES_TO_NAME = {4: PRESET_MODE_ON, 5: PRESET_MODE_AUTO, 6: PRESET_MODE_SMART}
+
 NAME_TO_PRESET_MODE = {v: k for k, v in PRESET_MODES_TO_NAME.items()}
 PRESET_MODES = list(NAME_TO_PRESET_MODE)
+
+DEFAULT_ON_PERCENTAGE = 50
+
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, DOMAIN)
 GROUP_MATCH = functools.partial(ZHA_ENTITIES.group_match, DOMAIN)
 
@@ -81,26 +73,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class BaseFan(FanEntity):
     """Base representation of a ZHA fan."""
 
-    def __init__(self, *args, **kwargs):
-        """Initialize the fan."""
-        super().__init__(*args, **kwargs)
-        self._state = None
-        self._fan_channel = None
-
-    @property
-    def percentage(self) -> str:
-        """Return the current speed percentage."""
-        if self._state is None or self._state > SPEED_RANGE[1]:
-            return None
-        if self._state == 0:
-            return 0
-        return ranged_value_to_percentage(SPEED_RANGE, self._state)
-
-    @property
-    def preset_mode(self) -> str:
-        """Return the current preset mode."""
-        return PRESET_MODES_TO_NAME.get(self._state)
-
     @property
     def preset_modes(self) -> str:
         """Return the available preset modes."""
@@ -124,7 +96,7 @@ class BaseFan(FanEntity):
     async def async_set_percentage(self, percentage: Optional[int]) -> None:
         """Set the speed percenage of the fan."""
         if percentage is None:
-            percentage = 50
+            percentage = DEFAULT_ON_PERCENTAGE
         fan_mode = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
         await self._async_set_fan_mode(fan_mode)
 
@@ -194,11 +166,23 @@ class FanGroup(BaseFan, ZhaGroupEntity):
         self._available: bool = False
         group = self.zha_device.gateway.get_group(self._group_id)
         self._fan_channel = group.endpoint[hvac.Fan.cluster_id]
+        self._percentage = None
+        self._preset_mode = None
+
+    @property
+    def percentage(self) -> str:
+        """Return the current speed percentage."""
+        return self._percentage
+
+    @property
+    def preset_mode(self) -> str:
+        """Return the current preset mode."""
+        return self._preset_mode
 
     async def async_set_percentage(self, percentage: Optional[int]) -> None:
         """Set the speed percenage of the fan."""
         if percentage is None:
-            percentage = 50
+            percentage = DEFAULT_ON_PERCENTAGE
         fan_mode = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
         await self._async_set_fan_mode(fan_mode)
 
@@ -219,14 +203,23 @@ class FanGroup(BaseFan, ZhaGroupEntity):
         """Attempt to retrieve on off state from the fan."""
         all_states = [self.hass.states.get(x) for x in self._entity_ids]
         states: List[State] = list(filter(None, all_states))
-        on_states: List[State] = [state for state in states if state.state != SPEED_OFF]
-
+        percentage_states: List[State] = [
+            state for state in states if state.attributes.get(ATTR_PERCENTAGE)
+        ]
+        preset_mode_states: List[State] = [
+            state for state in states if state.attributes.get(ATTR_PRESET_MODE)
+        ]
         self._available = any(state.state != STATE_UNAVAILABLE for state in states)
-        # for now just use first non off state since its kind of arbitrary
-        if not on_states:
-            self._state = SPEED_OFF
+
+        if percentage_states:
+            self._percentage = percentage_states[0].attributes[ATTR_PERCENTAGE]
+            self._preset_mode = None
+        elif preset_mode_states:
+            self._preset_mode = preset_mode_states[0].attributes[ATTR_PRESET_MODE]
+            self._percentage = None
         else:
-            self._state = on_states[0].state
+            self._percentage = None
+            self._preset_mode = None
 
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -1,4 +1,5 @@
 """Fans on Zigbee Home Automation networks."""
+from abc import abstractmethod
 import functools
 import math
 from typing import List, Optional
@@ -105,10 +106,9 @@ class BaseFan(FanEntity):
         fan_mode = NAME_TO_PRESET_MODE.get(preset_mode)
         await self._async_set_fan_mode(fan_mode)
 
+    @abstractmethod
     async def _async_set_fan_mode(self, fan_mode: int) -> None:
         """Set the fan mode for the fan."""
-        await self._fan_channel.async_set_speed(fan_mode)
-        self.async_set_state(0, "fan_mode", fan_mode)
 
     @callback
     def async_set_state(self, attr_id, attr_name, value):
@@ -152,6 +152,11 @@ class ZhaFan(BaseFan, ZhaEntity):
     def async_set_state(self, attr_id, attr_name, value):
         """Handle state update from channel."""
         self.async_write_ha_state()
+
+    async def _async_set_fan_mode(self, fan_mode: int) -> None:
+        """Set the fan mode for the fan."""
+        await self._fan_channel.async_set_speed(fan_mode)
+        self.async_set_state(0, "fan_mode", fan_mode)
 
 
 @GROUP_MATCH()

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -56,7 +56,7 @@ SPEED_LIST = [
 SPEED_RANGE = (1, 3)  # off is not included
 PRESET_MODES_TO_NAME = {5: SPEED_AUTO, 6: SPEED_SMART}
 NAME_TO_PRESET_MODE = {v: k for k, v in PRESET_MODES_TO_NAME.items()}
-
+PRESET_MODES = list(NAME_TO_PRESET_MODE)
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, DOMAIN)
 GROUP_MATCH = functools.partial(ZHA_ENTITIES.group_match, DOMAIN)
 
@@ -104,7 +104,7 @@ class BaseFan(FanEntity):
     @property
     def preset_modes(self) -> str:
         """Return the available preset modes."""
-        return NAME_TO_PRESET_MODE.keys()
+        return PRESET_MODES
 
     @property
     def supported_features(self) -> int:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update zha to use new fan entity model

Reviewers: This one involved a bit of guess work since the spec isn't 100% clear (https://zigbeealliance.org/wp-content/uploads/2019/12/07-5123-06-zigbee-cluster-library-specification.pdf) and I don't have a zha fan.  Please double and triple check that I didn't miss something once its ready for review.

I also had to tweak the fan back compat layer as I didn't account for the `on` speed or the speed being reported as `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
