### PR TITLE
Limit fronius error messages on failed connection

### DIFF
--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -148,7 +148,7 @@ class FroniusAdapter:
 
     @property
     def available(self):
-        """Is the fronius device active?"""
+        """Whether the fronius device is active."""
         return self._available
 
     async def async_update(self):
@@ -163,16 +163,16 @@ class FroniusAdapter:
             if self._available:
                 self._available = False
                 _LOGGER.error("Failed to update: connection error")
+            return
         except ValueError:
             _LOGGER.error(
                 "Failed to update: invalid response returned."
                 "Maybe the configured device is not supported"
             )
-        else:
-            self._available = True  # reset connection failure
-
-        if not values:
             return
+
+        self._available = True  # reset connection failure
+
         attributes = self._fetched
         # Copy data of current fronius device
         for key, entry in values.items():

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -2,6 +2,7 @@
 import copy
 from datetime import timedelta
 import logging
+from typing import Dict
 
 from pyfronius import Fronius
 import voluptuous as vol
@@ -153,7 +154,6 @@ class FroniusAdapter:
 
     async def async_update(self):
         """Retrieve and update latest state."""
-        values = {}
         try:
             values = await self._update()
         except ConnectionError:
@@ -195,7 +195,7 @@ class FroniusAdapter:
         for sensor in self._registered_sensors:
             sensor.async_schedule_update_ha_state(True)
 
-    async def _update(self):
+    async def _update(self) -> Dict:
         """Return values of interest."""
 
     async def register(self, sensor):

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -281,6 +281,12 @@ class FroniusTemplateSensor(Entity):
         """Device should not be polled, returns False."""
         return False
 
+    @property
+    def available(self):
+        """Whether the fronius device is active."""
+        return self.parent.available
+
+
     async def async_update(self):
         """Update the internal state."""
         state = self.parent.data.get(self._name)

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -286,7 +286,6 @@ class FroniusTemplateSensor(Entity):
         """Whether the fronius device is active."""
         return self.parent.available
 
-
     async def async_update(self):
         """Update the internal state."""
         state = self.parent.data.get(self._name)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fronius devices are often powered only by self-produced solar power.
They therefore turn off at night, resulting in connection errors.
This currently spams the home assistant log at a rate of 1/scan_interval.
As requested in #42046 it would already be a big help if the sensor only once logs an error about failed connection
and then keeps shut about it.

Even better would be to implement a system wide handler for sensors that exhibit connection errors when the target device is turned off (i.e. also for printers)

I am not sure whether this is the preferred way of handling such issues. Please let me know if there are any official guidelines about this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
Nothing changed to previous setup

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #42046 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
