### PR TITLE
Standardize AirVisual helper method in config flow

### DIFF
--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -89,42 +89,7 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Define the config flow to handle options."""
-        return AirVisualOptionsFlowHandler(config_entry)
-
-    async def async_step_geography(self, user_input, integration_type):
-        """Handle the initialization of the integration via the cloud API."""
-        self._geo_id = async_get_geography_id(user_input)
-        await self._async_set_unique_id(self._geo_id)
-        self._abort_if_unique_id_configured()
-        return await self.async_step_geography_finish(user_input, integration_type)
-
-    async def async_step_geography_by_coords(self, user_input=None):
-        """Handle the initialization of the cloud API based on latitude/longitude."""
-        if not user_input:
-            return self.async_show_form(
-                step_id="geography_by_coords", data_schema=self.geography_coords_schema
-            )
-
-        return await self.async_step_geography(
-            user_input, INTEGRATION_TYPE_GEOGRAPHY_COORDS
-        )
-
-    async def async_step_geography_by_name(self, user_input=None):
-        """Handle the initialization of the cloud API based on city/state/country."""
-        if not user_input:
-            return self.async_show_form(
-                step_id="geography_by_name", data_schema=GEOGRAPHY_NAME_SCHEMA
-            )
-
-        return await self.async_step_geography(
-            user_input, INTEGRATION_TYPE_GEOGRAPHY_NAME
-        )
-
-    async def async_step_geography_finish(self, user_input, integration_type):
+    async def async_geography_finish(self, user_input, integration_type):
         """Validate a Cloud API key."""
         websession = aiohttp_client.async_get_clientsession(self.hass)
         cloud_api = CloudAPI(user_input[CONF_API_KEY], session=websession)
@@ -183,6 +148,41 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data={**user_input, CONF_INTEGRATION_TYPE: integration_type},
         )
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Define the config flow to handle options."""
+        return AirVisualOptionsFlowHandler(config_entry)
+
+    async def async_step_geography(self, user_input, integration_type):
+        """Handle the initialization of the integration via the cloud API."""
+        self._geo_id = async_get_geography_id(user_input)
+        await self._async_set_unique_id(self._geo_id)
+        self._abort_if_unique_id_configured()
+        return await self.async_geography_finish(user_input, integration_type)
+
+    async def async_step_geography_by_coords(self, user_input=None):
+        """Handle the initialization of the cloud API based on latitude/longitude."""
+        if not user_input:
+            return self.async_show_form(
+                step_id="geography_by_coords", data_schema=self.geography_coords_schema
+            )
+
+        return await self.async_step_geography(
+            user_input, INTEGRATION_TYPE_GEOGRAPHY_COORDS
+        )
+
+    async def async_step_geography_by_name(self, user_input=None):
+        """Handle the initialization of the cloud API based on city/state/country."""
+        if not user_input:
+            return self.async_show_form(
+                step_id="geography_by_name", data_schema=GEOGRAPHY_NAME_SCHEMA
+            )
+
+        return await self.async_step_geography(
+            user_input, INTEGRATION_TYPE_GEOGRAPHY_NAME
+        )
+
     async def async_step_node_pro(self, user_input=None):
         """Handle the initialization of the integration with a Node/Pro."""
         if not user_input:
@@ -224,7 +224,7 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         conf = {CONF_API_KEY: user_input[CONF_API_KEY], **self._entry_data_for_reauth}
 
-        return await self.async_step_geography_finish(
+        return await self.async_geography_finish(
             conf, self._entry_data_for_reauth[CONF_INTEGRATION_TYPE]
         )
 

--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -84,12 +84,7 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-    async def _async_set_unique_id(self, unique_id):
-        """Set the unique ID of the config flow and abort if it already exists."""
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
-
-    async def async_geography_finish(self, user_input, integration_type):
+    async def _async_finish_geography(self, user_input, integration_type):
         """Validate a Cloud API key."""
         websession = aiohttp_client.async_get_clientsession(self.hass)
         cloud_api = CloudAPI(user_input[CONF_API_KEY], session=websession)
@@ -148,18 +143,23 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data={**user_input, CONF_INTEGRATION_TYPE: integration_type},
         )
 
+    async def _async_init_geography(self, user_input, integration_type):
+        """Handle the initialization of the integration via the cloud API."""
+        self._geo_id = async_get_geography_id(user_input)
+        await self._async_set_unique_id(self._geo_id)
+        self._abort_if_unique_id_configured()
+        return await self._async_finish_geography(user_input, integration_type)
+
+    async def _async_set_unique_id(self, unique_id):
+        """Set the unique ID of the config flow and abort if it already exists."""
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Define the config flow to handle options."""
         return AirVisualOptionsFlowHandler(config_entry)
-
-    async def async_step_geography(self, user_input, integration_type):
-        """Handle the initialization of the integration via the cloud API."""
-        self._geo_id = async_get_geography_id(user_input)
-        await self._async_set_unique_id(self._geo_id)
-        self._abort_if_unique_id_configured()
-        return await self.async_geography_finish(user_input, integration_type)
 
     async def async_step_geography_by_coords(self, user_input=None):
         """Handle the initialization of the cloud API based on latitude/longitude."""
@@ -168,7 +168,7 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="geography_by_coords", data_schema=self.geography_coords_schema
             )
 
-        return await self.async_step_geography(
+        return await self._async_init_geography(
             user_input, INTEGRATION_TYPE_GEOGRAPHY_COORDS
         )
 
@@ -179,7 +179,7 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="geography_by_name", data_schema=GEOGRAPHY_NAME_SCHEMA
             )
 
-        return await self.async_step_geography(
+        return await self._async_init_geography(
             user_input, INTEGRATION_TYPE_GEOGRAPHY_NAME
         )
 
@@ -224,7 +224,7 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         conf = {CONF_API_KEY: user_input[CONF_API_KEY], **self._entry_data_for_reauth}
 
-        return await self.async_geography_finish(
+        return await self._async_finish_geography(
             conf, self._entry_data_for_reauth[CONF_INTEGRATION_TYPE]
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on [@MartinHjelmare's comment](https://github.com/home-assistant/core/pull/44116#discussion_r570109361), this PR standardizes a helper method in the AirVisual config flow – since it's not a step, it shouldn't mimic a step.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
