### PR TITLE
Add entity specific force_update for DSMR

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -80,35 +80,59 @@ async def async_setup_entry(
 
     dsmr_version = config[CONF_DSMR_VERSION]
 
-    # Define list of name,obis mappings to generate entities
+    # Define list of name,obis,force_update mappings to generate entities
     obis_mapping = [
-        ["Power Consumption", obis_ref.CURRENT_ELECTRICITY_USAGE],
-        ["Power Production", obis_ref.CURRENT_ELECTRICITY_DELIVERY],
-        ["Power Tariff", obis_ref.ELECTRICITY_ACTIVE_TARIFF],
-        ["Energy Consumption (tarif 1)", obis_ref.ELECTRICITY_USED_TARIFF_1],
-        ["Energy Consumption (tarif 2)", obis_ref.ELECTRICITY_USED_TARIFF_2],
-        ["Energy Production (tarif 1)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_1],
-        ["Energy Production (tarif 2)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_2],
-        ["Power Consumption Phase L1", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE],
-        ["Power Consumption Phase L2", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE],
-        ["Power Consumption Phase L3", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE],
-        ["Power Production Phase L1", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE],
-        ["Power Production Phase L2", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE],
-        ["Power Production Phase L3", obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE],
-        ["Short Power Failure Count", obis_ref.SHORT_POWER_FAILURE_COUNT],
-        ["Long Power Failure Count", obis_ref.LONG_POWER_FAILURE_COUNT],
-        ["Voltage Sags Phase L1", obis_ref.VOLTAGE_SAG_L1_COUNT],
-        ["Voltage Sags Phase L2", obis_ref.VOLTAGE_SAG_L2_COUNT],
-        ["Voltage Sags Phase L3", obis_ref.VOLTAGE_SAG_L3_COUNT],
-        ["Voltage Swells Phase L1", obis_ref.VOLTAGE_SWELL_L1_COUNT],
-        ["Voltage Swells Phase L2", obis_ref.VOLTAGE_SWELL_L2_COUNT],
-        ["Voltage Swells Phase L3", obis_ref.VOLTAGE_SWELL_L3_COUNT],
-        ["Voltage Phase L1", obis_ref.INSTANTANEOUS_VOLTAGE_L1],
-        ["Voltage Phase L2", obis_ref.INSTANTANEOUS_VOLTAGE_L2],
-        ["Voltage Phase L3", obis_ref.INSTANTANEOUS_VOLTAGE_L3],
-        ["Current Phase L1", obis_ref.INSTANTANEOUS_CURRENT_L1],
-        ["Current Phase L2", obis_ref.INSTANTANEOUS_CURRENT_L2],
-        ["Current Phase L3", obis_ref.INSTANTANEOUS_CURRENT_L3],
+        ["Power Consumption", obis_ref.CURRENT_ELECTRICITY_USAGE, True],
+        ["Power Production", obis_ref.CURRENT_ELECTRICITY_DELIVERY, True],
+        ["Power Tariff", obis_ref.ELECTRICITY_ACTIVE_TARIFF, False],
+        ["Energy Consumption (tarif 1)", obis_ref.ELECTRICITY_USED_TARIFF_1, True],
+        ["Energy Consumption (tarif 2)", obis_ref.ELECTRICITY_USED_TARIFF_2, True],
+        ["Energy Production (tarif 1)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_1, True],
+        ["Energy Production (tarif 2)", obis_ref.ELECTRICITY_DELIVERED_TARIFF_2, True],
+        [
+            "Power Consumption Phase L1",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE,
+            False,
+        ],
+        [
+            "Power Consumption Phase L2",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE,
+            False,
+        ],
+        [
+            "Power Consumption Phase L3",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE,
+            False,
+        ],
+        [
+            "Power Production Phase L1",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE,
+            False,
+        ],
+        [
+            "Power Production Phase L2",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE,
+            False,
+        ],
+        [
+            "Power Production Phase L3",
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE,
+            False,
+        ],
+        ["Short Power Failure Count", obis_ref.SHORT_POWER_FAILURE_COUNT, False],
+        ["Long Power Failure Count", obis_ref.LONG_POWER_FAILURE_COUNT, False],
+        ["Voltage Sags Phase L1", obis_ref.VOLTAGE_SAG_L1_COUNT, False],
+        ["Voltage Sags Phase L2", obis_ref.VOLTAGE_SAG_L2_COUNT, False],
+        ["Voltage Sags Phase L3", obis_ref.VOLTAGE_SAG_L3_COUNT, False],
+        ["Voltage Swells Phase L1", obis_ref.VOLTAGE_SWELL_L1_COUNT, False],
+        ["Voltage Swells Phase L2", obis_ref.VOLTAGE_SWELL_L2_COUNT, False],
+        ["Voltage Swells Phase L3", obis_ref.VOLTAGE_SWELL_L3_COUNT, False],
+        ["Voltage Phase L1", obis_ref.INSTANTANEOUS_VOLTAGE_L1, False],
+        ["Voltage Phase L2", obis_ref.INSTANTANEOUS_VOLTAGE_L2, False],
+        ["Voltage Phase L3", obis_ref.INSTANTANEOUS_VOLTAGE_L3, False],
+        ["Current Phase L1", obis_ref.INSTANTANEOUS_CURRENT_L1, False],
+        ["Current Phase L2", obis_ref.INSTANTANEOUS_CURRENT_L2, False],
+        ["Current Phase L3", obis_ref.INSTANTANEOUS_CURRENT_L3, False],
     ]
 
     if dsmr_version == "5L":
@@ -117,22 +141,26 @@ async def async_setup_entry(
                 [
                     "Energy Consumption (total)",
                     obis_ref.LUXEMBOURG_ELECTRICITY_USED_TARIFF_GLOBAL,
+                    True,
                 ],
                 [
                     "Energy Production (total)",
                     obis_ref.LUXEMBOURG_ELECTRICITY_DELIVERED_TARIFF_GLOBAL,
+                    True,
                 ],
             ]
         )
     else:
         obis_mapping.extend(
-            [["Energy Consumption (total)", obis_ref.ELECTRICITY_IMPORTED_TOTAL]]
+            [["Energy Consumption (total)", obis_ref.ELECTRICITY_IMPORTED_TOTAL, True]]
         )
 
     # Generate device entities
     devices = [
-        DSMREntity(name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config)
-        for name, obis in obis_mapping
+        DSMREntity(
+            name, DEVICE_NAME_ENERGY, config[CONF_SERIAL_ID], obis, config, force_update
+        )
+        for name, obis, force_update in obis_mapping
     ]
 
     # Protocol version specific obis
@@ -152,6 +180,7 @@ async def async_setup_entry(
                 config[CONF_SERIAL_ID_GAS],
                 gas_obis,
                 config,
+                True,
             ),
             DerivativeDSMREntity(
                 "Hourly Gas Consumption",
@@ -159,6 +188,7 @@ async def async_setup_entry(
                 config[CONF_SERIAL_ID_GAS],
                 gas_obis,
                 config,
+                False,
             ),
         ]
 
@@ -257,7 +287,7 @@ async def async_setup_entry(
 class DSMREntity(Entity):
     """Entity reading values from DSMR telegram."""
 
-    def __init__(self, name, device_name, device_serial, obis, config):
+    def __init__(self, name, device_name, device_serial, obis, config, force_update):
         """Initialize entity."""
         self._name = name
         self._obis = obis
@@ -266,6 +296,7 @@ class DSMREntity(Entity):
 
         self._device_name = device_name
         self._device_serial = device_serial
+        self._force_update = force_update
         self._unique_id = f"{device_serial}_{name}".replace(" ", "_")
 
     @callback
@@ -341,7 +372,7 @@ class DSMREntity(Entity):
     @property
     def force_update(self):
         """Force update."""
-        return True
+        return self._force_update
 
     @property
     def should_poll(self):

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -183,7 +183,7 @@ async def test_derivative():
 
     config = {"platform": "dsmr"}
 
-    entity = DerivativeDSMREntity("test", "test_device", "5678", "1.0.0", config)
+    entity = DerivativeDSMREntity("test", "test_device", "5678", "1.0.0", config, False)
     await entity.async_update()
 
     assert entity.state is None, "initial state not unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#42086 changed the force_update property for each entity by default to `True` and with #43057 the interval of state updates can be modified. However, in some cases only a few properties are relevant to update every second, and for others it is fine to get updated when there is a new value. With this PR the property `force_update` is entity specific instead of default `True` for all.

This PR is in conflict when #43405 get merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43556
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
