### PR TITLE
Restore Tado binary sensor attributes

### DIFF
--- a/homeassistant/components/tado/binary_sensor.py
+++ b/homeassistant/components/tado/binary_sensor.py
@@ -183,6 +183,7 @@ class TadoZoneBinarySensor(TadoZoneEntity, BinarySensorEntity):
         self._unique_id = f"{zone_variable} {zone_id} {tado.home_id}"
 
         self._state = None
+        self._state_attributes = None
         self._tado_zone_data = None
 
     async def async_added_to_hass(self):
@@ -229,6 +230,11 @@ class TadoZoneBinarySensor(TadoZoneEntity, BinarySensorEntity):
             return DEVICE_CLASS_POWER
         return None
 
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._state_attributes
+
     @callback
     def _async_update_callback(self):
         """Update and write state."""
@@ -251,6 +257,11 @@ class TadoZoneBinarySensor(TadoZoneEntity, BinarySensorEntity):
 
         elif self.zone_variable == "overlay":
             self._state = self._tado_zone_data.overlay_active
+            self._state_attributes = (
+                {"termination": self._tado_zone_data.overlay_termination_type}
+                if self._tado_zone_data.overlay_active
+                else {}
+            )
 
         elif self.zone_variable == "early start":
             self._state = self._tado_zone_data.preparation
@@ -260,3 +271,4 @@ class TadoZoneBinarySensor(TadoZoneEntity, BinarySensorEntity):
                 self._tado_zone_data.open_window
                 or self._tado_zone_data.open_window_detected
             )
+            self._state_attributes = self._tado_zone_data.open_window_attr

--- a/homeassistant/components/tado/binary_sensor.py
+++ b/homeassistant/components/tado/binary_sensor.py
@@ -257,11 +257,10 @@ class TadoZoneBinarySensor(TadoZoneEntity, BinarySensorEntity):
 
         elif self.zone_variable == "overlay":
             self._state = self._tado_zone_data.overlay_active
-            self._state_attributes = (
-                {"termination": self._tado_zone_data.overlay_termination_type}
-                if self._tado_zone_data.overlay_active
-                else {}
-            )
+            if self._tado_zone_data.overlay_active:
+                self._state_attributes = {
+                    "termination": self._tado_zone_data.overlay_termination_type
+                }
 
         elif self.zone_variable == "early start":
             self._state = self._tado_zone_data.preparation

--- a/tests/components/tado/util.py
+++ b/tests/components/tado/util.py
@@ -46,6 +46,9 @@ async def async_init_integration(
     # Device Temp Offset
     device_temp_offset = "tado/device_temp_offset.json"
 
+    # Zone Default Overlay
+    zone_def_overlay = "tado/zone_default_overlay.json"
+
     with requests_mock.mock() as m:
         m.post("https://auth.tado.com/oauth/token", text=load_fixture(token_fixture))
         m.get(
@@ -91,6 +94,26 @@ async def async_init_integration(
         m.get(
             "https://my.tado.com/api/v2/homes/1/zones/1/capabilities",
             text=load_fixture(zone_1_capabilities_fixture),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/1/defaultOverlay",
+            text=load_fixture(zone_def_overlay),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/2/defaultOverlay",
+            text=load_fixture(zone_def_overlay),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/3/defaultOverlay",
+            text=load_fixture(zone_def_overlay),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/4/defaultOverlay",
+            text=load_fixture(zone_def_overlay),
+        )
+        m.get(
+            "https://my.tado.com/api/v2/homes/1/zones/5/defaultOverlay",
+            text=load_fixture(zone_def_overlay),
         )
         m.get(
             "https://my.tado.com/api/v2/homes/1/zones/5/state",

--- a/tests/fixtures/tado/zone_default_overlay.json
+++ b/tests/fixtures/tado/zone_default_overlay.json
@@ -1,0 +1,5 @@
+{
+    "terminationCondition": {
+        "type": "MANUAL"
+    }
+}


### PR DESCRIPTION
Attributes were removed from Overlay and Open Window sensors when converting them to binary sensors.

## Proposed change
Commit 067f2d0098d1 removed the state attributes from Overlay and Open Window sensors when they were converted to binary sensors.
Restore them to fix UI issues for some users: https://community.home-assistant.io/t/2021-2-x-breaks-tado-functionality-bring-it-back-please/277151


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
