### PR TITLE
Add stop_cover service for zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -21,6 +21,8 @@ from .entity import ZWaveBaseEntity
 
 LOGGER = logging.getLogger(__name__)
 SUPPORT_GARAGE = SUPPORT_OPEN | SUPPORT_CLOSE
+PRESS_BUTTON = True
+RELEASE_BUTTON = False
 
 
 async def async_setup_entry(
@@ -77,10 +79,17 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        target_value = self.get_zwave_value("targetValue")
-        await self.info.node.async_set_value(target_value, 99)
+        target_value = self.get_zwave_value("Open")
+        await self.info.node.async_set_value(target_value, PRESS_BUTTON)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        target_value = self.get_zwave_value("targetValue")
-        await self.info.node.async_set_value(target_value, 0)
+        target_value = self.get_zwave_value("Close")
+        await self.info.node.async_set_value(target_value, PRESS_BUTTON)
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop cover."""
+        target_value = self.get_zwave_value("Open")
+        await self.info.node.async_set_value(target_value, RELEASE_BUTTON)
+        target_value = self.get_zwave_value("Close")
+        await self.info.node.async_set_value(target_value, RELEASE_BUTTON)

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -109,45 +109,6 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
 
     client.async_send_command.reset_mock()
     # Test stop after opening
-
-    event = Event(
-        type="value updated",
-        data={
-            "source": "node",
-            "event": "value updated",
-            "nodeId": 6,
-            "args": {
-                "commandClassName": "Multilevel Switch",
-                "commandClass": 38,
-                "endpoint": 0,
-                "property": "Open",
-                "newValue": True,
-                "prevValue": 0,
-                "propertyName": "Open",
-            },
-        },
-    )
-    node.receive_event(event)
-
-    event = Event(
-        type="value updated",
-        data={
-            "source": "node",
-            "event": "value updated",
-            "nodeId": 6,
-            "args": {
-                "commandClassName": "Multilevel Switch",
-                "commandClass": 38,
-                "endpoint": 0,
-                "property": "Close",
-                "newValue": False,
-                "prevValue": 0,
-                "propertyName": "Close",
-            },
-        },
-    )
-    node.receive_event(event)
-
     await hass.services.async_call(
         "cover",
         "stop_cover",
@@ -156,16 +117,14 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
     )
 
     assert len(client.async_send_command.call_args_list) == 2
-    args = client.async_send_command.call_args[0][0]
-    assert args["command"] == "node.set_value"
-    assert args["nodeId"] == 6
-    assert args["valueId"] == {
+    open_args = client.async_send_command.call_args_list[0][0][0]
+    assert open_args["command"] == "node.set_value"
+    assert open_args["nodeId"] == 6
+    assert open_args["valueId"] == {
         "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
         "property": "Open",
-        "newValue": True,
-        "prevValue": 0,
         "propertyName": "Open",
         "metadata": {
             "type": "boolean",
@@ -175,7 +134,26 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
             "ccSpecific": {"switchType": 3},
         },
     }
-    assert not args["value"]
+    assert not open_args["value"]
+
+    close_args = client.async_send_command.call_args_list[1][0][0]
+    assert close_args["command"] == "node.set_value"
+    assert close_args["nodeId"] == 6
+    assert close_args["valueId"] == {
+        "commandClassName": "Multilevel Switch",
+        "commandClass": 38,
+        "endpoint": 0,
+        "property": "Close",
+        "propertyName": "Close",
+        "metadata": {
+            "type": "boolean",
+            "readable": True,
+            "writeable": True,
+            "label": "Perform a level change (Close)",
+            "ccSpecific": {"switchType": 3},
+        },
+    }
+    assert not close_args["value"]
 
     # Test position update from value updated event
     event = Event(
@@ -196,7 +174,6 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
         },
     )
     node.receive_event(event)
-
     client.async_send_command.reset_mock()
 
     state = hass.states.get(WINDOW_COVER_ENTITY)
@@ -209,7 +186,6 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
         {"entity_id": WINDOW_COVER_ENTITY},
         blocking=True,
     )
-
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
@@ -233,44 +209,6 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
     client.async_send_command.reset_mock()
 
     # Test stop after closing
-    event = Event(
-        type="value updated",
-        data={
-            "source": "node",
-            "event": "value updated",
-            "nodeId": 6,
-            "args": {
-                "commandClassName": "Multilevel Switch",
-                "commandClass": 38,
-                "endpoint": 0,
-                "property": "Open",
-                "newValue": False,
-                "prevValue": 0,
-                "propertyName": "Open",
-            },
-        },
-    )
-    node.receive_event(event)
-
-    event = Event(
-        type="value updated",
-        data={
-            "source": "node",
-            "event": "value updated",
-            "nodeId": 6,
-            "args": {
-                "commandClassName": "Multilevel Switch",
-                "commandClass": 38,
-                "endpoint": 0,
-                "property": "Close",
-                "newValue": True,
-                "prevValue": 0,
-                "propertyName": "Close",
-            },
-        },
-    )
-    node.receive_event(event)
-
     await hass.services.async_call(
         "cover",
         "stop_cover",
@@ -279,10 +217,29 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
     )
 
     assert len(client.async_send_command.call_args_list) == 2
-    args = client.async_send_command.call_args[0][0]
-    assert args["command"] == "node.set_value"
-    assert args["nodeId"] == 6
-    assert args["valueId"] == {
+    open_args = client.async_send_command.call_args_list[0][0][0]
+    assert open_args["command"] == "node.set_value"
+    assert open_args["nodeId"] == 6
+    assert open_args["valueId"] == {
+        "commandClassName": "Multilevel Switch",
+        "commandClass": 38,
+        "endpoint": 0,
+        "property": "Open",
+        "propertyName": "Open",
+        "metadata": {
+            "type": "boolean",
+            "readable": True,
+            "writeable": True,
+            "label": "Perform a level change (Open)",
+            "ccSpecific": {"switchType": 3},
+        },
+    }
+    assert not open_args["value"]
+
+    close_args = client.async_send_command.call_args_list[1][0][0]
+    assert close_args["command"] == "node.set_value"
+    assert close_args["nodeId"] == 6
+    assert close_args["valueId"] == {
         "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
@@ -296,7 +253,7 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
             "ccSpecific": {"switchType": 3},
         },
     }
-    assert not args["value"]
+    assert not close_args["value"]
 
     client.async_send_command.reset_mock()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add stop_cover service to zwave_js covers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45779
- This PR is related to issue: #45779
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
