### PR TITLE
Do not listen for dhcp packets if the filter cannot be setup

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -295,10 +295,10 @@ def _verify_l2socket_creation_permission():
     conf.L2socket()
 
 
-async def _async_verify_working_pcap(hass, filter):
+async def _async_verify_working_pcap(hass, cap_filter):
     """Verify we can create a packet filter.
 
     If we cannot create a filter we will be listening for
     all traffic which is too intensive.
     """
-    await hass.async_add_executor_job(compile_filter, filter)
+    await hass.async_add_executor_job(compile_filter, cap_filter)

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -7,6 +7,7 @@ import logging
 import os
 import threading
 
+from scapy.arch.common import compile_filter
 from scapy.config import conf
 from scapy.error import Scapy_Exception
 from scapy.layers.dhcp import DHCP
@@ -217,6 +218,15 @@ class DHCPWatcher(WatcherBase):
                 )
             return
 
+        try:
+            await _async_verify_working_pcap(self.hass, FILTER)
+        except (Scapy_Exception, ImportError) as ex:
+            _LOGGER.error(
+                "Cannot watch for dhcp packets without a functional packet filter: %s",
+                ex,
+            )
+            return
+
         self._sniffer = AsyncSniffer(
             filter=FILTER,
             started_callback=self._started.set,
@@ -283,3 +293,12 @@ def _verify_l2socket_creation_permission():
     any permission or bind errors.
     """
     conf.L2socket()
+
+
+async def _async_verify_working_pcap(hass, filter):
+    """Verify we can create a packet filter.
+
+    If we cannot create a filter we will be listening for
+    all traffic which is too intensive.
+    """
+    await hass.async_add_executor_job(compile_filter, filter)

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -325,19 +325,47 @@ async def test_setup_fails_non_root(hass, caplog):
     )
     await hass.async_block_till_done()
 
-    wait_event = threading.Event()
-
     with patch("os.geteuid", return_value=10), patch(
         "homeassistant.components.dhcp._verify_l2socket_creation_permission",
         side_effect=Scapy_Exception,
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
-    wait_event.set()
     assert "Cannot watch for dhcp packets without root or CAP_NET_RAW" in caplog.text
+
+
+async def test_setup_fails_with_broken_libpcap(hass, caplog):
+    """Test we abort if libpcap is missing or broken."""
+
+    assert await async_setup_component(
+        hass,
+        dhcp.DOMAIN,
+        {},
+    )
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
+    ), patch(
+        "homeassistant.components.dhcp.compile_filter",
+        side_effect=ImportError,
+    ) as compile_filter, patch(
+        "homeassistant.components.dhcp.AsyncSniffer",
+    ) as async_sniffer:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+    assert compile_filter.called
+    assert not async_sniffer.called
+    assert (
+        "Cannot watch for dhcp packets without a functional packet filter"
+        in caplog.text
+    )
 
 
 async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -280,7 +280,11 @@ async def test_setup_and_stop(hass):
     )
     await hass.async_block_till_done()
 
-    with patch("homeassistant.components.dhcp.AsyncSniffer.start") as start_call:
+    with patch("homeassistant.components.dhcp.AsyncSniffer.start") as start_call, patch(
+        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
+    ), patch(
+        "homeassistant.components.dhcp.compile_filter",
+    ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Do not listen for dhcp packets if the filter cannot be setup

If the filter could not be setup at the kernel level we have to do the filtering
in python which is too slow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46003
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
