### PR TITLE
Fix homekit options not being prefilled

### DIFF
--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -91,7 +91,8 @@ DEFAULT_DOMAINS = [
 
 DOMAINS_PREFER_ACCESSORY_MODE = ["camera", "media_player"]
 
-CAMERA_ENTITY_PREFIX = "camera."
+CAMERA_DOMAIN = "camera"
+CAMERA_ENTITY_PREFIX = f"{CAMERA_DOMAIN}."
 
 _EMPTY_ENTITY_FILTER = {
     CONF_INCLUDE_DOMAINS: [],
@@ -356,15 +357,23 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     if domain not in domains_with_entities_selected
                 ]
 
-                for entity_id in list(self.included_cameras):
-                    if entity_id not in entities:
-                        self.included_cameras.remove(entity_id)
+                self.included_cameras = {
+                    entity_id
+                    for entity_id in entities
+                    if entity_id.startswith(CAMERA_ENTITY_PREFIX)
+                }
             else:
                 entity_filter[CONF_INCLUDE_DOMAINS] = self.hk_options[CONF_DOMAINS]
                 entity_filter[CONF_EXCLUDE_ENTITIES] = entities
-                for entity_id in entities:
-                    if entity_id in self.included_cameras:
-                        self.included_cameras.remove(entity_id)
+                camera_entities = _async_get_matching_entities(
+                    self.hass,
+                    domains=[CAMERA_DOMAIN],
+                )
+                self.included_cameras = {
+                    entity_id
+                    for entity_id in camera_entities
+                    if entity_id not in entities
+                }
 
             self.hk_options[CONF_FILTER] = entity_filter
 
@@ -378,11 +387,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.hass,
             domains=self.hk_options[CONF_DOMAINS],
         )
-        self.included_cameras = {
-            entity_id
-            for entity_id in all_supported_entities
-            if entity_id.startswith(CAMERA_ENTITY_PREFIX)
-        }
 
         data_schema = {}
         entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
@@ -416,10 +420,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.hk_options.update(user_input)
             return await self.async_step_include_exclude()
 
-        hk_options = dict(self.config_entry.options)
-        entity_filter = hk_options.get(CONF_FILTER, {})
-
-        homekit_mode = hk_options.get(CONF_HOMEKIT_MODE, DEFAULT_HOMEKIT_MODE)
+        self.hk_options = dict(self.config_entry.options)
+        entity_filter = self.hk_options.get(CONF_FILTER, {})
+        homekit_mode = self.hk_options.get(CONF_HOMEKIT_MODE, DEFAULT_HOMEKIT_MODE)
         domains = entity_filter.get(CONF_INCLUDE_DOMAINS, [])
         include_entities = entity_filter.get(CONF_INCLUDE_ENTITIES)
         if include_entities:

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -365,15 +365,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             else:
                 entity_filter[CONF_INCLUDE_DOMAINS] = self.hk_options[CONF_DOMAINS]
                 entity_filter[CONF_EXCLUDE_ENTITIES] = entities
-                camera_entities = _async_get_matching_entities(
-                    self.hass,
-                    domains=[CAMERA_DOMAIN],
-                )
-                self.included_cameras = {
-                    entity_id
-                    for entity_id in camera_entities
-                    if entity_id not in entities
-                }
+                if CAMERA_DOMAIN in entity_filter[CONF_INCLUDE_DOMAINS]:
+                    camera_entities = _async_get_matching_entities(
+                        self.hass,
+                        domains=[CAMERA_DOMAIN],
+                    )
+                    self.included_cameras = {
+                        entity_id
+                        for entity_id in camera_entities
+                        if entity_id not in entities
+                    }
+                else:
+                    self.included_cameras = set()
 
             self.hk_options[CONF_FILTER] = entity_filter
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When changing homekit options, the existing ones
were not being prefilled on the form.

I noticed these issues when I started converting homekit
to create multiple config entries for devices that should
be paired in accessory mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
