### PR TITLE
Add apply_filter attribute to recorder.purge service

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -8,21 +8,27 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.expression import distinct
 
+from homeassistant.const import EVENT_STATE_CHANGED
 import homeassistant.util.dt as dt_util
 
 from .const import MAX_ROWS_TO_PURGE
 from .models import Events, RecorderRuns, States
 from .repack import repack_database
-from .util import session_scope
+from .util import execute, session_scope
 
 if TYPE_CHECKING:
     from . import Recorder
 
 _LOGGER = logging.getLogger(__name__)
 
+DEBUG_DATETIME_FMT = r"%Y-%m-%d %H:%M UTC"
 
-def purge_old_data(instance: Recorder, purge_days: int, repack: bool) -> bool:
+
+def purge_old_data(
+    instance: Recorder, purge_days: int, repack: bool, apply_filter: bool = False
+) -> bool:
     """Purge events and states older than purge_days ago.
 
     Cleans up an timeframe of an hour, based on the oldest record.
@@ -45,6 +51,9 @@ def purge_old_data(instance: Recorder, purge_days: int, repack: bool) -> bool:
                 # return false, as we are not done yet.
                 _LOGGER.debug("Purging hasn't fully completed yet")
                 return False
+            if apply_filter:
+                if _purge_filtered_data(instance, session) is False:
+                    return False
             _purge_old_recorder_runs(instance, session, purge_before)
         if repack:
             repack_database(instance)
@@ -140,3 +149,193 @@ def _purge_old_recorder_runs(
         .delete(synchronize_session=False)
     )
     _LOGGER.debug("Deleted %s recorder_runs", deleted_rows)
+
+
+def _purge_filtered_data(
+    instance: Recorder,
+    session: Session,
+    *,
+    batch_size_hours: int = 1,
+) -> bool:
+    """Purge filtered states and events that shouldn't be in database."""
+
+    _LOGGER.debug("Purging filtered states and events")
+    utc_now = dt_util.utcnow()
+    batch_purge_before_states = utc_now
+    batch_purge_before_events = utc_now
+
+    # Check if excluded entity_ids are in database
+    excluded_entity_ids: list[str] = [
+        entity_id
+        for (entity_id,) in session.query(distinct(States.entity_id)).all()
+        if not instance.entity_filter(entity_id)
+    ]
+
+    if len(excluded_entity_ids) != 0:
+        batch_purge_before_states = _purge_filtered_states(
+            session,
+            excluded_entity_ids,
+            batch_purge_before_states,
+            batch_size_hours,
+        )
+
+    # Check if excluded event_types are in database
+    excluded_event_types: list[str] = [
+        event_type
+        for (event_type,) in session.query(distinct(Events.event_type)).all()
+        if event_type in instance.exclude_t
+    ]
+
+    if len(excluded_event_types) != 0:
+        batch_purge_before_events = _purge_filtered_events(
+            session,
+            excluded_event_types,
+            batch_purge_before_events,
+            batch_size_hours,
+        )
+
+    if batch_purge_before_states < utc_now or batch_purge_before_events < utc_now:
+        _LOGGER.debug("Purging filter hasn't fully completed yet")
+        return False
+
+    return True
+
+
+def _purge_filtered_states(
+    session: Session,
+    excluded_entity_ids: list[str],
+    batch_purge_before: datetime,
+    batch_size_hours: int,
+) -> datetime:
+    """Handle purging filtered states."""
+
+    query = (
+        session.query(States)
+        .filter(States.entity_id.in_(excluded_entity_ids))
+        .order_by(States.last_updated.asc())
+        .limit(1)
+    )
+    states = execute(query, to_native=True, validate_entity_ids=False)  # type: ignore
+    if states:
+        batch_purge_before = states[0].last_updated + timedelta(hours=batch_size_hours)
+
+    _LOGGER.debug(
+        "Purging states before %s that should be filtered",
+        batch_purge_before.strftime(DEBUG_DATETIME_FMT),
+    )
+
+    disconnected_rows = (
+        session.query(States)
+        .filter(
+            States.old_state_id.in_(
+                session.query(States.state_id)
+                .filter(States.last_updated < batch_purge_before)
+                .filter(States.entity_id.in_(excluded_entity_ids))
+                .subquery()
+            )
+        )
+        .update({"old_state_id": None}, synchronize_session=False)
+    )
+    _LOGGER.debug("Updated %s states to remove old_state_id", disconnected_rows)
+
+    event_ids: list[int] = [
+        event_id
+        for (event_id,) in session.query(States.event_id)
+        .filter(States.last_updated < batch_purge_before)
+        .filter(States.event_id is not None)
+        .filter(States.entity_id.in_(excluded_entity_ids))
+        .all()
+    ]
+
+    deleted_rows_states = (
+        session.query(States)
+        .filter(States.last_updated < batch_purge_before)
+        .filter(States.entity_id.in_(excluded_entity_ids))
+        .delete(synchronize_session=False)
+    )
+    _LOGGER.debug(
+        "Deleted %s states because entity_id is excluded", deleted_rows_states
+    )
+
+    if event_ids:
+        deleted_rows_events = (
+            session.query(Events)
+            .filter(Events.event_type == EVENT_STATE_CHANGED)
+            .filter(Events.time_fired < batch_purge_before)
+            .filter(Events.event_id.in_(event_ids))
+            .delete(synchronize_session=False)
+        )
+        _LOGGER.debug(
+            "Deleted %s events because entity_id is excluded", deleted_rows_events
+        )
+
+    return batch_purge_before
+
+
+def _purge_filtered_events(
+    session: Session,
+    excluded_event_types: list[str],
+    batch_purge_before: datetime,
+    batch_size_hours: int,
+) -> datetime:
+    """Handle purging filtered events."""
+
+    query = (
+        session.query(Events)
+        .filter(Events.event_type.in_(excluded_event_types))
+        .order_by(Events.time_fired.asc())
+        .limit(1)
+    )
+    events = execute(query, to_native=True, validate_entity_ids=False)  # type: ignore
+    if events:
+        batch_purge_before = events[0].time_fired + timedelta(hours=batch_size_hours)
+
+    _LOGGER.debug(
+        "Purging events before %s the should be filtered",
+        batch_purge_before.strftime(DEBUG_DATETIME_FMT),
+    )
+
+    event_ids: list[int] = [
+        event_id
+        for (event_id,) in session.query(Events.event_id)
+        .filter(Events.time_fired < batch_purge_before)
+        .join(States)
+        .filter(Events.event_type.in_(excluded_event_types))
+        .all()
+    ]
+
+    if event_ids:
+        disconnected_rows = (
+            session.query(States)
+            .filter(
+                States.old_state_id.in_(
+                    session.query(States.state_id)
+                    .filter(States.last_updated < batch_purge_before)
+                    .filter(States.event_id.in_(event_ids))
+                )
+            )
+            .update({"old_state_id": None}, synchronize_session=False)
+        )
+
+        deleted_rows_states = (
+            session.query(States)
+            .filter(States.last_updated < batch_purge_before)
+            .filter(States.event_id.in_(event_ids))
+            .delete(synchronize_session=False)
+        )
+        _LOGGER.debug("Updated %s states to remove old_state_id", disconnected_rows)
+        _LOGGER.debug(
+            "Deleted %s states because event_type is excluded", deleted_rows_states
+        )
+
+    deleted_rows_events = (
+        session.query(Events)
+        .filter(Events.time_fired < batch_purge_before)
+        .filter(Events.event_type.in_(excluded_event_types))
+        .delete(synchronize_session=False)
+    )
+    _LOGGER.debug(
+        "Deleted %s events because event_type is excluded", deleted_rows_events
+    )
+
+    return batch_purge_before

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -10,20 +10,17 @@ from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import distinct
 
-from homeassistant.const import EVENT_STATE_CHANGED
 import homeassistant.util.dt as dt_util
 
 from .const import MAX_ROWS_TO_PURGE
 from .models import Events, RecorderRuns, States
 from .repack import repack_database
-from .util import execute, session_scope
+from .util import session_scope
 
 if TYPE_CHECKING:
     from . import Recorder
 
 _LOGGER = logging.getLogger(__name__)
-
-DEBUG_DATETIME_FMT = r"%Y-%m-%d %H:%M UTC"
 
 
 def purge_old_data(
@@ -51,9 +48,9 @@ def purge_old_data(
                 # return false, as we are not done yet.
                 _LOGGER.debug("Purging hasn't fully completed yet")
                 return False
-            if apply_filter:
-                if _purge_filtered_data(instance, session) is False:
-                    return False
+            if apply_filter and _purge_filtered_data(instance, session) is False:
+                _LOGGER.debug("Cleanup filtered data hasn't fully completed yet")
+                return False
             _purge_old_recorder_runs(instance, session, purge_before)
         if repack:
             repack_database(instance)
@@ -151,18 +148,9 @@ def _purge_old_recorder_runs(
     _LOGGER.debug("Deleted %s recorder_runs", deleted_rows)
 
 
-def _purge_filtered_data(
-    instance: Recorder,
-    session: Session,
-    *,
-    batch_size_hours: int = 1,
-) -> bool:
-    """Purge filtered states and events that shouldn't be in database."""
-
-    _LOGGER.debug("Purging filtered states and events")
-    utc_now = dt_util.utcnow()
-    batch_purge_before_states = utc_now
-    batch_purge_before_events = utc_now
+def _purge_filtered_data(instance: Recorder, session: Session) -> bool:
+    """Remove filtered states and events that shouldn't be in the database."""
+    _LOGGER.debug("Cleanup filtered data")
 
     # Check if excluded entity_ids are in database
     excluded_entity_ids: list[str] = [
@@ -170,14 +158,9 @@ def _purge_filtered_data(
         for (entity_id,) in session.query(distinct(States.entity_id)).all()
         if not instance.entity_filter(entity_id)
     ]
-
-    if len(excluded_entity_ids) != 0:
-        batch_purge_before_states = _purge_filtered_states(
-            session,
-            excluded_entity_ids,
-            batch_purge_before_states,
-            batch_size_hours,
-        )
+    if len(excluded_entity_ids) > 0:
+        _purge_filtered_states(session, excluded_entity_ids)
+        return False
 
     # Check if excluded event_types are in database
     excluded_event_types: list[str] = [
@@ -185,157 +168,48 @@ def _purge_filtered_data(
         for (event_type,) in session.query(distinct(Events.event_type)).all()
         if event_type in instance.exclude_t
     ]
-
-    if len(excluded_event_types) != 0:
-        batch_purge_before_events = _purge_filtered_events(
-            session,
-            excluded_event_types,
-            batch_purge_before_events,
-            batch_size_hours,
-        )
-
-    if batch_purge_before_states < utc_now or batch_purge_before_events < utc_now:
-        _LOGGER.debug("Purging filter hasn't fully completed yet")
+    if len(excluded_event_types) > 0:
+        _purge_filtered_events(session, excluded_event_types)
         return False
 
     return True
 
 
-def _purge_filtered_states(
-    session: Session,
-    excluded_entity_ids: list[str],
-    batch_purge_before: datetime,
-    batch_size_hours: int,
-) -> datetime:
-    """Handle purging filtered states."""
-
-    query = (
-        session.query(States)
-        .filter(States.entity_id.in_(excluded_entity_ids))
-        .order_by(States.last_updated.asc())
-        .limit(1)
-    )
-    states = execute(query, to_native=True, validate_entity_ids=False)  # type: ignore
-    if states:
-        batch_purge_before = states[0].last_updated + timedelta(hours=batch_size_hours)
-
-    _LOGGER.debug(
-        "Purging states before %s that should be filtered",
-        batch_purge_before.strftime(DEBUG_DATETIME_FMT),
-    )
-
-    disconnected_rows = (
-        session.query(States)
-        .filter(
-            States.old_state_id.in_(
-                session.query(States.state_id)
-                .filter(States.last_updated < batch_purge_before)
-                .filter(States.entity_id.in_(excluded_entity_ids))
-                .subquery()
-            )
+def _purge_filtered_states(session: Session, excluded_entity_ids: list[str]) -> None:
+    """Remove filtered states and linked events."""
+    state_ids: list[int]
+    event_ids: list[int | None]
+    state_ids, event_ids = zip(
+        *(
+            session.query(States.state_id, States.event_id)
+            .filter(States.entity_id.in_(excluded_entity_ids))
+            .limit(MAX_ROWS_TO_PURGE)
+            .all()
         )
-        .update({"old_state_id": None}, synchronize_session=False)
     )
-    _LOGGER.debug("Updated %s states to remove old_state_id", disconnected_rows)
+    event_ids = [id_ for id_ in event_ids if id_ is not None]
+    _LOGGER.debug(
+        "Selected %s state_ids to remove that should be filtered", len(state_ids)
+    )
+    _purge_state_ids(session, state_ids)
+    _purge_event_ids(session, event_ids)  # type: ignore  # type of event_ids already narrowed to 'list[int]'
 
-    event_ids: list[int] = [
-        event_id
-        for (event_id,) in session.query(States.event_id)
-        .filter(States.last_updated < batch_purge_before)
-        .filter(States.event_id is not None)
-        .filter(States.entity_id.in_(excluded_entity_ids))
+
+def _purge_filtered_events(session: Session, excluded_event_types: list[str]) -> None:
+    """Remove filtered events and linked states."""
+    events: list[Events] = (
+        session.query(Events.event_id)
+        .filter(Events.event_type.in_(excluded_event_types))
+        .limit(MAX_ROWS_TO_PURGE)
         .all()
-    ]
-
-    deleted_rows_states = (
-        session.query(States)
-        .filter(States.last_updated < batch_purge_before)
-        .filter(States.entity_id.in_(excluded_entity_ids))
-        .delete(synchronize_session=False)
     )
+    event_ids: list[int] = [event.event_id for event in events]
     _LOGGER.debug(
-        "Deleted %s states because entity_id is excluded", deleted_rows_states
+        "Selected %s event_ids to remove that should be filtered", len(event_ids)
     )
-
-    if event_ids:
-        deleted_rows_events = (
-            session.query(Events)
-            .filter(Events.event_type == EVENT_STATE_CHANGED)
-            .filter(Events.time_fired < batch_purge_before)
-            .filter(Events.event_id.in_(event_ids))
-            .delete(synchronize_session=False)
-        )
-        _LOGGER.debug(
-            "Deleted %s events because entity_id is excluded", deleted_rows_events
-        )
-
-    return batch_purge_before
-
-
-def _purge_filtered_events(
-    session: Session,
-    excluded_event_types: list[str],
-    batch_purge_before: datetime,
-    batch_size_hours: int,
-) -> datetime:
-    """Handle purging filtered events."""
-
-    query = (
-        session.query(Events)
-        .filter(Events.event_type.in_(excluded_event_types))
-        .order_by(Events.time_fired.asc())
-        .limit(1)
+    states: list[States] = (
+        session.query(States.state_id).filter(States.event_id.in_(event_ids)).all()
     )
-    events = execute(query, to_native=True, validate_entity_ids=False)  # type: ignore
-    if events:
-        batch_purge_before = events[0].time_fired + timedelta(hours=batch_size_hours)
-
-    _LOGGER.debug(
-        "Purging events before %s the should be filtered",
-        batch_purge_before.strftime(DEBUG_DATETIME_FMT),
-    )
-
-    event_ids: list[int] = [
-        event_id
-        for (event_id,) in session.query(Events.event_id)
-        .filter(Events.time_fired < batch_purge_before)
-        .join(States)
-        .filter(Events.event_type.in_(excluded_event_types))
-        .all()
-    ]
-
-    if event_ids:
-        disconnected_rows = (
-            session.query(States)
-            .filter(
-                States.old_state_id.in_(
-                    session.query(States.state_id)
-                    .filter(States.last_updated < batch_purge_before)
-                    .filter(States.event_id.in_(event_ids))
-                )
-            )
-            .update({"old_state_id": None}, synchronize_session=False)
-        )
-
-        deleted_rows_states = (
-            session.query(States)
-            .filter(States.last_updated < batch_purge_before)
-            .filter(States.event_id.in_(event_ids))
-            .delete(synchronize_session=False)
-        )
-        _LOGGER.debug("Updated %s states to remove old_state_id", disconnected_rows)
-        _LOGGER.debug(
-            "Deleted %s states because event_type is excluded", deleted_rows_states
-        )
-
-    deleted_rows_events = (
-        session.query(Events)
-        .filter(Events.time_fired < batch_purge_before)
-        .filter(Events.event_type.in_(excluded_event_types))
-        .delete(synchronize_session=False)
-    )
-    _LOGGER.debug(
-        "Deleted %s events because event_type is excluded", deleted_rows_events
-    )
-
-    return batch_purge_before
+    state_ids: list[int] = [state.state_id for state in states]
+    _purge_state_ids(session, state_ids)
+    _purge_event_ids(session, event_ids)

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -25,6 +25,14 @@ purge:
       selector:
         boolean:
 
+    apply_filter:
+      name: Apply filter
+      description: Apply entity_id and event_type filter in addition to time based purge.
+      example: true
+      default: false
+      selector:
+        boolean:
+
 disable:
   description: Stop the recording of events and state changes
 

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1,15 +1,18 @@
 """Test data purging."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
+
+from sqlalchemy.orm.session import Session
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder.models import Events, RecorderRuns, States
 from homeassistant.components.recorder.purge import purge_old_data
 from homeassistant.components.recorder.util import session_scope
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.const import EVENT_STATE_CHANGED
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util import dt as dt_util
 
-from .common import async_wait_recording_done
+from .common import async_recorder_block_till_done, async_wait_recording_done
 from .conftest import SetupRecorderInstanceT
 
 
@@ -154,6 +157,394 @@ async def test_purge_method(
         assert "Vacuuming SQL DB to free space" in caplog.text
 
 
+async def test_purge_edge_case(
+    hass: HomeAssistantType,
+    async_setup_recorder_instance: SetupRecorderInstanceT,
+):
+    """Test states and events are purged even if they occurred shortly before purge_before."""
+
+    async def _add_db_entries(hass: HomeAssistantType, timestamp: datetime) -> None:
+        with recorder.session_scope(hass=hass) as session:
+            session.add(
+                Events(
+                    event_id=1001,
+                    event_type="EVENT_TEST_PURGE",
+                    event_data="{}",
+                    origin="LOCAL",
+                    created=timestamp,
+                    time_fired=timestamp,
+                )
+            )
+            session.add(
+                States(
+                    entity_id="test.recorder2",
+                    domain="sensor",
+                    state="purgeme",
+                    attributes="{}",
+                    last_changed=timestamp,
+                    last_updated=timestamp,
+                    created=timestamp,
+                    event_id=1001,
+                )
+            )
+
+    instance = await async_setup_recorder_instance(hass, None)
+    await async_wait_recording_done(hass, instance)
+
+    service_data = {"keep_days": 2}
+    timestamp = dt_util.utcnow() - timedelta(days=2, minutes=1)
+
+    await _add_db_entries(hass, timestamp)
+    with session_scope(hass=hass) as session:
+        states = session.query(States)
+        assert states.count() == 1
+
+        events = session.query(Events).filter(Events.event_type == "EVENT_TEST_PURGE")
+        assert events.count() == 1
+
+        await hass.services.async_call(
+            recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
+        )
+        await hass.async_block_till_done()
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        assert states.count() == 0
+        assert events.count() == 0
+
+
+async def test_purge_filtered_states(
+    hass: HomeAssistantType,
+    async_setup_recorder_instance: SetupRecorderInstanceT,
+):
+    """Test filtered states are purged."""
+    config: ConfigType = {"exclude": {"entities": ["sensor.excluded"]}}
+    instance = await async_setup_recorder_instance(hass, config)
+    assert instance.entity_filter("sensor.excluded") is False
+
+    def _add_db_entries(hass: HomeAssistantType) -> None:
+        with recorder.session_scope(hass=hass) as session:
+            # Add states and state_changed events that should be purged
+            for days in range(1, 4):
+                timestamp = dt_util.utcnow() - timedelta(days=days)
+                for event_id in range(1000, 1020):
+                    _add_state_and_state_changed_event(
+                        session,
+                        "sensor.excluded",
+                        "purgeme",
+                        timestamp,
+                        event_id * days,
+                    )
+            # Add state **without** state_changed event that should be purged
+            timestamp = dt_util.utcnow() - timedelta(days=1)
+            session.add(
+                States(
+                    entity_id="sensor.excluded",
+                    domain="sensor",
+                    state="purgeme",
+                    attributes="{}",
+                    last_changed=timestamp,
+                    last_updated=timestamp,
+                    created=timestamp,
+                )
+            )
+            # Add states and state_changed events that should be keeped
+            timestamp = dt_util.utcnow() - timedelta(days=2)
+            for event_id in range(200, 210):
+                _add_state_and_state_changed_event(
+                    session,
+                    "sensor.keep",
+                    "keep",
+                    timestamp,
+                    event_id,
+                )
+            # Add states with linked old_state_ids that need to be handled
+            timestamp = dt_util.utcnow() - timedelta(days=0)
+            state_1 = States(
+                entity_id="sensor.linked_old_state_id",
+                domain="sensor",
+                state="keep",
+                attributes="{}",
+                last_changed=timestamp,
+                last_updated=timestamp,
+                created=timestamp,
+                old_state_id=1,
+            )
+            timestamp = dt_util.utcnow() - timedelta(days=4)
+            state_2 = States(
+                entity_id="sensor.linked_old_state_id",
+                domain="sensor",
+                state="keep",
+                attributes="{}",
+                last_changed=timestamp,
+                last_updated=timestamp,
+                created=timestamp,
+                old_state_id=2,
+            )
+            state_3 = States(
+                entity_id="sensor.linked_old_state_id",
+                domain="sensor",
+                state="keep",
+                attributes="{}",
+                last_changed=timestamp,
+                last_updated=timestamp,
+                created=timestamp,
+                old_state_id=62,  # keep
+            )
+            session.add_all((state_1, state_2, state_3))
+            # Add event that should be keeped
+            session.add(
+                Events(
+                    event_id=100,
+                    event_type="EVENT_KEEP",
+                    event_data="{}",
+                    origin="LOCAL",
+                    created=timestamp,
+                    time_fired=timestamp,
+                )
+            )
+
+    service_data = {"keep_days": 10}
+    _add_db_entries(hass)
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States)
+        assert states.count() == 74
+
+        events_state_changed = session.query(Events).filter(
+            Events.event_type == EVENT_STATE_CHANGED
+        )
+        events_keep = session.query(Events).filter(Events.event_type == "EVENT_KEEP")
+        assert events_state_changed.count() == 70
+        assert events_keep.count() == 1
+
+        # Normal purge doesn't remove excluded entities
+        await hass.services.async_call(
+            recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
+        )
+        await hass.async_block_till_done()
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        assert states.count() == 74
+        assert events_state_changed.count() == 70
+        assert events_keep.count() == 1
+
+        # Test with 'apply_filter' = True
+        service_data["apply_filter"] = True
+        await hass.services.async_call(
+            recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
+        )
+        await hass.async_block_till_done()
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        assert states.count() == 13
+        assert events_state_changed.count() == 10
+        assert events_keep.count() == 1
+
+        states_sensor_excluded = session.query(States).filter(
+            States.entity_id == "sensor.excluded"
+        )
+        assert states_sensor_excluded.count() == 0
+
+        session.query(States).get(71).old_state_id is None
+        session.query(States).get(72).old_state_id is None
+        session.query(States).get(73).old_state_id == 62  # should have been keeped
+
+
+async def test_purge_filtered_events(
+    hass: HomeAssistantType,
+    async_setup_recorder_instance: SetupRecorderInstanceT,
+):
+    """Test filtered events are purged."""
+    config: ConfigType = {"exclude": {"event_types": ["EVENT_PURGE"]}}
+    instance = await async_setup_recorder_instance(hass, config)
+
+    def _add_db_entries(hass: HomeAssistantType) -> None:
+        with recorder.session_scope(hass=hass) as session:
+            # Add events that should be purged
+            for days in range(1, 4):
+                timestamp = dt_util.utcnow() - timedelta(days=days)
+                for event_id in range(1000, 1020):
+                    session.add(
+                        Events(
+                            event_id=event_id * days,
+                            event_type="EVENT_PURGE",
+                            event_data="{}",
+                            origin="LOCAL",
+                            created=timestamp,
+                            time_fired=timestamp,
+                        )
+                    )
+
+            # Add states and state_changed events that should be keeped
+            timestamp = dt_util.utcnow() - timedelta(days=1)
+            for event_id in range(200, 210):
+                _add_state_and_state_changed_event(
+                    session,
+                    "sensor.keep",
+                    "keep",
+                    timestamp,
+                    event_id,
+                )
+
+    service_data = {"keep_days": 10}
+    _add_db_entries(hass)
+
+    with session_scope(hass=hass) as session:
+        events_purge = session.query(Events).filter(Events.event_type == "EVENT_PURGE")
+        events_keep = session.query(Events).filter(
+            Events.event_type == EVENT_STATE_CHANGED
+        )
+        states = session.query(States)
+
+        assert events_purge.count() == 60
+        assert events_keep.count() == 10
+        assert states.count() == 10
+
+        # Normal purge doesn't remove excluded events
+        await hass.services.async_call(
+            recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
+        )
+        await hass.async_block_till_done()
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        assert events_purge.count() == 60
+        assert events_keep.count() == 10
+        assert states.count() == 10
+
+        # Test with 'apply_filter' = True
+        service_data["apply_filter"] = True
+        await hass.services.async_call(
+            recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
+        )
+        await hass.async_block_till_done()
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        assert events_purge.count() == 0
+        assert events_keep.count() == 10
+        assert states.count() == 10
+
+
+async def test_purge_filtered_events_state_changed(
+    hass: HomeAssistantType,
+    async_setup_recorder_instance: SetupRecorderInstanceT,
+):
+    """Test filtered state_changed events are purged. This should also remove all states."""
+    config: ConfigType = {"exclude": {"event_types": [EVENT_STATE_CHANGED]}}
+    instance = await async_setup_recorder_instance(hass, config)
+    # Assert entity_id is NOT excluded
+    assert instance.entity_filter("sensor.excluded") is True
+
+    def _add_db_entries(hass: HomeAssistantType) -> None:
+        with recorder.session_scope(hass=hass) as session:
+            # Add states and state_changed events that should be purged
+            for days in range(1, 4):
+                timestamp = dt_util.utcnow() - timedelta(days=days)
+                for event_id in range(1000, 1020):
+                    _add_state_and_state_changed_event(
+                        session,
+                        "sensor.excluded",
+                        "purgeme",
+                        timestamp,
+                        event_id * days,
+                    )
+            # Add events that should be keeped
+            timestamp = dt_util.utcnow() - timedelta(days=1)
+            for event_id in range(200, 210):
+                session.add(
+                    Events(
+                        event_id=event_id,
+                        event_type="EVENT_KEEP",
+                        event_data="{}",
+                        origin="LOCAL",
+                        created=timestamp,
+                        time_fired=timestamp,
+                    )
+                )
+            # Add states with linked old_state_ids that need to be handled
+            timestamp = dt_util.utcnow() - timedelta(days=0)
+            state_1 = States(
+                entity_id="sensor.linked_old_state_id",
+                domain="sensor",
+                state="keep",
+                attributes="{}",
+                last_changed=timestamp,
+                last_updated=timestamp,
+                created=timestamp,
+                old_state_id=1,
+            )
+            timestamp = dt_util.utcnow() - timedelta(days=4)
+            state_2 = States(
+                entity_id="sensor.linked_old_state_id",
+                domain="sensor",
+                state="keep",
+                attributes="{}",
+                last_changed=timestamp,
+                last_updated=timestamp,
+                created=timestamp,
+                old_state_id=2,
+            )
+            state_3 = States(
+                entity_id="sensor.linked_old_state_id",
+                domain="sensor",
+                state="keep",
+                attributes="{}",
+                last_changed=timestamp,
+                last_updated=timestamp,
+                created=timestamp,
+                old_state_id=62,  # keep
+            )
+            session.add_all((state_1, state_2, state_3))
+
+    service_data = {"keep_days": 10, "apply_filter": True}
+    _add_db_entries(hass)
+
+    with session_scope(hass=hass) as session:
+        events_keep = session.query(Events).filter(Events.event_type == "EVENT_KEEP")
+        events_purge = session.query(Events).filter(
+            Events.event_type == EVENT_STATE_CHANGED
+        )
+        states = session.query(States)
+
+        assert events_keep.count() == 10
+        assert events_purge.count() == 60
+        assert states.count() == 63
+
+        await hass.services.async_call(
+            recorder.DOMAIN, recorder.SERVICE_PURGE, service_data
+        )
+        await hass.async_block_till_done()
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        await async_recorder_block_till_done(hass, instance)
+        await async_wait_recording_done(hass, instance)
+
+        assert events_keep.count() == 10
+        assert events_purge.count() == 0
+        assert states.count() == 3
+
+        session.query(States).get(61).old_state_id is None
+        session.query(States).get(62).old_state_id is None
+        session.query(States).get(63).old_state_id == 62  # should have been keeped
+
+
 async def _add_test_states(hass: HomeAssistantType, instance: recorder.Recorder):
     """Add multiple states to the db for testing."""
     utcnow = dt_util.utcnow()
@@ -260,3 +651,35 @@ async def _add_test_recorder_runs(hass: HomeAssistantType, instance: recorder.Re
                     end=timestamp + timedelta(days=1),
                 )
             )
+
+
+def _add_state_and_state_changed_event(
+    session: Session,
+    entity_id: str,
+    state: str,
+    timestamp: datetime,
+    event_id: int,
+) -> None:
+    """Add state and state_changed event to database for testing."""
+    session.add(
+        States(
+            entity_id=entity_id,
+            domain="sensor",
+            state=state,
+            attributes="{}",
+            last_changed=timestamp,
+            last_updated=timestamp,
+            created=timestamp,
+            event_id=event_id,
+        )
+    )
+    session.add(
+        Events(
+            event_id=event_id,
+            event_type=EVENT_STATE_CHANGED,
+            event_data="{}",
+            origin="LOCAL",
+            created=timestamp,
+            time_fired=timestamp,
+        )
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the `apply_filter` attribute to the `recorder.purge` service. The attribute indicates that the purge service should remove all filtered states and events even if they occurred between `now` and `now - purge_days`. This feature is intended to be used by a user only, so there is no change to the daily purge.

## Rational / Use case
I recently noticed that my production database had quadrupled in size after I missed excluding a few entity_ids. Since I use a Raspberry PI with an SD card, this caused my whole system to crash. After updating my config, I ran a manual purge, to try to reduce the db size. I noticed then, that the filter is only applied when a state or event is being added. I could have used `keep_days: 0` or removed the database completely but I just wanted to remove the falsely added entries. I had to remove them manually.

With this change, a user can just run `recorder.purge` with `repack: true` and `apply_filter: true` to remove the entries without loosing their entire history or knowing SQL.

## Implementation details
- `apply_filter: true` has to be set in a manual service call to `recorder.purge`. As described earlier, the daily purge doesn't change.
- To check which `states` should be removed, I used `distinct(States.entity_id).all()` and check for each entity if it should be filtered. For events I used `distinct(Events.event_type).all()`.
- Only states and events between `now` and `now - purge_days` are considered. Everything before then will be removed by the existing logic.
- If a state is to be removed, I also remove the event with the matching `event_id`. (`state_changed` events)
- If an event is to be removed, I also remove the matching state. (for `state_changed` events)
- Similar to the existing purge, the deletion happens in small increments, currently set to one hour. If the purge isn't finished, it will return False, which calls the purge method again.
- I have added extensive integration tests to validate the change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
recorder:
  exclude:
    entities:
      - sensor.purge
    event_types:
      - timer_out_of_sync


# Service call
recorder.purge:
  apply_filter: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16377

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
