### PR TITLE
Remove v4 multilevel transitional currentValue workaround in zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -105,14 +105,6 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 
         Z-Wave multilevel switches use a range of [0, 99] to control brightness.
         """
-        # prefer targetValue only if CC Version >= 4
-        # otherwise use currentValue (pre V4 dimmers)
-        if (
-            self._target_value
-            and self._target_value.value is not None
-            and self._target_value.cc_version >= 4
-        ):
-            return round((self._target_value.value / 99) * 255)
         if self.info.primary_value.value is not None:
             return round((self.info.primary_value.value / 99) * 255)
         return 0

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -88,7 +88,7 @@ def bulb_6_multi_color_state_fixture():
 
 @pytest.fixture(name="eaton_rf9640_dimmer_state", scope="session")
 def eaton_rf9640_dimmer_state_fixture():
-    """Load the bulb 6 multi-color node state fixture data."""
+    """Load the eaton rf9640 dimmer node state fixture data."""
     return json.loads(load_fixture("zwave_js/eaton_rf9640_dimmer_state.json"))
 
 

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -395,5 +395,5 @@ async def test_v4_dimmer_light(hass, client, eaton_rf9640_dimmer, integration):
 
     assert state
     assert state.state == STATE_ON
-    # the light should pick targetvalue which has zwave value 20
-    assert state.attributes[ATTR_BRIGHTNESS] == 52
+    # the light should pick currentvalue which has zwave value 22
+    assert state.attributes[ATTR_BRIGHTNESS] == 57

--- a/tests/fixtures/zwave_js/eaton_rf9640_dimmer_state.json
+++ b/tests/fixtures/zwave_js/eaton_rf9640_dimmer_state.json
@@ -124,7 +124,7 @@
                 "max": 99,
                 "label": "Current value"
             },
-            "value": 0,
+            "value": 22,
             "ccVersion": 4
         },
         {


### PR DESCRIPTION
This was only needed because the get-after-set was reporting a
transitional currentValue instead of the final one.
zwave-js v6.1.1 removes the get-after-set functionality completely, so
this is no longer required (and breaks status reporting entirely)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the now-broken workaround for transitional currentValue numbers as reported by zwave-js before v6.1.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45883
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
