### PR TITLE
Bump pymyq to 3.0.1

### DIFF
--- a/homeassistant/components/myq/__init__.py
+++ b/homeassistant/components/myq/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, MYQ_COORDINATOR, MYQ_GATEWAY, PLATFORMS, UPDATE_INTERVAL
 
@@ -40,11 +40,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except MyQError as err:
         raise ConfigEntryNotReady from err
 
+    async def async_update_data():
+        try:
+            return await myq.update_device_info()
+        except MyQError as err:
+            raise UpdateFailed(err)
+
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="myq devices",
-        update_method=myq.update_device_info,
+        update_method=async_update_data,
         update_interval=timedelta(seconds=UPDATE_INTERVAL),
     )
 

--- a/homeassistant/components/myq/__init__.py
+++ b/homeassistant/components/myq/__init__.py
@@ -40,6 +40,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except MyQError as err:
         raise ConfigEntryNotReady from err
 
+    # Called by DataUpdateCoordinator, allows to capture any MyQError exceptions and to throw an HASS UpdateFailed
+    # exception instead, preventing traceback in HASS logs.
     async def async_update_data():
         try:
             return await myq.update_device_info()

--- a/homeassistant/components/myq/__init__.py
+++ b/homeassistant/components/myq/__init__.py
@@ -44,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         try:
             return await myq.update_device_info()
         except MyQError as err:
-            raise UpdateFailed(err)
+            raise UpdateFailed(str(err)) from err
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/homeassistant/components/myq/binary_sensor.py
+++ b/homeassistant/components/myq/binary_sensor.py
@@ -1,7 +1,5 @@
 """Support for MyQ gateways."""
 from pymyq.const import (
-    DEVICE_FAMILY as MYQ_DEVICE_FAMILY,
-    DEVICE_FAMILY_GATEWAY as MYQ_DEVICE_FAMILY_GATEWAY,
     DEVICE_STATE as MYQ_DEVICE_STATE,
     DEVICE_STATE_ONLINE as MYQ_DEVICE_STATE_ONLINE,
     KNOWN_MODELS,
@@ -25,9 +23,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = []
 
-    for device in myq.devices.values():
-        if device.device_json[MYQ_DEVICE_FAMILY] == MYQ_DEVICE_FAMILY_GATEWAY:
-            entities.append(MyQBinarySensorEntity(coordinator, device))
+    for device in myq.gateways.values():
+        entities.append(MyQBinarySensorEntity(coordinator, device))
 
     async_add_entities(entities, True)
 

--- a/homeassistant/components/myq/const.py
+++ b/homeassistant/components/myq/const.py
@@ -24,7 +24,7 @@ MYQ_COORDINATOR = "coordinator"
 
 # myq has some ratelimits in place
 # and 61 seemed to be work every time
-UPDATE_INTERVAL = 30
+UPDATE_INTERVAL = 15
 
 # Estimated time it takes myq to start transition from one
 # state to the next.

--- a/homeassistant/components/myq/const.py
+++ b/homeassistant/components/myq/const.py
@@ -1,9 +1,9 @@
 """The MyQ integration."""
-from pymyq.device import (
-    STATE_CLOSED as MYQ_STATE_CLOSED,
-    STATE_CLOSING as MYQ_STATE_CLOSING,
-    STATE_OPEN as MYQ_STATE_OPEN,
-    STATE_OPENING as MYQ_STATE_OPENING,
+from pymyq.garagedoor import (
+    STATE_CLOSED as MYQ_COVER_STATE_CLOSED,
+    STATE_CLOSING as MYQ_COVER_STATE_CLOSING,
+    STATE_OPEN as MYQ_COVER_STATE_OPEN,
+    STATE_OPENING as MYQ_COVER_STATE_OPENING,
 )
 
 from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
@@ -13,10 +13,10 @@ DOMAIN = "myq"
 PLATFORMS = ["cover", "binary_sensor"]
 
 MYQ_TO_HASS = {
-    MYQ_STATE_CLOSED: STATE_CLOSED,
-    MYQ_STATE_CLOSING: STATE_CLOSING,
-    MYQ_STATE_OPEN: STATE_OPEN,
-    MYQ_STATE_OPENING: STATE_OPENING,
+    MYQ_COVER_STATE_CLOSED: STATE_CLOSED,
+    MYQ_COVER_STATE_CLOSING: STATE_CLOSING,
+    MYQ_COVER_STATE_OPEN: STATE_OPEN,
+    MYQ_COVER_STATE_OPENING: STATE_OPENING,
 }
 
 MYQ_GATEWAY = "myq_gateway"
@@ -24,7 +24,7 @@ MYQ_COORDINATOR = "coordinator"
 
 # myq has some ratelimits in place
 # and 61 seemed to be work every time
-UPDATE_INTERVAL = 61
+UPDATE_INTERVAL = 30
 
 # Estimated time it takes myq to start transition from one
 # state to the next.

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -108,22 +108,22 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
             wait_task = await self._device.close(wait_for_state=False)
         except MyQError as err:
             _LOGGER.error(
-                f"Closing of cover {self._device.name} failed with error: {str(err)}"
+                "Closing of cover %s failed with error: %s", self._device.name, str(err)
             )
+
             return
 
         # Write closing state to HASS
         self.async_write_ha_state()
 
         if not await wait_task:
-            _LOGGER.error(f"Closing of cover {self._device.name} failed")
+            _LOGGER.error("Closing of cover %s failed", self._device.name)
 
         # Write final state to HASS
         self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs):
         """Issue open command to cover."""
-        """Issue close command to cover."""
         if self.is_opening or self.is_open:
             return
 
@@ -131,7 +131,7 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
             wait_task = await self._device.open(wait_for_state=False)
         except MyQError as err:
             _LOGGER.error(
-                f"Opening of cover {self._device.name} failed with error: {str(err)}"
+                "Opening of cover %s failed with error: %s", self._device.name, str(err)
             )
             return
 
@@ -139,7 +139,7 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         self.async_write_ha_state()
 
         if not await wait_task:
-            _LOGGER.error(f"Opening of cover {self._device.name} failed")
+            _LOGGER.error("Opening of cover %s failed", self._device.name)
 
         # Write final state to HASS
         self.async_write_ha_state()

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -72,22 +72,22 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return true if cover is closed, else False."""
-        return self._device.state == STATE_CLOSED
+        return MYQ_TO_HASS.get(self._device.state) == STATE_CLOSED
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        return self._device.state == STATE_CLOSING
+        return MYQ_TO_HASS.get(self._device.state) == STATE_CLOSING
 
     @property
     def is_open(self):
         """Return if the cover is opening or not."""
-        return self._device.state == STATE_OPEN
+        return MYQ_TO_HASS.get(self._device.state) == STATE_OPEN
 
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        return self._device.state == STATE_OPENING
+        return MYQ_TO_HASS.get(self._device.state) == STATE_OPENING
 
     @property
     def supported_features(self):

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -21,7 +21,7 @@ from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_O
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MYQ_COORDINATOR, MYQ_GATEWAY
+from .const import DOMAIN, MYQ_COORDINATOR, MYQ_GATEWAY, MYQ_TO_HASS
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -160,8 +160,6 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
             device_info["via_device"] = (DOMAIN, self._device.parent_device_id)
         return device_info
 
-    @callback
-    def _async_consume_update(self):
     async def async_added_to_hass(self):
         """Subscribe to updates."""
         self.async_on_remove(

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -18,7 +18,6 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
-from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MYQ_COORDINATOR, MYQ_GATEWAY, MYQ_TO_HASS

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -165,5 +165,5 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
     async def async_added_to_hass(self):
         """Subscribe to updates."""
         self.async_on_remove(
-            self.coordinator.async_add_listener(self._async_consume_update)
+            self.coordinator.async_add_listener(self.async_write_ha_state)
         )

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -162,8 +162,6 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
 
     @callback
     def _async_consume_update(self):
-        self.async_write_ha_state()
-
     async def async_added_to_hass(self):
         """Subscribe to updates."""
         self.async_on_remove(

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.3", "pkce==1.0.2"],
+  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.0b3", "pkce==1.0.2"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.0b3", "pkce==1.0.2"],
+  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.0b4", "pkce==1.0.2"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["pymyq==2.0.14"],
+  "requirements": ["pymyq==3.0.0"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["pymyq==3.0.0"],
+  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.3"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.0b4", "pkce==1.0.2"],
+  "requirements": ["git+https://github.com/arraylabs/pymyq@3.0.0b4#pymyq==3.0.0b4", "pkce==1.0.2"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.3"],
+  "requirements": ["git+https://github.com/arraylabs/pymyq.git@v6_API#pymyq==3.0.3", "pkce==1.0.2"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["git+https://github.com/arraylabs/pymyq@3.0.0b4#pymyq==3.0.0b4", "pkce==1.0.2"],
+  "requirements": ["pymyq==3.0.0"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -2,7 +2,7 @@
   "domain": "myq",
   "name": "MyQ",
   "documentation": "https://www.home-assistant.io/integrations/myq",
-  "requirements": ["pymyq==3.0.0"],
+  "requirements": ["pymyq==3.0.1"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "homekit": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1548,7 +1548,7 @@ pymsteams==0.1.12
 pymusiccast==0.1.6
 
 # homeassistant.components.myq
-pymyq==3.0.0
+pymyq==3.0.1
 
 # homeassistant.components.mysensors
 pymysensors==0.20.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1548,7 +1548,7 @@ pymsteams==0.1.12
 pymusiccast==0.1.6
 
 # homeassistant.components.myq
-pymyq==2.0.14
+pymyq==3.0.0
 
 # homeassistant.components.mysensors
 pymysensors==0.20.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -808,7 +808,7 @@ pymodbus==2.3.0
 pymonoprice==0.3
 
 # homeassistant.components.myq
-pymyq==3.0.0
+pymyq==3.0.1
 
 # homeassistant.components.mysensors
 pymysensors==0.20.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -808,7 +808,7 @@ pymodbus==2.3.0
 pymonoprice==0.3
 
 # homeassistant.components.myq
-pymyq==2.0.14
+pymyq==3.0.0
 
 # homeassistant.components.mysensors
 pymysensors==0.20.1

--- a/tests/components/myq/util.py
+++ b/tests/components/myq/util.py
@@ -1,13 +1,17 @@
 """Tests for the myq integration."""
-
 import json
+import logging
 from unittest.mock import patch
+
+from pymyq.const import ACCOUNTS_ENDPOINT, DEVICES_ENDPOINT
 
 from homeassistant.components.myq.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_init_integration(
@@ -20,16 +24,24 @@ async def async_init_integration(
     devices_json = load_fixture(devices_fixture)
     devices_dict = json.loads(devices_json)
 
-    def _handle_mock_api_request(method, endpoint, **kwargs):
-        if endpoint == "Login":
-            return {"SecurityToken": 1234}
-        if endpoint == "My":
-            return {"Account": {"Id": 1}}
-        if endpoint == "Accounts/1/Devices":
-            return devices_dict
-        return {}
+    def _handle_mock_api_oauth_authenticate():
+        return 1234, 1800
 
-    with patch("pymyq.api.API.request", side_effect=_handle_mock_api_request):
+    def _handle_mock_api_request(method, returns, url, **kwargs):
+        _LOGGER.debug("URL: %s", url)
+        if url == ACCOUNTS_ENDPOINT:
+            _LOGGER.debug("Accounts")
+            return None, {"accounts": [{"id": 1, "name": "mock"}]}
+        if url == DEVICES_ENDPOINT.format(account_id=1):
+            _LOGGER.debug("Devices")
+            return None, devices_dict
+        _LOGGER.debug("Something else")
+        return None, {}
+
+    with patch(
+        "pymyq.api.API._oauth_authenticate",
+        side_effect=_handle_mock_api_oauth_authenticate,
+    ), patch("pymyq.api.API.request", side_effect=_handle_mock_api_request):
         entry = MockConfigEntry(
             domain=DOMAIN, data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"}
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update pymyq to 3.0.1 leveraging new MyQ V6 API and many other improvements. This component was updated to new functionality for opening/closing garage doors reducing complexity and allowing HASS to show intermediate state (opening/closing) and faster update to final state (open/close). Update interval changed from 61 seconds to 15 seconds.

Release notes: https://github.com/arraylabs/pymyq/releases/tag/v3.0.0
Compare view: https://github.com/arraylabs/pymyq/compare/v2.0.14..v3.0.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44851 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
