### PR TITLE
Raise ConditionError for numeric_state errors

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.core import (
     callback,
     split_entity_id,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConditionError, HomeAssistantError
 from homeassistant.helpers import condition, extract_domain_configs, template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
@@ -588,7 +588,11 @@ async def _async_process_if(hass, config, p_config):
 
     def if_action(variables=None):
         """AND all conditions."""
-        return all(check(hass, variables) for check in checks)
+        try:
+            return all(check(hass, variables) for check in checks)
+        except ConditionError as ex:
+            LOGGER.warning("Error in 'condition' evaluation: %s", ex)
+            return False
 
     if_action.config = if_configs
 

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import callback
-from homeassistant.exceptions import TemplateError
+from homeassistant.exceptions import ConditionError, TemplateError
 from homeassistant.helpers import condition
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import (
@@ -340,14 +340,17 @@ class BayesianBinarySensor(BinarySensorEntity):
         """Return True if numeric condition is met."""
         entity = entity_observation["entity_id"]
 
-        return condition.async_numeric_state(
-            self.hass,
-            entity,
-            entity_observation.get("below"),
-            entity_observation.get("above"),
-            None,
-            entity_observation,
-        )
+        try:
+            return condition.async_numeric_state(
+                self.hass,
+                entity,
+                entity_observation.get("below"),
+                entity_observation.get("above"),
+                None,
+                entity_observation,
+            )
+        except ConditionError:
+            return False
 
     def _process_state(self, entity_observation):
         """Return True if state conditions are met."""

--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -96,12 +96,19 @@ async def async_attach_trigger(
     @callback
     def check_numeric_state(entity_id, from_s, to_s):
         """Return True if criteria are now met."""
-        if to_s is None:
+        try:
+            return condition.async_numeric_state(
+                hass,
+                to_s,
+                below,
+                above,
+                value_template,
+                variables(entity_id),
+                attribute,
+            )
+        except exceptions.ConditionError as err:
+            _LOGGER.warning("%s", err)
             return False
-
-        return condition.async_numeric_state(
-            hass, to_s, below, above, value_template, variables(entity_id), attribute
-        )
 
     @callback
     def state_automation_listener(event):

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -25,6 +25,10 @@ class TemplateError(HomeAssistantError):
         super().__init__(f"{exception.__class__.__name__}: {exception}")
 
 
+class ConditionError(HomeAssistantError):
+    """Error during condition evaluation."""
+
+
 class PlatformNotReady(HomeAssistantError):
     """Error to indicate that platform is not ready."""
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -162,18 +162,20 @@ async def test_trigger_service_ignoring_condition(hass, calls):
                 "alias": "test",
                 "trigger": [{"platform": "event", "event_type": "test_event"}],
                 "condition": {
-                    "condition": "state",
+                    "condition": "numeric_state",
                     "entity_id": "non.existing",
-                    "state": "beer",
+                    "above": "1",
                 },
                 "action": {"service": "test.automation"},
             }
         },
     )
 
-    hass.bus.async_fire("test_event")
-    await hass.async_block_till_done()
-    assert len(calls) == 0
+    with patch("homeassistant.components.automation.LOGGER.warning") as logwarn:
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(calls) == 0
+        assert len(logwarn.mock_calls) == 1
 
     await hass.services.async_call(
         "automation", "trigger", {"entity_id": "automation.test"}, blocking=True

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -572,6 +572,32 @@ async def test_if_not_fires_if_entity_not_match(hass, calls, below):
     assert len(calls) == 0
 
 
+async def test_if_not_fires_and_warns_if_below_entity_unknown(hass, calls):
+    """Test if warns with unknown below entity."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "numeric_state",
+                    "entity_id": "test.entity",
+                    "below": "input_number.unknown",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    with patch(
+        "homeassistant.components.homeassistant.triggers.numeric_state._LOGGER.warning"
+    ) as logwarn:
+        hass.states.async_set("test.entity", 1)
+        await hass.async_block_till_done()
+        assert len(calls) == 0
+        assert len(logwarn.mock_calls) == 1
+
+
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
 async def test_if_fires_on_entity_change_below_with_attribute(hass, calls, below):
     """Test attributes change."""


### PR DESCRIPTION
## Proposed change

This introduces a `ConditionError` exception for cases where the condition helpers are unable to decide a condition. An example is when an entity is unavailable. The helpers have previously returned `False` in this situation but that is really just an arbitrary guess and a potential silent failure.

As a MVP the exception is implemented for the `numeric_state` condition.

With this PR, more useful logging becomes available, for example:
```
[homeassistant.components.automation] Error in 'condition' evaluation: Unknown entity sensor.front_door
[homeassistant.components.automation] Error in 'condition' evaluation: Attribute 'battery_level' (of entity binary_sensor.front_door) does not exist
[homeassistant.components.automation] Error in 'condition' evaluation: Template error: ZeroDivisionError: division by zero
[homeassistant.components.automation] Error in 'condition' evaluation: The below entity input_number.temperature_threshold_low is not available

[homeassistant.helpers.script] Error in 'choose' evaluation: Entity sensor.front_door_battery_level state 'one-hundred' cannot be processed as a number
[homeassistant.helpers.script] Error in 'condition' evaluation: Unknown entity sensor.missing
[homeassistant.helpers.script] Error in 'while' evaluation: Unknown entity sensor.front_door_battery_level
[homeassistant.helpers.script] Error in 'until' evaluation: Template error: ZeroDivisionError: division by zero

[homeassistant.components.homeassistant.triggers.numeric_state] Entity media_player.office state 'paused' cannot be processed as a number
```

This PR is actually a bit of a detour while working on home-assistant/architecture#456. Specifically, we do not want to trigger `numeric_state` when moving from true to unavailable and back to true. However, before this PR we cannot identify unavailable because it just evaluates the condition to false.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #40331, home-assistant/architecture#456
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
