### PR TITLE
Add zwave_js binary sensors property name for Notification CC

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -350,6 +350,19 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         return bool(self.info.primary_value.value != 0)
 
     @property
+    def name(self) -> str:
+        """Return default name from device name and value name combination."""
+        base_name = super().name
+        value_label = self.info.primary_value.metadata.states.get(
+            str(self.info.primary_value.value)
+        )
+        # Strip "on location" / "at location" from name
+        # Note: We're assuming that we don't retrieve 2 values with different location
+        value_label = value_label.split(" on ")[0]
+        value_label = value_label.split(" at ")[0]
+        return f"{base_name}: {value_label}"
+
+    @property
     def device_class(self) -> Optional[str]:
         """Return device class."""
         return self._mapping_info.get("device_class")

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -352,15 +352,10 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     @property
     def name(self) -> str:
         """Return default name from device name and value name combination."""
-        base_name = super().name
-        value_label = self.info.primary_value.metadata.states.get(
-            str(self.info.primary_value.value)
-        )
-        # Strip "on location" / "at location" from name
-        # Note: We're assuming that we don't retrieve 2 values with different location
-        value_label = value_label.split(" on ")[0]
-        value_label = value_label.split(" at ")[0]
-        return f"{base_name}: {value_label}"
+        node_name = self.info.node.name or self.info.node.device_config.description
+        property_name = self.info.primary_value.property_name
+        property_key_name = self.info.primary_value.property_key_name
+        return f"{node_name}: {property_name}: {property_key_name}"
 
     @property
     def device_class(self) -> Optional[str]:

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -6,7 +6,9 @@ SWITCH_ENTITY = "switch.smart_plug_with_two_usb_ports_current_value"
 LOW_BATTERY_BINARY_SENSOR = "binary_sensor.multisensor_6_low_battery_level"
 ENABLED_LEGACY_BINARY_SENSOR = "binary_sensor.z_wave_door_window_sensor_any"
 DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
-NOTIFICATION_MOTION_BINARY_SENSOR = "binary_sensor.multisensor_6_motion_sensor_status"
+NOTIFICATION_MOTION_BINARY_SENSOR = (
+    "binary_sensor.multisensor_6_motion_sensor_status_motion_detection"
+)
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
 )

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -7,7 +7,7 @@ LOW_BATTERY_BINARY_SENSOR = "binary_sensor.multisensor_6_low_battery_level"
 ENABLED_LEGACY_BINARY_SENSOR = "binary_sensor.z_wave_door_window_sensor_any"
 DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
 NOTIFICATION_MOTION_BINARY_SENSOR = (
-    "binary_sensor.multisensor_6_motion_sensor_status_motion_detection"
+    "binary_sensor.multisensor_6_home_security_motion_sensor_status"
 )
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"


### PR DESCRIPTION
## Proposed change
Right now for a `ZWaveNotificationBinarySensor` the name returns as `<node name>: <metadata label>`. For values in the Notification command class, the `metadata label` is equivalent to the `property key name`. The problem is that some devices will have multiple values with the same `property key name` in the notification class (see https://pastebin.com/ZYgLTdS8 node 11). So we need to better namespace these entities.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
