### PR TITLE
Centralize keepalive logic in Stream class

### DIFF
--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -15,6 +15,8 @@ OUTPUT_FORMATS = ["hls"]
 
 FORMAT_CONTENT_TYPE = {"hls": "application/vnd.apple.mpegurl"}
 
+OUTPUT_IDLE_TIMEOUT = 300  # Idle timeout due to inactivity
+
 MAX_SEGMENTS = 3  # Max number of segments to keep around
 MIN_SEGMENT_DURATION = 1.5  # Each segment is at least this many seconds
 
@@ -23,8 +25,6 @@ MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably rea
 
 MAX_MISSING_DTS = 6  # Number of packets missing DTS to allow
 STREAM_TIMEOUT = 30  # Timeout for reading stream
-
-STREAM_IDLE_TIMEOUT = 300  # Default idle timeout for each output
 
 STREAM_RESTART_INCREMENT = 10  # Increase wait_timeout by this amount each retry
 STREAM_RESTART_RESET_TIME = 300  # Reset wait_timeout after this many seconds

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -24,5 +24,7 @@ MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably rea
 MAX_MISSING_DTS = 6  # Number of packets missing DTS to allow
 STREAM_TIMEOUT = 30  # Timeout for reading stream
 
+STREAM_IDLE_TIMEOUT = 300  # Default idle timeout for each output
+
 STREAM_RESTART_INCREMENT = 10  # Increase wait_timeout by this amount each retry
 STREAM_RESTART_RESET_TIME = 300  # Reset wait_timeout after this many seconds

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -36,23 +36,61 @@ class Segment:
     duration: float = attr.ib()
 
 
+class IdleTimer:
+    """Invokes a callback after an inactivity timeout."""
+
+    def __init__(self, hass, timeout, callback):
+        """Initialize IdleTimer."""
+        self._hass = hass
+        self._unsub = None
+        self._timeout = timeout
+        self._callback = callback
+        self.idle = False
+
+    def start(self):
+        """Start the idle timer if not already started."""
+        self.idle = False
+        if self._unsub is None:
+            self._unsub = async_call_later(self._hass, self._timeout, self._fire)
+
+    def alive(self):
+        """Reset the idle timeout."""
+        self.idle = False
+        # Reset idle timeout
+        self.clear()
+        self._unsub = async_call_later(self._hass, self._timeout, self._fire)
+
+    def clear(self):
+        """Clear and disable the timer."""
+        if self._unsub is not None:
+            self._unsub()
+
+    def _fire(self, now=None):
+        self.idle = True
+        self._unsub = None
+        self._callback()
+
+
 class StreamOutput:
     """Represents a stream output."""
 
-    def __init__(self, stream, timeout: int = 300) -> None:
+    def __init__(self, hass, idle_timer) -> None:
         """Initialize a stream output."""
-        self.idle = False
-        self.timeout = timeout
-        self._stream = stream
+        self._hass = hass
+        self._idle_timer = idle_timer
         self._cursor = None
         self._event = asyncio.Event()
         self._segments = deque(maxlen=MAX_SEGMENTS)
-        self._unsub = None
 
     @property
     def name(self) -> str:
         """Return provider name."""
         return None
+
+    @property
+    def idle(self) -> bool:
+        """Return True if the output is idle."""
+        return self._idle_timer.idle
 
     @property
     def format(self) -> str:
@@ -90,11 +128,7 @@ class StreamOutput:
 
     def get_segment(self, sequence: int = None) -> Any:
         """Retrieve a specific segment, or the whole list."""
-        self.idle = False
-        # Reset idle timeout
-        if self._unsub is not None:
-            self._unsub()
-        self._unsub = async_call_later(self._stream.hass, self.timeout, self._timeout)
+        self._idle_timer.alive()
 
         if not sequence:
             return self._segments
@@ -119,43 +153,26 @@ class StreamOutput:
 
     def put(self, segment: Segment) -> None:
         """Store output."""
-        self._stream.hass.loop.call_soon_threadsafe(self._async_put, segment)
+        self._hass.loop.call_soon_threadsafe(self._async_put, segment)
 
     @callback
     def _async_put(self, segment: Segment) -> None:
         """Store output from event loop."""
         # Start idle timeout when we start receiving data
-        if self._unsub is None:
-            self._unsub = async_call_later(
-                self._stream.hass, self.timeout, self._timeout
-            )
-
-        if segment is None:
-            self._event.set()
-            # Cleanup provider
-            if self._unsub is not None:
-                self._unsub()
-            self.cleanup()
-            return
-
+        self._idle_timer.start()
         self._segments.append(segment)
         self._event.set()
         self._event.clear()
 
-    @callback
-    def _timeout(self, _now=None):
-        """Handle stream timeout."""
-        self._unsub = None
-        if self._stream.keepalive:
-            self.idle = True
-            self._stream.check_idle()
-        else:
-            self.cleanup()
+    def finish(self):
+        """End the stream and cleanup."""
+        self._event.set()
+        self._idle_timer.clear()
+        self.cleanup()
 
     def cleanup(self):
         """Handle cleanup."""
         self._segments = deque(maxlen=MAX_SEGMENTS)
-        self._stream.remove_provider(self)
 
 
 class StreamView(HomeAssistantView):

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -43,11 +43,13 @@ class IdleTimer:
     resets the internal alarm, extending the inactivity time.
     """
 
-    def __init__(self, hass: HomeAssistant, timeout: int, callback: Callable[[], None]):
+    def __init__(
+        self, hass: HomeAssistant, timeout: int, idle_callback: Callable[[], None]
+    ):
         """Initialize IdleTimer."""
         self._hass = hass
         self._timeout = timeout
-        self._callback = callback
+        self._callback = idle_callback
         self._unsub = None
         self.idle = False
 

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -6,9 +6,9 @@ from typing import List
 
 import av
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 
-from .core import PROVIDERS, Segment, StreamOutput
+from .core import PROVIDERS, IdleTimer, Segment, StreamOutput
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ def recorder_save_worker(file_out: str, segments: List[Segment], container_forma
 class RecorderOutput(StreamOutput):
     """Represents HLS Output formats."""
 
-    def __init__(self, hass, idle_timer) -> None:
+    def __init__(self, hass: HomeAssistant, idle_timer: IdleTimer) -> None:
         """Initialize recorder output."""
         super().__init__(hass, idle_timer)
         self.video_path = None
@@ -113,4 +113,6 @@ class RecorderOutput(StreamOutput):
             args=(self.video_path, self._segments, self.format),
         )
         thread.start()
+
+        super().cleanup()
         self._segments = []

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -72,9 +72,9 @@ def recorder_save_worker(file_out: str, segments: List[Segment], container_forma
 class RecorderOutput(StreamOutput):
     """Represents HLS Output formats."""
 
-    def __init__(self, stream, timeout: int = 30) -> None:
+    def __init__(self, hass, idle_timer) -> None:
         """Initialize recorder output."""
-        super().__init__(stream, timeout)
+        super().__init__(hass, idle_timer)
         self.video_path = None
         self._segments = []
 
@@ -104,12 +104,6 @@ class RecorderOutput(StreamOutput):
         segments = [s for s in segments if s.sequence not in own_segments]
         self._segments = segments + self._segments
 
-    @callback
-    def _timeout(self, _now=None):
-        """Handle recorder timeout."""
-        self._unsub = None
-        self.cleanup()
-
     def cleanup(self):
         """Write recording and clean up."""
         _LOGGER.debug("Starting recorder worker thread")
@@ -119,6 +113,4 @@ class RecorderOutput(StreamOutput):
             args=(self.video_path, self._segments, self.format),
         )
         thread.start()
-
         self._segments = []
-        self._stream.remove_provider(self)

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -150,13 +150,10 @@ def stream_worker(hass, stream, quit_event):
                 )  # Some streams declare an audio stream and never send any packets
                 audio_stream = None
 
-        except av.AVError as ex:
+        except (av.AVError, StopIteration) as ex:
             _LOGGER.error(
                 "Error demuxing stream while finding first packet: %s", str(ex)
             )
-            return False
-        except StopIteration:
-            _LOGGER.error("Stream has ended")
             return False
         return True
 
@@ -214,11 +211,8 @@ def stream_worker(hass, stream, quit_event):
                 missing_dts += 1
                 continue
             missing_dts = 0
-        except av.AVError as ex:
+        except (av.AVError, StopIteration) as ex:
             _LOGGER.error("Error demuxing stream: %s", str(ex))
-            break
-        except StopIteration:
-            _LOGGER.error("Stream has ended")
             break
 
         # Discard packet if dts is not monotonic

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -2,7 +2,6 @@
 from collections import deque
 import io
 import logging
-import time
 
 import av
 
@@ -11,8 +10,6 @@ from .const import (
     MAX_TIMESTAMP_GAP,
     MIN_SEGMENT_DURATION,
     PACKETS_TO_WAIT_FOR_AUDIO,
-    STREAM_RESTART_INCREMENT,
-    STREAM_RESTART_RESET_TIME,
     STREAM_TIMEOUT,
 )
 from .core import Segment, StreamBuffer
@@ -47,32 +44,6 @@ def create_stream_buffer(stream_output, video_stream, audio_stream, sequence):
 
 
 def stream_worker(hass, stream, quit_event):
-    """Handle consuming streams and restart keepalive streams."""
-
-    wait_timeout = 0
-    while not quit_event.wait(timeout=wait_timeout):
-        start_time = time.time()
-        try:
-            _stream_worker_internal(hass, stream, quit_event)
-        except av.error.FFmpegError:  # pylint: disable=c-extension-no-member
-            _LOGGER.exception("Stream connection failed: %s", stream.source)
-        if not stream.keepalive or quit_event.is_set():
-            break
-        # To avoid excessive restarts, wait before restarting
-        # As the required recovery time may be different for different setups, start
-        # with trying a short wait_timeout and increase it on each reconnection attempt.
-        # Reset the wait_timeout after the worker has been up for several minutes
-        if time.time() - start_time > STREAM_RESTART_RESET_TIME:
-            wait_timeout = 0
-        wait_timeout += STREAM_RESTART_INCREMENT
-        _LOGGER.debug(
-            "Restarting stream worker in %d seconds: %s",
-            wait_timeout,
-            stream.source,
-        )
-
-
-def _stream_worker_internal(hass, stream, quit_event):
     """Handle consuming streams."""
 
     try:
@@ -179,11 +150,13 @@ def _stream_worker_internal(hass, stream, quit_event):
                 )  # Some streams declare an audio stream and never send any packets
                 audio_stream = None
 
-        except (av.AVError, StopIteration) as ex:
+        except av.AVError as ex:
             _LOGGER.error(
                 "Error demuxing stream while finding first packet: %s", str(ex)
             )
-            finalize_stream()
+            return False
+        except StopIteration:
+            _LOGGER.error("Stream has ended")
             return False
         return True
 
@@ -220,12 +193,6 @@ def _stream_worker_internal(hass, stream, quit_event):
                 packet.stream = output_streams[audio_stream]
                 buffer.output.mux(packet)
 
-    def finalize_stream():
-        if not stream.keepalive:
-            # End of stream, clear listeners and stop thread
-            for fmt in stream.outputs:
-                stream.outputs[fmt].put(None)
-
     if not peek_first_pts():
         container.close()
         return
@@ -247,9 +214,11 @@ def _stream_worker_internal(hass, stream, quit_event):
                 missing_dts += 1
                 continue
             missing_dts = 0
-        except (av.AVError, StopIteration) as ex:
+        except av.AVError as ex:
             _LOGGER.error("Error demuxing stream: %s", str(ex))
-            finalize_stream()
+            break
+        except StopIteration:
+            _LOGGER.error("Stream has ended")
             break
 
         # Discard packet if dts is not monotonic
@@ -263,7 +232,6 @@ def _stream_worker_internal(hass, stream, quit_event):
                     last_dts[packet.stream],
                     packet.dts,
                 )
-                finalize_stream()
                 break
             continue
 

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -9,14 +9,13 @@ nothing for the test to verify. The solution is the WorkerSync class that
 allows the tests to pause the worker thread before finalizing the stream
 so that it can inspect the output.
 """
-
 import logging
 import threading
 from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.stream.core import Segment, StreamOutput
+from homeassistant.components.stream import Stream
 
 
 class WorkerSync:
@@ -25,7 +24,7 @@ class WorkerSync:
     def __init__(self):
         """Initialize WorkerSync."""
         self._event = None
-        self._put_original = StreamOutput.put
+        self._finish_original = Stream._worker_finished
 
     def pause(self):
         """Pause the worker before it finalizes the stream."""
@@ -35,17 +34,14 @@ class WorkerSync:
         """Allow the worker thread to finalize the stream."""
         self._event.set()
 
-    def blocking_put(self, stream_output: StreamOutput, segment: Segment):
-        """Proxy StreamOutput.put, intercepted for test to pause worker."""
-        if segment is None and self._event:
-            # Worker is ending the stream, which clears all output buffers.
-            # Block the worker thread until the test has a chance to verify
-            # the segments under test.
-            logging.error("blocking worker")
-            self._event.wait()
-
-        # Forward to actual StreamOutput.put
-        self._put_original(stream_output, segment)
+    def blocking_finish(self, stream: Stream):
+        """Proxy StreamOutput.finish, intercepted for test to pause worker."""
+        # Worker is ending the stream, which clears all output buffers.
+        # Block the worker thread until the test has a chance to verify
+        # the segments under test.
+        logging.info("blocking_finish")
+        self._event.wait()
+        self._finish_original(stream)
 
 
 @pytest.fixture()
@@ -53,8 +49,8 @@ def stream_worker_sync(hass):
     """Patch StreamOutput to allow test to synchronize worker stream end."""
     sync = WorkerSync()
     with patch(
-        "homeassistant.components.stream.core.StreamOutput.put",
-        side_effect=sync.blocking_put,
+        "homeassistant.components.stream.Stream._worker_finished",
+        side_effect=sync.blocking_finish,
         autospec=True,
     ):
         yield sync

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -35,12 +35,14 @@ class WorkerSync:
         self._event.set()
 
     def blocking_finish(self, stream: Stream):
-        """Proxy StreamOutput.finish, intercepted for test to pause worker."""
+        """Intercept call to pause stream worker."""
         # Worker is ending the stream, which clears all output buffers.
         # Block the worker thread until the test has a chance to verify
         # the segments under test.
-        logging.info("blocking_finish")
+        logging.debug("blocking worker")
         self._event.wait()
+
+        # Forward to actual Stream._worker_finished
         self._finish_original(stream)
 
 

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -24,7 +24,7 @@ class WorkerSync:
     def __init__(self):
         """Initialize WorkerSync."""
         self._event = None
-        self._finish_original = Stream._worker_finished
+        self._original = Stream._worker_finished
 
     def pause(self):
         """Pause the worker before it finalizes the stream."""
@@ -42,8 +42,8 @@ class WorkerSync:
         logging.debug("blocking worker")
         self._event.wait()
 
-        # Forward to actual Stream._worker_finished
-        self._finish_original(stream)
+        # Forward to actual implementation
+        self._original(stream)
 
 
 @pytest.fixture()

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -98,6 +98,7 @@ async def test_stream_timeout(hass, hass_client, stream_worker_sync):
     # Wait 5 minutes
     future = dt_util.utcnow() + timedelta(minutes=5)
     async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
 
     # Ensure playlist not accessible
     fail_response = await http_client.get(parsed_url.path)
@@ -155,9 +156,9 @@ async def test_stream_keepalive(hass):
         return cur_time
 
     with patch("av.open") as av_open, patch(
-        "homeassistant.components.stream.worker.time"
+        "homeassistant.components.stream.time"
     ) as mock_time, patch(
-        "homeassistant.components.stream.worker.STREAM_RESTART_INCREMENT", 0
+        "homeassistant.components.stream.STREAM_RESTART_INCREMENT", 0
     ):
         av_open.side_effect = av.error.InvalidDataError(-2, "error")
         mock_time.time.side_effect = time_side_effect

--- a/tests/components/stream/test_init.py
+++ b/tests/components/stream/test_init.py
@@ -80,5 +80,7 @@ async def test_record_service_lookback(hass):
         await hass.services.async_call(DOMAIN, SERVICE_RECORD, data, blocking=True)
 
         assert stream_mock.called
-        stream_mock.return_value.add_provider.assert_called_once_with("recorder")
+        stream_mock.return_value.add_provider.assert_called_once_with(
+            "recorder", timeout=30
+        )
         assert hls_mock.recv.called

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -106,13 +106,11 @@ async def test_recorder_timeout(hass, hass_client, stream_worker_sync):
 
     stream_worker_sync.pause()
 
-    with patch(
-        "homeassistant.components.stream.recorder.RecorderOutput.cleanup"
-    ) as mock_cleanup:
+    with patch("homeassistant.components.stream.Stream._idle_timeout") as mock_timeout:
         # Setup demo track
         source = generate_h264_video()
         stream = preload_stream(hass, source)
-        recorder = stream.add_provider("recorder")
+        recorder = stream.add_provider("recorder", timeout=30)
         stream.start()
 
         await recorder.recv()
@@ -122,7 +120,7 @@ async def test_recorder_timeout(hass, hass_client, stream_worker_sync):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-        assert mock_cleanup.called
+        assert mock_timeout.called
 
         stream_worker_sync.resume()
         stream.stop()

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -106,7 +106,7 @@ async def test_recorder_timeout(hass, hass_client, stream_worker_sync):
 
     stream_worker_sync.pause()
 
-    with patch("homeassistant.components.stream.Stream._idle_timeout") as mock_timeout:
+    with patch("homeassistant.components.stream.IdleTimer.fire") as mock_timeout:
         # Setup demo track
         source = generate_h264_video()
         stream = preload_stream(hass, source)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move all keepalive logic from `StreamOutput` and `stream_worker` into `Stream` in preparation for further improving support for expiring stream urls with preload/keepalive, as outlined in https://github.com/home-assistant/architecture/issues/482

The general idea behind this change is centered around two changes:
- Remove dependencies in `StreamOutput` on `Stream`, including checking `keepalive` and having the `StreamOutput` remove itself from the stream.  Now the logic to end a stream and handle idle timeout is managed by `Stream`, where it invokes any cleanup methods on the output, flipping around the relationship.
- Move stream worker keepalive handling logic into `Stream`. This may make it slightly easier to combine how keepalive and stream url changes are handled, since they are a somewhat similar concept.

Changes to make preload/keepalive work across stream restarts for `nest` will happen in follow up changes using the interface exposed in https://github.com/home-assistant/core/pull/45431

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/issues/482 and https://github.com/home-assistant/core/issues/42793
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
