### PR TITLE
Allow to setup of a previously discovered sleeping Shelly device

### DIFF
--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -65,6 +65,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
     host = None
     info = None
+    device_info = None
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
@@ -160,6 +161,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(info["mac"])
         self._abort_if_unique_id_configured({CONF_HOST: zeroconf_info["host"]})
         self.host = zeroconf_info["host"]
+
+        if not info["auth"] and info["sleep_mode"]:
+            try:
+                self.device_info = info = await validate_input(self.hass, self.host, {})
+            except HTTP_CONNECT_ERRORS:
+                return self.async_abort(reason="cannot_connect")
+
         # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context["title_placeholders"] = {
             "name": zeroconf_info.get("name", "").split(".")[0]
@@ -172,6 +180,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if self.info["auth"]:
                 return await self.async_step_credentials()
+
+            if self.device_info:
+                return self.async_create_entry(
+                    title=self.device_info["title"] or self.device_info["hostname"],
+                    data={
+                        "host": self.host,
+                        "sleep_period": self.device_info["sleep_period"],
+                        "model": self.device_info["model"],
+                    },
+                )
 
             try:
                 device_info = await validate_input(self.hass, self.host, {})

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -162,7 +162,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured({CONF_HOST: zeroconf_info["host"]})
         self.host = zeroconf_info["host"]
 
-        if not info["auth"] and info["sleep_mode"]:
+        if not info["auth"] and info.get("sleep_mode", False):
             try:
                 self.device_info = info = await validate_input(self.hass, self.host, {})
             except HTTP_CONNECT_ERRORS:

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -164,7 +164,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if not info["auth"] and info.get("sleep_mode", False):
             try:
-                self.device_info = info = await validate_input(self.hass, self.host, {})
+                self.device_info = await validate_input(self.hass, self.host, {})
             except HTTP_CONNECT_ERRORS:
                 return self.async_abort(reason="cannot_connect")
 

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "Before set up, battery-powered devices must be woken up by pressing the button on the device.",
+        "description": "Before set up, battery powered devices must be woken up, you can now wake the device up using a button on it.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         }
@@ -15,7 +15,7 @@
         }
       },
       "confirm_discovery": {
-        "description": "Do you want to set up the {model} at {host}?\n\nBattery powered devices that are password protected must wake up before continuing with configuration.\nBattery powered devices that are not password protected will be added when the device wakes up, you can now manually wake the device using a button on the device or wait for the next data update from the device."
+        "description": "Do you want to set up the {model} at {host}?\n\nBattery powered devices that are password protected must be woken up before continuing with set up.\nBattery powered devices that are not password protected will be added when the device wakes up, you can now manually wake the device up using a button on it or wait for the next data update from the device."
       }
     },
     "error": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -15,7 +15,7 @@
         }
       },
       "confirm_discovery": {
-        "description": "Do you want to set up the {model} at {host}?\n\nBefore set up, battery-powered devices must be woken up by pressing the button on the device."
+        "description": "Do you want to set up the {model} at {host}?\n\nBattery powered devices that are password protected must wake up before continuing with configuration.\nBattery powered devices that are not password protected will be added when the device wakes up, you can now manually wake the device using a button on the device or wait for the next data update from the device."
       }
     },
     "error": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "Before set up, battery powered devices must be woken up, you can now wake the device up using a button on it.",
+        "description": "Before set up, battery-powered devices must be woken up, you can now wake the device up using a button on it.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -15,7 +15,7 @@
         }
       },
       "confirm_discovery": {
-        "description": "Do you want to set up the {model} at {host}?\n\nBattery powered devices that are password protected must be woken up before continuing with set up.\nBattery powered devices that are not password protected will be added when the device wakes up, you can now manually wake the device up using a button on it or wait for the next data update from the device."
+        "description": "Do you want to set up the {model} at {host}?\n\nBattery-powered devices that are password protected must be woken up before continuing with setting up.\nBattery-powered devices that are not password protected will be added when the device wakes up, you can now manually wake the device up using a button on it or wait for the next data update from the device."
       }
     },
     "error": {

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -316,7 +316,7 @@ async def test_form_auth_errors_test_connection(hass, error):
 
     with patch(
         "aioshelly.get_info",
-        return_value={"mac": "test-mac", "auth": True, "sleep_mode": 0},
+        return_value={"mac": "test-mac", "auth": True},
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -14,7 +14,6 @@ from tests.common import MockConfigEntry
 MOCK_SETTINGS = {
     "name": "Test name",
     "device": {"mac": "test-mac", "hostname": "test-host", "type": "SHSW-1"},
-    "sleep_period": 0,
 }
 DISCOVERY_INFO = {
     "host": "1.1.1.1",
@@ -341,12 +340,7 @@ async def test_zeroconf(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-            "sleep_mode": 0,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -401,7 +395,7 @@ async def test_zeroconf_sleeping_device(hass):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "sleep_mode": 600,
+            "sleep_mode": True,
         },
     ), patch(
         "aioshelly.Device.create",
@@ -473,7 +467,7 @@ async def test_zeroconf_sleeping_device_error(hass, error):
             "mac": "test-mac",
             "type": "SHSW-1",
             "auth": False,
-            "sleep_mode": 600,
+            "sleep_mode": True,
         },
     ), patch(
         "aioshelly.Device.create",
@@ -498,12 +492,7 @@ async def test_zeroconf_confirm_error(hass, error):
 
     with patch(
         "aioshelly.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": "SHSW-1",
-            "auth": False,
-            "sleep_mode": 0,
-        },
+        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -314,7 +314,10 @@ async def test_form_auth_errors_test_connection(hass, error):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("aioshelly.get_info", return_value={"mac": "test-mac", "auth": True}):
+    with patch(
+        "aioshelly.get_info",
+        return_value={"mac": "test-mac", "auth": True, "sleep_mode": 0},
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1"},
@@ -338,7 +341,12 @@ async def test_zeroconf(hass):
 
     with patch(
         "aioshelly.get_info",
-        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
+        return_value={
+            "mac": "test-mac",
+            "type": "SHSW-1",
+            "auth": False,
+            "sleep_mode": 0,
+        },
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -383,6 +391,103 @@ async def test_zeroconf(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_zeroconf_sleeping_device(hass):
+    """Test sleeping device configuration via zeroconf."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "aioshelly.get_info",
+        return_value={
+            "mac": "test-mac",
+            "type": "SHSW-1",
+            "auth": False,
+            "sleep_mode": 600,
+        },
+    ), patch(
+        "aioshelly.Device.create",
+        new=AsyncMock(
+            return_value=Mock(
+                settings={
+                    "name": "Test name",
+                    "device": {
+                        "mac": "test-mac",
+                        "hostname": "test-host",
+                        "type": "SHSW-1",
+                    },
+                    "sleep_mode": {"period": 10, "unit": "m"},
+                },
+            )
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DISCOVERY_INFO,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {}
+        context = next(
+            flow["context"]
+            for flow in hass.config_entries.flow.async_progress()
+            if flow["flow_id"] == result["flow_id"]
+        )
+        assert context["title_placeholders"]["name"] == "shelly1pm-12345"
+    with patch(
+        "homeassistant.components.shelly.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.shelly.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "Test name"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "model": "SHSW-1",
+        "sleep_period": 600,
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        (aiohttp.ClientResponseError(Mock(), (), status=400), "cannot_connect"),
+        (asyncio.TimeoutError, "cannot_connect"),
+    ],
+)
+async def test_zeroconf_sleeping_device_error(hass, error):
+    """Test sleeping device configuration via zeroconf with error."""
+    exc = error
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "aioshelly.get_info",
+        return_value={
+            "mac": "test-mac",
+            "type": "SHSW-1",
+            "auth": False,
+            "sleep_mode": 600,
+        },
+    ), patch(
+        "aioshelly.Device.create",
+        new=AsyncMock(side_effect=exc),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DISCOVERY_INFO,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "cannot_connect"
+
+
 @pytest.mark.parametrize(
     "error", [(asyncio.TimeoutError, "cannot_connect"), (ValueError, "unknown")]
 )
@@ -393,7 +498,12 @@ async def test_zeroconf_confirm_error(hass, error):
 
     with patch(
         "aioshelly.get_info",
-        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
+        return_value={
+            "mac": "test-mac",
+            "type": "SHSW-1",
+            "auth": False,
+            "sleep_mode": 0,
+        },
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -313,10 +313,7 @@ async def test_form_auth_errors_test_connection(hass, error):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch(
-        "aioshelly.get_info",
-        return_value={"mac": "test-mac", "auth": True},
-    ):
+    with patch("aioshelly.get_info", return_value={"mac": "test-mac", "auth": True}):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"host": "1.1.1.1"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to confirm the setup of previously discovered sleeping device that is offline.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
