### PR TITLE
Insteon create entities in event loop

### DIFF
--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/apple_tv",
   "requirements": [
-    "pyatv==0.7.5"
+    "pyatv==0.7.6"
   ],
   "zeroconf": [
     "_mediaremotetv._tcp.local.",

--- a/homeassistant/components/insteon/binary_sensor.py
+++ b/homeassistant/components/insteon/binary_sensor.py
@@ -51,9 +51,9 @@ SENSOR_TYPES = {
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Insteon binary sensors from a config entry."""
 
-    def add_entities(discovery_info=None):
+    async def async_add_insteon_binary_sensor_entities(discovery_info=None):
         """Add the Insteon entities for the platform."""
-        async_add_insteon_entities(
+        await async_add_insteon_entities(
             hass,
             BINARY_SENSOR_DOMAIN,
             InsteonBinarySensorEntity,
@@ -62,8 +62,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     signal = f"{SIGNAL_ADD_ENTITIES}_{BINARY_SENSOR_DOMAIN}"
-    async_dispatcher_connect(hass, signal, add_entities)
-    add_entities()
+    async_dispatcher_connect(hass, signal, async_add_insteon_binary_sensor_entities)
+    await async_add_insteon_binary_sensor_entities()
 
 
 class InsteonBinarySensorEntity(InsteonEntity, BinarySensorEntity):

--- a/homeassistant/components/insteon/climate.py
+++ b/homeassistant/components/insteon/climate.py
@@ -64,9 +64,9 @@ SUPPORTED_FEATURES = (
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Insteon climate entities from a config entry."""
 
-    def add_entities(discovery_info=None):
+    async def async_add_insteon_climate_entities(discovery_info=None):
         """Add the Insteon entities for the platform."""
-        async_add_insteon_entities(
+        await async_add_insteon_entities(
             hass,
             CLIMATE_DOMAIN,
             InsteonClimateEntity,
@@ -75,8 +75,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     signal = f"{SIGNAL_ADD_ENTITIES}_{CLIMATE_DOMAIN}"
-    async_dispatcher_connect(hass, signal, add_entities)
-    add_entities()
+    async_dispatcher_connect(hass, signal, async_add_insteon_climate_entities)
+    await async_add_insteon_climate_entities()
 
 
 class InsteonClimateEntity(InsteonEntity, ClimateEntity):

--- a/homeassistant/components/insteon/cover.py
+++ b/homeassistant/components/insteon/cover.py
@@ -21,15 +21,15 @@ SUPPORTED_FEATURES = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Insteon covers from a config entry."""
 
-    def add_entities(discovery_info=None):
+    async def async_add_insteon_cover_entities(discovery_info=None):
         """Add the Insteon entities for the platform."""
-        async_add_insteon_entities(
+        await async_add_insteon_entities(
             hass, COVER_DOMAIN, InsteonCoverEntity, async_add_entities, discovery_info
         )
 
     signal = f"{SIGNAL_ADD_ENTITIES}_{COVER_DOMAIN}"
-    async_dispatcher_connect(hass, signal, add_entities)
-    add_entities()
+    async_dispatcher_connect(hass, signal, async_add_insteon_cover_entities)
+    await async_add_insteon_cover_entities()
 
 
 class InsteonCoverEntity(InsteonEntity, CoverEntity):

--- a/homeassistant/components/insteon/fan.py
+++ b/homeassistant/components/insteon/fan.py
@@ -28,15 +28,15 @@ SPEED_TO_VALUE = {
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Insteon fans from a config entry."""
 
-    def add_entities(discovery_info=None):
+    async def async_add_insteon_fan_entities(discovery_info=None):
         """Add the Insteon entities for the platform."""
-        async_add_insteon_entities(
+        await async_add_insteon_entities(
             hass, FAN_DOMAIN, InsteonFanEntity, async_add_entities, discovery_info
         )
 
     signal = f"{SIGNAL_ADD_ENTITIES}_{FAN_DOMAIN}"
-    async_dispatcher_connect(hass, signal, add_entities)
-    add_entities()
+    async_dispatcher_connect(hass, signal, async_add_insteon_fan_entities)
+    await async_add_insteon_fan_entities()
 
 
 class InsteonFanEntity(InsteonEntity, FanEntity):

--- a/homeassistant/components/insteon/fan.py
+++ b/homeassistant/components/insteon/fan.py
@@ -24,15 +24,15 @@ SPEED_RANGE = (1, FanSpeed.HIGH)  # off is not included
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Insteon fans from a config entry."""
 
-    def add_entities(discovery_info=None):
+    async def async_add_insteon_fan_entities(discovery_info=None):
         """Add the Insteon entities for the platform."""
-        async_add_insteon_entities(
+        await async_add_insteon_entities(
             hass, FAN_DOMAIN, InsteonFanEntity, async_add_entities, discovery_info
         )
 
     signal = f"{SIGNAL_ADD_ENTITIES}_{FAN_DOMAIN}"
-    async_dispatcher_connect(hass, signal, add_entities)
-    add_entities()
+    async_dispatcher_connect(hass, signal, async_add_insteon_fan_entities)
+    await async_add_insteon_fan_entities()
 
 
 class InsteonFanEntity(InsteonEntity, FanEntity):

--- a/homeassistant/components/insteon/light.py
+++ b/homeassistant/components/insteon/light.py
@@ -18,15 +18,15 @@ MAX_BRIGHTNESS = 255
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Insteon lights from a config entry."""
 
-    def add_entities(discovery_info=None):
+    async def async_add_insteon_light_entities(discovery_info=None):
         """Add the Insteon entities for the platform."""
-        async_add_insteon_entities(
+        await async_add_insteon_entities(
             hass, LIGHT_DOMAIN, InsteonDimmerEntity, async_add_entities, discovery_info
         )
 
     signal = f"{SIGNAL_ADD_ENTITIES}_{LIGHT_DOMAIN}"
-    async_dispatcher_connect(hass, signal, add_entities)
-    add_entities()
+    async_dispatcher_connect(hass, signal, async_add_insteon_light_entities)
+    await async_add_insteon_light_entities()
 
 
 class InsteonDimmerEntity(InsteonEntity, LightEntity):

--- a/homeassistant/components/insteon/switch.py
+++ b/homeassistant/components/insteon/switch.py
@@ -10,15 +10,15 @@ from .utils import async_add_insteon_entities
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Insteon switches from a config entry."""
 
-    def add_entities(discovery_info=None):
+    async def async_add_insteon_switch_entities(discovery_info=None):
         """Add the Insteon entities for the platform."""
-        async_add_insteon_entities(
+        await async_add_insteon_entities(
             hass, SWITCH_DOMAIN, InsteonSwitchEntity, async_add_entities, discovery_info
         )
 
     signal = f"{SIGNAL_ADD_ENTITIES}_{SWITCH_DOMAIN}"
-    async_dispatcher_connect(hass, signal, add_entities)
-    add_entities()
+    async_dispatcher_connect(hass, signal, async_add_insteon_switch_entities)
+    await async_add_insteon_switch_entities()
 
 
 class InsteonSwitchEntity(InsteonEntity, SwitchEntity):

--- a/homeassistant/components/insteon/utils.py
+++ b/homeassistant/components/insteon/utils.py
@@ -377,6 +377,7 @@ def print_aldb_to_log(aldb):
         )
         logger.info(log_msg)
 
+
 async def async_add_insteon_entities(
     hass, platform, entity_type, async_add_entities, discovery_info
 ):

--- a/homeassistant/components/insteon/utils.py
+++ b/homeassistant/components/insteon/utils.py
@@ -377,9 +377,7 @@ def print_aldb_to_log(aldb):
         )
         logger.info(log_msg)
 
-
-@callback
-def async_add_insteon_entities(
+async def async_add_insteon_entities(
     hass, platform, entity_type, async_add_entities, discovery_info
 ):
     """Add Insteon devices to a platform."""

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -110,6 +110,8 @@ class ControllerDevice(ClimateEntity):
 
         self._supported_features = SUPPORT_FAN_MODE
 
+        # If mode RAS, or mode master with CtrlZone 13 then can set master temperature,
+        # otherwise the unit determines which zone to use as target. See interface manual p. 8
         if (
             controller.ras_mode == "master" and controller.zone_ctrl == 13
         ) or controller.ras_mode == "RAS":
@@ -269,6 +271,16 @@ class ControllerDevice(ClimateEntity):
                 self.temperature_unit,
                 PRECISION_HALVES,
             ),
+            "control_zone": self._controller.zone_ctrl,
+            "control_zone_name": self.control_zone_name,
+            # Feature SUPPORT_TARGET_TEMPERATURE controls both displaying target temp & setting it
+            # As the feature is turned off for zone control, report target temp as extra state attribute
+            "control_zone_setpoint": show_temp(
+                self.hass,
+                self.control_zone_setpoint,
+                self.temperature_unit,
+                PRECISION_HALVES,
+            ),
         }
 
     @property
@@ -315,12 +327,34 @@ class ControllerDevice(ClimateEntity):
         return self._controller.temp_return
 
     @property
+    def control_zone_name(self):
+        """Return the zone that currently controls the AC unit (if target temp not set by controller)."""
+        if self._supported_features & SUPPORT_TARGET_TEMPERATURE:
+            return None
+        zone_ctrl = self._controller.zone_ctrl
+        zone = next((z for z in self.zones.values() if z.zone_index == zone_ctrl), None)
+        if zone is None:
+            return None
+        return zone.name
+
+    @property
+    def control_zone_setpoint(self) -> Optional[float]:
+        """Return the temperature setpoint of the zone that currently controls the AC unit (if target temp not set by controller)."""
+        if self._supported_features & SUPPORT_TARGET_TEMPERATURE:
+            return None
+        zone_ctrl = self._controller.zone_ctrl
+        zone = next((z for z in self.zones.values() if z.zone_index == zone_ctrl), None)
+        if zone is None:
+            return None
+        return zone.target_temperature
+
+    @property
     @_return_on_connection_error()
     def target_temperature(self) -> Optional[float]:
-        """Return the temperature we try to reach."""
-        if not self._supported_features & SUPPORT_TARGET_TEMPERATURE:
-            return None
-        return self._controller.temp_setpoint
+        """Return the temperature we try to reach (either from control zone or master unit)."""
+        if self._supported_features & SUPPORT_TARGET_TEMPERATURE:
+            return self._controller.temp_setpoint
+        return self.control_zone_setpoint
 
     @property
     def supply_temperature(self) -> float:
@@ -569,3 +603,15 @@ class ZoneDevice(ClimateEntity):
         """Turn device off (close zone)."""
         await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.CLOSE))
         self.async_write_ha_state()
+
+    @property
+    def zone_index(self):
+        """Return the zone index for matching to CtrlZone."""
+        return self._zone.index
+
+    @property
+    def device_state_attributes(self):
+        """Return the optional state attributes."""
+        return {
+            "zone_index": self.zone_index,
+        }

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -104,16 +104,16 @@ async def async_setup_entry(hass, config_entry):
             hostname=host, keyfile=keyfile, certfile=certfile, ca_certs=ca_certs
         )
     except ssl.SSLError:
-        _LOGGER.error("Invalid certificate used to connect to bridge at %s.", host)
+        _LOGGER.error("Invalid certificate used to connect to bridge at %s", host)
         return False
 
     timed_out = True
     try:
-        with async_timeout.timeout(BRIDGE_TIMEOUT):
+        async with async_timeout.timeout(BRIDGE_TIMEOUT):
             await bridge.connect()
             timed_out = False
     except asyncio.TimeoutError:
-        _LOGGER.error("Timeout while trying to connect to bridge at %s.", host)
+        _LOGGER.error("Timeout while trying to connect to bridge at %s", host)
 
     if timed_out or not bridge.is_connected():
         await bridge.close()

--- a/homeassistant/components/lutron_caseta/config_flow.py
+++ b/homeassistant/components/lutron_caseta/config_flow.py
@@ -228,19 +228,19 @@ class LutronCasetaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
         except ssl.SSLError:
             _LOGGER.error(
-                "Invalid certificate used to connect to bridge at %s.",
+                "Invalid certificate used to connect to bridge at %s",
                 self.data[CONF_HOST],
             )
             return False
 
         connected_ok = False
         try:
-            with async_timeout.timeout(BRIDGE_TIMEOUT):
+            async with async_timeout.timeout(BRIDGE_TIMEOUT):
                 await bridge.connect()
             connected_ok = bridge.is_connected()
         except asyncio.TimeoutError:
             _LOGGER.error(
-                "Timeout while trying to connect to bridge at %s.",
+                "Timeout while trying to connect to bridge at %s",
                 self.data[CONF_HOST],
             )
 

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -175,7 +175,7 @@ class RoonDevice(MediaPlayerEntity):
             "name": self.name,
             "manufacturer": "RoonLabs",
             "model": dev_model,
-            "via_hub": (DOMAIN, self._server.roon_id),
+            "via_device": (DOMAIN, self._server.roon_id),
         }
 
     def update_data(self, player_data=None):

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -188,7 +188,7 @@ class SomfyEntity(CoordinatorEntity, Entity):
             "identifiers": {(DOMAIN, self.unique_id)},
             "name": self.name,
             "model": self.device.type,
-            "via_hub": (DOMAIN, self.device.parent_id),
+            "via_device": (DOMAIN, self.device.parent_id),
             # For the moment, Somfy only returns their own device.
             "manufacturer": "Somfy",
         }

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -350,6 +350,14 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         return bool(self.info.primary_value.value != 0)
 
     @property
+    def name(self) -> str:
+        """Return default name from device name and value name combination."""
+        node_name = self.info.node.name or self.info.node.device_config.description
+        property_name = self.info.primary_value.property_name
+        property_key_name = self.info.primary_value.property_key_name
+        return f"{node_name}: {property_name}: {property_key_name}"
+
+    @property
     def device_class(self) -> Optional[str]:
         """Return device class."""
         return self._mapping_info.get("device_class")

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.14.2"],
+  "requirements": ["zwave-js-server-python==0.15.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["http", "websocket_api"]
 }

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -49,7 +49,7 @@ DATA_CUSTOM_COMPONENTS = "custom_components"
 PACKAGE_CUSTOM_COMPONENTS = "custom_components"
 PACKAGE_BUILTIN = "homeassistant.components"
 CUSTOM_WARNING = (
-    "You are using a custom integration for %s which has not "
+    "You are using a custom integration %s which has not "
     "been tested by Home Assistant. This component might "
     "cause stability problems, be sure to disable it if you "
     "experience issues with Home Assistant."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1286,7 +1286,7 @@ pyatmo==4.2.2
 pyatome==0.1.1
 
 # homeassistant.components.apple_tv
-pyatv==0.7.5
+pyatv==0.7.6
 
 # homeassistant.components.bbox
 pybbox==0.0.5-alpha

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2381,4 +2381,4 @@ zigpy==0.32.0
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.14.2
+zwave-js-server-python==0.15.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -669,7 +669,7 @@ pyatag==0.3.4.4
 pyatmo==4.2.2
 
 # homeassistant.components.apple_tv
-pyatv==0.7.5
+pyatv==0.7.6
 
 # homeassistant.components.blackbird
 pyblackbird==0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1200,4 +1200,4 @@ zigpy-znp==0.3.0
 zigpy==0.32.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.14.2
+zwave-js-server-python==0.15.0

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -6,7 +6,9 @@ SWITCH_ENTITY = "switch.smart_plug_with_two_usb_ports_current_value"
 LOW_BATTERY_BINARY_SENSOR = "binary_sensor.multisensor_6_low_battery_level"
 ENABLED_LEGACY_BINARY_SENSOR = "binary_sensor.z_wave_door_window_sensor_any"
 DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
-NOTIFICATION_MOTION_BINARY_SENSOR = "binary_sensor.multisensor_6_motion_sensor_status"
+NOTIFICATION_MOTION_BINARY_SENSOR = (
+    "binary_sensor.multisensor_6_home_security_motion_sensor_status"
+)
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
 )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -131,10 +131,10 @@ async def test_custom_component_name(hass):
 async def test_log_warning_custom_component(hass, caplog):
     """Test that we log a warning when loading a custom component."""
     hass.components.test_standalone
-    assert "You are using a custom integration for test_standalone" in caplog.text
+    assert "You are using a custom integration test_standalone" in caplog.text
 
     await loader.async_get_integration(hass, "test")
-    assert "You are using a custom integration for test " in caplog.text
+    assert "You are using a custom integration test " in caplog.text
 
 
 async def test_get_integration(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Insteon module can create entities dynamically when a device is auto-discovered in the underlying module or when added manually via config options. The creation of the entities was using a `callback` method but the call was not from within the event loop / main_thread and was is not thread safe. This PR updates the `insteon.utils.async_add_insteon_entities` method to be async to ensure it runs in the event loop.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
