### PR TITLE
Use Hyperion human-readable effect names instead of API identifiers

### DIFF
--- a/homeassistant/components/hyperion/const.py
+++ b/homeassistant/components/hyperion/const.py
@@ -1,29 +1,5 @@
 """Constants for Hyperion integration."""
 
-from hyperion.const import (
-    KEY_COMPONENTID_ALL,
-    KEY_COMPONENTID_BLACKBORDER,
-    KEY_COMPONENTID_BOBLIGHTSERVER,
-    KEY_COMPONENTID_FORWARDER,
-    KEY_COMPONENTID_GRABBER,
-    KEY_COMPONENTID_LEDDEVICE,
-    KEY_COMPONENTID_SMOOTHING,
-    KEY_COMPONENTID_V4L,
-)
-
-# Maps between Hyperion API component names to Hyperion UI names. This allows Home
-# Assistant to use names that match what Hyperion users may expect from the Hyperion UI.
-COMPONENT_TO_NAME = {
-    KEY_COMPONENTID_ALL: "All",
-    KEY_COMPONENTID_SMOOTHING: "Smoothing",
-    KEY_COMPONENTID_BLACKBORDER: "Blackbar Detection",
-    KEY_COMPONENTID_FORWARDER: "Forwarder",
-    KEY_COMPONENTID_BOBLIGHTSERVER: "Boblight Server",
-    KEY_COMPONENTID_GRABBER: "Platform Capture",
-    KEY_COMPONENTID_LEDDEVICE: "LED Device",
-    KEY_COMPONENTID_V4L: "USB Capture",
-}
-
 CONF_AUTH_ID = "auth_id"
 CONF_CREATE_TOKEN = "create_token"
 CONF_INSTANCE = "instance"

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -618,9 +618,10 @@ class HyperionPriorityLight(HyperionBaseLight):
     @classmethod
     def _is_priority_entry_black(cls, priority: dict[str, Any] | None) -> bool:
         """Determine if a given priority entry is the color black."""
-        if not priority:
-            return False
-        if priority.get(const.KEY_COMPONENTID) == const.KEY_COMPONENTID_COLOR:
+        if (
+            priority
+            and priority.get(const.KEY_COMPONENTID) == const.KEY_COMPONENTID_COLOR
+        ):
             rgb_color = priority.get(const.KEY_VALUE, {}).get(const.KEY_RGB)
             if rgb_color is not None and tuple(rgb_color) == COLOR_BLACK:
                 return True

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -147,7 +147,10 @@ class HyperionBaseLight(LightEntity):
 
         self._static_effect_list: list[str] = [KEY_EFFECT_SOLID]
         if self._support_external_effects:
-            self._static_effect_list += list(const.KEY_COMPONENTID_EXTERNAL_SOURCES)
+            self._static_effect_list += [
+                const.KEY_COMPONENTID_TO_NAME[component]
+                for component in const.KEY_COMPONENTID_EXTERNAL_SOURCES
+            ]
         self._effect_list: list[str] = self._static_effect_list[:]
 
         self._client_callbacks: Mapping[str, Callable[[dict[str, Any]], None]] = {
@@ -195,7 +198,11 @@ class HyperionBaseLight(LightEntity):
     def icon(self) -> str:
         """Return state specific icon."""
         if self.is_on:
-            if self.effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES:
+            if (
+                self.effect in const.KEY_COMPONENTID_FROM_NAME
+                and const.KEY_COMPONENTID_FROM_NAME[self.effect]
+                in const.KEY_COMPONENTID_EXTERNAL_SOURCES
+            ):
                 return ICON_EXTERNAL_SOURCE
             if self.effect != KEY_EFFECT_SOLID:
                 return ICON_EFFECT
@@ -280,8 +287,21 @@ class HyperionBaseLight(LightEntity):
         if (
             effect
             and self._support_external_effects
-            and effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES
+            and (
+                effect in const.KEY_COMPONENTID_EXTERNAL_SOURCES
+                or effect in const.KEY_COMPONENTID_FROM_NAME
+            )
         ):
+            if effect in const.KEY_COMPONENTID_FROM_NAME:
+                component = const.KEY_COMPONENTID_FROM_NAME[effect]
+            else:
+                _LOGGER.warning(
+                    "Use of Hyperion effect '%s' is deprecated and will be removed "
+                    "in a future release. Please use '%s' instead.",
+                    effect,
+                    const.KEY_COMPONENTID_TO_NAME[effect],
+                )
+                component = effect
 
             # Clear any color/effect.
             if not await self._client.async_send_clear(
@@ -295,7 +315,7 @@ class HyperionBaseLight(LightEntity):
                     **{
                         const.KEY_COMPONENTSTATE: {
                             const.KEY_COMPONENT: key,
-                            const.KEY_STATE: effect == key,
+                            const.KEY_STATE: component == key,
                         }
                     }
                 ):
@@ -371,8 +391,12 @@ class HyperionBaseLight(LightEntity):
             if (
                 self._support_external_effects
                 and componentid in const.KEY_COMPONENTID_EXTERNAL_SOURCES
+                and componentid in const.KEY_COMPONENTID_TO_NAME
             ):
-                self._set_internal_state(rgb_color=DEFAULT_COLOR, effect=componentid)
+                self._set_internal_state(
+                    rgb_color=DEFAULT_COLOR,
+                    effect=const.KEY_COMPONENTID_TO_NAME[componentid],
+                )
             elif componentid == const.KEY_COMPONENTID_EFFECT:
                 # Owner is the effect name.
                 # See: https://docs.hyperion-project.org/en/json/ServerInfo.html#priorities

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -297,7 +297,7 @@ class HyperionBaseLight(LightEntity):
             else:
                 _LOGGER.warning(
                     "Use of Hyperion effect '%s' is deprecated and will be removed "
-                    "in a future release. Please use '%s' instead.",
+                    "in a future release. Please use '%s' instead",
                     effect,
                     const.KEY_COMPONENTID_TO_NAME[effect],
                 )

--- a/homeassistant/components/hyperion/manifest.json
+++ b/homeassistant/components/hyperion/manifest.json
@@ -5,7 +5,7 @@
   "domain": "hyperion",
   "name": "Hyperion",
   "quality_scale": "platinum",
-  "requirements": ["hyperion-py==0.7.1"],
+  "requirements": ["hyperion-py==0.7.2"],
   "ssdp": [
     {
       "manufacturer": "Hyperion Open Source Ambient Lighting",

--- a/homeassistant/components/hyperion/manifest.json
+++ b/homeassistant/components/hyperion/manifest.json
@@ -5,7 +5,7 @@
   "domain": "hyperion",
   "name": "Hyperion",
   "quality_scale": "platinum",
-  "requirements": ["hyperion-py==0.7.0"],
+  "requirements": ["hyperion-py==0.7.1"],
   "ssdp": [
     {
       "manufacturer": "Hyperion Open Source Ambient Lighting",

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -14,6 +14,7 @@ from hyperion.const import (
     KEY_COMPONENTID_GRABBER,
     KEY_COMPONENTID_LEDDEVICE,
     KEY_COMPONENTID_SMOOTHING,
+    KEY_COMPONENTID_TO_NAME,
     KEY_COMPONENTID_V4L,
     KEY_COMPONENTS,
     KEY_COMPONENTSTATE,
@@ -39,7 +40,6 @@ from . import (
     listen_for_instance_updates,
 )
 from .const import (
-    COMPONENT_TO_NAME,
     CONF_INSTANCE_CLIENTS,
     DOMAIN,
     HYPERION_MANUFACTURER_NAME,
@@ -67,7 +67,7 @@ def _component_to_unique_id(server_id: str, component: str, instance_num: int) -
         server_id,
         instance_num,
         slugify(
-            f"{TYPE_HYPERION_COMPONENT_SWITCH_BASE} {COMPONENT_TO_NAME[component]}"
+            f"{TYPE_HYPERION_COMPONENT_SWITCH_BASE} {KEY_COMPONENTID_TO_NAME[component]}"
         ),
     )
 
@@ -77,7 +77,7 @@ def _component_to_switch_name(component: str, instance_name: str) -> str:
     return (
         f"{instance_name} "
         f"{NAME_SUFFIX_HYPERION_COMPONENT_SWITCH} "
-        f"{COMPONENT_TO_NAME.get(component, component.capitalize())}"
+        f"{KEY_COMPONENTID_TO_NAME.get(component, component.capitalize())}"
     )
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -793,7 +793,7 @@ huisbaasje-client==0.1.0
 hydrawiser==0.2
 
 # homeassistant.components.hyperion
-hyperion-py==0.7.1
+hyperion-py==0.7.2
 
 # homeassistant.components.bh1750
 # homeassistant.components.bme280

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -793,7 +793,7 @@ huisbaasje-client==0.1.0
 hydrawiser==0.2
 
 # homeassistant.components.hyperion
-hyperion-py==0.7.0
+hyperion-py==0.7.1
 
 # homeassistant.components.bh1750
 # homeassistant.components.bme280

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -448,7 +448,7 @@ huawei-lte-api==1.4.17
 huisbaasje-client==0.1.0
 
 # homeassistant.components.hyperion
-hyperion-py==0.7.1
+hyperion-py==0.7.2
 
 # homeassistant.components.iaqualink
 iaqualink==0.3.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -448,7 +448,7 @@ huawei-lte-api==1.4.17
 huisbaasje-client==0.1.0
 
 # homeassistant.components.hyperion
-hyperion-py==0.7.0
+hyperion-py==0.7.1
 
 # homeassistant.components.iaqualink
 iaqualink==0.3.4

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -1289,15 +1289,17 @@ async def test_light_option_effect_hide_list(hass: HomeAssistantType) -> None:
     client.effects = [{const.KEY_NAME: "One"}, {const.KEY_NAME: "Two"}]
 
     await setup_test_config_entry(
-        hass, hyperion_client=client, options={CONF_EFFECT_HIDE_LIST: ["Two", "V4L"]}
+        hass,
+        hyperion_client=client,
+        options={CONF_EFFECT_HIDE_LIST: ["Two", "USB Capture"]},
     )
 
     entity_state = hass.states.get(TEST_ENTITY_ID_1)
     assert entity_state
     assert entity_state.attributes["effect_list"] == [
         "Solid",
-        "BOBLIGHTSERVER",
-        "GRABBER",
+        "Boblight Server",
+        "Platform Capture",
         "One",
     ]
 

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -5,14 +5,7 @@ from unittest.mock import AsyncMock, call, patch
 from hyperion.const import (
     KEY_COMPONENT,
     KEY_COMPONENTID_ALL,
-    KEY_COMPONENTID_BLACKBORDER,
-    KEY_COMPONENTID_BOBLIGHTSERVER,
-    KEY_COMPONENTID_FORWARDER,
-    KEY_COMPONENTID_GRABBER,
-    KEY_COMPONENTID_LEDDEVICE,
-    KEY_COMPONENTID_SMOOTHING,
     KEY_COMPONENTID_TO_NAME,
-    KEY_COMPONENTID_V4L,
     KEY_COMPONENTSTATE,
     KEY_STATE,
 )
@@ -135,7 +128,7 @@ async def test_switch_has_correct_entities(hass: HomeAssistantType) -> None:
 
     # Setup component switch.
     for component in TEST_COMPONENTS:
-        name = slugify(COMPONENT_TO_NAME[str(component["name"])])
+        name = slugify(KEY_COMPONENTID_TO_NAME[str(component["name"])])
         register_test_entity(
             hass,
             SWITCH_DOMAIN,
@@ -145,7 +138,7 @@ async def test_switch_has_correct_entities(hass: HomeAssistantType) -> None:
     await setup_test_config_entry(hass, hyperion_client=client)
 
     for component in TEST_COMPONENTS:
-        name = slugify(COMPONENT_TO_NAME[str(component["name"])])
+        name = slugify(KEY_COMPONENTID_TO_NAME[str(component["name"])])
         entity_id = TEST_SWITCH_COMPONENT_BASE_ENTITY_ID + "_" + name
         entity_state = hass.states.get(entity_id)
         assert entity_state, f"Couldn't find entity: {entity_id}"
@@ -157,7 +150,7 @@ async def test_device_info(hass: HomeAssistantType) -> None:
     client.components = TEST_COMPONENTS
 
     for component in TEST_COMPONENTS:
-        name = slugify(COMPONENT_TO_NAME[str(component["name"])])
+        name = slugify(KEY_COMPONENTID_TO_NAME[str(component["name"])])
         register_test_entity(
             hass,
             SWITCH_DOMAIN,
@@ -186,7 +179,7 @@ async def test_device_info(hass: HomeAssistantType) -> None:
     ]
 
     for component in TEST_COMPONENTS:
-        name = slugify(COMPONENT_TO_NAME[str(component["name"])])
+        name = slugify(KEY_COMPONENTID_TO_NAME[str(component["name"])])
         entity_id = TEST_SWITCH_COMPONENT_BASE_ENTITY_ID + "_" + name
         assert entity_id in entities_from_device
 
@@ -200,7 +193,7 @@ async def test_switches_can_be_enabled(hass: HomeAssistantType) -> None:
     entity_registry = er.async_get(hass)
 
     for component in TEST_COMPONENTS:
-        name = slugify(COMPONENT_TO_NAME[str(component["name"])])
+        name = slugify(KEY_COMPONENTID_TO_NAME[str(component["name"])])
         entity_id = TEST_SWITCH_COMPONENT_BASE_ENTITY_ID + "_" + name
 
         entry = entity_registry.async_get(entity_id)

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -5,13 +5,20 @@ from unittest.mock import AsyncMock, call, patch
 from hyperion.const import (
     KEY_COMPONENT,
     KEY_COMPONENTID_ALL,
+    KEY_COMPONENTID_BLACKBORDER,
+    KEY_COMPONENTID_BOBLIGHTSERVER,
+    KEY_COMPONENTID_FORWARDER,
+    KEY_COMPONENTID_GRABBER,
+    KEY_COMPONENTID_LEDDEVICE,
+    KEY_COMPONENTID_SMOOTHING,
+    KEY_COMPONENTID_TO_NAME,
+    KEY_COMPONENTID_V4L,
     KEY_COMPONENTSTATE,
     KEY_STATE,
 )
 
 from homeassistant.components.hyperion import get_hyperion_device_id
 from homeassistant.components.hyperion.const import (
-    COMPONENT_TO_NAME,
     DOMAIN,
     HYPERION_MANUFACTURER_NAME,
     HYPERION_MODEL_NAME,
@@ -157,6 +164,7 @@ async def test_device_info(hass: HomeAssistantType) -> None:
             f"{TYPE_HYPERION_COMPONENT_SWITCH_BASE}_{name}",
             f"{TEST_SWITCH_COMPONENT_BASE_ENTITY_ID}_{name}",
         )
+
     await setup_test_config_entry(hass, hyperion_client=client)
     assert hass.states.get(TEST_SWITCH_COMPONENT_ALL_ENTITY_ID) is not None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Hyperion itself uses one set of identifiers in its API to refer to components/"sources" (e.g. "GRABBER", "V4L"), but its UI uses a different set of friendlier names (e.g. "Platform Capture", "USB Capture"). The home assistant integration currently uses the "unfriendly" API identifier in the light component, but the friendly UI names in the switch component.

This change deprecates these API identifiers (they won't be shown in the list, but automations that use them will still work and will print a warning).

Once this  change is submitted,  the switch component, light component and the Hyperion UI will all be using the same names.

Underlying library changes: https://github.com/dermotduffy/hyperion-py/compare/v0.7.0...v0.7.2

**Home Assistant Hyperion component:**

<img width="361" alt="Screen Shot 2021-01-30 at 8 36 55 PM" src="https://user-images.githubusercontent.com/1136829/106374794-00a58580-633b-11eb-88e3-9911274d920e.png">

**Hyperion-UI (remote panel):**

<img width="225" alt="Screen Shot 2021-01-30 at 8 38 05 PM" src="https://user-images.githubusercontent.com/1136829/106374807-2763bc00-633b-11eb-81b1-24810c527dca.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/41892
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16363

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
