### PR TITLE
Fix sensor discovery for zwave_js integration

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -72,7 +72,6 @@ NOTIFICATION_SENSOR_MAPPINGS: List[NotificationSensorMapping] = [
     },
     {
         # NotificationType 1: Smoke Alarm - All other State Id's
-        # Create as disabled sensors
         "type": NOTIFICATION_SMOKE_ALARM,
         "device_class": DEVICE_CLASS_PROBLEM,
     },

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -306,7 +306,7 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     def name(self) -> str:
         """Return default name from device name and value name combination."""
         node_name = self.info.node.name or self.info.node.device_config.description
-        value_name = self.info.primary_value.property
+        value_name = self.info.primary_value.property_name
         state_label = self.info.primary_value.metadata.states[self.state_key]
         return f"{node_name}: {value_name} - {state_label}"
 

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -300,7 +300,7 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return if the sensor is on or off."""
-        return self.info.primary_value.value is int(self.state_key)
+        return int(self.info.primary_value.value) == int(self.state_key)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -304,9 +304,11 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
 
     @property
     def name(self) -> str:
-        """Return entity name with the state label appended."""
+        """Return default name from device name and value name combination."""
+        node_name = self.info.node.name or self.info.node.device_config.description
+        value_name = self.info.primary_value.property
         state_label = self.info.primary_value.metadata.states[self.state_key]
-        return f"{super().name} - {state_label}"
+        return f"{node_name}: {value_name} - {state_label}"
 
     @property
     def device_class(self) -> Optional[str]:

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -14,7 +14,6 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_LOCK,
     DEVICE_CLASS_MOISTURE,
     DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_POWER,
     DEVICE_CLASS_PROBLEM,
     DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
@@ -57,200 +56,144 @@ class NotificationSensorMapping(TypedDict, total=False):
     """Represent a notification sensor mapping dict type."""
 
     type: int  # required
-    states: List[int]  # required
+    states: List[str]
     device_class: str
     enabled: bool
 
 
 # Mappings for Notification sensors
+# https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/notifications.json
 NOTIFICATION_SENSOR_MAPPINGS: List[NotificationSensorMapping] = [
     {
-        # NotificationType 1: Smoke Alarm - State Id's 1 and 2
-        # Assuming here that Value 1 and 2 are not present at the same time
+        # NotificationType 1: Smoke Alarm - State Id's 1 and 2 - Smoke detected
         "type": NOTIFICATION_SMOKE_ALARM,
-        "states": [1, 2],
+        "states": ["1", "2"],
         "device_class": DEVICE_CLASS_SMOKE,
     },
     {
         # NotificationType 1: Smoke Alarm - All other State Id's
         # Create as disabled sensors
         "type": NOTIFICATION_SMOKE_ALARM,
-        "states": [3, 4, 5, 6, 7, 8],
-        "device_class": DEVICE_CLASS_SMOKE,
-        "enabled": False,
+        "device_class": DEVICE_CLASS_PROBLEM,
     },
     {
         # NotificationType 2: Carbon Monoxide - State Id's 1 and 2
         "type": NOTIFICATION_CARBON_MONOOXIDE,
-        "states": [1, 2],
+        "states": ["1", "2"],
         "device_class": DEVICE_CLASS_GAS,
     },
     {
         # NotificationType 2: Carbon Monoxide - All other State Id's
         "type": NOTIFICATION_CARBON_MONOOXIDE,
-        "states": [4, 5, 7],
-        "device_class": DEVICE_CLASS_GAS,
-        "enabled": False,
+        "device_class": DEVICE_CLASS_PROBLEM,
     },
     {
         # NotificationType 3: Carbon Dioxide - State Id's 1 and 2
         "type": NOTIFICATION_CARBON_DIOXIDE,
-        "states": [1, 2],
+        "states": ["1", "2"],
         "device_class": DEVICE_CLASS_GAS,
     },
     {
         # NotificationType 3: Carbon Dioxide - All other State Id's
         "type": NOTIFICATION_CARBON_DIOXIDE,
-        "states": [4, 5, 7],
-        "device_class": DEVICE_CLASS_GAS,
-        "enabled": False,
+        "device_class": DEVICE_CLASS_PROBLEM,
     },
     {
         # NotificationType 4: Heat - State Id's 1, 2, 5, 6 (heat/underheat)
         "type": NOTIFICATION_HEAT,
-        "states": [1, 2, 5, 6],
+        "states": ["1", "2", "5", "6"],
         "device_class": DEVICE_CLASS_HEAT,
     },
     {
         # NotificationType 4: Heat - All other State Id's
         "type": NOTIFICATION_HEAT,
-        "states": [3, 4, 8, 10, 11],
-        "device_class": DEVICE_CLASS_HEAT,
-        "enabled": False,
+        "device_class": DEVICE_CLASS_PROBLEM,
     },
     {
         # NotificationType 5: Water - State Id's 1, 2, 3, 4
         "type": NOTIFICATION_WATER,
-        "states": [1, 2, 3, 4],
+        "states": ["1", "2", "3", "4"],
         "device_class": DEVICE_CLASS_MOISTURE,
     },
     {
         # NotificationType 5: Water - All other State Id's
         "type": NOTIFICATION_WATER,
-        "states": [5],
-        "device_class": DEVICE_CLASS_MOISTURE,
-        "enabled": False,
+        "device_class": DEVICE_CLASS_PROBLEM,
     },
     {
         # NotificationType 6: Access Control - State Id's 1, 2, 3, 4 (Lock)
         "type": NOTIFICATION_ACCESS_CONTROL,
-        "states": [1, 2, 3, 4],
+        "states": ["1", "2", "3", "4"],
         "device_class": DEVICE_CLASS_LOCK,
     },
     {
-        # NotificationType 6: Access Control - State Id 22 (door/window open)
+        # NotificationType 6: Access Control - State Id 16 (door/window open)
         "type": NOTIFICATION_ACCESS_CONTROL,
-        "states": [22],
+        "states": ["22"],
         "device_class": DEVICE_CLASS_DOOR,
     },
     {
+        # NotificationType 6: Access Control - State Id 17 (door/window closed)
+        "type": NOTIFICATION_ACCESS_CONTROL,
+        "states": ["23"],
+        "enabled": False,
+    },
+    {
         # NotificationType 7: Home Security - State Id's 1, 2 (intrusion)
-        # Assuming that value 1 and 2 are not present at the same time
         "type": NOTIFICATION_HOME_SECURITY,
-        "states": [1, 2],
+        "states": ["1", "2"],
         "device_class": DEVICE_CLASS_SAFETY,
     },
     {
         # NotificationType 7: Home Security - State Id's 3, 4, 9 (tampering)
         "type": NOTIFICATION_HOME_SECURITY,
-        "states": [3, 4, 9],
+        "states": ["3", "4", "9"],
         "device_class": DEVICE_CLASS_SAFETY,
     },
     {
         # NotificationType 7: Home Security - State Id's 5, 6 (glass breakage)
-        # Assuming that value 5 and 6 are not present at the same time
         "type": NOTIFICATION_HOME_SECURITY,
-        "states": [5, 6],
+        "states": ["5", "6"],
         "device_class": DEVICE_CLASS_SAFETY,
     },
     {
         # NotificationType 7: Home Security - State Id's 7, 8 (motion)
         "type": NOTIFICATION_HOME_SECURITY,
-        "states": [7, 8],
+        "states": ["7", "8"],
         "device_class": DEVICE_CLASS_MOTION,
-    },
-    {
-        # NotificationType 8: Power management - Values 1...9
-        "type": NOTIFICATION_POWER_MANAGEMENT,
-        "states": [1, 2, 3, 4, 5, 6, 7, 8, 9],
-        "device_class": DEVICE_CLASS_POWER,
-        "enabled": False,
-    },
-    {
-        # NotificationType 8: Power management - Values 10...15
-        # Battery values (mutually exclusive)
-        "type": NOTIFICATION_POWER_MANAGEMENT,
-        "states": [10, 11, 12, 13, 14, 15],
-        "device_class": DEVICE_CLASS_BATTERY,
-        "enabled": False,
     },
     {
         # NotificationType 9: System - State Id's 1, 2, 6, 7
         "type": NOTIFICATION_SYSTEM,
-        "states": [1, 2, 6, 7],
+        "states": ["1", "2", "6", "7"],
         "device_class": DEVICE_CLASS_PROBLEM,
-        "enabled": False,
     },
     {
         # NotificationType 10: Emergency - State Id's 1, 2, 3
         "type": NOTIFICATION_EMERGENCY,
-        "states": [1, 2, 3],
+        "states": ["1", "2", "3"],
         "device_class": DEVICE_CLASS_PROBLEM,
-    },
-    {
-        # NotificationType 11: Clock - State Id's 1, 2
-        "type": NOTIFICATION_CLOCK,
-        "states": [1, 2],
-        "enabled": False,
-    },
-    {
-        # NotificationType 12: Appliance - All State Id's
-        "type": NOTIFICATION_APPLIANCE,
-        "states": list(range(1, 22)),
-    },
-    {
-        # NotificationType 13: Home Health - State Id's 1,2,3,4,5
-        "type": NOTIFICATION_APPLIANCE,
-        "states": [1, 2, 3, 4, 5],
     },
     {
         # NotificationType 14: Siren
         "type": NOTIFICATION_SIREN,
-        "states": [1],
+        "states": ["1"],
         "device_class": DEVICE_CLASS_SOUND,
-    },
-    {
-        # NotificationType 15: Water valve
-        # ignore non-boolean values
-        "type": NOTIFICATION_WATER_VALVE,
-        "states": [3, 4],
-        "device_class": DEVICE_CLASS_PROBLEM,
-    },
-    {
-        # NotificationType 16: Weather
-        "type": NOTIFICATION_WEATHER,
-        "states": [1, 2],
-        "device_class": DEVICE_CLASS_PROBLEM,
-    },
-    {
-        # NotificationType 17: Irrigation
-        # ignore non-boolean values
-        "type": NOTIFICATION_IRRIGATION,
-        "states": [1, 2, 3, 4, 5],
     },
     {
         # NotificationType 18: Gas
         "type": NOTIFICATION_GAS,
-        "states": [1, 2, 3, 4],
+        "states": ["1", "2", "3", "4"],
         "device_class": DEVICE_CLASS_GAS,
     },
     {
         # NotificationType 18: Gas
         "type": NOTIFICATION_GAS,
-        "states": [6],
+        "states": ["6"],
         "device_class": DEVICE_CLASS_PROBLEM,
     },
 ]
+
 
 PROPERTY_DOOR_STATUS = "doorStatus"
 
@@ -284,10 +227,17 @@ async def async_setup_entry(
     @callback
     def async_add_binary_sensor(info: ZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Binary Sensor."""
-        entities: List[ZWaveBaseEntity] = []
+        entities: List[BinarySensorEntity] = []
 
         if info.platform_hint == "notification":
-            entities.append(ZWaveNotificationBinarySensor(config_entry, client, info))
+            # Get all sensors from Notification CC states
+            for state_key in info.primary_value.metadata.states:
+                # ignore idle key (0)
+                if state_key == "0":
+                    continue
+                entities.append(
+                    ZWaveNotificationBinarySensor(config_entry, client, info, state_key)
+                )
         elif info.platform_hint == "property":
             entities.append(ZWavePropertyBinarySensor(config_entry, client, info))
         else:
@@ -335,27 +285,28 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     """Representation of a Z-Wave binary_sensor from Notification CommandClass."""
 
     def __init__(
-        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+        self,
+        config_entry: ConfigEntry,
+        client: ZwaveClient,
+        info: ZwaveDiscoveryInfo,
+        state_key: str,
     ) -> None:
         """Initialize a ZWaveNotificationBinarySensor entity."""
         super().__init__(config_entry, client, info)
+        self.state_key = state_key
         # check if we have a custom mapping for this value
         self._mapping_info = self._get_sensor_mapping()
 
     @property
     def is_on(self) -> bool:
         """Return if the sensor is on or off."""
-        if self._mapping_info:
-            return self.info.primary_value.value in self._mapping_info["states"]
-        return bool(self.info.primary_value.value != 0)
+        return self.info.primary_value.value is int(self.state_key)
 
     @property
     def name(self) -> str:
-        """Return default name from device name and value name combination."""
-        node_name = self.info.node.name or self.info.node.device_config.description
-        property_name = self.info.primary_value.property_name
-        property_key_name = self.info.primary_value.property_key_name
-        return f"{node_name}: {property_name}: {property_key_name}"
+        """Return entity name with the state label appended."""
+        state_label = self.info.primary_value.metadata.states[self.state_key]
+        return f"{super().name} - {state_label}"
 
     @property
     def device_class(self) -> Optional[str]:
@@ -363,30 +314,29 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         return self._mapping_info.get("device_class")
 
     @property
+    def unique_id(self) -> str:
+        """Return unique id for this entity."""
+        return f"{super().unique_id}.{self.state_key}"
+
+    @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        # We hide some more advanced sensors by default to not overwhelm users
         if not self._mapping_info:
-            # consider value for which we do not have a mapping as advanced.
-            return False
+            return True
         return self._mapping_info.get("enabled", True)
 
     @callback
     def _get_sensor_mapping(self) -> NotificationSensorMapping:
         """Try to get a device specific mapping for this sensor."""
         for mapping in NOTIFICATION_SENSOR_MAPPINGS:
-            if mapping["type"] != int(
-                self.info.primary_value.metadata.cc_specific["notificationType"]
+            if (
+                mapping["type"]
+                != self.info.primary_value.metadata.cc_specific["notificationType"]
             ):
                 continue
-            for state_key in self.info.primary_value.metadata.states:
-                # make sure the key is int
-                state_key = int(state_key)
-                if state_key not in mapping["states"]:
-                    continue
+            if not mapping.get("states") or self.state_key in mapping["states"]:
                 # match found
-                mapping_info = mapping.copy()
-                return mapping_info
+                return mapping
         return {}
 
 

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -162,9 +162,17 @@ DISCOVERY_SCHEMAS = [
             CommandClass.INDICATOR,
             CommandClass.BATTERY,
             CommandClass.NOTIFICATION,
+        },
+        type={"number"},
+    ),
+    ZWaveDiscoverySchema(
+        platform="sensor",
+        hint="numeric_sensor",
+        command_class={
             CommandClass.BASIC,
         },
         type={"number"},
+        property={"currentValue"},
     ),
     # binary switches
     ZWaveDiscoverySchema(

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -204,54 +204,44 @@ DISCOVERY_SCHEMAS = [
 def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None, None]:
     """Run discovery on ZWave node and return matching (primary) values."""
     for value in node.values.values():
-        disc_val = async_discover_value(value)
-        if disc_val:
-            yield disc_val
-
-
-@callback
-def async_discover_value(value: ZwaveValue) -> Optional[ZwaveDiscoveryInfo]:
-    """Run discovery on Z-Wave value and return ZwaveDiscoveryInfo if match found."""
-    for schema in DISCOVERY_SCHEMAS:
-        # check device_class_basic
-        if (
-            schema.device_class_basic is not None
-            and value.node.device_class.basic not in schema.device_class_basic
-        ):
-            continue
-        # check device_class_generic
-        if (
-            schema.device_class_generic is not None
-            and value.node.device_class.generic not in schema.device_class_generic
-        ):
-            continue
-        # check device_class_specific
-        if (
-            schema.device_class_specific is not None
-            and value.node.device_class.specific not in schema.device_class_specific
-        ):
-            continue
-        # check command_class
-        if (
-            schema.command_class is not None
-            and value.command_class not in schema.command_class
-        ):
-            continue
-        # check endpoint
-        if schema.endpoint is not None and value.endpoint not in schema.endpoint:
-            continue
-        # check property
-        if schema.property is not None and value.property_ not in schema.property:
-            continue
-        # check metadata_type
-        if schema.type is not None and value.metadata.type not in schema.type:
-            continue
-        # all checks passed, this value belongs to an entity
-        return ZwaveDiscoveryInfo(
-            node=value.node,
-            primary_value=value,
-            platform=schema.platform,
-            platform_hint=schema.hint,
-        )
-
-    return None
+        for schema in DISCOVERY_SCHEMAS:
+            # check device_class_basic
+            if (
+                schema.device_class_basic is not None
+                and value.node.device_class.basic not in schema.device_class_basic
+            ):
+                continue
+            # check device_class_generic
+            if (
+                schema.device_class_generic is not None
+                and value.node.device_class.generic not in schema.device_class_generic
+            ):
+                continue
+            # check device_class_specific
+            if (
+                schema.device_class_specific is not None
+                and value.node.device_class.specific not in schema.device_class_specific
+            ):
+                continue
+            # check command_class
+            if (
+                schema.command_class is not None
+                and value.command_class not in schema.command_class
+            ):
+                continue
+            # check endpoint
+            if schema.endpoint is not None and value.endpoint not in schema.endpoint:
+                continue
+            # check property
+            if schema.property is not None and value.property_ not in schema.property:
+                continue
+            # check metadata_type
+            if schema.type is not None and value.metadata.type not in schema.type:
+                continue
+            # all checks passed, this value belongs to an entity
+            yield ZwaveDiscoveryInfo(
+                node=value.node,
+                primary_value=value,
+                platform=schema.platform,
+                platform_hint=schema.hint,
+            )

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -146,7 +146,6 @@ DISCOVERY_SCHEMAS = [
             CommandClass.ALARM,
             CommandClass.SENSOR_ALARM,
             CommandClass.INDICATOR,
-            CommandClass.NOTIFICATION,
         },
         type={"string"},
     ),

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -143,7 +143,6 @@ DISCOVERY_SCHEMAS = [
         platform="sensor",
         hint="string_sensor",
         command_class={
-            CommandClass.ALARM,
             CommandClass.SENSOR_ALARM,
             CommandClass.INDICATOR,
         },
@@ -156,14 +155,22 @@ DISCOVERY_SCHEMAS = [
         command_class={
             CommandClass.SENSOR_MULTILEVEL,
             CommandClass.METER,
-            CommandClass.ALARM,
             CommandClass.SENSOR_ALARM,
             CommandClass.INDICATOR,
             CommandClass.BATTERY,
+        },
+        type={"number"},
+    ),
+    # special list sensors (Notification CC)
+    ZWaveDiscoverySchema(
+        platform="sensor",
+        hint="list_sensor",
+        command_class={
             CommandClass.NOTIFICATION,
         },
         type={"number"},
     ),
+    # sensor for basic CC
     ZWaveDiscoverySchema(
         platform="sensor",
         hint="numeric_sensor",

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -77,6 +77,9 @@ class ZWaveBaseEntity(Entity):
             or self.info.primary_value.property_key_name
             or self.info.primary_value.property_name
         )
+        # append endpoint if > 1
+        if self.info.primary_value.endpoint > 1:
+            value_name += f" ({self.info.primary_value.endpoint})"
         return f"{node_name}: {value_name}"
 
     @property

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -162,3 +162,12 @@ class ZWaveNumericSensor(ZwaveSensorBase):
             str(self.info.primary_value.value)
         )
         return {"label": label}
+
+    @property
+    def name(self) -> str:
+        """Return default name from device name and value name combination."""
+        if self.info.primary_value.command_class == CommandClass.BASIC:
+            node_name = self.info.node.name or self.info.node.device_config.description
+            label = self.info.primary_value.command_class_name
+            return f"{node_name}: {label}"
+        return super().name

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -153,15 +153,15 @@ class ZWaveListSensor(ZwaveSensorBase):
     """Representation of a Z-Wave Numeric sensor with multiple states."""
 
     @property
-    def state(self) -> str:
+    def state(self) -> Optional[str]:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:
-            return ""
+            return None
         if (
             not str(self.info.primary_value.value)
             in self.info.primary_value.metadata.states
         ):
-            return ""
+            return None
         return str(
             self.info.primary_value.metadata.states[str(self.info.primary_value.value)]
         )

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -9,6 +9,7 @@ from zwave_js_server.const import CommandClass
 from homeassistant.components.sensor import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
     DOMAIN as SENSOR_DOMAIN,
 )
@@ -67,11 +68,15 @@ class ZwaveSensorBase(ZWaveBaseEntity):
         if self.info.primary_value.command_class == CommandClass.BATTERY:
             return DEVICE_CLASS_BATTERY
         if self.info.primary_value.command_class == CommandClass.METER:
-            if self.info.primary_value.property_key_name == "kWh_Consumed":
+            if self.info.primary_value.metadata.unit == "kWh":
                 return DEVICE_CLASS_ENERGY
             return DEVICE_CLASS_POWER
-        if self.info.primary_value.property_ == "Air temperature":
+        if "temperature" in self.info.primary_value.property_.lower():
             return DEVICE_CLASS_TEMPERATURE
+        if self.info.primary_value.metadata.unit == "W":
+            return DEVICE_CLASS_POWER
+        if self.info.primary_value.metadata.unit == "Lux":
+            return DEVICE_CLASS_ILLUMINANCE
         return None
 
     @property

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -40,6 +40,8 @@ async def async_setup_entry(
             entities.append(ZWaveStringSensor(config_entry, client, info))
         elif info.platform_hint == "numeric_sensor":
             entities.append(ZWaveNumericSensor(config_entry, client, info))
+        elif info.platform_hint == "list_sensor":
+            entities.append(ZWaveListSensor(config_entry, client, info))
         else:
             LOGGER.warning(
                 "Sensor not implemented for %s/%s",
@@ -138,31 +140,42 @@ class ZWaveNumericSensor(ZwaveSensorBase):
         return str(self.info.primary_value.metadata.unit)
 
     @property
-    def device_state_attributes(self) -> Optional[Dict[str, str]]:
-        """Return the device specific state attributes."""
-        if (
-            self.info.primary_value.value is None
-            or not self.info.primary_value.metadata.states
-        ):
-            return None
-        # add the value's label as property for multi-value (list) items
-        label = self.info.primary_value.metadata.states.get(
-            self.info.primary_value.value
-        ) or self.info.primary_value.metadata.states.get(
-            str(self.info.primary_value.value)
-        )
-        return {"label": label}
-
-    @property
     def name(self) -> str:
         """Return default name from device name and value name combination."""
-        if self.info.primary_value.command_class == CommandClass.NOTIFICATION:
-            node_name = self.info.node.name or self.info.node.device_config.description
-            prop_name = self.info.primary_value.property_name
-            prop_key_name = self.info.primary_value.property_key_name
-            return f"{node_name}: {prop_name} - {prop_key_name}"
         if self.info.primary_value.command_class == CommandClass.BASIC:
             node_name = self.info.node.name or self.info.node.device_config.description
             label = self.info.primary_value.command_class_name
             return f"{node_name}: {label}"
         return super().name
+
+
+class ZWaveListSensor(ZwaveSensorBase):
+    """Representation of a Z-Wave Numeric sensor with multiple states."""
+
+    @property
+    def state(self) -> str:
+        """Return state of the sensor."""
+        if self.info.primary_value.value is None:
+            return ""
+        if (
+            not str(self.info.primary_value.value)
+            in self.info.primary_value.metadata.states
+        ):
+            return ""
+        return str(
+            self.info.primary_value.metadata.states[str(self.info.primary_value.value)]
+        )
+
+    @property
+    def device_state_attributes(self) -> Optional[Dict[str, str]]:
+        """Return the device specific state attributes."""
+        # add the value's int value as property for multi-value (list) items
+        return {"value": self.info.primary_value.value}
+
+    @property
+    def name(self) -> str:
+        """Return default name from device name and value name combination."""
+        node_name = self.info.node.name or self.info.node.device_config.description
+        prop_name = self.info.primary_value.property_name
+        prop_key_name = self.info.primary_value.property_key_name
+        return f"{node_name}: {prop_name} - {prop_key_name}"

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -114,6 +114,16 @@ class ZWaveStringSensor(ZwaveSensorBase):
             return None
         return str(self.info.primary_value.metadata.unit)
 
+    @property
+    def name(self) -> str:
+        """Return default name from device name and value name combination."""
+        if self.info.primary_value.command_class == CommandClass.NOTIFICATION:
+            node_name = self.info.node.name or self.info.node.device_config.description
+            prop_name = self.info.primary_value.property_name
+            prop_key_name = self.info.primary_value.property_key_name
+            return f"{node_name}: {prop_name} - {prop_key_name}"
+        return super().name
+
 
 class ZWaveNumericSensor(ZwaveSensorBase):
     """Representation of a Z-Wave Numeric sensor."""

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -114,16 +114,6 @@ class ZWaveStringSensor(ZwaveSensorBase):
             return None
         return str(self.info.primary_value.metadata.unit)
 
-    @property
-    def name(self) -> str:
-        """Return default name from device name and value name combination."""
-        if self.info.primary_value.command_class == CommandClass.NOTIFICATION:
-            node_name = self.info.node.name or self.info.node.device_config.description
-            prop_name = self.info.primary_value.property_name
-            prop_key_name = self.info.primary_value.property_key_name
-            return f"{node_name}: {prop_name} - {prop_key_name}"
-        return super().name
-
 
 class ZWaveNumericSensor(ZwaveSensorBase):
     """Representation of a Z-Wave Numeric sensor."""
@@ -166,6 +156,11 @@ class ZWaveNumericSensor(ZwaveSensorBase):
     @property
     def name(self) -> str:
         """Return default name from device name and value name combination."""
+        if self.info.primary_value.command_class == CommandClass.NOTIFICATION:
+            node_name = self.info.node.name or self.info.node.device_config.description
+            prop_name = self.info.primary_value.property_name
+            prop_key_name = self.info.primary_value.property_key_name
+            return f"{node_name}: {prop_name} - {prop_key_name}"
         if self.info.primary_value.command_class == CommandClass.BASIC:
             node_name = self.info.node.name or self.info.node.device_config.description
             label = self.info.primary_value.command_class_name

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -7,7 +7,7 @@ LOW_BATTERY_BINARY_SENSOR = "binary_sensor.multisensor_6_low_battery_level"
 ENABLED_LEGACY_BINARY_SENSOR = "binary_sensor.z_wave_door_window_sensor_any"
 DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
 NOTIFICATION_MOTION_BINARY_SENSOR = (
-    "binary_sensor.multisensor_6_home_security_motion_sensor_status"
+    "binary_sensor.multisensor_6_home_security_motion_detection"
 )
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -9,6 +9,7 @@ DISABLED_LEGACY_BINARY_SENSOR = "binary_sensor.multisensor_6_any"
 NOTIFICATION_MOTION_BINARY_SENSOR = (
     "binary_sensor.multisensor_6_home_security_motion_detection"
 )
+NOTIFICATION_MOTION_SENSOR = "sensor.multisensor_6_home_security_motion_sensor_status"
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
 )

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -60,10 +60,12 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
     updated_entry = ent_reg.async_update_entity(
         entity_entry.entity_id, **{"disabled_by": None}
     )
+    await hass.async_block_till_done()
     assert updated_entry != entity_entry
     assert updated_entry.disabled is False
 
     # the part below needs to be fixed
+    # the entity state is not available yet after enabling the entity
 
     # state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
     # assert state == "Motion detection"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -69,4 +69,4 @@ async def test_notification_sensor(hass, multisensor_6, integration):
 
     state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
     assert state == "Motion detection"
-    assert state.attributes["Value"] == "8"
+    assert state.attributes["value"] == "8"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -66,7 +66,10 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
 
     # the part below needs to be fixed
     # the entity state is not available yet after enabling the entity
+    await hass.config_entries.async_reload(integration.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-    # state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
-    # assert state == "Motion detection"
-    # assert state.attributes["value"] == "8"
+    state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
+    assert state.state == "Motion detection"
+    assert state.attributes["value"] == 8

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -63,8 +63,7 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
     assert updated_entry != entity_entry
     assert updated_entry.disabled is False
 
-    # the part below needs to be fixed
-    # the entity state is not available yet after enabling the entity
+    # reload integration and check if entity is correctly there
     await hass.config_entries.async_reload(integration.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -47,26 +47,24 @@ async def test_energy_sensors(hass, hank_binary_switch, integration):
     assert state.attributes["device_class"] == DEVICE_CLASS_ENERGY
 
 
-async def test_notification_sensor(hass, multisensor_6, integration):
+async def test_disabled_notification_sensor(hass, multisensor_6, integration):
     """Test sensor is created from Notification CC and is disabled."""
     ent_reg = await async_get_registry(hass)
-    entity = ent_reg.async_get(NOTIFICATION_MOTION_SENSOR)
+    entity_entry = ent_reg.async_get(NOTIFICATION_MOTION_SENSOR)
 
-    assert entity
-    assert entity.disabled
-    assert entity.disabled_by == DISABLED_INTEGRATION
+    assert entity_entry
+    assert entity_entry.disabled
+    assert entity_entry.disabled_by == DISABLED_INTEGRATION
 
     # Test enabling entity
     updated_entry = ent_reg.async_update_entity(
-        entity.entity_id, **{"disabled_by": None}
+        entity_entry.entity_id, **{"disabled_by": None}
     )
-    await hass.async_block_till_done()
-    assert updated_entry != entity
+    assert updated_entry != entity_entry
     assert updated_entry.disabled is False
 
-    # this part is still broken, the entity is not yet there
-    # I want to wait for the entity to be created here
+    # the part below needs to be fixed
 
-    state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
-    assert state == "Motion detection"
-    assert state.attributes["value"] == "8"
+    # state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
+    # assert state == "Motion detection"
+    # assert state.attributes["value"] == "8"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -60,14 +60,12 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
     updated_entry = ent_reg.async_update_entity(
         entity_entry.entity_id, **{"disabled_by": None}
     )
-    await hass.async_block_till_done()
     assert updated_entry != entity_entry
     assert updated_entry.disabled is False
 
     # the part below needs to be fixed
     # the entity state is not available yet after enabling the entity
     await hass.config_entries.async_reload(integration.entry_id)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get(NOTIFICATION_MOTION_SENSOR)

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -7,8 +7,17 @@ from homeassistant.const import (
     POWER_WATT,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers.entity_registry import (
+    DISABLED_INTEGRATION,
+    async_get_registry,
+)
 
-from .common import AIR_TEMPERATURE_SENSOR, ENERGY_SENSOR, POWER_SENSOR
+from .common import (
+    AIR_TEMPERATURE_SENSOR,
+    ENERGY_SENSOR,
+    NOTIFICATION_MOTION_SENSOR,
+    POWER_SENSOR,
+)
 
 
 async def test_numeric_sensor(hass, multisensor_6, integration):
@@ -36,3 +45,28 @@ async def test_energy_sensors(hass, hank_binary_switch, integration):
     assert state.state == "0.16"
     assert state.attributes["unit_of_measurement"] == ENERGY_KILO_WATT_HOUR
     assert state.attributes["device_class"] == DEVICE_CLASS_ENERGY
+
+
+async def test_notification_sensor(hass, multisensor_6, integration):
+    """Test sensor is created from Notification CC and is disabled."""
+    ent_reg = await async_get_registry(hass)
+    entity = ent_reg.async_get(NOTIFICATION_MOTION_SENSOR)
+
+    assert entity
+    assert entity.disabled
+    assert entity.disabled_by == DISABLED_INTEGRATION
+
+    # Test enabling entity
+    updated_entry = ent_reg.async_update_entity(
+        entity.entity_id, **{"disabled_by": None}
+    )
+    await hass.async_block_till_done()
+    assert updated_entry != entity
+    assert updated_entry.disabled is False
+
+    # this part is still broken, the entity is not yet there
+    # I want to wait for the entity to be created here
+
+    state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
+    assert state == "Motion detection"
+    assert state.attributes["Value"] == "8"


### PR DESCRIPTION
## Breaking change
Binary sensors will get a new unique_id. It is important that this fix is merged before release of 2021.2.


## Proposed change
This fixes multiple issues with sensors creation:

- For each state of a ValueNotification there will be a binary sensor created after this fix.
- The discovery of entities will now allow a ZWaveValue to be used for multiple platforms (e.g. the notification CC as string sensor and multiple binary sensors).
- Fixed a few missing deviceclass mappings I could spot.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:


## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
