### PR TITLE
Add zwave_js sensors property name for Notification CC

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -351,7 +351,7 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
 
     @property
     def name(self) -> str:
-        """Return default name from device name and value name combination."""
+        """Return name with property name and property key name."""
         node_name = self.info.node.name or self.info.node.device_config.description
         property_name = self.info.primary_value.property_name
         property_key_name = self.info.primary_value.property_key_name

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -96,6 +96,16 @@ class ZWaveStringSensor(ZwaveSensorBase):
     """Representation of a Z-Wave String sensor."""
 
     @property
+    def name(self) -> str:
+        """Return alternate name for notification sensors."""
+        if self.info.primary_value.command_class == CommandClass.NOTIFICATION:
+            node_name = self.info.node.name or self.info.node.device_config.description
+            property_name = self.info.primary_value.property_name
+            property_key_name = self.info.primary_value.property_key_name
+            return f"{node_name}: {property_name}: {property_key_name}"
+        return super().name
+
+    @property
     def state(self) -> Optional[str]:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -9,6 +9,7 @@ DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
 NOTIFICATION_MOTION_BINARY_SENSOR = (
     "binary_sensor.multisensor_6_home_security_motion_sensor_status"
 )
+NOTIFICATION_MOTION_SENSOR = "sensor.multisensor_6_home_security_motion_sensor_status"
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
 )

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -7,8 +7,17 @@ from homeassistant.const import (
     POWER_WATT,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers.entity_registry import (
+    DISABLED_INTEGRATION,
+    async_get_registry,
+)
 
-from .common import AIR_TEMPERATURE_SENSOR, ENERGY_SENSOR, POWER_SENSOR
+from .common import (
+    AIR_TEMPERATURE_SENSOR,
+    ENERGY_SENSOR,
+    NOTIFICATION_MOTION_SENSOR,
+    POWER_SENSOR,
+)
 
 
 async def test_numeric_sensor(hass, multisensor_6, integration):
@@ -36,3 +45,13 @@ async def test_energy_sensors(hass, hank_binary_switch, integration):
     assert state.state == "0.16"
     assert state.attributes["unit_of_measurement"] == ENERGY_KILO_WATT_HOUR
     assert state.attributes["device_class"] == DEVICE_CLASS_ENERGY
+
+
+async def test_notification_sensor(hass, multisensor_6, integration):
+    """Test sensor is created from Notification CC and is disabled."""
+    ent_reg = await async_get_registry(hass)
+    entity = ent_reg.async_get(NOTIFICATION_MOTION_SENSOR)
+
+    assert entity
+    assert entity.disabled
+    assert entity.disabled_by == DISABLED_INTEGRATION


### PR DESCRIPTION
## Proposed change
I just learned we create sensors for Notification CC values as well. This follows #45810 to improve the name of the entities. I also updated the docstring for the binary sensor because it was incorrect.

I did not see any tests for these sensors so I didn't add anything. Let me know if you would like me to.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
