### PR TITLE
Use the local timezone when parsing Todoist due dates

### DIFF
--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -529,8 +529,10 @@ class TodoistProjectData:
             if task["due"] is None:
                 continue
             due_date = _parse_due_date(task["due"], self._api.state['user']['tz_info']['gmt_string'])
+            midnight = dt.as_utc(dt.parse_datetime(due_date.strftime("%Y-%m-%d") + "T00:00:00" + self._api.state['user']['tz_info']['gmt_string']))
+
             if start_date < due_date < end_date:
-                if dt.as_local(due_date).hour == 0 and dt.as_local(due_date).minute == 0:
+                if due_date == midnight:
                     # If the due date has no time data, return just the date so that it
                     # will render correctly as an all day event on a calendar.
                     due_date_value = due_date.strftime("%Y-%m-%d")

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -231,7 +231,7 @@ def _parse_due_date(data: dict, gmt_string) -> datetime:
     # Add time information to date only strings.
     if len(data["date"]) == 10:
         data["date"] += "T00:00:00"
-    if not data["date"].endswith("Z"):
+    if dt.parse_datetime(data["date"]).tzinfo is None:
         data["date"] += gmt_string
     return dt.as_utc(dt.parse_datetime(data["date"]))
 

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -231,10 +231,7 @@ def _parse_due_date(data: dict) -> datetime:
     # Add time information to date only strings.
     if len(data["date"]) == 10:
         data["date"] += "T00:00:00"
-    # If there is no timezone provided, use UTC.
-    if data["timezone"] is None:
-        data["date"] += "Z"
-    return dt.parse_datetime(data["date"])
+    return dt.as_utc(dt.parse_datetime(data["date"]))
 
 
 class TodoistProjectDevice(CalendarEventDevice):
@@ -531,7 +528,7 @@ class TodoistProjectData:
                 continue
             due_date = _parse_due_date(task["due"])
             if start_date < due_date < end_date:
-                if due_date.hour == 0 and due_date.minute == 0:
+                if dt.as_local(due_date).hour == 0 and dt.as_local(due_date).minute == 0:
                     # If the due date has no time data, return just the date so that it
                     # will render correctly as an all day event on a calendar.
                     due_date_value = due_date.strftime("%Y-%m-%d")

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -406,7 +406,9 @@ class TodoistProjectData:
         # Generally speaking, that means right now.
         task[START] = dt.utcnow()
         if data[DUE] is not None:
-            task[END] = _parse_due_date(data[DUE], self._api.state['user']['tz_info']['gmt_string'])
+            task[END] = _parse_due_date(
+                data[DUE], self._api.state["user"]["tz_info"]["gmt_string"]
+            )
 
             if self._due_date_days is not None and (
                 task[END] > dt.utcnow() + self._due_date_days
@@ -528,8 +530,16 @@ class TodoistProjectData:
         for task in project_task_data:
             if task["due"] is None:
                 continue
-            due_date = _parse_due_date(task["due"], self._api.state['user']['tz_info']['gmt_string'])
-            midnight = dt.as_utc(dt.parse_datetime(due_date.strftime("%Y-%m-%d") + "T00:00:00" + self._api.state['user']['tz_info']['gmt_string']))
+            due_date = _parse_due_date(
+                task["due"], self._api.state["user"]["tz_info"]["gmt_string"]
+            )
+            midnight = dt.as_utc(
+                dt.parse_datetime(
+                    due_date.strftime("%Y-%m-%d")
+                    + "T00:00:00"
+                    + self._api.state["user"]["tz_info"]["gmt_string"]
+                )
+            )
 
             if start_date < due_date < end_date:
                 if due_date == midnight:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

The Todoist API uses local timestamps for due dates, however the integration was improperly converting them to UTC which caused the times to appear wrong in the Calendar view.  I've modified `_parse_due_date()` to properly convert the times from local time to UTC using `dt.as_utc()`, and changed the all day event check to look for midnight in the local time zone.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
