### PR TITLE
Implement additional DataUpdateCoordinator to harmonize the data update handling of Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -415,7 +415,7 @@ class SynoApi:
         await self._hass.async_add_executor_job(self._fetch_device_configuration)
         await self.async_update()
 
-    def set_fetching_entities(self, fetching_entities={}):
+    def set_fetching_entities(self, fetching_entities: Dict[str, bool]):
         """Set entries to be fetch from api."""
         self._fetching_entities = fetching_entities
 
@@ -529,7 +529,7 @@ class SynoApi:
         """Stop interacting with the NAS and prepare for removal from hass."""
         try:
             await self._hass.async_add_executor_job(self.dsm.logout)
-        except Exception as err:
+        except (SynologyDSMAPIErrorException, SynologyDSMRequestException) as err:
             _LOGGER.debug("Logout not possible:%s", err)
 
     async def async_update(self, now=None):

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -307,7 +307,7 @@ async def _async_setup_services(hass: HomeAssistantType):
         if call.service == SERVICE_REBOOT:
             await dsm_api.async_reboot()
         elif call.service == SERVICE_SHUTDOWN:
-            await dsm_api.system.shutdown()
+            await dsm_api.async_shutdown()
 
     for service in SERVICES:
         hass.services.async_register(DOMAIN, service, service_handler)

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -425,7 +425,7 @@ class SynoApi:
             self._fetching_entities.get(SynoCoreSecurity.API_KEY)
         )
         self._with_storage = bool(self._fetching_entities.get(SynoStorage.API_KEY))
-        self._with_system = bool(self._fetching_entities.get(SynoCoreSystem.API_KEY))
+        self._with_system = bool(self.dsm.apis.get(SynoCoreSystem.API_KEY))
         self._with_upgrade = bool(self._fetching_entities.get(SynoCoreUpgrade.API_KEY))
         self._with_utilisation = bool(
             self._fetching_entities.get(SynoCoreUtilization.API_KEY)

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -410,7 +410,7 @@ class SynoApi:
             self._with_surveillance_station,
         )
 
-        self._async_setup_api_requests()
+        self._setup_api_requests()
 
         await self._hass.async_add_executor_job(self._fetch_device_configuration)
         await self.async_update()
@@ -420,12 +420,12 @@ class SynoApi:
         self._fetching_entities = fetching_entities
 
     @callback
-    def _async_setup_api_requests(self):
+    def _setup_api_requests(self):
         """Determine if we should fetch each API, if one entity needs it."""
         # Entities not added yet, fetch all
         if not self._fetching_entities:
             _LOGGER.debug(
-                "SynoAPI._async_setup_api_requests() - Entities not added yet, fetch all"
+                "SynoAPI._setup_api_requests() - Entities not added yet, fetch all"
             )
             return
 
@@ -448,33 +448,33 @@ class SynoApi:
 
         # Reset not used API, information is not reset since it's used in device_info
         if not self._with_security:
-            _LOGGER.debug("SynoAPI._async_setup_api_requests() - disable security")
+            _LOGGER.debug("SynoAPI._setup_api_requests() - disable security")
             self.dsm.reset(self.security)
             self.security = None
 
         if not self._with_storage:
-            _LOGGER.debug("SynoAPI._async_setup_api_requests() - disable storage")
+            _LOGGER.debug("SynoAPI._setup_api_requests() - disable storage")
             self.dsm.reset(self.storage)
             self.storage = None
 
         if not self._with_system:
-            _LOGGER.debug("SynoAPI._async_setup_api_requests() - disable system")
+            _LOGGER.debug("SynoAPI._setup_api_requests() - disable system")
             self.dsm.reset(self.system)
             self.system = None
 
         if not self._with_upgrade:
-            _LOGGER.debug("SynoAPI._async_setup_api_requests() - disable upgrade")
+            _LOGGER.debug("SynoAPI._setup_api_requests() - disable upgrade")
             self.dsm.reset(self.upgrade)
             self.upgrade = None
 
         if not self._with_utilisation:
-            _LOGGER.debug("SynoAPI._async_setup_api_requests() - disable utilisation")
+            _LOGGER.debug("SynoAPI._setup_api_requests() - disable utilisation")
             self.dsm.reset(self.utilisation)
             self.utilisation = None
 
         if not self._with_surveillance_station:
             _LOGGER.debug(
-                "SynoAPI._async_setup_api_requests() - disable surveillance_station"
+                "SynoAPI._setup_api_requests() - disable surveillance_station"
             )
             self.dsm.reset(self.surveillance_station)
             self.surveillance_station = None
@@ -537,7 +537,7 @@ class SynoApi:
     async def async_update(self, now=None):
         """Update function for updating API information."""
         _LOGGER.debug("SynoAPI.async_update()")
-        self._async_setup_api_requests()
+        self._setup_api_requests()
         try:
             await self._hass.async_add_executor_job(
                 self.dsm.update, self._with_information

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -223,6 +223,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
             async with async_timeout.timeout(10):
                 await hass.async_add_executor_job(surveillance_station.update)
         except SynologyDSMAPIErrorException as err:
+            _LOGGER.debug(
+                "async_coordinator_update_data_cameras() - exception: %s", err
+            )
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
         return {
@@ -246,6 +249,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
         try:
             await api.async_update()
         except Exception as err:
+            _LOGGER.debug(
+                "async_coordinator_update_data_central() - exception: %s", err
+            )
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         return None
 

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -47,6 +47,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import (
+    CONF_DEVICE_TOKEN,
     CONF_SERIAL,
     CONF_VOLUMES,
     COORDINATOR_CAMERAS,
@@ -385,8 +386,6 @@ class SynoApi:
         self._with_upgrade = True
         self._with_utilisation = True
 
-        self._unsub_dispatcher = None
-
     async def async_setup(self):
         """Start interacting with the NAS."""
         self.dsm = SynologyDSM(
@@ -397,7 +396,7 @@ class SynoApi:
             self._entry.data[CONF_SSL],
             self._entry.data[CONF_VERIFY_SSL],
             timeout=self._entry.options.get(CONF_TIMEOUT),
-            device_token=self._entry.data.get("device_token"),
+            device_token=self._entry.data.get(CONF_DEVICE_TOKEN),
         )
         await self._hass.async_add_executor_job(self.dsm.login)
 
@@ -434,6 +433,7 @@ class SynoApi:
         self._with_surveillance_station = bool(
             self.dsm.apis.get(SynoSurveillanceStation.CAMERA_API_KEY)
         ) or bool(self.dsm.apis.get(SynoSurveillanceStation.HOME_MODE_API_KEY))
+
         self._with_security = bool(
             self._fetching_entities.get(SynoCoreSecurity.API_KEY)
         )

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -513,17 +513,19 @@ class SynoApi:
 
     async def async_reboot(self):
         """Reboot NAS."""
-        if not self.system:
-            _LOGGER.debug("SynoAPI.async_reboot() - System API not ready: %s", self)
-            return
-        await self._hass.async_add_executor_job(self.system.reboot)
+        try:
+            await self._hass.async_add_executor_job(self.system.reboot)
+        except (SynologyDSMLoginFailedException, SynologyDSMRequestException) as err:
+            _LOGGER.error("Reboot not possible, please try again later")
+            _LOGGER.debug("Exception:%s", err)
 
     async def async_shutdown(self):
         """Shutdown NAS."""
-        if not self.system:
-            _LOGGER.debug("SynoAPI.async_shutdown() - System API not ready: %s", self)
-            return
-        await self._hass.async_add_executor_job(self.system.shutdown)
+        try:
+            await self._hass.async_add_executor_job(self.system.shutdown)
+        except (SynologyDSMLoginFailedException, SynologyDSMRequestException) as err:
+            _LOGGER.error("Shutdown not possible, please try again later")
+            _LOGGER.debug("Exception:%s", err)
 
     async def async_unload(self):
         """Stop interacting with the NAS and prepare for removal from hass."""

--- a/homeassistant/components/synology_dsm/binary_sensor.py
+++ b/homeassistant/components/synology_dsm/binary_sensor.py
@@ -6,8 +6,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DISKS
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import SynologyDSMDeviceEntity, SynologyDSMDispatcherEntity
+from . import SynologyDSMBaseEntity, SynologyDSMDeviceEntity
 from .const import (
+    COORDINATOR_CENTRAL,
     DOMAIN,
     SECURITY_BINARY_SENSORS,
     STORAGE_DISK_BINARY_SENSORS,
@@ -21,18 +22,20 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Synology NAS binary sensor."""
 
-    api = hass.data[DOMAIN][entry.unique_id][SYNO_API]
+    data = hass.data[DOMAIN][entry.unique_id]
+    api = data[SYNO_API]
+    coordinator = data[COORDINATOR_CENTRAL]
 
     entities = [
         SynoDSMSecurityBinarySensor(
-            api, sensor_type, SECURITY_BINARY_SENSORS[sensor_type]
+            api, sensor_type, SECURITY_BINARY_SENSORS[sensor_type], coordinator
         )
         for sensor_type in SECURITY_BINARY_SENSORS
     ]
 
     entities += [
         SynoDSMUpgradeBinarySensor(
-            api, sensor_type, UPGRADE_BINARY_SENSORS[sensor_type]
+            api, sensor_type, UPGRADE_BINARY_SENSORS[sensor_type], coordinator
         )
         for sensor_type in UPGRADE_BINARY_SENSORS
     ]
@@ -42,7 +45,11 @@ async def async_setup_entry(
         for disk in entry.data.get(CONF_DISKS, api.storage.disks_ids):
             entities += [
                 SynoDSMStorageBinarySensor(
-                    api, sensor_type, STORAGE_DISK_BINARY_SENSORS[sensor_type], disk
+                    api,
+                    sensor_type,
+                    STORAGE_DISK_BINARY_SENSORS[sensor_type],
+                    coordinator,
+                    disk,
                 )
                 for sensor_type in STORAGE_DISK_BINARY_SENSORS
             ]
@@ -50,7 +57,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SynoDSMSecurityBinarySensor(SynologyDSMDispatcherEntity, BinarySensorEntity):
+class SynoDSMSecurityBinarySensor(SynologyDSMBaseEntity, BinarySensorEntity):
     """Representation a Synology Security binary sensor."""
 
     @property
@@ -78,7 +85,7 @@ class SynoDSMStorageBinarySensor(SynologyDSMDeviceEntity, BinarySensorEntity):
         return getattr(self._api.storage, self.entity_type)(self._device_id)
 
 
-class SynoDSMUpgradeBinarySensor(SynologyDSMDispatcherEntity, BinarySensorEntity):
+class SynoDSMUpgradeBinarySensor(SynologyDSMBaseEntity, BinarySensorEntity):
     """Representation a Synology Upgrade binary sensor."""
 
     @property

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -31,6 +31,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
+    CONF_DEVICE_TOKEN,
     CONF_VOLUMES,
     DEFAULT_PORT,
     DEFAULT_PORT_SSL,
@@ -180,7 +181,7 @@ class SynologyDSMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_MAC: api.network.macs,
         }
         if otp_code:
-            config_data["device_token"] = api.device_token
+            config_data[CONF_DEVICE_TOKEN] = api.device_token
         if user_input.get(CONF_DISKS):
             config_data[CONF_DISKS] = user_input[CONF_DISKS]
         if user_input.get(CONF_VOLUMES):

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -19,7 +19,10 @@ from homeassistant.const import (
 
 DOMAIN = "synology_dsm"
 PLATFORMS = ["binary_sensor", "camera", "sensor", "switch"]
-COORDINATOR_SURVEILLANCE = "coordinator_surveillance_station"
+COORDINATOR_CAMERAS = "coordinator_cameras"
+COORDINATOR_CENTRAL = "coordinator_central"
+COORDINATOR_SWITCHES = "coordinator_switches"
+SYSTEM_LOADED = "system_loaded"
 
 # Entry keys
 SYNO_API = "syno_api"

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -31,6 +31,7 @@ UNDO_UPDATE_LISTENER = "undo_update_listener"
 # Configuration
 CONF_SERIAL = "serial"
 CONF_VOLUMES = "volumes"
+CONF_DEVICE_TOKEN = "device_token"
 
 DEFAULT_USE_SSL = True
 DEFAULT_VERIFY_SSL = False

--- a/homeassistant/components/synology_dsm/switch.py
+++ b/homeassistant/components/synology_dsm/switch.py
@@ -7,9 +7,10 @@ from synology_dsm.api.surveillance_station import SynoSurveillanceStation
 from homeassistant.components.switch import ToggleEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import SynoApi, SynologyDSMDispatcherEntity
-from .const import DOMAIN, SURVEILLANCE_SWITCH, SYNO_API
+from . import SynoApi, SynologyDSMBaseEntity
+from .const import COORDINATOR_SWITCHES, DOMAIN, SURVEILLANCE_SWITCH, SYNO_API
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,16 +20,21 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Synology NAS switch."""
 
-    api = hass.data[DOMAIN][entry.unique_id][SYNO_API]
+    data = hass.data[DOMAIN][entry.unique_id]
+    api = data[SYNO_API]
 
     entities = []
 
     if SynoSurveillanceStation.INFO_API_KEY in api.dsm.apis:
         info = await hass.async_add_executor_job(api.dsm.surveillance_station.get_info)
         version = info["data"]["CMSMinVersion"]
+
+        # initial data fetch
+        coordinator = data[COORDINATOR_SWITCHES]
+        await coordinator.async_refresh()
         entities += [
             SynoDSMSurveillanceHomeModeToggle(
-                api, sensor_type, SURVEILLANCE_SWITCH[sensor_type], version
+                api, sensor_type, SURVEILLANCE_SWITCH[sensor_type], version, coordinator
             )
             for sensor_type in SURVEILLANCE_SWITCH
         ]
@@ -36,58 +42,52 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class SynoDSMSurveillanceHomeModeToggle(SynologyDSMDispatcherEntity, ToggleEntity):
+class SynoDSMSurveillanceHomeModeToggle(SynologyDSMBaseEntity, ToggleEntity):
     """Representation a Synology Surveillance Station Home Mode toggle."""
 
     def __init__(
-        self, api: SynoApi, entity_type: str, entity_info: Dict[str, str], version: str
+        self,
+        api: SynoApi,
+        entity_type: str,
+        entity_info: Dict[str, str],
+        version: str,
+        coordinator: DataUpdateCoordinator,
     ):
         """Initialize a Synology Surveillance Station Home Mode."""
         super().__init__(
             api,
             entity_type,
             entity_info,
+            coordinator,
         )
         self._version = version
-        self._state = None
 
     @property
     def is_on(self) -> bool:
         """Return the state."""
-        if self.entity_type == "home_mode":
-            return self._state
-        return None
+        return self.coordinator.data["switches"][self.entity_type]
 
-    @property
-    def should_poll(self) -> bool:
-        """No polling needed."""
-        return True
-
-    async def async_update(self):
-        """Update the toggle state."""
-        _LOGGER.debug(
-            "SynoDSMSurveillanceHomeModeToggle.async_update(%s)",
-            self._api.information.serial,
-        )
-        self._state = await self.hass.async_add_executor_job(
-            self._api.surveillance_station.get_home_mode_status
-        )
-
-    def turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs) -> None:
         """Turn on Home mode."""
         _LOGGER.debug(
             "SynoDSMSurveillanceHomeModeToggle.turn_on(%s)",
             self._api.information.serial,
         )
-        self._api.surveillance_station.set_home_mode(True)
+        await self.hass.async_add_executor_job(
+            self._api.dsm.surveillance_station.set_home_mode, True
+        )
+        await self.coordinator.async_request_refresh()
 
-    def turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn off Home mode."""
         _LOGGER.debug(
             "SynoDSMSurveillanceHomeModeToggle.turn_off(%s)",
             self._api.information.serial,
         )
-        self._api.surveillance_station.set_home_mode(False)
+        await self.hass.async_add_executor_job(
+            self._api.dsm.surveillance_station.set_home_mode, False
+        )
+        await self.coordinator.async_request_refresh()
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will implement additional `DataUpdateCoordinator` to harmonize the data update handling overall, address open comments from #43683 and an very small fix for #45278. May be #43529 will also be fixed.
Target is to have 3 `DataUpdateCoordinator` in place:

1. central `DataUpdateCoordinator`
- is updated every 15 minutes (_configurable via OptionsFlow_)
- handles all sensor and device data 
2. camera `DataUpdateCoordinator`
- is updated every 30 seconds
3. switch `DataUpdateCoordinator`
- is updated every 30 seconds
- independent ad-hoc updates possible, when switch is toggled



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45278 #43529 #43080 
- This PR is related to issue: #43683
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
