### PR TITLE
Add unavailable to Vera

### DIFF
--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -232,6 +232,11 @@ class VeraDevice(Generic[DeviceType], Entity):
         """Update the state."""
         self.schedule_update_ha_state(True)
 
+    def update(self):
+        """Force a refresh from the device if the device is unavailable."""
+        if not self.available:
+            self.vera_device.refresh()
+
     @property
     def name(self) -> str:
         """Return the name of the device."""
@@ -275,6 +280,11 @@ class VeraDevice(Generic[DeviceType], Entity):
         attr["Vera Device Id"] = self.vera_device.vera_device_id
 
         return attr
+
+    @property
+    def available(self):
+        """If device communications have failed return false."""
+        return not self.vera_device.comm_failure
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/vera/binary_sensor.py
+++ b/homeassistant/components/vera/binary_sensor.py
@@ -50,4 +50,5 @@ class VeraBinarySensor(VeraDevice[veraApi.VeraBinarySensor], BinarySensorEntity)
 
     def update(self) -> None:
         """Get the latest data and update the state."""
+        super().update()
         self._state = self.vera_device.is_tripped

--- a/homeassistant/components/vera/light.py
+++ b/homeassistant/components/vera/light.py
@@ -93,6 +93,7 @@ class VeraLight(VeraDevice[veraApi.VeraDimmer], LightEntity):
 
     def update(self) -> None:
         """Call to update state."""
+        super().update()
         self._state = self.vera_device.is_switched_on()
         if self.vera_device.is_dimmable:
             # If it is dimmable, both functions exist. In case color

--- a/homeassistant/components/vera/manifest.json
+++ b/homeassistant/components/vera/manifest.json
@@ -3,6 +3,6 @@
   "name": "Vera",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/vera",
-  "requirements": ["pyvera==0.3.11"],
+  "requirements": ["pyvera==0.3.12"],
   "codeowners": ["@vangorra"]
 }

--- a/homeassistant/components/vera/manifest.json
+++ b/homeassistant/components/vera/manifest.json
@@ -3,6 +3,6 @@
   "name": "Vera",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/vera",
-  "requirements": ["pyvera==0.3.12"],
+  "requirements": ["pyvera==0.3.13"],
   "codeowners": ["@vangorra"]
 }

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -68,7 +68,7 @@ class VeraSensor(VeraDevice[veraApi.VeraSensor], Entity):
 
     def update(self) -> None:
         """Update the state."""
-
+        super().update()
         if self.vera_device.category == veraApi.CATEGORY_TEMPERATURE_SENSOR:
             self.current_value = self.vera_device.temperature
 

--- a/homeassistant/components/vera/switch.py
+++ b/homeassistant/components/vera/switch.py
@@ -70,4 +70,5 @@ class VeraSwitch(VeraDevice[veraApi.VeraSwitch], SwitchEntity):
 
     def update(self) -> None:
         """Update device state."""
+        super().update()
         self._state = self.vera_device.is_switched_on()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1880,7 +1880,7 @@ pyuptimerobot==0.0.5
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.3.11
+pyvera==0.3.12
 
 # homeassistant.components.versasense
 pyversasense==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1880,7 +1880,7 @@ pyuptimerobot==0.0.5
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.3.12
+pyvera==0.3.13
 
 # homeassistant.components.versasense
 pyversasense==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -950,7 +950,7 @@ pytraccar==0.9.0
 pytradfri[async]==7.0.6
 
 # homeassistant.components.vera
-pyvera==0.3.11
+pyvera==0.3.12
 
 # homeassistant.components.vesync
 pyvesync==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -950,7 +950,7 @@ pytraccar==0.9.0
 pytradfri[async]==7.0.6
 
 # homeassistant.components.vera
-pyvera==0.3.12
+pyvera==0.3.13
 
 # homeassistant.components.vesync
 pyvesync==1.2.0

--- a/tests/components/vera/test_binary_sensor.py
+++ b/tests/components/vera/test_binary_sensor.py
@@ -14,6 +14,7 @@ async def test_binary_sensor(
     """Test function."""
     vera_device = MagicMock(spec=pv.VeraBinarySensor)  # type: pv.VeraBinarySensor
     vera_device.device_id = 1
+    vera_device.comm_failure = False
     vera_device.vera_device_id = vera_device.device_id
     vera_device.name = "dev1"
     vera_device.is_tripped = False

--- a/tests/components/vera/test_climate.py
+++ b/tests/components/vera/test_climate.py
@@ -23,6 +23,7 @@ async def test_climate(
     vera_device = MagicMock(spec=pv.VeraThermostat)  # type: pv.VeraThermostat
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = pv.CATEGORY_THERMOSTAT
     vera_device.power = 10
@@ -133,6 +134,7 @@ async def test_climate_f(
     vera_device = MagicMock(spec=pv.VeraThermostat)  # type: pv.VeraThermostat
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = pv.CATEGORY_THERMOSTAT
     vera_device.power = 10

--- a/tests/components/vera/test_cover.py
+++ b/tests/components/vera/test_cover.py
@@ -15,6 +15,7 @@ async def test_cover(
     vera_device = MagicMock(spec=pv.VeraCurtain)  # type: pv.VeraCurtain
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = pv.CATEGORY_CURTAIN
     vera_device.is_closed = False

--- a/tests/components/vera/test_light.py
+++ b/tests/components/vera/test_light.py
@@ -16,6 +16,7 @@ async def test_light(
     vera_device = MagicMock(spec=pv.VeraDimmer)  # type: pv.VeraDimmer
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = pv.CATEGORY_DIMMER
     vera_device.is_switched_on = MagicMock(return_value=False)

--- a/tests/components/vera/test_lock.py
+++ b/tests/components/vera/test_lock.py
@@ -16,6 +16,7 @@ async def test_lock(
     vera_device = MagicMock(spec=pv.VeraLock)  # type: pv.VeraLock
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = pv.CATEGORY_LOCK
     vera_device.is_locked = MagicMock(return_value=False)

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -23,6 +23,7 @@ async def run_sensor_test(
     vera_device = MagicMock(spec=pv.VeraSensor)  # type: pv.VeraSensor
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = category
     setattr(vera_device, class_property, "33")
@@ -178,6 +179,7 @@ async def test_scene_controller_sensor(
     vera_device = MagicMock(spec=pv.VeraSensor)  # type: pv.VeraSensor
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = pv.CATEGORY_SCENE_CONTROLLER
     vera_device.get_last_scene_id = MagicMock(return_value="id0")

--- a/tests/components/vera/test_switch.py
+++ b/tests/components/vera/test_switch.py
@@ -15,6 +15,7 @@ async def test_switch(
     vera_device = MagicMock(spec=pv.VeraSwitch)  # type: pv.VeraSwitch
     vera_device.device_id = 1
     vera_device.vera_device_id = vera_device.device_id
+    vera_device.comm_failure = False
     vera_device.name = "dev1"
     vera_device.category = pv.CATEGORY_SWITCH
     vera_device.is_switched_on = MagicMock(return_value=False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This marks vera devices as unavailable if comms has failed to the device.

It also contains some logic to force a refresh from the vera device for failed devices that otherwise use subscriptions. Subscriptions are not 100% reliable when devices recover.

This requires a new version of pyvera with improved support for comms failures.

https://github.com/pavoni/pyvera/compare/0.3.11...0.3.13

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/pavoni/pyvera/issues/147
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
