### PR TITLE
Fire an event when an automation fails

### DIFF
--- a/homeassistant/components/automation/const.py
+++ b/homeassistant/components/automation/const.py
@@ -16,4 +16,8 @@ CONF_INPUT = "input"
 
 DEFAULT_INITIAL_STATE = True
 
+EVENT_AUTOMATION_FAILED = f"{DOMAIN}_failed"
+
+ATTR_EXCEPTION = "exception"
+
 LOGGER = logging.getLogger(__package__)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -9,6 +9,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.automation import (
     ATTR_SOURCE,
     DOMAIN,
+    EVENT_AUTOMATION_FAILED,
     EVENT_AUTOMATION_RELOADED,
     EVENT_AUTOMATION_TRIGGERED,
     SERVICE_TRIGGER,
@@ -29,7 +30,12 @@ from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import assert_setup_component, async_mock_service, mock_restore_cache
+from tests.common import (
+    assert_setup_component,
+    async_capture_events,
+    async_mock_service,
+    mock_restore_cache,
+)
 from tests.components.logbook.test_init import MockLazyEventPartialState
 
 
@@ -932,6 +938,7 @@ async def test_automation_bad_trigger(hass, caplog):
 
 async def test_automation_with_error_in_script(hass, caplog):
     """Test automation with an error in script."""
+    failures = async_capture_events(hass, EVENT_AUTOMATION_FAILED)
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -948,6 +955,7 @@ async def test_automation_with_error_in_script(hass, caplog):
     await hass.async_block_till_done()
     assert "Service not found" in caplog.text
     assert "Traceback" not in caplog.text
+    assert len(failures) == 1
 
 
 async def test_automation_with_error_in_script_2(hass, caplog):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The only way that a user can know that an automation failed is by checking the logs. There are scenarios where a user may want to act on an automation failure by e.g. sending themselves a notification (imagine a situation where you have an automation to close a garage door or lock your door and it fails). This change adds an event that can be used in an automation to act on a failure.

This needs docs changes which I can add once a reviewer validates the proposal

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
