### PR TITLE
Add enable and disable services for recorder

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -48,6 +48,8 @@ from .util import (
 _LOGGER = logging.getLogger(__name__)
 
 SERVICE_PURGE = "purge"
+SERVICE_ENABLE = "enable"
+SERVICE_DISABLE = "disable"
 
 ATTR_KEEP_DAYS = "keep_days"
 ATTR_REPACK = "repack"
@@ -58,6 +60,8 @@ SERVICE_PURGE_SCHEMA = vol.Schema(
         vol.Optional(ATTR_REPACK, default=False): cv.boolean,
     }
 )
+SERVICE_ENABLE_SCHEMA = vol.Schema({})
+SERVICE_DISABLE_SCHEMA = vol.Schema({})
 
 DEFAULT_URL = "sqlite:///{hass_config_path}"
 DEFAULT_DB_FILE = "home-assistant_v2.db"
@@ -199,6 +203,20 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         DOMAIN, SERVICE_PURGE, async_handle_purge_service, schema=SERVICE_PURGE_SCHEMA
     )
 
+    async def async_handle_enable_sevice(service):
+        instance.set_enable(True)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ENABLE, async_handle_enable_sevice, schema=SERVICE_ENABLE_SCHEMA
+    )
+
+    async def async_handle_disable_service(service):
+        instance.set_enable(False)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_DISABLE, async_handle_disable_service, schema=SERVICE_DISABLE_SCHEMA
+    )
+
     return await instance.async_db_ready
 
 
@@ -254,6 +272,11 @@ class Recorder(threading.Thread):
         self.event_session = None
         self.get_session = None
         self._completed_database_setup = None
+
+        self.enabled = True
+
+    def set_enable(self, enable):
+        self.enabled = enable
 
     @callback
     def async_initialize(self):
@@ -411,6 +434,9 @@ class Recorder(threading.Thread):
                 if self._timechanges_seen >= self.commit_interval:
                     self._timechanges_seen = 0
                     self._commit_event_session_or_recover()
+            return
+
+        if not self.enabled:
             return
 
         try:

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -214,7 +214,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         instance.set_enable(False)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_DISABLE, async_handle_disable_service, schema=SERVICE_DISABLE_SCHEMA
+        DOMAIN,
+        SERVICE_DISABLE,
+        async_handle_disable_service,
+        schema=SERVICE_DISABLE_SCHEMA,
     )
 
     return await instance.async_db_ready
@@ -276,6 +279,7 @@ class Recorder(threading.Thread):
         self.enabled = True
 
     def set_enable(self, enable):
+        """Enables or disables recording events and states"""
         self.enabled = enable
 
     @callback

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -279,7 +279,7 @@ class Recorder(threading.Thread):
         self.enabled = True
 
     def set_enable(self, enable):
-        """Enables or disables recording events and states"""
+        """Enable or disable recording events and states."""
         self.enabled = enable
 
     @callback

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -23,3 +23,9 @@ purge:
       default: false
       selector:
         boolean:
+
+disable:
+  description: Stop the recording of events and state changes
+
+enabled:
+  description: Start the recording of events and state changes

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -10,14 +10,14 @@ from homeassistant.components.recorder import (
     CONFIG_SCHEMA,
     DATA_INSTANCE,
     DOMAIN,
-    Recorder,
-    run_information,
-    run_information_from_instance,
-    run_information_with_session,
     SERVICE_DISABLE,
     SERVICE_ENABLE,
     SERVICE_PURGE,
     SQLITE_URL_PREFIX,
+    Recorder,
+    run_information,
+    run_information_from_instance,
+    run_information_with_session,
 )
 from homeassistant.components.recorder.models import Events, RecorderRuns, States
 from homeassistant.components.recorder.util import session_scope

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -8,13 +8,17 @@ from sqlalchemy.exc import OperationalError
 from homeassistant.components.recorder import (
     CONF_DB_URL,
     CONFIG_SCHEMA,
+    DATA_INSTANCE,
     DOMAIN,
     Recorder,
     run_information,
     run_information_from_instance,
     run_information_with_session,
+    SERVICE_DISABLE,
+    SERVICE_ENABLE,
+    SERVICE_PURGE,
+    SQLITE_URL_PREFIX,
 )
-from homeassistant.components.recorder.const import DATA_INSTANCE, SQLITE_URL_PREFIX
 from homeassistant.components.recorder.models import Events, RecorderRuns, States
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import (
@@ -516,6 +520,113 @@ def test_run_information(hass_recorder):
     run_info = run_information(hass, dt_util.utcnow())
     assert isinstance(run_info, RecorderRuns)
     assert run_info.closed_incorrect is False
+
+
+def test_has_services(hass_recorder):
+    """Test the services exist."""
+    hass = hass_recorder()
+
+    assert hass.services.has_service(DOMAIN, SERVICE_DISABLE)
+    assert hass.services.has_service(DOMAIN, SERVICE_ENABLE)
+    assert hass.services.has_service(DOMAIN, SERVICE_PURGE)
+
+
+def test_service_disable_events_not_recording(hass, hass_recorder):
+    """Test that events are not recorded when recorder is disabled using service."""
+    hass = hass_recorder()
+
+    assert hass.services.call(
+        DOMAIN,
+        SERVICE_DISABLE,
+        {},
+        blocking=True,
+    )
+
+    event_type = "EVENT_TEST"
+
+    events = []
+
+    @callback
+    def event_listener(event):
+        """Record events from eventbus."""
+        if event.event_type == event_type:
+            events.append(event)
+
+    hass.bus.listen(MATCH_ALL, event_listener)
+
+    event_data1 = {"test_attr": 5, "test_attr_10": "nice"}
+    hass.bus.fire(event_type, event_data1)
+    wait_recording_done(hass)
+
+    assert len(events) == 1
+    event = events[0]
+
+    with session_scope(hass=hass) as session:
+        db_events = list(session.query(Events).filter_by(event_type=event_type))
+        assert len(db_events) == 0
+
+    assert hass.services.call(
+        DOMAIN,
+        SERVICE_ENABLE,
+        {},
+        blocking=True,
+    )
+
+    event_data2 = {"attr_one": 5, "attr_two": "nice"}
+    hass.bus.fire(event_type, event_data2)
+    wait_recording_done(hass)
+
+    assert len(events) == 2
+    assert events[0] != events[1]
+    assert events[0].data != events[1].data
+
+    with session_scope(hass=hass) as session:
+        db_events = list(session.query(Events).filter_by(event_type=event_type))
+        assert len(db_events) == 1
+        db_event = db_events[0].to_native()
+
+    event = events[1]
+
+    assert event.event_type == db_event.event_type
+    assert event.data == db_event.data
+    assert event.origin == db_event.origin
+    assert event.time_fired.replace(microsecond=0) == db_event.time_fired.replace(
+        microsecond=0
+    )
+
+
+def test_service_disable_states_not_recording(hass, hass_recorder):
+    """Test that state changes are not recorded when recorder is disabled using service."""
+    hass = hass_recorder()
+
+    assert hass.services.call(
+        DOMAIN,
+        SERVICE_DISABLE,
+        {},
+        blocking=True,
+    )
+
+    hass.states.set("test.one", "on", {})
+    wait_recording_done(hass)
+
+    with session_scope(hass=hass) as session:
+        assert len(list(session.query(States))) == 0
+
+    assert hass.services.call(
+        DOMAIN,
+        SERVICE_ENABLE,
+        {},
+        blocking=True,
+    )
+
+    hass.states.set("test.two", "off", {})
+    wait_recording_done(hass)
+
+    with session_scope(hass=hass) as session:
+        db_states = list(session.query(States))
+        assert len(db_states) == 1
+        assert db_states[0].event_id > 0
+        assert db_states[0].to_native() == _state_empty_context(hass, "test.two")
 
 
 class CannotSerializeMe:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added two new services for recorder, **disable** and **enable**, that help to control the recording of events and states to the database. These can be helpful when using multiple home assistant instances carefully set up to provide high availability and backed up by the same recorder database. Disabling the recorder on the passive home assistant instance helps to reduce duplicated events and state changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16366

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
