### PR TITLE
Use oauthv3 for Tesla

### DIFF
--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -103,6 +103,8 @@ async def async_setup(hass, base_config):
         _update_entry(
             email,
             data={
+                CONF_USERNAME: email,
+                CONF_PASSWORD: password,
                 CONF_ACCESS_TOKEN: info[CONF_ACCESS_TOKEN],
                 CONF_TOKEN: info[CONF_TOKEN],
             },
@@ -136,6 +138,8 @@ async def async_setup_entry(hass, config_entry):
     try:
         controller = TeslaAPI(
             websession,
+            email=config.get(CONF_USERNAME),
+            password=config.get(CONF_PASSWORD),
             refresh_token=config[CONF_TOKEN],
             access_token=config[CONF_ACCESS_TOKEN],
             update_interval=config_entry.options.get(

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -140,6 +140,8 @@ async def validate_input(hass: core.HomeAssistant, data):
         (config[CONF_TOKEN], config[CONF_ACCESS_TOKEN]) = await controller.connect(
             test_login=True
         )
+        config[CONF_USERNAME] = data[CONF_USERNAME]
+        config[CONF_PASSWORD] = data[CONF_PASSWORD]
     except TeslaException as ex:
         if ex.code == HTTP_UNAUTHORIZED:
             _LOGGER.error("Invalid credentials: %s", ex)

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tesla",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
-  "requirements": ["teslajsonpy==0.11.4"],
+  "requirements": ["teslajsonpy==0.11.5"],
   "codeowners": ["@zabuldon", "@alandtse"],
   "dhcp": [
     { "hostname": "tesla_*", "macaddress": "4CFCAA*" },

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -3,11 +3,11 @@
   "name": "Tesla",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
-  "requirements": ["teslajsonpy==0.10.4"],
+  "requirements": ["teslajsonpy==0.11.3"],
   "codeowners": ["@zabuldon", "@alandtse"],
   "dhcp": [
-     {"hostname":"tesla_*","macaddress":"4CFCAA*"},
-     {"hostname":"tesla_*","macaddress":"044EAF*"},
-     {"hostname":"tesla_*","macaddress":"98ED5C*"}
+    { "hostname": "tesla_*", "macaddress": "4CFCAA*" },
+    { "hostname": "tesla_*", "macaddress": "044EAF*" },
+    { "hostname": "tesla_*", "macaddress": "98ED5C*" }
   ]
 }

--- a/homeassistant/components/tesla/manifest.json
+++ b/homeassistant/components/tesla/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tesla",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tesla",
-  "requirements": ["teslajsonpy==0.11.3"],
+  "requirements": ["teslajsonpy==0.11.4"],
   "codeowners": ["@zabuldon", "@alandtse"],
   "dhcp": [
     { "hostname": "tesla_*", "macaddress": "4CFCAA*" },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2181,7 +2181,7 @@ temperusb==1.5.3
 tesla-powerwall==0.3.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.11.4
+teslajsonpy==0.11.5
 
 # homeassistant.components.tensorflow
 # tf-models-official==2.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2181,7 +2181,7 @@ temperusb==1.5.3
 tesla-powerwall==0.3.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.11.3
+teslajsonpy==0.11.4
 
 # homeassistant.components.tensorflow
 # tf-models-official==2.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2181,7 +2181,7 @@ temperusb==1.5.3
 tesla-powerwall==0.3.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.10.4
+teslajsonpy==0.11.3
 
 # homeassistant.components.tensorflow
 # tf-models-official==2.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1093,7 +1093,7 @@ tellduslive==0.10.11
 tesla-powerwall==0.3.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.11.4
+teslajsonpy==0.11.5
 
 # homeassistant.components.toon
 toonapi==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1093,7 +1093,7 @@ tellduslive==0.10.11
 tesla-powerwall==0.3.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.11.3
+teslajsonpy==0.11.4
 
 # homeassistant.components.toon
 toonapi==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1093,7 +1093,7 @@ tellduslive==0.10.11
 tesla-powerwall==0.3.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.10.4
+teslajsonpy==0.11.3
 
 # homeassistant.components.toon
 toonapi==0.2.0

--- a/tests/components/tesla/test_config_flow.py
+++ b/tests/components/tesla/test_config_flow.py
@@ -48,6 +48,8 @@ async def test_form(hass):
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "test@email.com"
     assert result2["data"] == {
+        CONF_USERNAME: "test@email.com",
+        CONF_PASSWORD: "test",
         CONF_TOKEN: "test-refresh-token",
         CONF_ACCESS_TOKEN: "test-access-token",
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Due to changes to Tesla oauth, users need to remove and readd the integration to store username/password in the config files. The new oauth login requires using a sso page to retrieve a bearer token that will be used to get the actual oauth tokens.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates underlying library to use Tesla's oauth3 to address change in Tesla login requirements.
https://github.com/zabuldon/teslajsonpy/releases/tag/v0.11.5
https://github.com/zabuldon/teslajsonpy/releases/tag/v0.11.4
https://github.com/zabuldon/teslajsonpy/releases/tag/v0.11.3
https://github.com/zabuldon/teslajsonpy/releases/tag/v0.11.2
https://github.com/zabuldon/teslajsonpy/releases/tag/v0.11.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44777

- This PR is related to issue: fixes #44777
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
