### PR TITLE
Fix Insteon config flow with add X10 and device override

### DIFF
--- a/homeassistant/components/insteon/schemas.py
+++ b/homeassistant/components/insteon/schemas.py
@@ -187,47 +187,47 @@ def add_device_override(config_data, new_override):
     except ValueError as err:
         raise ValueError("Incorrect values") from err
 
-    overrides = config_data.get(CONF_OVERRIDE, [])
+    overrides = []
+
+    for override in config_data.get(CONF_OVERRIDE, []):
+        if override[CONF_ADDRESS] != address:
+            overrides.append(override)
+
     curr_override = {}
-
-    # If this address has an override defined, remove it
-    for override in overrides:
-        if override[CONF_ADDRESS] == address:
-            curr_override = override
-            break
-    if curr_override:
-        overrides.remove(curr_override)
-
     curr_override[CONF_ADDRESS] = address
     curr_override[CONF_CAT] = cat
     curr_override[CONF_SUBCAT] = subcat
     overrides.append(curr_override)
-    config_data[CONF_OVERRIDE] = overrides
-    return config_data
+
+    new_config = {}
+    if config_data.get(CONF_X10):
+        new_config[CONF_X10] = config_data[CONF_X10]
+    new_config[CONF_OVERRIDE] = overrides
+    return new_config
 
 
 def add_x10_device(config_data, new_x10):
     """Add a new X10 device to X10 device list."""
-    curr_device = {}
-    x10_devices = config_data.get(CONF_X10, [])
-    for x10_device in x10_devices:
+    x10_devices = []
+    for x10_device in config_data.get(CONF_X10, []):
         if (
-            x10_device[CONF_HOUSECODE] == new_x10[CONF_HOUSECODE]
-            and x10_device[CONF_UNITCODE] == new_x10[CONF_UNITCODE]
+            x10_device[CONF_HOUSECODE] != new_x10[CONF_HOUSECODE]
+            or x10_device[CONF_UNITCODE] != new_x10[CONF_UNITCODE]
         ):
-            curr_device = x10_device
-            break
+            x10_devices.append(x10_device)
 
-    if curr_device:
-        x10_devices.remove(curr_device)
-
+    curr_device = {}
     curr_device[CONF_HOUSECODE] = new_x10[CONF_HOUSECODE]
     curr_device[CONF_UNITCODE] = new_x10[CONF_UNITCODE]
     curr_device[CONF_PLATFORM] = new_x10[CONF_PLATFORM]
     curr_device[CONF_DIM_STEPS] = new_x10[CONF_DIM_STEPS]
     x10_devices.append(curr_device)
-    config_data[CONF_X10] = x10_devices
-    return config_data
+
+    new_config = {}
+    if config_data.get(CONF_OVERRIDE):
+        new_config[CONF_OVERRIDE] = config_data[CONF_OVERRIDE]
+    new_config[CONF_X10] = x10_devices
+    return new_config
 
 
 def build_device_override_schema(

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -602,3 +602,36 @@ async def test_options_override_bad_data(hass: HomeAssistantType):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "input_error"}
+
+
+async def test_options_add_second_x10_device(hass: HomeAssistantType):
+    """Test adding a a second X10 device."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="abcde12345",
+        data={**MOCK_USER_INPUT_HUB_V2, CONF_HUB_VERSION: 2},
+        options={},
+    )
+
+    config_entry.add_to_hass(hass)
+    result = await _options_init_form(hass, config_entry.entry_id, STEP_ADD_X10)
+
+    user_input = {
+        CONF_HOUSECODE: "c",
+        CONF_UNITCODE: 12,
+        CONF_PLATFORM: "light",
+        CONF_DIM_STEPS: 18,
+    }
+    result1, _ = await _options_form(hass, result["flow_id"], user_input)
+
+    result = await _options_init_form(hass, config_entry.entry_id, STEP_ADD_X10)
+    user_input = {
+        CONF_HOUSECODE: "d",
+        CONF_UNITCODE: 10,
+        CONF_PLATFORM: "binary_sensor",
+        CONF_DIM_STEPS: 15,
+    }
+    result2, _ = await _options_form(hass, result["flow_id"], user_input)
+
+    # If result1 eq result2 the changes will not save
+    assert result1 != result2

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -369,12 +369,15 @@ async def test_options_add_device_override(hass: HomeAssistantType):
         CONF_CAT: "05",
         CONF_SUBCAT: "bb",
     }
-    await _options_form(hass, result2["flow_id"], user_input)
+    result3, _ = await _options_form(hass, result2["flow_id"], user_input)
 
     assert len(config_entry.options[CONF_OVERRIDE]) == 2
     assert config_entry.options[CONF_OVERRIDE][1][CONF_ADDRESS] == "4D.5E.6F"
     assert config_entry.options[CONF_OVERRIDE][1][CONF_CAT] == 5
     assert config_entry.options[CONF_OVERRIDE][1][CONF_SUBCAT] == 187
+
+    # If result1 eq result2 the changes will not save
+    assert result["data"] != result3["data"]
 
 
 async def test_options_remove_device_override(hass: HomeAssistantType):
@@ -476,6 +479,9 @@ async def test_options_add_x10_device(hass: HomeAssistantType):
     assert config_entry.options[CONF_X10][1][CONF_UNITCODE] == 10
     assert config_entry.options[CONF_X10][1][CONF_PLATFORM] == "binary_sensor"
     assert config_entry.options[CONF_X10][1][CONF_DIM_STEPS] == 15
+
+    # If result2 eq result3 the changes will not save
+    assert result2["data"] != result3["data"]
 
 
 async def test_options_remove_x10_device(hass: HomeAssistantType):
@@ -602,36 +608,3 @@ async def test_options_override_bad_data(hass: HomeAssistantType):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "input_error"}
-
-
-async def test_options_add_second_x10_device(hass: HomeAssistantType):
-    """Test adding a a second X10 device."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="abcde12345",
-        data={**MOCK_USER_INPUT_HUB_V2, CONF_HUB_VERSION: 2},
-        options={},
-    )
-
-    config_entry.add_to_hass(hass)
-    result = await _options_init_form(hass, config_entry.entry_id, STEP_ADD_X10)
-
-    user_input = {
-        CONF_HOUSECODE: "c",
-        CONF_UNITCODE: 12,
-        CONF_PLATFORM: "light",
-        CONF_DIM_STEPS: 18,
-    }
-    result1, _ = await _options_form(hass, result["flow_id"], user_input)
-
-    result = await _options_init_form(hass, config_entry.entry_id, STEP_ADD_X10)
-    user_input = {
-        CONF_HOUSECODE: "d",
-        CONF_UNITCODE: 10,
-        CONF_PLATFORM: "binary_sensor",
-        CONF_DIM_STEPS: 15,
-    }
-    result2, _ = await _options_form(hass, result["flow_id"], user_input)
-
-    # If result1 eq result2 the changes will not save
-    assert result1 != result2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Insteon integration options flow allows for the addition of X10 devices and Insteon device overrides. The methods change `config_data` directly so HA does not recognize that a change has been made therefore the changes are not stored to `core.config_entries`. This change modifies a copy of `config_data` so that HA knows a change has been made when the comparison is performed in `config_entries.async_update_entry`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44848
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
