### PR TITLE
Add select selector for blueprints

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -183,5 +183,5 @@ class SelectSelector(Selector):
     """Selector for an single-choice input select."""
 
     CONFIG_SCHEMA = vol.Schema(
-        {vol.Required("options"): vol.All(vol.Length(min=1), [str])}
+        {vol.Required("options"): vol.All([str], vol.Length(min=1))}
     )

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -176,3 +176,10 @@ class StringSelector(Selector):
     """Selector for a multi-line text string."""
 
     CONFIG_SCHEMA = vol.Schema({vol.Optional("multiline", default=False): bool})
+
+
+@SELECTORS.register("select")
+class SelectSelector(Selector):
+    """Selector for an single-choice input select."""
+
+    CONFIG_SCHEMA = vol.Schema({vol.Required("options"): [str]})

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -182,4 +182,6 @@ class StringSelector(Selector):
 class SelectSelector(Selector):
     """Selector for an single-choice input select."""
 
-    CONFIG_SCHEMA = vol.Schema({vol.Required("options"): [str]})
+    CONFIG_SCHEMA = vol.Schema(
+        {vol.Required("options"): vol.All(vol.Length(min=1), [str])}
+    )

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -187,3 +187,15 @@ def test_object_selector_schema(schema):
 def test_text_selector_schema(schema):
     """Test text selector."""
     selector.validate_selector({"text": schema})
+
+
+@pytest.mark.parametrize(
+    "schema",
+    (
+        {"options": []},
+        {"options": ["red", "green", "blue"]},
+    ),
+)
+def test_select_selector_schema(schema):
+    """Test select selector."""
+    selector.validate_selector({"select": schema})

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -191,10 +191,7 @@ def test_text_selector_schema(schema):
 
 @pytest.mark.parametrize(
     "schema",
-    (
-        {"options": []},
-        {"options": ["red", "green", "blue"]},
-    ),
+    ({"options": ["red", "green", "blue"]},),
 )
 def test_select_selector_schema(schema):
     """Test select selector."""

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -191,7 +191,15 @@ def test_text_selector_schema(schema):
 
 @pytest.mark.parametrize(
     "schema",
-    ({"options": ["red", "green", "blue"]},),
+    (
+        {"options": ["red", "green", "blue"]},
+        pytest.param(
+            {"options": []},
+            marks=pytest.mark.xfail(
+                reason="Cannot provide an empty options list to the selector."
+            ),
+        ),
+    ),
 )
 def test_select_selector_schema(schema):
     """Test select selector."""

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -191,16 +191,22 @@ def test_text_selector_schema(schema):
 
 @pytest.mark.parametrize(
     "schema",
-    (
-        {"options": ["red", "green", "blue"]},
-        pytest.param(
-            {"options": []},
-            marks=pytest.mark.xfail(
-                reason="Cannot provide an empty options list to the selector."
-            ),
-        ),
-    ),
+    ({"options": ["red", "green", "blue"]},),
 )
 def test_select_selector_schema(schema):
     """Test select selector."""
     selector.validate_selector({"select": schema})
+
+
+@pytest.mark.parametrize(
+    "schema",
+    (
+        {},
+        {"options": {"hello": "World"}},
+        {"options": []},
+    ),
+)
+def test_select_selector_schema_error(schema):
+    """Test select selector."""
+    with pytest.raises(vol.Invalid):
+        selector.validate_selector({"select": schema})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Architecture discussion: home-assistant/architecture#486

This adds the `select` input for blueprints. The `select` input defines a generic single-choice select input fairly similar to the `input_select` integration. 

It only defines a single property, `options`, which developers are required to provide when defining the blueprint.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `blueprint.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
blueprint:
  name: Test inputs
  description: ""
  domain: automation
  input:
    select_input:
      name: Select Input
      default: yellow
      selector:
        select:
          options:
          - red
          - green
          - blue

trigger: []
action: []

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16383

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
