### PR TITLE
Ask for PIN before closing closed cover in google assistant

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1692,7 +1692,11 @@ class OpenCloseTrait(_Trait):
                 svc_params[cover.ATTR_POSITION] = position
             elif position == 0:
                 service = cover.SERVICE_CLOSE_COVER
-                should_verify = False
+                # Ask for a PIN if the cover isn't open, in case the open/close command is a toggle.
+                if self.state.state != cover.STATE_OPEN:
+                    should_verify = True
+                else:
+                    should_verify = False
             elif position == 100:
                 service = cover.SERVICE_OPEN_COVER
                 should_verify = True

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1687,10 +1687,7 @@ class OpenCloseTrait(_Trait):
             elif position == 0:
                 service = cover.SERVICE_CLOSE_COVER
                 # Ask for a PIN if the cover isn't open, in case the open/close command is a toggle.
-                if self.state.state != cover.STATE_OPEN:
-                    should_verify = True
-                else:
-                    should_verify = False
+                should_verify = bool(self.state.state != cover.STATE_OPEN)
             elif position == 100:
                 service = cover.SERVICE_OPEN_COVER
                 should_verify = True

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1312,9 +1312,7 @@ class FanSpeedTrait(_Trait):
                 context=data.context,
             )
         if domain == fan.DOMAIN:
-            service_params = {
-                ATTR_ENTITY_ID: self.state.entity_id,
-            }
+            service_params = {ATTR_ENTITY_ID: self.state.entity_id}
             if "fanSpeedPercent" in params:
                 service = fan.SERVICE_SET_PERCENTAGE
                 service_params[fan.ATTR_PERCENTAGE] = params["fanSpeedPercent"]
@@ -1323,11 +1321,7 @@ class FanSpeedTrait(_Trait):
                 service_params[fan.ATTR_SPEED] = params["fanSpeed"]
 
             await self.hass.services.async_call(
-                fan.DOMAIN,
-                service,
-                service_params,
-                blocking=True,
-                context=data.context,
+                fan.DOMAIN, service, service_params, blocking=True, context=data.context
             )
 
 


### PR DESCRIPTION
## Proposed change
Some covers may be implemented by a toggle, so closing a closed cover might actually open it.

e.g. my garage door cover just presses the "open/close/stop" button on the remote control, so the current implementation is a [physical] security issue.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
google_assistant:
  project_id: foo
  service_account: !include google_account.json
  report_state: true
  secure_devices_pin: "1234"
  exposed_domains:
    - cover

cover:                         
  - platform: template                                                    
    covers:                                                    
      garage_door:                                           
        device_class: garage                                               
        friendly_name: "Garage Door"                                     
        value_template: "{{ states('switch.garagedoor_sensor') == 'off' }}"
        open_cover:                                                         
          service: switch.toggle           
          data:                                                                           
            entity_id: switch.garagedoor                                             
        close_cover:                         
          service: switch.toggle        
          data:                                                                  
            entity_id: switch.garagedoor                    
        stop_cover:                       
          service: switch.toggle                       
          data:
            entity_id: switch.garagedoor
```

## Additional information
(none)

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

I have *not* successfully run local tests, I tried setting up an environment but there are multiple dependency resolution issues (certifi==2018.11.29 is required, but so is certifi>=2020.12.5; aiobotocore 0.11.1 depends on botocore<1.13.15 and >=1.13.14 but boto3 1.9.252 depends on botocore<1.13.0 and >=1.12.252). Looks like there's a CI bot that can run the tests, so I'll leave tests to that.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

(no, as far as I can tell I don't have access to review PRs?)

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
