### PR TITLE
Fix zwave_js cover control for Up/Down and Open/Close

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -79,17 +79,17 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        target_value = self.get_zwave_value("Open")
+        target_value = self.get_zwave_value("Open") or self.get_zwave_value("Up")
         await self.info.node.async_set_value(target_value, PRESS_BUTTON)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        target_value = self.get_zwave_value("Close")
+        target_value = self.get_zwave_value("Close") or self.get_zwave_value("Down")
         await self.info.node.async_set_value(target_value, PRESS_BUTTON)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
-        target_value = self.get_zwave_value("Open")
+        target_value = self.get_zwave_value("Open") or self.get_zwave_value("Up")
         await self.info.node.async_set_value(target_value, RELEASE_BUTTON)
-        target_value = self.get_zwave_value("Close")
+        target_value = self.get_zwave_value("Close") or self.get_zwave_value("Down")
         await self.info.node.async_set_value(target_value, RELEASE_BUTTON)

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -80,16 +80,26 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         target_value = self.get_zwave_value("Open") or self.get_zwave_value("Up")
-        await self.info.node.async_set_value(target_value, PRESS_BUTTON)
+        if target_value:
+            await self.info.node.async_set_value(target_value, PRESS_BUTTON)
+        else:
+            target_value = self.get_zwave_value("targetValue")
+            await self.info.node.async_set_value(target_value, 99)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         target_value = self.get_zwave_value("Close") or self.get_zwave_value("Down")
-        await self.info.node.async_set_value(target_value, PRESS_BUTTON)
+        if target_value:
+            await self.info.node.async_set_value(target_value, PRESS_BUTTON)
+        else:
+            target_value = self.get_zwave_value("targetValue")
+            await self.info.node.async_set_value(target_value, 0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
         target_value = self.get_zwave_value("Open") or self.get_zwave_value("Up")
-        await self.info.node.async_set_value(target_value, RELEASE_BUTTON)
+        if target_value:
+            await self.info.node.async_set_value(target_value, RELEASE_BUTTON)
         target_value = self.get_zwave_value("Close") or self.get_zwave_value("Down")
-        await self.info.node.async_set_value(target_value, RELEASE_BUTTON)
+        if target_value:
+            await self.info.node.async_set_value(target_value, RELEASE_BUTTON)

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -79,21 +79,13 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        target_value = self.get_zwave_value("Open") or self.get_zwave_value("Up")
-        if target_value:
-            await self.info.node.async_set_value(target_value, PRESS_BUTTON)
-        else:
-            target_value = self.get_zwave_value("targetValue")
-            await self.info.node.async_set_value(target_value, 99)
+        target_value = self.get_zwave_value("targetValue")
+        await self.info.node.async_set_value(target_value, 99)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        target_value = self.get_zwave_value("Close") or self.get_zwave_value("Down")
-        if target_value:
-            await self.info.node.async_set_value(target_value, PRESS_BUTTON)
-        else:
-            target_value = self.get_zwave_value("targetValue")
-            await self.info.node.async_set_value(target_value, 0)
+        target_value = self.get_zwave_value("targetValue")
+        await self.info.node.async_set_value(target_value, 0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -21,8 +21,6 @@ from .entity import ZWaveBaseEntity
 
 LOGGER = logging.getLogger(__name__)
 SUPPORT_GARAGE = SUPPORT_OPEN | SUPPORT_CLOSE
-PRESS_BUTTON = True
-RELEASE_BUTTON = False
 
 
 async def async_setup_entry(
@@ -91,7 +89,7 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
         """Stop cover."""
         target_value = self.get_zwave_value("Open") or self.get_zwave_value("Up")
         if target_value:
-            await self.info.node.async_set_value(target_value, RELEASE_BUTTON)
+            await self.info.node.async_set_value(target_value, False)
         target_value = self.get_zwave_value("Close") or self.get_zwave_value("Down")
         if target_value:
-            await self.info.node.async_set_value(target_value, RELEASE_BUTTON)
+            await self.info.node.async_set_value(target_value, False)

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -95,14 +95,16 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
         "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
-        "property": "Open",
-        "propertyName": "Open",
+        "property": "targetValue",
+        "propertyName": "targetValue",
         "metadata": {
-            "type": "boolean",
+            "label": "Target value",
+            "max": 99,
+            "min": 0,
+            "type": "number",
             "readable": True,
             "writeable": True,
-            "label": "Perform a level change (Open)",
-            "ccSpecific": {"switchType": 3},
+            "label": "Target value",
         },
     }
     assert args["value"]
@@ -194,17 +196,19 @@ async def test_cover(hass, client, chain_actuator_zws12, integration):
         "commandClassName": "Multilevel Switch",
         "commandClass": 38,
         "endpoint": 0,
-        "property": "Close",
-        "propertyName": "Close",
+        "property": "targetValue",
+        "propertyName": "targetValue",
         "metadata": {
-            "type": "boolean",
+            "label": "Target value",
+            "max": 99,
+            "min": 0,
+            "type": "number",
             "readable": True,
             "writeable": True,
-            "label": "Perform a level change (Close)",
-            "ccSpecific": {"switchType": 3},
+            "label": "Target value",
         },
     }
-    assert args["value"]
+    assert args["value"] == 0
 
     client.async_send_command.reset_mock()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes bug with zwave_js integration for control of covers when the target_value of Open/Close does not exist, but Up/Down does

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/45922
- This PR is related to issue: https://github.com/home-assistant/core/issues/45922
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
