### PR TITLE
Fix foscam to work again with non-admin accounts and make RTSP port configurable again

### DIFF
--- a/homeassistant/components/foscam/__init__.py
+++ b/homeassistant/components/foscam/__init__.py
@@ -58,6 +58,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
     LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:
+        # Change unique id
         new_unique_id = camera_unique_id(config_entry.data)
 
         @callback
@@ -67,9 +68,8 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         await async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
 
         config_entry.unique_id = new_unique_id
-        config_entry.version = 2
 
-    if config_entry.version == 2:
+        # Get RTSP port from the camera or use the fallback one and store it in data
         camera = FoscamCamera(
             config_entry.data[CONF_HOST],
             config_entry.data[CONF_PORT],
@@ -86,7 +86,9 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             rtsp_port = response.get("rtspPort") or response.get("mediaPort")
 
         config_entry.data = {**config_entry.data, CONF_RTSP_PORT: rtsp_port}
-        config_entry.version = 3
+
+        # Change entry version
+        config_entry.version = 2
 
     LOGGER.info("Migration to version %s successful", config_entry.version)
 

--- a/homeassistant/components/foscam/__init__.py
+++ b/homeassistant/components/foscam/__init__.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
 
-    hass.data[DOMAIN][entry.unique_id] = entry.data
+    hass.data[DOMAIN][entry.entry_id] = entry.data
 
     return True
 
@@ -44,7 +44,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.unique_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
 
         if not hass.data[DOMAIN]:
             hass.services.async_remove(domain=DOMAIN, service=SERVICE_PTZ)

--- a/homeassistant/components/foscam/__init__.py
+++ b/homeassistant/components/foscam/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNA
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_registry import async_migrate_entries
 
-from .config_flow import DEFAULT_RTSP_PORT, camera_unique_id
+from .config_flow import DEFAULT_RTSP_PORT
 from .const import CONF_RTSP_PORT, DOMAIN, LOGGER, SERVICE_PTZ, SERVICE_PTZ_PRESET
 
 PLATFORMS = ["camera"]
@@ -59,15 +59,13 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
     if config_entry.version == 1:
         # Change unique id
-        new_unique_id = camera_unique_id(config_entry.data)
-
         @callback
         def update_unique_id(entry):
-            return {"new_unique_id": new_unique_id}
+            return {"new_unique_id": config_entry.entry_id}
 
         await async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
 
-        config_entry.unique_id = new_unique_id
+        config_entry.unique_id = None
 
         # Get RTSP port from the camera or use the fallback one and store it in data
         camera = FoscamCamera(

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -142,7 +142,7 @@ class HassFoscamCamera(Camera):
         self._username = config_entry.data[CONF_USERNAME]
         self._password = config_entry.data[CONF_PASSWORD]
         self._stream = config_entry.data[CONF_STREAM]
-        self._unique_id = config_entry.unique_id
+        self._unique_id = config_entry.entry_id
         self._rtsp_port = config_entry.data[CONF_RTSP_PORT]
         self._motion_status = False
 

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -155,7 +155,7 @@ class HassFoscamCamera(Camera):
 
         if ret == -3:
             LOGGER.info(
-                "Can't get motion detection status, camera %s configured with non-admin user.",
+                "Can't get motion detection status, camera %s configured with non-admin user",
                 self._name,
             )
 
@@ -210,7 +210,7 @@ class HassFoscamCamera(Camera):
             if ret != 0:
                 if ret == -3:
                     LOGGER.info(
-                        "Can't set motion detection status, camera %s configured with non-admin user.",
+                        "Can't set motion detection status, camera %s configured with non-admin user",
                         self._name,
                     )
                 return
@@ -230,7 +230,7 @@ class HassFoscamCamera(Camera):
             if ret != 0:
                 if ret == -3:
                     LOGGER.info(
-                        "Can't set motion detection status, camera %s configured with non-admin user.",
+                        "Can't set motion detection status, camera %s configured with non-admin user",
                         self._name,
                     )
                 return

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -145,7 +145,13 @@ class HassFoscamCamera(Camera):
             self._foscam_session.get_motion_detect_config
         )
 
-        if ret != 0:
+        if ret == -3:
+            LOGGER.info(
+                "Can't get motion detection status, camera %s configured with non-admin user.",
+                self._name,
+            )
+
+        elif ret != 0:
             LOGGER.error(
                 "Error getting motion detection status of %s: %s", self._name, ret
             )
@@ -205,6 +211,11 @@ class HassFoscamCamera(Camera):
             ret = self._foscam_session.enable_motion_detection()
 
             if ret != 0:
+                if ret == -3:
+                    LOGGER.info(
+                        "Can't set motion detection status, camera %s configured with non-admin user.",
+                        self._name,
+                    )
                 return
 
             self._motion_status = True
@@ -220,6 +231,11 @@ class HassFoscamCamera(Camera):
             ret = self._foscam_session.disable_motion_detection()
 
             if ret != 0:
+                if ret == -3:
+                    LOGGER.info(
+                        "Can't set motion detection status, camera %s configured with non-admin user.",
+                        self._name,
+                    )
                 return
 
             self._motion_status = False

--- a/homeassistant/components/foscam/config_flow.py
+++ b/homeassistant/components/foscam/config_flow.py
@@ -112,7 +112,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_auth"
 
             except InvalidResponse:
-                errors["base"] = "unknown"
+                errors["base"] = "invalid_response"
 
             except AbortFlow:
                 raise
@@ -142,7 +142,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             LOGGER.exception(
                 "Error importing foscam platform config: invalid response from camera."
             )
-            return self.async_abort(reason="unknown")
+            return self.async_abort(reason="invalid_response")
 
         except AbortFlow:
             raise

--- a/homeassistant/components/foscam/config_flow.py
+++ b/homeassistant/components/foscam/config_flow.py
@@ -49,7 +49,7 @@ def camera_unique_id(data):
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for foscam."""
 
-    VERSION = 3
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def _validate_and_create(self, data):

--- a/homeassistant/components/foscam/config_flow.py
+++ b/homeassistant/components/foscam/config_flow.py
@@ -17,12 +17,13 @@ from homeassistant.const import (
 )
 from homeassistant.data_entry_flow import AbortFlow
 
-from .const import CONF_STREAM, LOGGER
+from .const import CONF_RTSP_PORT, CONF_STREAM, LOGGER
 from .const import DOMAIN  # pylint:disable=unused-import
 
 STREAMS = ["Main", "Sub"]
 
 DEFAULT_PORT = 88
+DEFAULT_RTSP_PORT = 554
 
 
 DATA_SCHEMA = vol.Schema(
@@ -32,6 +33,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Required(CONF_STREAM, default=STREAMS[0]): vol.In(STREAMS),
+        vol.Required(CONF_RTSP_PORT, default=DEFAULT_RTSP_PORT): int,
     }
 )
 
@@ -47,7 +49,7 @@ def camera_unique_id(data):
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for foscam."""
 
-    VERSION = 2
+    VERSION = 3
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def _validate_and_create(self, data):

--- a/homeassistant/components/foscam/const.py
+++ b/homeassistant/components/foscam/const.py
@@ -5,6 +5,7 @@ LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "foscam"
 
+CONF_RTSP_PORT = "rtsp_port"
 CONF_STREAM = "stream"
 
 SERVICE_PTZ = "ptz"

--- a/homeassistant/components/foscam/strings.json
+++ b/homeassistant/components/foscam/strings.json
@@ -18,6 +18,9 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_response": "Invalid response from the device",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/foscam/strings.json
+++ b/homeassistant/components/foscam/strings.json
@@ -8,6 +8,7 @@
           "port": "[%key:common::config_flow::data::port%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
+          "rtsp_port": "RTSP port",
           "stream": "Stream"
         }
       }

--- a/homeassistant/components/foscam/strings.json
+++ b/homeassistant/components/foscam/strings.json
@@ -16,6 +16,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_response": "Invalid response from the device",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/foscam/strings.json
+++ b/homeassistant/components/foscam/strings.json
@@ -18,9 +18,6 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_response": "Invalid response from the device",
       "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/foscam/translations/en.json
+++ b/homeassistant/components/foscam/translations/en.json
@@ -1,5 +1,8 @@
 {
     "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",

--- a/homeassistant/components/foscam/translations/en.json
+++ b/homeassistant/components/foscam/translations/en.json
@@ -1,8 +1,5 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",

--- a/homeassistant/components/foscam/translations/en.json
+++ b/homeassistant/components/foscam/translations/en.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
+            "invalid_response": "Invalid response from the device",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/homeassistant/components/foscam/translations/en.json
+++ b/homeassistant/components/foscam/translations/en.json
@@ -14,6 +14,7 @@
                     "host": "Host",
                     "password": "Password",
                     "port": "Port",
+                    "rtsp_port": "RTSP port",
                     "stream": "Stream",
                     "username": "Username"
                 }

--- a/tests/components/foscam/test_config_flow.py
+++ b/tests/components/foscam/test_config_flow.py
@@ -19,6 +19,7 @@ VALID_CONFIG = {
     config_flow.CONF_USERNAME: "admin",
     config_flow.CONF_PASSWORD: "1234",
     config_flow.CONF_STREAM: "Main",
+    config_flow.CONF_RTSP_PORT: 554,
 }
 OPERATOR_CONFIG = {
     config_flow.CONF_USERNAME: "operator",

--- a/tests/components/foscam/test_config_flow.py
+++ b/tests/components/foscam/test_config_flow.py
@@ -195,7 +195,7 @@ async def test_user_invalid_response(hass):
         await hass.async_block_till_done()
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "unknown"}
+        assert result["errors"] == {"base": "invalid_response"}
 
 
 async def test_user_already_configured(hass):
@@ -392,7 +392,7 @@ async def test_import_invalid_response(hass):
         await hass.async_block_till_done()
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "unknown"
+        assert result["reason"] == "invalid_response"
 
 
 async def test_import_already_configured(hass):

--- a/tests/components/foscam/test_config_flow.py
+++ b/tests/components/foscam/test_config_flow.py
@@ -205,7 +205,6 @@ async def test_user_already_configured(hass):
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
         data=VALID_CONFIG,
-        unique_id=config_flow.camera_unique_id(VALID_CONFIG),
     )
     entry.add_to_hass(hass)
 
@@ -402,7 +401,6 @@ async def test_import_already_configured(hass):
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
         data=VALID_CONFIG,
-        unique_id=config_flow.camera_unique_id(VALID_CONFIG),
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/foscam/test_config_flow.py
+++ b/tests/components/foscam/test_config_flow.py
@@ -11,8 +11,6 @@ from libpyfoscam.foscam import (
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.foscam import config_flow
 
-from tests.common import MockConfigEntry
-
 VALID_CONFIG = {
     config_flow.CONF_HOST: "10.0.0.2",
     config_flow.CONF_PORT: 88,
@@ -198,39 +196,6 @@ async def test_user_invalid_response(hass):
         assert result["errors"] == {"base": "invalid_response"}
 
 
-async def test_user_already_configured(hass):
-    """Test we handle already configured from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    entry = MockConfigEntry(
-        domain=config_flow.DOMAIN,
-        data=VALID_CONFIG,
-        unique_id=config_flow.camera_unique_id(VALID_CONFIG),
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {}
-
-    with patch(
-        "homeassistant.components.foscam.config_flow.FoscamCamera",
-    ) as mock_foscam_camera:
-        setup_mock_foscam_camera(mock_foscam_camera)
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            VALID_CONFIG,
-        )
-
-        await hass.async_block_till_done()
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
-
-
 async def test_user_unknown_exception(hass):
     """Test we handle unknown exceptions from user input."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -393,34 +358,6 @@ async def test_import_invalid_response(hass):
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "invalid_response"
-
-
-async def test_import_already_configured(hass):
-    """Test we handle already configured from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    entry = MockConfigEntry(
-        domain=config_flow.DOMAIN,
-        data=VALID_CONFIG,
-        unique_id=config_flow.camera_unique_id(VALID_CONFIG),
-    )
-    entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.foscam.config_flow.FoscamCamera",
-    ) as mock_foscam_camera:
-        setup_mock_foscam_camera(mock_foscam_camera)
-
-        result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=VALID_CONFIG,
-        )
-
-        await hass.async_block_till_done()
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
 
 
 async def test_import_unknown_exception(hass):

--- a/tests/components/foscam/test_config_flow.py
+++ b/tests/components/foscam/test_config_flow.py
@@ -1,7 +1,12 @@
 """Test the Foscam config flow."""
 from unittest.mock import patch
 
-from libpyfoscam.foscam import ERROR_FOSCAM_AUTH, ERROR_FOSCAM_UNAVAILABLE
+from libpyfoscam.foscam import (
+    ERROR_FOSCAM_AUTH,
+    ERROR_FOSCAM_CMD,
+    ERROR_FOSCAM_UNAVAILABLE,
+    ERROR_FOSCAM_UNKNOWN,
+)
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.foscam import config_flow
@@ -15,6 +20,12 @@ VALID_CONFIG = {
     config_flow.CONF_PASSWORD: "1234",
     config_flow.CONF_STREAM: "Main",
 }
+OPERATOR_CONFIG = {
+    config_flow.CONF_USERNAME: "operator",
+}
+INVALID_RESPONSE_CONFIG = {
+    config_flow.CONF_USERNAME: "interr",
+}
 CAMERA_NAME = "Mocked Foscam Camera"
 CAMERA_MAC = "C0:C1:D0:F4:B4:D4"
 
@@ -23,26 +34,39 @@ def setup_mock_foscam_camera(mock_foscam_camera):
     """Mock FoscamCamera simulating behaviour using a base valid config."""
 
     def configure_mock_on_init(host, port, user, passwd, verbose=False):
-        return_code = 0
-        data = {}
+        product_all_info_rc = 0
+        dev_info_rc = 0
+        dev_info_data = {}
 
         if (
             host != VALID_CONFIG[config_flow.CONF_HOST]
             or port != VALID_CONFIG[config_flow.CONF_PORT]
         ):
-            return_code = ERROR_FOSCAM_UNAVAILABLE
+            product_all_info_rc = dev_info_rc = ERROR_FOSCAM_UNAVAILABLE
 
         elif (
-            user != VALID_CONFIG[config_flow.CONF_USERNAME]
+            user
+            not in [
+                VALID_CONFIG[config_flow.CONF_USERNAME],
+                OPERATOR_CONFIG[config_flow.CONF_USERNAME],
+                INVALID_RESPONSE_CONFIG[config_flow.CONF_USERNAME],
+            ]
             or passwd != VALID_CONFIG[config_flow.CONF_PASSWORD]
         ):
-            return_code = ERROR_FOSCAM_AUTH
+            product_all_info_rc = dev_info_rc = ERROR_FOSCAM_AUTH
+
+        elif user == INVALID_RESPONSE_CONFIG[config_flow.CONF_USERNAME]:
+            product_all_info_rc = dev_info_rc = ERROR_FOSCAM_UNKNOWN
+
+        elif user == OPERATOR_CONFIG[config_flow.CONF_USERNAME]:
+            dev_info_rc = ERROR_FOSCAM_CMD
 
         else:
-            data["devName"] = CAMERA_NAME
-            data["mac"] = CAMERA_MAC
+            dev_info_data["devName"] = CAMERA_NAME
+            dev_info_data["mac"] = CAMERA_MAC
 
-        mock_foscam_camera.get_dev_info.return_value = (return_code, data)
+        mock_foscam_camera.get_product_all_info.return_value = (product_all_info_rc, {})
+        mock_foscam_camera.get_dev_info.return_value = (dev_info_rc, dev_info_data)
 
         return mock_foscam_camera
 
@@ -142,12 +166,45 @@ async def test_user_cannot_connect(hass):
         assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_user_invalid_response(hass):
+    """Test we handle invalid response error from user input."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.foscam.config_flow.FoscamCamera",
+    ) as mock_foscam_camera:
+        setup_mock_foscam_camera(mock_foscam_camera)
+
+        invalid_response = VALID_CONFIG.copy()
+        invalid_response[config_flow.CONF_USERNAME] = INVALID_RESPONSE_CONFIG[
+            config_flow.CONF_USERNAME
+        ]
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            invalid_response,
+        )
+
+        await hass.async_block_till_done()
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "unknown"}
+
+
 async def test_user_already_configured(hass):
     """Test we handle already configured from user input."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
-        domain=config_flow.DOMAIN, data=VALID_CONFIG, unique_id=CAMERA_MAC
+        domain=config_flow.DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=config_flow.camera_unique_id(VALID_CONFIG),
     )
     entry.add_to_hass(hass)
 
@@ -201,6 +258,8 @@ async def test_user_unknown_exception(hass):
 
 async def test_import_user_valid(hass):
     """Test valid config from import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
     ) as mock_foscam_camera, patch(
@@ -229,6 +288,8 @@ async def test_import_user_valid(hass):
 
 async def test_import_user_valid_with_name(hass):
     """Test valid config with extra name from import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
     ) as mock_foscam_camera, patch(
@@ -261,10 +322,7 @@ async def test_import_user_valid_with_name(hass):
 
 async def test_import_invalid_auth(hass):
     """Test we handle invalid auth from import."""
-    entry = MockConfigEntry(
-        domain=config_flow.DOMAIN, data=VALID_CONFIG, unique_id=CAMERA_MAC
-    )
-    entry.add_to_hass(hass)
+    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
@@ -287,11 +345,8 @@ async def test_import_invalid_auth(hass):
 
 
 async def test_import_cannot_connect(hass):
-    """Test we handle invalid auth from import."""
-    entry = MockConfigEntry(
-        domain=config_flow.DOMAIN, data=VALID_CONFIG, unique_id=CAMERA_MAC
-    )
-    entry.add_to_hass(hass)
+    """Test we handle cannot connect error from import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
@@ -313,10 +368,40 @@ async def test_import_cannot_connect(hass):
         assert result["reason"] == "cannot_connect"
 
 
+async def test_import_invalid_response(hass):
+    """Test we handle invalid response error from import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "homeassistant.components.foscam.config_flow.FoscamCamera",
+    ) as mock_foscam_camera:
+        setup_mock_foscam_camera(mock_foscam_camera)
+
+        invalid_response = VALID_CONFIG.copy()
+        invalid_response[config_flow.CONF_USERNAME] = INVALID_RESPONSE_CONFIG[
+            config_flow.CONF_USERNAME
+        ]
+
+        result = await hass.config_entries.flow.async_init(
+            config_flow.DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=invalid_response,
+        )
+
+        await hass.async_block_till_done()
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "unknown"
+
+
 async def test_import_already_configured(hass):
     """Test we handle already configured from import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
-        domain=config_flow.DOMAIN, data=VALID_CONFIG, unique_id=CAMERA_MAC
+        domain=config_flow.DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=config_flow.camera_unique_id(VALID_CONFIG),
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The integration is currently broken for users using non-admin accounts and for some models that incorrectly reports its RTSP port wrongly (sorry! 😓).

Foscam cameras require admin account for getting the MAC address, requiring an admin account in the integration is not desirable as an operator one is good enough (and a good practice). 

Old entries using the MAC address as unique_id are migrated to the new unique_id format so everything is consistent.

Related to this issue I've found that motion detection setting is also restricted to admin accounts and was throwing an error that was not helpful so I've also added proper error messages to those cases.

Also fixed unhandled invalid responses from the camera in the config flow process.

Also the RTSP port is reported incorrectly in some models which causes stream not to work, so I made RTSP port configurable again (and importing it correctly from the old config).

So to recap:
1. Changed unique_id so it doesn't use MAC address (restricted for foscam admin accounts) and migrate old configs.
2. Added logs to optional parts that require admin accounts (motion detection setting).
3. Fix error handling when an invalid response is received from a camera.
4. Update config flow tests to test new errors and consider the new unique_id.
5. Make configurable RTSP port again, adding it to the config flow to both UI and import flows.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45921 and fixes #45939
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
