### PR TITLE
Add Epson serial/usb/tcp connections

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,7 +137,7 @@ homeassistant/components/enphase_envoy/* @gtdiehl
 homeassistant/components/entur_public_transport/* @hfurubotten
 homeassistant/components/environment_canada/* @michaeldavie
 homeassistant/components/ephember/* @ttroy50
-homeassistant/components/epson/* @pszafer
+homeassistant/components/epson/* @pszafer @vzahradnik
 homeassistant/components/epsonworkforce/* @ThaStealth
 homeassistant/components/eq3btsmart/* @rytilahti
 homeassistant/components/esphome/* @OttoWinter

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -7,7 +7,7 @@ from epson_projector.const import POWER, STATE_UNAVAILABLE as EPSON_STATE_UNAVAI
 
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_PLATFORM
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -19,12 +19,13 @@ PLATFORMS = [MEDIA_PLAYER_PLATFORM]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def validate_projector(hass: HomeAssistant, host, port):
+async def validate_projector(hass: HomeAssistant, host, port, type):
     """Validate the given host and port allows us to connect."""
     epson_proj = Projector(
         host=host,
         websession=async_get_clientsession(hass, verify_ssl=False),
         port=port,
+        type=type,
     )
     _power = await epson_proj.get_property(POWER)
     if not _power or _power == EPSON_STATE_UNAVAILABLE:
@@ -42,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up epson from a config entry."""
     try:
         projector = await validate_projector(
-            hass, entry.data[CONF_HOST], entry.data[CONF_PORT]
+            hass, entry.data[CONF_HOST], entry.data[CONF_PORT], entry.data[CONF_TYPE]
         )
     except CannotConnect:
         _LOGGER.warning("Cannot connect to projector %s", entry.data[CONF_HOST])

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -24,9 +24,10 @@ async def async_setup(hass: HomeAssistant, config: dict):
     hass.data.setdefault(DOMAIN, {})
 
     # Load platforms
-    for component, conf_key in ((MEDIA_PLAYER_PLATFORM, CONF_PROJECTORS),):
-        if conf_key in config[DOMAIN]:
-            load_platform(hass, component, DOMAIN, config[DOMAIN][conf_key], config)
+    if config.get(DOMAIN) is not None:
+        for component, conf_key in ((MEDIA_PLAYER_PLATFORM, CONF_PROJECTORS),):
+            if conf_key in config[DOMAIN]:
+                load_platform(hass, component, DOMAIN, config[DOMAIN][conf_key], config)
 
     return True
 

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -1,50 +1,24 @@
-"""Config flow for epson integration."""
-import voluptuous as vol
+"""Config flow for the Epson integration."""
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.const import CONF_NAME
 
-from . import validate_projector
-from .const import DOMAIN, TYPE_HTTP
-from .exceptions import CannotConnect
-
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): str,
-        vol.Required(CONF_NAME, default=DOMAIN): str,
-        vol.Required(CONF_PORT, default=80): int,
-        vol.Optional(CONF_TYPE, default=TYPE_HTTP): str,
-    }
-)
+from .const import EPSON_DOMAIN as DOMAIN, PROJECTOR_CONFIG_FLOW_SCHEMA as DATA_SCHEMA
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for epson."""
+    """Handle a config flow for Epson."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user(import_config)
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
         if user_input is not None:
-            try:
-                await validate_projector(
-                    self.hass,
-                    user_input[CONF_HOST],
-                    user_input[CONF_PORT],
-                    user_input[CONF_TYPE],
-                )
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            else:
-                return self.async_create_entry(
-                    title=user_input.pop(CONF_NAME), data=user_input
-                )
+            return self.async_create_entry(
+                title=user_input.pop(CONF_NAME), data=user_input
+            )
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -2,10 +2,10 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
 
 from . import validate_projector
-from .const import DOMAIN
+from .const import DOMAIN, TYPE_HTTP
 from .exceptions import CannotConnect
 
 DATA_SCHEMA = vol.Schema(
@@ -13,6 +13,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_NAME, default=DOMAIN): str,
         vol.Required(CONF_PORT, default=80): int,
+        vol.Optional(CONF_TYPE, default=TYPE_HTTP): str,
     }
 )
 
@@ -33,7 +34,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await validate_projector(
-                    self.hass, user_input[CONF_HOST], user_input[CONF_PORT]
+                    self.hass,
+                    user_input[CONF_HOST],
+                    user_input[CONF_PORT],
+                    user_input[CONF_TYPE],
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -1,5 +1,4 @@
 """Constants for the Epson integration."""
-from epson_projector.const import CMODE_LIST_SET
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -19,8 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 # Configuration names
 CONF_PROJECTORS = "projectors"
-CONF_SERVICE_SELECT_CMODE = "select_cmode"
-CONF_CMODE = "cmode"
+ATTR_CMODE = "cmode"
 
 # Integration name
 EPSON_DOMAIN = "epson"
@@ -68,10 +66,6 @@ PROJECTOR_CONFIG_FLOW_SCHEMA = BASE_SCHEMA.extend(
             [PROTO_HTTP, PROTO_TCP, PROTO_SERIAL]
         ),
     }
-)
-
-SERVICE_SELECT_CMODE_SCHEMA = vol.Schema(
-    {vol.Required(CONF_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))}
 )
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -6,3 +6,7 @@ SERVICE_SELECT_CMODE = "select_cmode"
 ATTR_CMODE = "cmode"
 
 DEFAULT_NAME = "EPSON Projector"
+
+TYPE_HTTP = "http"
+TYPE_TCP = "tcp"
+TYPE_SERIAL = "serial"

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -1,12 +1,84 @@
-"""Constants for the epson integration."""
+"""Constants for the Epson integration."""
+from epson_projector.const import CMODE_LIST_SET
+import voluptuous as vol
 
-DOMAIN = "epson"
-SERVICE_SELECT_CMODE = "select_cmode"
+from homeassistant.components.media_player import (
+    DEVICE_CLASSES_SCHEMA as MEDIA_PLAYER_DEVICE_CLASSES_SCHEMA,
+    DOMAIN as MEDIA_PLAYER_PLATFORM,
+)
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_ENTITY_NAMESPACE,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_PROTOCOL,
+    CONF_SCAN_INTERVAL,
+)
+import homeassistant.helpers.config_validation as cv
 
-ATTR_CMODE = "cmode"
+# Configuration names
+CONF_PROJECTORS = "projectors"
+CONF_SERVICE_SELECT_CMODE = "select_cmode"
+CONF_CMODE = "cmode"
 
+# Integration name
+EPSON_DOMAIN = "epson"
+
+# Default values
 DEFAULT_NAME = "EPSON Projector"
+DEFAULT_SCAN_INTERVAL = 10  # seconds
+DEFAULT_PORT = 80
 
-TYPE_HTTP = "http"
-TYPE_TCP = "tcp"
-TYPE_SERIAL = "serial"
+# Supported protocols
+PROTO_HTTP = "http"
+PROTO_TCP = "tcp"
+PROTO_SERIAL = "serial"
+
+# Supported platforms
+PLATFORMS = [MEDIA_PLAYER_PLATFORM]
+
+# Schemes
+BASE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+    }
+)
+
+PROJECTORS_SCHEMA = BASE_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PROTOCOL, default=PROTO_HTTP): vol.In(
+            [PROTO_HTTP, PROTO_TCP, PROTO_SERIAL]
+        ),
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+            cv.time_period, lambda value: value.total_seconds()
+        ),
+        vol.Optional(CONF_ENTITY_NAMESPACE): cv.string,
+        vol.Optional(CONF_DEVICE_CLASS): MEDIA_PLAYER_DEVICE_CLASSES_SCHEMA,
+    }
+)
+
+PROJECTOR_CONFIG_FLOW_SCHEMA = BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_PROTOCOL, default=PROTO_HTTP): vol.In(
+            [PROTO_HTTP, PROTO_TCP, PROTO_SERIAL]
+        ),
+    }
+)
+
+SERVICE_SELECT_CMODE_SCHEMA = vol.Schema(
+    {vol.Required(CONF_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))}
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        EPSON_DOMAIN: {
+            vol.Optional(CONF_PROJECTORS): vol.All(cv.ensure_list, [PROJECTORS_SCHEMA]),
+        }
+    },
+    extra=vol.ALLOW_EXTRA,
+)

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -1,13 +1,8 @@
 """Constants for the Epson integration."""
 import voluptuous as vol
 
-from homeassistant.components.media_player import (
-    DEVICE_CLASSES_SCHEMA as MEDIA_PLAYER_DEVICE_CLASSES_SCHEMA,
-    DOMAIN as MEDIA_PLAYER_PLATFORM,
-)
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_PLATFORM
 from homeassistant.const import (
-    CONF_DEVICE_CLASS,
-    CONF_ENTITY_NAMESPACE,
     CONF_HOST,
     CONF_NAME,
     CONF_PORT,
@@ -46,24 +41,25 @@ BASE_SCHEMA = vol.Schema(
 PROJECTORS_SCHEMA = BASE_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PROTOCOL, default=PROTO_HTTP): vol.In(
             [PROTO_HTTP, PROTO_TCP, PROTO_SERIAL]
         ),
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
             cv.time_period, lambda value: value.total_seconds()
         ),
-        vol.Optional(CONF_ENTITY_NAMESPACE): cv.string,
-        vol.Optional(CONF_DEVICE_CLASS): MEDIA_PLAYER_DEVICE_CLASSES_SCHEMA,
     }
 )
 
 PROJECTOR_CONFIG_FLOW_SCHEMA = BASE_SCHEMA.extend(
     {
         vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
         vol.Required(CONF_PROTOCOL, default=PROTO_HTTP): vol.In(
             [PROTO_HTTP, PROTO_TCP, PROTO_SERIAL]
+        ),
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+            vol.Coerce(int), vol.Range(min=1)
         ),
     }
 )

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 
 # Configuration names
 CONF_PROJECTORS = "projectors"
-ATTR_CMODE = "cmode"
+ATTR_COLOR_MODE = "color_mode"
 
 # Integration name
 EPSON_DOMAIN = "epson"

--- a/homeassistant/components/epson/exceptions.py
+++ b/homeassistant/components/epson/exceptions.py
@@ -1,6 +1,0 @@
-"""The errors of Epson integration."""
-from homeassistant import exceptions
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""

--- a/homeassistant/components/epson/manifest.json
+++ b/homeassistant/components/epson/manifest.json
@@ -4,5 +4,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/epson",
   "requirements": ["epson-projector==0.2.3"],
-  "codeowners": ["@pszafer"]
+  "codeowners": ["@pszafer", "@vzahradnik"]
 }

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -65,7 +65,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     projector = EpsonProjector(
         config_entry.title,
         config_entry.data,
-        config_entry.entry_id,
+        unique_id=config_entry.entry_id,
         websession=async_get_clientsession(hass, verify_ssl=False),
     )
     async_add_entities([projector], True)
@@ -98,7 +98,7 @@ async def async_setup_platform(
 class EpsonProjector(MediaPlayerEntity):
     """Representation of Epson Projector Device."""
 
-    def __init__(self, name, config: Dict[str, Any], websession=None):
+    def __init__(self, name, config: Dict[str, Any], unique_id=None, websession=None):
         """Initialize entity to control Epson projector."""
         self._name = name
         self._available = False
@@ -107,6 +107,7 @@ class EpsonProjector(MediaPlayerEntity):
         self._source = None
         self._volume = None
         self._state = None
+        self._unique_id = unique_id
         self._scan_interval = timedelta(seconds=config[CONF_SCAN_INTERVAL])
 
         self._projector = Projector(
@@ -147,6 +148,11 @@ class EpsonProjector(MediaPlayerEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return unique ID."""
+        return self._unique_id
 
     @property
     def state(self):

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -144,6 +144,8 @@ class EpsonProjector(MediaPlayerEntity):
         else:
             self._state = STATE_OFF
 
+        self.async_schedule_update_ha_state()
+
     @property
     def name(self):
         """Return the name of the device."""
@@ -179,7 +181,7 @@ class EpsonProjector(MediaPlayerEntity):
 
     @property
     def device_class(self) -> Optional[str]:
-        """Return the device class of the sensor."""
+        """Return the device class of the projector."""
         return DEVICE_CLASS_TV
 
     @property

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -37,11 +37,18 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TYPE,
+    STATE_OFF,
+    STATE_ON,
+)
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 
-from .const import ATTR_CMODE, DEFAULT_NAME, DOMAIN, SERVICE_SELECT_CMODE
+from .const import ATTR_CMODE, DEFAULT_NAME, DOMAIN, SERVICE_SELECT_CMODE, TYPE_HTTP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +67,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PORT, default=80): cv.port,
+        vol.Optional(CONF_TYPE, default=TYPE_HTTP): cv.string,
     }
 )
 

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -55,7 +55,7 @@ from homeassistant.helpers.typing import (
     HomeAssistantType,
 )
 
-from .const import ATTR_CMODE
+from .const import ATTR_COLOR_MODE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ class EpsonProjector(MediaPlayerEntity):
         """Initialize entity to control Epson projector."""
         self._name = name
         self._available = False
-        self._cmode = None
+        self._color_mode = None
         self._source_list = list(DEFAULT_SOURCES.values())
         self._source = None
         self._volume = None
@@ -131,8 +131,8 @@ class EpsonProjector(MediaPlayerEntity):
         if power_state == EPSON_CODES[POWER]:
             self._state = STATE_ON
             self._source_list = list(DEFAULT_SOURCES.values())
-            cmode = await self._projector.get_property(CMODE)
-            self._cmode = CMODE_LIST.get(cmode, self._cmode)
+            color_mode = await self._projector.get_property(CMODE)
+            self._color_mode = CMODE_LIST.get(color_mode, self._color_mode)
             source = await self._projector.get_property(SOURCE)
             self._source = SOURCE_LIST.get(source, self._source)
             volume = await self._projector.get_property(VOLUME)
@@ -211,9 +211,9 @@ class EpsonProjector(MediaPlayerEntity):
         """Return the volume level of the media player (0..1)."""
         return self._volume
 
-    async def select_cmode(self, cmode):
+    async def select_color_mode(self, color_mode):
         """Set color mode in Epson."""
-        await self._projector.send_command(CMODE_LIST_SET[cmode])
+        await self._projector.send_command(CMODE_LIST_SET[color_mode])
 
     async def async_select_source(self, source):
         """Select input source."""
@@ -251,6 +251,6 @@ class EpsonProjector(MediaPlayerEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        if self._cmode is None:
+        if self._color_mode is None:
             return {}
-        return {ATTR_CMODE: self._cmode}
+        return {ATTR_COLOR_MODE: self._color_mode}

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -52,7 +52,7 @@ from homeassistant.helpers.typing import (
     HomeAssistantType,
 )
 
-from .const import CONF_CMODE
+from .const import ATTR_CMODE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -237,4 +237,4 @@ class EpsonProjector(MediaPlayerEntity):
         """Return device specific state attributes."""
         if self._cmode is None:
             return {}
-        return {CONF_CMODE: self._cmode}
+        return {ATTR_CMODE: self._cmode}

--- a/homeassistant/components/epson/services.yaml
+++ b/homeassistant/components/epson/services.yaml
@@ -1,9 +1,0 @@
-select_cmode:
-  description: Select Color mode of Epson projector
-  fields:
-    entity_id:
-      description: Name of projector
-      example: "media_player.epson_projector"
-    cmode:
-      description: Name of Cmode
-      example: "cinema"

--- a/homeassistant/components/epson/strings.json
+++ b/homeassistant/components/epson/strings.json
@@ -5,7 +5,9 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "name": "[%key:common::config_flow::data::name%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "port": "[%key:common::config_flow::data::port%]",
+          "protocol": "Protocol",
+          "scan_interval": "Scan Interval [seconds]"
         }
       }
     },

--- a/homeassistant/components/epson/translations/en.json
+++ b/homeassistant/components/epson/translations/en.json
@@ -8,7 +8,9 @@
                 "data": {
                     "host": "Host",
                     "name": "Name",
-                    "port": "Port"
+                    "port": "Port",
+                    "protocol": "Protocol",
+                    "scan_interval": "Scan Interval [seconds]"
                 }
             }
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This integration used old configuration style in yaml. Because I added new parameter, I reworked the configuration to meet this requirement:
https://github.com/home-assistant/architecture/blob/master/adr/0007-integration-config-yaml-structure.md

New configuration looks like this:
```yaml
epson:
  projectors:
    - host: /dev/ttyUSB0
      protocol: serial
      scan_interval: 1
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for connections over serial, usb or tcp. As it turned out, the support was already in the underlying `epson-projector` library, but it was not used here.

This change also required changes in yaml configuration as described above.
Finally, I cleaned up and refactored the whole integration.

- Epson services were removed completely. As it turned out, they were not implemented properly - there was no code to be executed after the service was called. There was only one service to control `color mode`.
- Because each Epson projector used a separate underlying `projector` instance, I moved the initialization directly into the `EpsonProjector` entity. I saw no point in managing the internal projector instances globally from the platform level. This also simplified the code (for instance, when we're removing the entity dynamically).
- Connection check during config flow was removed. I believe this check is very basic and brings more limitations than benefits. I think users should be able to add whatever configuration they want as long as it's valid. If the projector doesn't respond, they'll later know from UI/logs and can rework their setup.
- Polling is handled inside the Epson component. It's because I wanted to maintain the `scan_interval` behavior used in legacy initialization via `media_player` platform.
- The `EpsonProjector` properly sets `device_class` to `tv`
- Connection errors are handled in the `epson-projector` library. Usually, we get `False` when there's a timeout or something. Anyway, while testing I properly saw all the errors and there was no uncaught exception in the HA code.
- I was also trying to use newer version of the underlying `epson-projector` library. However, there seem to be bugs. I think the best approach is to get this PR merged first, and then I will work on the issues with the new library.
- My changes were tested with an Epson projector over `serial` (both via config flow and `configuration.yaml`)
- I didn't update documentation yet. First, I'd like to clean the code and implement changes per your comments.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
epson:
  projectors:
    - host: /dev/ttyUSB0
      protocol: serial
      scan_interval: 1
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TBD

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
