### PR TITLE
Fix shutdown deadlock with run_callback_threadsafe

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -554,10 +554,11 @@ class HomeAssistant:
         self.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
 
         # Prevent run_callback_threadsafe from scheduling any additional
-        # callbacks in the event loop since they will block forever after
-        # the final `self.async_block_till_done` is called which will result
-        # in a deadlock when shutting down the executor.
-        shutdown_run_callback_threadsafe()
+        # callbacks in the event loop as callbacks created on the futures
+        # it returns will never run after the final `self.async_block_till_done`
+        # which will cause the futures to block forever when waiting for
+        # the `result()` which will cause a deadlock when shutting down the executor.
+        shutdown_run_callback_threadsafe(self.loop)
 
         try:
             async with self.timeout.async_timeout(30):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -71,7 +71,11 @@ from homeassistant.exceptions import (
     Unauthorized,
 )
 from homeassistant.util import location, network
-from homeassistant.util.async_ import fire_coroutine_threadsafe, run_callback_threadsafe
+from homeassistant.util.async_ import (
+    fire_coroutine_threadsafe,
+    run_callback_threadsafe,
+    shutdown_run_callback_threadsafe,
+)
 import homeassistant.util.dt as dt_util
 from homeassistant.util.timeout import TimeoutManager
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
@@ -548,6 +552,13 @@ class HomeAssistant:
         # stage 3
         self.state = CoreState.not_running
         self.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+
+        # Prevent run_callback_threadsafe from scheduling any additional
+        # callbacks in the event loop since they will block forever after
+        # the final `self.async_block_till_done` is called which will result
+        # in a deadlock when shutting down the executor.
+        shutdown_run_callback_threadsafe()
+
         try:
             async with self.timeout.async_timeout(30):
                 await self.async_block_till_done()

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -10,7 +10,7 @@ from typing import Any, Awaitable, Callable, Coroutine, TypeVar
 
 _LOGGER = logging.getLogger(__name__)
 
-_SHUTDOWN_RUN_CALLBACK_THREADSAFE = "_shutdown"
+_SHUTDOWN_RUN_CALLBACK_THREADSAFE = "_shutdown_run_callback_threadsafe"
 
 T = TypeVar("T")
 
@@ -61,7 +61,7 @@ def run_callback_threadsafe(
 
     loop.call_soon_threadsafe(run_callback)
 
-    if hasattr(run_callback_threadsafe, _SHUTDOWN_RUN_CALLBACK_THREADSAFE):
+    if hasattr(loop, _SHUTDOWN_RUN_CALLBACK_THREADSAFE):
         #
         # If the final `HomeAssistant.async_block_till_done` in
         # `HomeAssistant.async_stop` has already been called, the callback
@@ -166,7 +166,7 @@ async def gather_with_concurrency(
     )
 
 
-def shutdown_run_callback_threadsafe() -> None:
+def shutdown_run_callback_threadsafe(loop: AbstractEventLoop) -> None:
     """Call when run_callback_threadsafe should prevent creating new futures.
 
     We must finish all callbacks before the executor is shutdown
@@ -180,4 +180,4 @@ def shutdown_run_callback_threadsafe() -> None:
     be called when Home Assistant is going to shutdown and
     python is going to exit.
     """
-    setattr(run_callback_threadsafe, _SHUTDOWN_RUN_CALLBACK_THREADSAFE, True)
+    setattr(loop, _SHUTDOWN_RUN_CALLBACK_THREADSAFE, True)

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -10,6 +10,8 @@ from typing import Any, Awaitable, Callable, Coroutine, TypeVar
 
 _LOGGER = logging.getLogger(__name__)
 
+_SHUTDOWN_RUN_CALLBACK_THREADSAFE = "_shutdown"
+
 T = TypeVar("T")
 
 
@@ -58,6 +60,29 @@ def run_callback_threadsafe(
                 _LOGGER.warning("Exception on lost future: ", exc_info=True)
 
     loop.call_soon_threadsafe(run_callback)
+
+    if hasattr(run_callback_threadsafe, _SHUTDOWN_RUN_CALLBACK_THREADSAFE):
+        #
+        # If the final `HomeAssistant.async_block_till_done` in
+        # `HomeAssistant.async_stop` has already been called, the callback
+        # will never run and, `future.result()` will block forever which
+        # will prevent the thread running this code from shutting down which
+        # will result in a deadlock when the main thread attempts to shutdown
+        # the executor and `.join()` the thread running this code.
+        #
+        # To prevent this deadlock we do the following on shutdown:
+        #
+        # 1. Set the _SHUTDOWN_RUN_CALLBACK_THREADSAFE attr on this function
+        #    by calling `shutdown_run_callback_threadsafe`
+        # 2. Call `hass.async_block_till_done` at least once after shutdown
+        #    to ensure all callbacks have run
+        # 3. Raise an exception here to ensure `future.result()` can never be
+        #    called and hit the deadlock since once `shutdown_run_callback_threadsafe`
+        #    we cannot promise the callback will be executed.
+        #
+        future.cancel()
+        raise RuntimeError("Shutdown occurred")
+
     return future
 
 
@@ -139,3 +164,20 @@ async def gather_with_concurrency(
     return await gather(
         *(sem_task(task) for task in tasks), return_exceptions=return_exceptions
     )
+
+
+def shutdown_run_callback_threadsafe() -> None:
+    """Call when run_callback_threadsafe should prevent creating new futures.
+
+    We must finish all callbacks before the executor is shutdown
+    or we can end up in a deadlock state where:
+
+    `executor.result()` is waiting for its `._condition`
+    and the executor shutdown is trying to `.join()` the
+    executor thread.
+
+    This function is considered irreversible and should only ever
+    be called when Home Assistant is going to shutdown and
+    python is going to exit.
+    """
+    setattr(run_callback_threadsafe, _SHUTDOWN_RUN_CALLBACK_THREADSAFE, True)

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -81,7 +81,7 @@ def run_callback_threadsafe(
         #    we cannot promise the callback will be executed.
         #
         future.cancel()
-        raise RuntimeError("The event loop is shutting down and cannot accept new callbacks.")
+        raise RuntimeError("The event loop is in the process of shutting down.")
 
     return future
 

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -81,7 +81,7 @@ def run_callback_threadsafe(
         #    we cannot promise the callback will be executed.
         #
         future.cancel()
-        raise RuntimeError("Shutdown occurred")
+        raise RuntimeError("The event loop is shutting down and cannot accept new callbacks.")
 
     return future
 

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -80,7 +80,6 @@ def run_callback_threadsafe(
         #    called and hit the deadlock since once `shutdown_run_callback_threadsafe`
         #    we cannot promise the callback will be executed.
         #
-        future.cancel()
         raise RuntimeError("The event loop is in the process of shutting down.")
 
     return future

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -169,6 +169,30 @@ async def test_stage_shutdown(hass):
     assert len(test_all) == 2
 
 
+async def test_shutdown_calls_block_till_done_after_shutdown_run_callback_threadsafe(
+    hass,
+):
+    """Ensure shutdown_run_callback_threadsafe is called before the final async_block_till_done."""
+    stop_calls = []
+
+    async def _record_block_till_done():
+        nonlocal stop_calls
+        stop_calls.append("async_block_till_done")
+
+    def _record_shutdown_run_callback_threadsafe():
+        nonlocal stop_calls
+        stop_calls.append("shutdown_run_callback_threadsafe")
+
+    with patch.object(hass, "async_block_till_done", _record_block_till_done), patch(
+        "homeassistant.core.shutdown_run_callback_threadsafe",
+        _record_shutdown_run_callback_threadsafe,
+    ):
+        await hass.async_stop()
+
+    assert stop_calls[-2] == "shutdown_run_callback_threadsafe"
+    assert stop_calls[-1] == "async_block_till_done"
+
+
 async def test_pending_sheduler(hass):
     """Add a coro to pending tasks."""
     call_count = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -179,9 +179,9 @@ async def test_shutdown_calls_block_till_done_after_shutdown_run_callback_thread
         nonlocal stop_calls
         stop_calls.append("async_block_till_done")
 
-    def _record_shutdown_run_callback_threadsafe():
+    def _record_shutdown_run_callback_threadsafe(loop):
         nonlocal stop_calls
-        stop_calls.append("shutdown_run_callback_threadsafe")
+        stop_calls.append(("shutdown_run_callback_threadsafe", loop))
 
     with patch.object(hass, "async_block_till_done", _record_block_till_done), patch(
         "homeassistant.core.shutdown_run_callback_threadsafe",
@@ -189,7 +189,7 @@ async def test_shutdown_calls_block_till_done_after_shutdown_run_callback_thread
     ):
         await hass.async_stop()
 
-    assert stop_calls[-2] == "shutdown_run_callback_threadsafe"
+    assert stop_calls[-2] == ("shutdown_run_callback_threadsafe", hass.loop)
     assert stop_calls[-1] == "async_block_till_done"
 
 

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -182,8 +182,6 @@ async def test_shutdown_run_callback_threadsafe():
     with pytest.raises(RuntimeError):
         hasync.run_callback_threadsafe(loop, callback)
 
-    delattr(hasync.run_callback_threadsafe, hasync._SHUTDOWN_RUN_CALLBACK_THREADSAFE)
-
 
 async def test_run_callback_threadsafe(hass):
     """Test run_callback_threadsafe runs code in the event loop."""

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -199,7 +199,7 @@ async def test_run_callback_threadsafe(hass):
 
 async def test_callback_is_always_scheduled(hass):
     """Test run_callback_threadsafe always calls call_soon_threadsafe before checking for shutdown."""
-    # We have to check the shutdown state after the callback is scheduled otherwise
+    # We have to check the shutdown state AFTER the callback is scheduled otherwise
     # the function could continue on and the caller call `future.result()` after
     # the point in the main thread where callbacks are no longer run.
 

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -172,10 +172,7 @@ async def test_gather_with_concurrency():
 
 
 async def test_shutdown_run_callback_threadsafe(hass):
-    """Test we can shutdown run_callback_threadsafe.
-
-    This test modifys global state because it
-    """
+    """Test we can shutdown run_callback_threadsafe."""
     hasync.shutdown_run_callback_threadsafe(hass.loop)
     callback = MagicMock()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

run_callback_threadsafe could submit callbacks to the
event loop during shutdown that would never be run which
would cause the thread waiting for the callback (`future.result()`) to block
forever and deadlock the executor shutdown.

concurrency is hard, and destructor order is harder.

🤦 🤦 🤦 🤦 🤦
Looking back at the logs this actually happened at least once a
week on one of my systems that I restart frequently.  I didn't realize
what was happening which is why I setup a cron job to check for failed
restarts that restarts the docker container.

I wish I had dug into what is going on before I setup the cronjob as I was thinking
I had some flakey integration that was blocking shutdown. ☹️ 

I'm relatively sure this is the cause of _almost_ all the random shutdown problems
I've seen over the last year that I chalked up to running `upstream/dev`
in production or a flakey custom integration.

Its likely the reason I found it now is partially due to not having 300
homekit threads anymore (yah! conversion to async) and its a little easier
to catch what is going on with `py-spy`.
🤦 🤦 🤦 🤦 🤦

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45795
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
