### PR TITLE
Enable emulated_hue setting XY color and transition time by client

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -389,17 +389,17 @@ class HueOneLightChangeView(HomeAssistantView):
                 except ValueError:
                     _LOGGER.error("Unable to parse data (2): %s", request_json)
                     return self.json_message("Bad request", HTTP_BAD_REQUEST)
-            if HUE_API_STATE_XY in request_json:
-                try:
-                    parsed[STATE_XY] = tuple(
-                        (
-                            float(request_json[HUE_API_STATE_XY][0]),
-                            float(request_json[HUE_API_STATE_XY][1]),
-                        )
+        if HUE_API_STATE_XY in request_json:
+            try:
+                parsed[STATE_XY] = tuple(
+                    (
+                        float(request_json[HUE_API_STATE_XY][0]),
+                        float(request_json[HUE_API_STATE_XY][1]),
                     )
-                except ValueError:
-                    _LOGGER.error("Unable to parse data (2): %s", request_json)
-                    return self.json_message("Bad request", HTTP_BAD_REQUEST)
+                )
+            except ValueError:
+                _LOGGER.error("Unable to parse data (2): %s", request_json)
+                return self.json_message("Bad request", HTTP_BAD_REQUEST)
 
         if HUE_API_STATE_BRI in request_json:
             if entity.domain == light.DOMAIN:

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -43,9 +43,12 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
+    ATTR_TRANSITION,
+    ATTR_XY_COLOR,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
+    SUPPORT_TRANSITION,
 )
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_VOLUME_LEVEL,
@@ -82,6 +85,8 @@ STATE_COLORMODE = "colormode"
 STATE_HUE = "hue"
 STATE_SATURATION = "sat"
 STATE_COLOR_TEMP = "ct"
+STATE_TRANSITON = "tt"
+STATE_XY = "xy"
 
 # Hue API states, defined separately in case they change
 HUE_API_STATE_ON = "on"
@@ -90,7 +95,9 @@ HUE_API_STATE_COLORMODE = "colormode"
 HUE_API_STATE_HUE = "hue"
 HUE_API_STATE_SAT = "sat"
 HUE_API_STATE_CT = "ct"
+HUE_API_STATE_XY = "xy"
 HUE_API_STATE_EFFECT = "effect"
+HUE_API_STATE_TRANSITION = "transitiontime"
 
 # Hue API min/max values - https://developers.meethue.com/develop/hue-api/lights-api/
 HUE_API_STATE_BRI_MIN = 1  # Brightness
@@ -357,6 +364,8 @@ class HueOneLightChangeView(HomeAssistantView):
             STATE_HUE: None,
             STATE_SATURATION: None,
             STATE_COLOR_TEMP: None,
+            STATE_XY: None,
+            STATE_TRANSITON: None,
         }
 
         if HUE_API_STATE_ON in request_json:
@@ -372,10 +381,22 @@ class HueOneLightChangeView(HomeAssistantView):
             (HUE_API_STATE_HUE, STATE_HUE),
             (HUE_API_STATE_SAT, STATE_SATURATION),
             (HUE_API_STATE_CT, STATE_COLOR_TEMP),
+            (HUE_API_STATE_TRANSITION, STATE_TRANSITON),
         ):
             if key in request_json:
                 try:
                     parsed[attr] = int(request_json[key])
+                except ValueError:
+                    _LOGGER.error("Unable to parse data (2): %s", request_json)
+                    return self.json_message("Bad request", HTTP_BAD_REQUEST)
+            if HUE_API_STATE_XY in request_json:
+                try:
+                    parsed[STATE_XY] = tuple(
+                        (
+                            float(request_json[HUE_API_STATE_XY][0]),
+                            float(request_json[HUE_API_STATE_XY][1]),
+                        )
+                    )
                 except ValueError:
                     _LOGGER.error("Unable to parse data (2): %s", request_json)
                     return self.json_message("Bad request", HTTP_BAD_REQUEST)
@@ -444,9 +465,16 @@ class HueOneLightChangeView(HomeAssistantView):
 
                         data[ATTR_HS_COLOR] = (hue, sat)
 
+                    if parsed[STATE_XY] is not None:
+                        data[ATTR_XY_COLOR] = parsed[STATE_XY]
+
                 if entity_features & SUPPORT_COLOR_TEMP:
                     if parsed[STATE_COLOR_TEMP] is not None:
                         data[ATTR_COLOR_TEMP] = parsed[STATE_COLOR_TEMP]
+
+                if entity_features & SUPPORT_TRANSITION:
+                    if parsed[STATE_TRANSITON] is not None:
+                        data[ATTR_TRANSITION] = parsed[STATE_TRANSITON] / 10
 
         # If the requested entity is a script, add some variables
         elif entity.domain == script.DOMAIN:
@@ -557,6 +585,8 @@ class HueOneLightChangeView(HomeAssistantView):
             (STATE_HUE, HUE_API_STATE_HUE),
             (STATE_SATURATION, HUE_API_STATE_SAT),
             (STATE_COLOR_TEMP, HUE_API_STATE_CT),
+            (STATE_XY, HUE_API_STATE_XY),
+            (STATE_TRANSITON, HUE_API_STATE_TRANSITION),
         ):
             if parsed[key] is not None:
                 json_response.append(

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -759,7 +759,7 @@ async def test_put_light_state(hass, hass_hue, hue_client):
 
     await hass.async_block_till_done()
     assert call_turn_on[0]
-    # assert call_turn_on[0].data[ATTR_ENTITY_ID] == "light.ceiling_lights"
+    assert call_turn_on[0].data[ATTR_ENTITY_ID] == ["light.ceiling_lights"]
     assert call_turn_on[0].data[light.ATTR_BRIGHTNESS] == 99
     assert call_turn_on[0].data[light.ATTR_XY_COLOR] == ((0.488, 0.48))
     assert call_turn_on[0].data[light.ATTR_TRANSITION] == 6

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -28,6 +28,7 @@ from homeassistant.components.emulated_hue.hue_api import (
     HUE_API_STATE_HUE,
     HUE_API_STATE_ON,
     HUE_API_STATE_SAT,
+    HUE_API_STATE_XY,
     HUE_API_USERNAME,
     HueAllGroupsStateView,
     HueAllLightsStateView,
@@ -663,6 +664,25 @@ async def test_put_light_state(hass, hass_hue, hue_client):
     assert ceiling_json["state"][HUE_API_STATE_HUE] == 4369
     assert ceiling_json["state"][HUE_API_STATE_SAT] == 127
 
+    # update light state through api
+    await perform_put_light_state(
+        hass_hue,
+        hue_client,
+        "light.ceiling_lights",
+        True,
+        brightness=100,
+        xy=((0.488, 0.48)),
+    )
+
+    # go through api to get the state back
+    ceiling_json = await perform_get_light_state(
+        hue_client, "light.ceiling_lights", HTTP_OK
+    )
+    assert ceiling_json["state"][HUE_API_STATE_BRI] == 100
+    assert hass.states.get("light.ceiling_lights").attributes[light.ATTR_XY_COLOR] == (
+        (0.488, 0.48)
+    )
+
     # Go through the API to turn it off
     ceiling_result = await perform_put_light_state(
         hass_hue, hue_client, "light.ceiling_lights", False
@@ -1173,6 +1193,7 @@ async def perform_put_light_state(
     saturation=None,
     color_temp=None,
     with_state=True,
+    xy=None,
 ):
     """Test the setting of a light state."""
     req_headers = {"Content-Type": content_type}
@@ -1188,6 +1209,8 @@ async def perform_put_light_state(
         data[HUE_API_STATE_HUE] = hue
     if saturation is not None:
         data[HUE_API_STATE_SAT] = saturation
+    if xy is not None:
+        data[HUE_API_STATE_XY] = xy
     if color_temp is not None:
         data[HUE_API_STATE_CT] = color_temp
 

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -28,6 +28,7 @@ from homeassistant.components.emulated_hue.hue_api import (
     HUE_API_STATE_HUE,
     HUE_API_STATE_ON,
     HUE_API_STATE_SAT,
+    HUE_API_STATE_TRANSITION,
     HUE_API_STATE_XY,
     HUE_API_USERNAME,
     HueAllGroupsStateView,
@@ -40,6 +41,7 @@ from homeassistant.components.emulated_hue.hue_api import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
     CONTENT_TYPE_JSON,
     HTTP_NOT_FOUND,
     HTTP_OK,
@@ -52,7 +54,11 @@ from homeassistant.const import (
 from homeassistant.core import callback
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed, get_test_instance_port
+from tests.common import (
+    async_fire_time_changed,
+    async_mock_service,
+    get_test_instance_port,
+)
 
 HTTP_SERVER_PORT = get_test_instance_port()
 BRIDGE_SERVER_PORT = get_test_instance_port()
@@ -734,6 +740,30 @@ async def test_put_light_state(hass, hass_hue, hue_client):
         == 50
     )
 
+    # mock light.turn_on call
+    hass.states.async_set(
+        "light.ceiling_lights", STATE_ON, {ATTR_SUPPORTED_FEATURES: 55}
+    )
+    call_turn_on = async_mock_service(hass, "light", "turn_on")
+
+    # update light state through api
+    await perform_put_light_state(
+        hass_hue,
+        hue_client,
+        "light.ceiling_lights",
+        True,
+        brightness=99,
+        xy=((0.488, 0.48)),
+        transitiontime=60,
+    )
+
+    await hass.async_block_till_done()
+    assert call_turn_on[0]
+    # assert call_turn_on[0].data[ATTR_ENTITY_ID] == "light.ceiling_lights"
+    assert call_turn_on[0].data[light.ATTR_BRIGHTNESS] == 99
+    assert call_turn_on[0].data[light.ATTR_XY_COLOR] == ((0.488, 0.48))
+    assert call_turn_on[0].data[light.ATTR_TRANSITION] == 6
+
 
 async def test_put_light_state_script(hass, hass_hue, hue_client):
     """Test the setting of script variables."""
@@ -1194,6 +1224,7 @@ async def perform_put_light_state(
     color_temp=None,
     with_state=True,
     xy=None,
+    transitiontime=None,
 ):
     """Test the setting of a light state."""
     req_headers = {"Content-Type": content_type}
@@ -1213,6 +1244,8 @@ async def perform_put_light_state(
         data[HUE_API_STATE_XY] = xy
     if color_temp is not None:
         data[HUE_API_STATE_CT] = color_temp
+    if transitiontime is not None:
+        data[HUE_API_STATE_TRANSITION] = transitiontime
 
     entity_number = ENTITY_NUMBERS_BY_ID[entity_id]
     result = await client.put(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some clients (especially Philips Amblight TVs) are only able to set the lights color by XY value. These clients also use the transitiontime value of the Hue API to correctly display color changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/45621
- This PR is related to issue: https://github.com/home-assistant/core/issues/45621
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
