### PR TITLE
Use core constants for dynalite

### DIFF
--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.cover import DEVICE_CLASSES_SCHEMA
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.const import CONF_DEFAULT, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
@@ -29,7 +29,6 @@ from .const import (
     CONF_CHANNEL,
     CONF_CHANNEL_COVER,
     CONF_CLOSE_PRESET,
-    CONF_DEFAULT,
     CONF_DEVICE_CLASS,
     CONF_DURATION,
     CONF_FADE,
@@ -181,7 +180,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: Dict[str, Any]) -> bool:
     """Set up the Dynalite platform."""
-
     conf = config.get(DOMAIN)
     LOGGER.debug("Setting up dynalite component config = %s", conf)
 

--- a/homeassistant/components/dynalite/const.py
+++ b/homeassistant/components/dynalite/const.py
@@ -1,7 +1,7 @@
 """Constants for the Dynalite component."""
 import logging
 
-from homeassistant.const import CONF_DEFAULT, CONF_ROOM  # NOQA
+from homeassistant.const import CONF_ROOM
 
 LOGGER = logging.getLogger(__package__)
 DOMAIN = "dynalite"

--- a/homeassistant/components/dynalite/const.py
+++ b/homeassistant/components/dynalite/const.py
@@ -1,7 +1,7 @@
 """Constants for the Dynalite component."""
 import logging
 
-from homeassistant.const import CONF_ROOM
+from homeassistant.const import CONF_DEFAULT, CONF_ROOM  # NOQA
 
 LOGGER = logging.getLogger(__package__)
 DOMAIN = "dynalite"
@@ -19,7 +19,6 @@ CONF_BRIDGES = "bridges"
 CONF_CHANNEL = "channel"
 CONF_CHANNEL_COVER = "channel_cover"
 CONF_CLOSE_PRESET = "close"
-CONF_DEFAULT = "default"
 CONF_DEVICE_CLASS = "class"
 CONF_DURATION = "duration"
 CONF_FADE = "fade"

--- a/homeassistant/components/dynalite/convert_config.py
+++ b/homeassistant/components/dynalite/convert_config.py
@@ -4,7 +4,14 @@ from typing import Any, Dict
 
 from dynalite_devices_lib import const as dyn_const
 
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_ROOM, CONF_TYPE
+from homeassistant.const import (
+    CONF_DEFAULT,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_ROOM,
+    CONF_TYPE,
+)
 
 from .const import (
     ACTIVE_INIT,
@@ -16,7 +23,6 @@ from .const import (
     CONF_CHANNEL,
     CONF_CHANNEL_COVER,
     CONF_CLOSE_PRESET,
-    CONF_DEFAULT,
     CONF_DEVICE_CLASS,
     CONF_DURATION,
     CONF_FADE,

--- a/homeassistant/components/dynalite/light.py
+++ b/homeassistant/components/dynalite/light.py
@@ -12,7 +12,6 @@ async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
 ) -> None:
     """Record the async_add_entities function to add them later when received from Dynalite."""
-
     async_setup_entry_base(
         hass, config_entry, async_add_entities, "light", DynaliteLight
     )

--- a/homeassistant/components/dynalite/switch.py
+++ b/homeassistant/components/dynalite/switch.py
@@ -12,7 +12,6 @@ async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
 ) -> None:
     """Record the async_add_entities function to add them later when received from Dynalite."""
-
     async_setup_entry_base(
         hass, config_entry, async_add_entities, "switch", DynaliteSwitch
     )

--- a/tests/components/dynalite/test_init.py
+++ b/tests/components/dynalite/test_init.py
@@ -7,10 +7,12 @@ import pytest
 from voluptuous import MultipleInvalid
 
 import homeassistant.components.dynalite.const as dynalite
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_ROOM
+from homeassistant.const import CONF_DEFAULT, CONF_HOST, CONF_NAME, CONF_PORT, CONF_ROOM
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+
+dynalite.CONF_DEFAULT = CONF_DEFAULT
 
 
 async def test_empty_config(hass):

--- a/tests/components/dynalite/test_init.py
+++ b/tests/components/dynalite/test_init.py
@@ -12,8 +12,6 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
-dynalite.CONF_DEFAULT = CONF_DEFAULT
-
 
 async def test_empty_config(hass):
     """Test with an empty config."""
@@ -56,7 +54,7 @@ async def test_async_setup(hass):
                                     dynalite.CONF_TEMPLATE: dynalite.CONF_TIME_COVER,
                                 },
                             },
-                            dynalite.CONF_DEFAULT: {dynalite.CONF_FADE: 2.3},
+                            CONF_DEFAULT: {dynalite.CONF_FADE: 2.3},
                             dynalite.CONF_ACTIVE: dynalite.ACTIVE_INIT,
                             dynalite.CONF_PRESET: {
                                 "5": {CONF_NAME: "pres5", dynalite.CONF_FADE: 4.5}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
lgtm

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
