### PR TITLE
Improve deCONZ logbook to be more robust in different situations

### DIFF
--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 
 from homeassistant.components import logbook
+from homeassistant.components.deconz.const import CONF_GESTURE
 from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.const import CONF_DEVICE_ID, CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
@@ -34,6 +35,23 @@ async def test_humanifying_deconz_event(hass):
             "config": {},
             "uniqueid": "00:00:00:00:00:00:00:02-00",
         },
+        "2": {
+            "id": "Xiaomi cube id",
+            "name": "Xiaomi cube",
+            "type": "ZHASwitch",
+            "modelid": "lumi.sensor_cube",
+            "state": {"buttonevent": 1000, "gesture": 1},
+            "config": {},
+            "uniqueid": "00:00:00:00:00:00:00:03-00",
+        },
+        "3": {
+            "id": "faulty",
+            "name": "Faulty event",
+            "type": "ZHASwitch",
+            "state": {},
+            "config": {},
+            "uniqueid": "00:00:00:00:00:00:00:04-00",
+        },
     }
     config_entry = await setup_deconz_integration(hass, get_state_response=data)
     gateway = get_gateway_from_config_entry(hass, config_entry)
@@ -46,6 +64,7 @@ async def test_humanifying_deconz_event(hass):
         logbook.humanify(
             hass,
             [
+                # Event without matching device trigger
                 MockLazyEventPartialState(
                     CONF_DECONZ_EVENT,
                     {
@@ -55,6 +74,7 @@ async def test_humanifying_deconz_event(hass):
                         CONF_UNIQUE_ID: gateway.events[0].serial,
                     },
                 ),
+                # Event with matching device trigger
                 MockLazyEventPartialState(
                     CONF_DECONZ_EVENT,
                     {
@@ -62,6 +82,36 @@ async def test_humanifying_deconz_event(hass):
                         CONF_EVENT: 2001,
                         CONF_ID: gateway.events[1].event_id,
                         CONF_UNIQUE_ID: gateway.events[1].serial,
+                    },
+                ),
+                # Gesture with matching device trigger
+                MockLazyEventPartialState(
+                    CONF_DECONZ_EVENT,
+                    {
+                        CONF_DEVICE_ID: gateway.events[2].device_id,
+                        CONF_GESTURE: 1,
+                        CONF_ID: gateway.events[2].event_id,
+                        CONF_UNIQUE_ID: gateway.events[2].serial,
+                    },
+                ),
+                # Unsupported device trigger
+                MockLazyEventPartialState(
+                    CONF_DECONZ_EVENT,
+                    {
+                        CONF_DEVICE_ID: gateway.events[2].device_id,
+                        CONF_GESTURE: "unsupported_gesture",
+                        CONF_ID: gateway.events[2].event_id,
+                        CONF_UNIQUE_ID: gateway.events[2].serial,
+                    },
+                ),
+                # Unknown event
+                MockLazyEventPartialState(
+                    CONF_DECONZ_EVENT,
+                    {
+                        CONF_DEVICE_ID: gateway.events[3].device_id,
+                        "unknown_event": None,
+                        CONF_ID: gateway.events[3].event_id,
+                        CONF_UNIQUE_ID: gateway.events[3].serial,
                     },
                 ),
             ],
@@ -77,3 +127,15 @@ async def test_humanifying_deconz_event(hass):
     assert events[1]["name"] == "Hue remote"
     assert events[1]["domain"] == "deconz"
     assert events[1]["message"] == "'Long press' event for 'Dim up' was fired."
+
+    assert events[2]["name"] == "Xiaomi cube"
+    assert events[2]["domain"] == "deconz"
+    assert events[2]["message"] == "fired event 'Shake'."
+
+    assert events[3]["name"] == "Xiaomi cube"
+    assert events[3]["domain"] == "deconz"
+    assert events[3]["message"] == "fired event 'unsupported_gesture'."
+
+    assert events[4]["name"] == "Faulty event"
+    assert events[4]["domain"] == "deconz"
+    assert events[4]["message"] == "fired an unknown event."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Certain devices can trigger events which are not key "event", this expands so it supports gestures but also handles more situations with different types of unexpected data

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46002
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
