### PR TITLE
Fix backwards compatiblity with fan update to new model

### DIFF
--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -15,6 +15,8 @@ from homeassistant.components.fan import (
 
 PRESET_MODE_AUTO = "auto"
 PRESET_MODE_SMART = "smart"
+PRESET_MODE_SLEEP = "sleep"
+PRESET_MODE_ON = "on"
 
 FULL_SUPPORT = SUPPORT_SET_SPEED | SUPPORT_OSCILLATE | SUPPORT_DIRECTION
 LIMITED_SUPPORT = SUPPORT_SET_SPEED
@@ -38,6 +40,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                     SPEED_HIGH,
                     PRESET_MODE_AUTO,
                     PRESET_MODE_SMART,
+                    PRESET_MODE_SLEEP,
+                    PRESET_MODE_ON,
                 ],
             ),
             DemoFan(
@@ -54,7 +58,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 "fan3",
                 "Percentage Full Fan",
                 FULL_SUPPORT,
-                [PRESET_MODE_AUTO, PRESET_MODE_SMART],
+                [
+                    PRESET_MODE_AUTO,
+                    PRESET_MODE_SMART,
+                    PRESET_MODE_SLEEP,
+                    PRESET_MODE_ON,
+                ],
                 None,
             ),
             DemoPercentageFan(
@@ -62,7 +71,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 "fan4",
                 "Percentage Limited Fan",
                 LIMITED_SUPPORT,
-                [PRESET_MODE_AUTO, PRESET_MODE_SMART],
+                [
+                    PRESET_MODE_AUTO,
+                    PRESET_MODE_SMART,
+                    PRESET_MODE_SLEEP,
+                    PRESET_MODE_ON,
+                ],
                 None,
             ),
             AsyncDemoPercentageFan(
@@ -70,7 +84,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 "fan5",
                 "Preset Only Limited Fan",
                 SUPPORT_PRESET_MODE,
-                [PRESET_MODE_AUTO, PRESET_MODE_SMART],
+                [
+                    PRESET_MODE_AUTO,
+                    PRESET_MODE_SMART,
+                    PRESET_MODE_SLEEP,
+                    PRESET_MODE_ON,
+                ],
                 [],
             ),
         ]
@@ -99,7 +118,7 @@ class BaseDemoFan(FanEntity):
         self._unique_id = unique_id
         self._supported_features = supported_features
         self._speed = SPEED_OFF
-        self._percentage = 0
+        self._percentage = None
         self._speed_list = speed_list
         self._preset_modes = preset_modes
         self._preset_mode = None

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -64,24 +64,30 @@ ATTR_PRESET_MODES = "preset_modes"
 # into core integrations at some point so we are temporarily
 # accommodating them in the transition to percentages.
 _NOT_SPEED_OFF = "off"
+_NOT_SPEED_ON = "on"
 _NOT_SPEED_AUTO = "auto"
 _NOT_SPEED_SMART = "smart"
 _NOT_SPEED_INTERVAL = "interval"
 _NOT_SPEED_IDLE = "idle"
 _NOT_SPEED_FAVORITE = "favorite"
+_NOT_SPEED_SLEEP = "sleep"
 
 _NOT_SPEEDS_FILTER = {
     _NOT_SPEED_OFF,
+    _NOT_SPEED_ON,
     _NOT_SPEED_AUTO,
     _NOT_SPEED_SMART,
     _NOT_SPEED_INTERVAL,
     _NOT_SPEED_IDLE,
+    _NOT_SPEED_SLEEP,
     _NOT_SPEED_FAVORITE,
 }
 
 _FAN_NATIVE = "_fan_native"
 
 OFF_SPEED_VALUES = [SPEED_OFF, None]
+
+LEGACY_SPEED_LIST = [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 
 class NoValidSpeedsError(ValueError):
@@ -386,7 +392,10 @@ class FanEntity(ToggleEntity):
             if preset_mode:
                 return preset_mode
         if self._implemented_percentage:
-            return self.percentage_to_speed(self.percentage)
+            percentage = self.percentage
+            if percentage is None:
+                return None
+            return self.percentage_to_speed(percentage)
         return None
 
     @property
@@ -404,7 +413,7 @@ class FanEntity(ToggleEntity):
         """Get the list of available speeds."""
         speeds = []
         if self._implemented_percentage:
-            speeds += [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+            speeds += [SPEED_OFF, *LEGACY_SPEED_LIST]
         if self._implemented_preset_mode:
             speeds += self.preset_modes
         return speeds
@@ -434,6 +443,17 @@ class FanEntity(ToggleEntity):
 
         return attrs
 
+    @property
+    def _speed_list_without_preset_modes(self) -> list:
+        """Return the speed list without preset modes.
+
+        This property provides forward and backwards
+        compatibility for conversion to percentage speeds.
+        """
+        if self._implemented_percentage:
+            return LEGACY_SPEED_LIST
+        return speed_list_without_preset_modes(self.speed_list)
+
     def speed_to_percentage(self, speed: str) -> int:
         """
         Map a speed to a percentage.
@@ -453,7 +473,7 @@ class FanEntity(ToggleEntity):
         if speed in OFF_SPEED_VALUES:
             return 0
 
-        speed_list = speed_list_without_preset_modes(self.speed_list)
+        speed_list = self._speed_list_without_preset_modes
 
         if speed_list and speed not in speed_list:
             raise NotValidSpeedError(f"The speed {speed} is not a valid speed.")
@@ -487,7 +507,7 @@ class FanEntity(ToggleEntity):
         if percentage == 0:
             return SPEED_OFF
 
-        speed_list = speed_list_without_preset_modes(self.speed_list)
+        speed_list = self._speed_list_without_preset_modes
 
         try:
             return percentage_to_ordered_list_item(speed_list, percentage)

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -450,7 +450,7 @@ class FanEntity(ToggleEntity):
         This property provides forward and backwards
         compatibility for conversion to percentage speeds.
         """
-        if self._implemented_percentage:
+        if not self._implemented_speed:
             return LEGACY_SPEED_LIST
         return speed_list_without_preset_modes(self.speed_list)
 

--- a/tests/components/demo/test_fan.py
+++ b/tests/components/demo/test_fan.py
@@ -2,7 +2,12 @@
 import pytest
 
 from homeassistant.components import fan
-from homeassistant.components.demo.fan import PRESET_MODE_AUTO, PRESET_MODE_SMART
+from homeassistant.components.demo.fan import (
+    PRESET_MODE_AUTO,
+    PRESET_MODE_ON,
+    PRESET_MODE_SLEEP,
+    PRESET_MODE_SMART,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ENTITY_MATCH_ALL,
@@ -63,6 +68,28 @@ async def test_turn_on_with_speed_and_percentage(hass, fan_entity_id):
     await hass.services.async_call(
         fan.DOMAIN,
         SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: fan_entity_id, fan.ATTR_SPEED: fan.SPEED_MEDIUM},
+        blocking=True,
+    )
+    state = hass.states.get(fan_entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_MEDIUM
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 66
+
+    await hass.services.async_call(
+        fan.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: fan_entity_id, fan.ATTR_SPEED: fan.SPEED_LOW},
+        blocking=True,
+    )
+    state = hass.states.get(fan_entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_LOW
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 33
+
+    await hass.services.async_call(
+        fan.DOMAIN,
+        SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: fan_entity_id, fan.ATTR_PERCENTAGE: 100},
         blocking=True,
     )
@@ -70,6 +97,39 @@ async def test_turn_on_with_speed_and_percentage(hass, fan_entity_id):
     assert state.state == STATE_ON
     assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_HIGH
     assert state.attributes[fan.ATTR_PERCENTAGE] == 100
+
+    await hass.services.async_call(
+        fan.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: fan_entity_id, fan.ATTR_PERCENTAGE: 66},
+        blocking=True,
+    )
+    state = hass.states.get(fan_entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_MEDIUM
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 66
+
+    await hass.services.async_call(
+        fan.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: fan_entity_id, fan.ATTR_PERCENTAGE: 33},
+        blocking=True,
+    )
+    state = hass.states.get(fan_entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_LOW
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 33
+
+    await hass.services.async_call(
+        fan.DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: fan_entity_id, fan.ATTR_PERCENTAGE: 0},
+        blocking=True,
+    )
+    state = hass.states.get(fan_entity_id)
+    assert state.state == STATE_OFF
+    assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_OFF
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 0
 
 
 @pytest.mark.parametrize("fan_entity_id", FANS_WITH_PRESET_MODE_ONLY)
@@ -89,6 +149,8 @@ async def test_turn_on_with_preset_mode_only(hass, fan_entity_id):
     assert state.attributes[fan.ATTR_PRESET_MODES] == [
         PRESET_MODE_AUTO,
         PRESET_MODE_SMART,
+        PRESET_MODE_SLEEP,
+        PRESET_MODE_ON,
     ]
 
     await hass.services.async_call(
@@ -145,10 +207,14 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
         fan.SPEED_HIGH,
         PRESET_MODE_AUTO,
         PRESET_MODE_SMART,
+        PRESET_MODE_SLEEP,
+        PRESET_MODE_ON,
     ]
     assert state.attributes[fan.ATTR_PRESET_MODES] == [
         PRESET_MODE_AUTO,
         PRESET_MODE_SMART,
+        PRESET_MODE_SLEEP,
+        PRESET_MODE_ON,
     ]
 
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There were some non-speeds and devices that report a none
speed. These problems were discovered when updating zha (#45758)
tasmota (#45877) and vesync (#45950) to the new model in #45407


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
