### PR TITLE
Handle missing value in all platforms of zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -192,9 +192,6 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         if self._current_mode is None:
             # Thermostat(valve) with no support for setting a mode is considered heating-only
             return [ThermostatSetpointType.HEATING]
-        if self._current_mode.value is None:
-            # guard missing value
-            return []
         return THERMOSTAT_MODE_SETPOINT_MAP.get(int(self._current_mode.value), [])  # type: ignore
 
     @property
@@ -243,12 +240,18 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     @property
     def target_temperature(self) -> Optional[float]:
         """Return the temperature we try to reach."""
+        if self._current_mode and self._current_mode.value is None:
+            # guard missing value
+            return None
         temp = self._setpoint_value(self._current_mode_setpoint_enums[0])
         return temp.value if temp else None
 
     @property
     def target_temperature_high(self) -> Optional[float]:
         """Return the highbound target temperature we try to reach."""
+        if self._current_mode and self._current_mode.value is None:
+            # guard missing value
+            return None
         temp = self._setpoint_value(self._current_mode_setpoint_enums[1])
         return temp.value if temp else None
 

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -192,6 +192,9 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         if self._current_mode is None:
             # Thermostat(valve) with no support for setting a mode is considered heating-only
             return [ThermostatSetpointType.HEATING]
+        if self._current_mode.value is None:
+            # guard missing value
+            return []
         return THERMOSTAT_MODE_SETPOINT_MAP.get(int(self._current_mode.value), [])  # type: ignore
 
     @property
@@ -207,6 +210,9 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         if self._current_mode is None:
             # Thermostat(valve) with no support for setting a mode is considered heating-only
             return HVAC_MODE_HEAT
+        if self._current_mode.value is None:
+            # guard missing value
+            return HVAC_MODE_HEAT
         return ZW_HVAC_MODE_MAP.get(int(self._current_mode.value), HVAC_MODE_HEAT_COOL)
 
     @property
@@ -218,6 +224,9 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     def hvac_action(self) -> Optional[str]:
         """Return the current running hvac operation if supported."""
         if not self._operating_state:
+            return None
+        if self._operating_state.value is None:
+            # guard missing value
             return None
         return HVAC_CURRENT_MAP.get(int(self._operating_state.value))
 
@@ -251,6 +260,9 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     @property
     def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
+        if self._current_mode and self._current_mode.value is None:
+            # guard missing value
+            return None
         if self._current_mode and int(self._current_mode.value) not in THERMOSTAT_MODES:
             return_val: str = self._current_mode.metadata.states.get(
                 self._current_mode.value

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -61,11 +61,17 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     @property
     def is_closed(self) -> bool:
         """Return true if cover is closed."""
+        if self.info.primary_value.value is None:
+            # guard missing value
+            return True
         return bool(self.info.primary_value.value == 0)
 
     @property
     def current_cover_position(self) -> int:
         """Return the current position of cover where 0 means closed and 100 is fully open."""
+        if self.info.primary_value.value is None:
+            # guard missing value
+            return 0
         return round((self.info.primary_value.value / 99) * 100)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -1,6 +1,6 @@
 """Support for Z-Wave cover devices."""
 import logging
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Optional
 
 from zwave_js_server.client import Client as ZwaveClient
 
@@ -59,19 +59,19 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     """Representation of a Z-Wave Cover device."""
 
     @property
-    def is_closed(self) -> bool:
+    def is_closed(self) -> Optional[bool]:
         """Return true if cover is closed."""
         if self.info.primary_value.value is None:
             # guard missing value
-            return True
+            return None
         return bool(self.info.primary_value.value == 0)
 
     @property
-    def current_cover_position(self) -> int:
+    def current_cover_position(self) -> Optional[int]:
         """Return the current position of cover where 0 means closed and 100 is fully open."""
         if self.info.primary_value.value is None:
             # guard missing value
-            return 0
+            return None
         return round((self.info.primary_value.value / 99) * 100)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -83,13 +83,7 @@ class ZWaveBaseEntity(Entity):
     @property
     def available(self) -> bool:
         """Return entity availability."""
-        return (
-            self.client.connected
-            and bool(self.info.node.ready)
-            # a None value indicates something wrong with the device,
-            # or the value is simply not yet there (it will arrive later).
-            and self.info.primary_value.value is not None
-        )
+        return self.client.connected and bool(self.info.node.ready)
 
     @callback
     def _value_changed(self, event_data: dict) -> None:

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -86,11 +86,17 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
     @property
     def is_on(self) -> bool:
         """Return true if device is on (speed above 0)."""
+        if self.info.primary_value.value is None:
+            # guard missing value
+            return False
         return bool(self.info.primary_value.value > 0)
 
     @property
     def percentage(self) -> int:
         """Return the current speed percentage."""
+        if self.info.primary_value.value is None:
+            # guard missing value
+            return 0
         return ranged_value_to_percentage(SPEED_RANGE, self.info.primary_value.value)
 
     @property

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -84,11 +84,11 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
         await self.info.node.async_set_value(target_value, 0)
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> Optional[bool]:  # type: ignore
         """Return true if device is on (speed above 0)."""
         if self.info.primary_value.value is None:
             # guard missing value
-            return False
+            return None
         return bool(self.info.primary_value.value > 0)
 
     @property

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -92,11 +92,11 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
         return bool(self.info.primary_value.value > 0)
 
     @property
-    def percentage(self) -> int:
+    def percentage(self) -> Optional[int]:
         """Return the current speed percentage."""
         if self.info.primary_value.value is None:
             # guard missing value
-            return 0
+            return None
         return ranged_value_to_percentage(SPEED_RANGE, self.info.primary_value.value)
 
     @property

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -90,6 +90,9 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
     @property
     def is_locked(self) -> Optional[bool]:
         """Return true if the lock is locked."""
+        if self.info.primary_value.value is None:
+            # guard missing value
+            return None
         return int(
             LOCK_CMD_CLASS_TO_LOCKED_STATE_MAP[
                 CommandClass(self.info.primary_value.command_class)

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -46,6 +46,9 @@ class ZWaveSwitch(ZWaveBaseEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return a boolean for the state of the switch."""
+        if self.info.primary_value.value is None:
+            # guard missing value
+            return False
         return bool(self.info.primary_value.value)
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -1,7 +1,7 @@
 """Representation of Z-Wave switches."""
 
 import logging
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Optional
 
 from zwave_js_server.client import Client as ZwaveClient
 
@@ -44,11 +44,11 @@ class ZWaveSwitch(ZWaveBaseEntity, SwitchEntity):
     """Representation of a Z-Wave switch."""
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> Optional[bool]:  # type: ignore
         """Return a boolean for the state of the switch."""
         if self.info.primary_value.value is None:
             # guard missing value
-            return False
+            return None
         return bool(self.info.primary_value.value)
 
     async def async_turn_on(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Breaking change

## Proposed change
We get a lot of issue reports of confused users because their entities are shown as unavailable, due to the fact that we render an entity as unavailable when the ZWaveValue.value is missing.
I've had a little discussion about this with @AlCalzone and he said we should never assume that the value is there upfront, it may be added later when the device reports its status or is (partially) reinterviewed. It might even come only once the user has done an action, such as toggling a switch/light. Hence this proposal to not render the entity unavailable but instead allow the user to use the entity. The incorrect state due to the missing value will correct itself over time, maybe even if the user toggles the device from within HA.

I'm still a bit doubting if we should leave the unavailable state for sensors as their state is kind of pointless without data.



## Type of change


- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information
Fixes several issues mentioned on discord. I'll collect any issues created on the GH issue tracker.

Fixes https://github.com/zwave-js/node-zwave-js/issues/1609

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
