### PR TITLE
Convert old deCONZ groups unique ids

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -84,7 +84,6 @@ async def async_update_master_gateway(hass, config_entry):
 
 async def async_update_group_unique_id(hass, config_entry) -> None:
     """Update unique ID entities based on deCONZ groups."""
-    # if old_unique_id := config_entry.data.get(CONF_GROUP_ID_BASE):
     old_unique_id = config_entry.data.get(CONF_GROUP_ID_BASE)
     if old_unique_id:
         new_unique_id: str = config_entry.unique_id

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -1,7 +1,12 @@
 """Support for deCONZ devices."""
 import voluptuous as vol
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.entity_registry import async_migrate_entries
 
@@ -99,6 +104,12 @@ async def async_migrate_entry(hass, config_entry) -> bool:
 
         if old_unique_id:
             await async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
+            data = {
+                CONF_API_KEY: config_entry.data[CONF_API_KEY],
+                CONF_HOST: config_entry.data[CONF_HOST],
+                CONF_PORT: config_entry.data[CONF_PORT],
+            }
+            hass.config_entries.async_update_entry(config_entry, data=data)
 
     LOGGER.info("Migration to version %s successful", config_entry.version)
 

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -84,10 +84,9 @@ async def async_update_master_gateway(hass, config_entry):
 
 async def async_update_group_unique_id(hass, config_entry) -> None:
     """Update unique ID entities based on deCONZ groups."""
-    if CONF_GROUP_ID_BASE not in config_entry.data:
+    if not (old_unique_id := config_entry.data.get(CONF_GROUP_ID_BASE)):
         return
 
-    old_unique_id = config_entry.data[CONF_GROUP_ID_BASE]
     new_unique_id: str = config_entry.unique_id
 
     @callback

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -84,9 +84,11 @@ async def async_update_master_gateway(hass, config_entry):
 
 async def async_update_group_unique_id(hass, config_entry) -> None:
     """Update unique ID entities based on deCONZ groups."""
-    old_unique_id = config_entry.data.get(CONF_GROUP_ID_BASE)
-    if old_unique_id:
-        new_unique_id: str = config_entry.unique_id
+    if CONF_GROUP_ID_BASE not in config_entry.data:
+        return
+
+    old_unique_id = config_entry.data[CONF_GROUP_ID_BASE]
+    new_unique_id: str = config_entry.unique_id
 
     @callback
     def update_unique_id(entity_entry):
@@ -99,11 +101,10 @@ async def async_update_group_unique_id(hass, config_entry) -> None:
             )
         }
 
-    if old_unique_id:
-        await async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
-        data = {
-            CONF_API_KEY: config_entry.data[CONF_API_KEY],
-            CONF_HOST: config_entry.data[CONF_HOST],
-            CONF_PORT: config_entry.data[CONF_PORT],
-        }
-        hass.config_entries.async_update_entry(config_entry, data=data)
+    await async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
+    data = {
+        CONF_API_KEY: config_entry.data[CONF_API_KEY],
+        CONF_HOST: config_entry.data[CONF_HOST],
+        CONF_PORT: config_entry.data[CONF_PORT],
+    }
+    hass.config_entries.async_update_entry(config_entry, data=data)

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -46,7 +46,7 @@ def get_master_gateway(hass):
 class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a deCONZ config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     _hassio_discovery = None

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -46,7 +46,7 @@ def get_master_gateway(hass):
 class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a deCONZ config flow."""
 
-    VERSION = 2
+    VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     _hassio_discovery = None

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -26,7 +26,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.util.color as color_util
 
 from .const import (
-    CONF_GROUP_ID_BASE,
     COVER_TYPES,
     DOMAIN as DECONZ_DOMAIN,
     LOCK_TYPES,
@@ -248,10 +247,7 @@ class DeconzGroup(DeconzBaseLight):
 
     def __init__(self, device, gateway):
         """Set up group and create an unique id."""
-        group_id_base = gateway.config_entry.unique_id
-        if CONF_GROUP_ID_BASE in gateway.config_entry.data:
-            group_id_base = gateway.config_entry.data[CONF_GROUP_ID_BASE]
-        self._unique_id = f"{group_id_base}-{device.deconz_id}"
+        self._unique_id = f"{gateway.bridgeid}-{device.deconz_id}"
 
         super().__init__(device, gateway)
 

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -66,6 +66,7 @@ async def setup_deconz_integration(
     options=ENTRY_OPTIONS,
     get_state_response=DECONZ_WEB_REQUEST,
     entry_id="1",
+    unique_id=BRIDGEID,
     source="user",
 ):
     """Create the deCONZ gateway."""
@@ -76,6 +77,7 @@ async def setup_deconz_integration(
         connection_class=CONN_CLASS_LOCAL_PUSH,
         options=deepcopy(options),
         entry_id=entry_id,
+        unique_id=unique_id,
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -8,6 +8,7 @@ from homeassistant.components.deconz import (
     DeconzGateway,
     async_setup_entry,
     async_unload_entry,
+    async_update_group_unique_id,
 )
 from homeassistant.components.deconz.const import (
     CONF_GROUP_ID_BASE,
@@ -145,7 +146,7 @@ async def test_migrate_entry(hass):
         config_entry=entry,
     )
 
-    await entry.async_migrate(hass)
+    await async_update_group_unique_id(hass, entry)
 
     assert entry.data == {CONF_API_KEY: "1", CONF_HOST: "2", CONF_PORT: "3"}
 
@@ -176,7 +177,7 @@ async def test_migrate_entry_no_legacy_group_id(hass):
         config_entry=entry,
     )
 
-    await entry.async_migrate(hass)
+    await async_update_group_unique_id(hass, entry)
 
     old_entity = registry.async_get(f"{LIGHT_DOMAIN}.old")
     assert old_entity.unique_id == f"{old_unique_id}-OLD"

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -9,10 +9,17 @@ from homeassistant.components.deconz import (
     async_setup_entry,
     async_unload_entry,
 )
-from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
+from homeassistant.components.deconz.const import (
+    CONF_GROUP_ID_BASE,
+    DOMAIN as DECONZ_DOMAIN,
+)
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.helpers import entity_registry
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
+
+from tests.common import MockConfigEntry
 
 ENTRY1_HOST = "1.2.3.4"
 ENTRY1_PORT = 80
@@ -67,7 +74,7 @@ async def test_setup_entry_multiple_gateways(hass):
     data = deepcopy(DECONZ_WEB_REQUEST)
     data["config"]["bridgeid"] = "01234E56789B"
     config_entry2 = await setup_deconz_integration(
-        hass, get_state_response=data, entry_id="2"
+        hass, get_state_response=data, entry_id="2", unique_id="01234E56789B"
     )
     gateway2 = get_gateway_from_config_entry(hass, config_entry2)
 
@@ -92,7 +99,7 @@ async def test_unload_entry_multiple_gateways(hass):
     data = deepcopy(DECONZ_WEB_REQUEST)
     data["config"]["bridgeid"] = "01234E56789B"
     config_entry2 = await setup_deconz_integration(
-        hass, get_state_response=data, entry_id="2"
+        hass, get_state_response=data, entry_id="2", unique_id="01234E56789B"
     )
     gateway2 = get_gateway_from_config_entry(hass, config_entry2)
 
@@ -102,3 +109,66 @@ async def test_unload_entry_multiple_gateways(hass):
 
     assert len(hass.data[DECONZ_DOMAIN]) == 1
     assert hass.data[DECONZ_DOMAIN][gateway2.bridgeid].master
+
+
+async def test_migrate_entry(hass):
+    """Test successful migration of entry data."""
+    old_unique_id = "123"
+    new_unique_id = "1234"
+    entry = MockConfigEntry(
+        domain=DECONZ_DOMAIN,
+        unique_id=new_unique_id,
+        data={CONF_GROUP_ID_BASE: old_unique_id},
+    )
+
+    registry = await entity_registry.async_get_registry(hass)
+    # Create entity entry to migrate to new unique ID
+    registry.async_get_or_create(
+        LIGHT_DOMAIN,
+        DECONZ_DOMAIN,
+        f"{old_unique_id}-OLD",
+        suggested_object_id="old",
+        config_entry=entry,
+    )
+    # Create entity entry with new unique ID
+    registry.async_get_or_create(
+        LIGHT_DOMAIN,
+        DECONZ_DOMAIN,
+        f"{new_unique_id}-NEW",
+        suggested_object_id="new",
+        config_entry=entry,
+    )
+
+    await entry.async_migrate(hass)
+
+    old_entity = registry.async_get(f"{LIGHT_DOMAIN}.old")
+    assert old_entity.unique_id == f"{new_unique_id}-OLD"
+
+    new_entity = registry.async_get(f"{LIGHT_DOMAIN}.new")
+    assert new_entity.unique_id == f"{new_unique_id}-NEW"
+
+
+async def test_migrate_entry_no_legacy_group_id(hass):
+    """Test migration doesn't trigger without old legacy group id in entry data."""
+    old_unique_id = "123"
+    new_unique_id = "1234"
+    entry = MockConfigEntry(
+        domain=DECONZ_DOMAIN,
+        unique_id=new_unique_id,
+        data={},
+    )
+
+    registry = await entity_registry.async_get_registry(hass)
+    # Create entity entry to migrate to new unique ID
+    registry.async_get_or_create(
+        LIGHT_DOMAIN,
+        DECONZ_DOMAIN,
+        f"{old_unique_id}-OLD",
+        suggested_object_id="old",
+        config_entry=entry,
+    )
+
+    await entry.async_migrate(hass)
+
+    old_entity = registry.async_get(f"{LIGHT_DOMAIN}.old")
+    assert old_entity.unique_id == f"{old_unique_id}-OLD"

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -113,7 +113,7 @@ async def test_unload_entry_multiple_gateways(hass):
     assert hass.data[DECONZ_DOMAIN][gateway2.bridgeid].master
 
 
-async def test_migrate_entry(hass):
+async def test_update_group_unique_id(hass):
     """Test successful migration of entry data."""
     old_unique_id = "123"
     new_unique_id = "1234"
@@ -157,7 +157,7 @@ async def test_migrate_entry(hass):
     assert new_entity.unique_id == f"{new_unique_id}-NEW"
 
 
-async def test_migrate_entry_no_legacy_group_id(hass):
+async def test_update_group_unique_id_no_legacy_group_id(hass):
     """Test migration doesn't trigger without old legacy group id in entry data."""
     old_unique_id = "123"
     new_unique_id = "1234"

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.components.deconz.const import (
 )
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.helpers import entity_registry
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
@@ -118,7 +119,12 @@ async def test_migrate_entry(hass):
     entry = MockConfigEntry(
         domain=DECONZ_DOMAIN,
         unique_id=new_unique_id,
-        data={CONF_GROUP_ID_BASE: old_unique_id},
+        data={
+            CONF_API_KEY: "1",
+            CONF_HOST: "2",
+            CONF_GROUP_ID_BASE: old_unique_id,
+            CONF_PORT: "3",
+        },
     )
 
     registry = await entity_registry.async_get_registry(hass)
@@ -140,6 +146,8 @@ async def test_migrate_entry(hass):
     )
 
     await entry.async_migrate(hass)
+
+    assert entry.data == {CONF_API_KEY: "1", CONF_HOST: "2", CONF_PORT: "3"}
 
     old_entity = registry.async_get(f"{LIGHT_DOMAIN}.old")
     assert old_entity.unique_id == f"{new_unique_id}-OLD"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert old group unique ids to match new config entry unique ids
Work around for walrus operator not working properly :/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
