### PR TITLE
Use activity ids for unique_id for Harmony switches

### DIFF
--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -1,15 +1,19 @@
 """The Logitech Harmony Hub integration."""
 import asyncio
+import logging
 
 from homeassistant.components.remote import ATTR_ACTIVITY, ATTR_DELAY_SECS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DOMAIN, HARMONY_OPTIONS_UPDATE, PLATFORMS
 from .data import HarmonyData
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -40,6 +44,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = data
 
+    await _migrate_old_unique_ids(hass, entry.entry_id, data)
+
     entry.add_update_listener(_update_listener)
 
     for component in PLATFORMS:
@@ -48,6 +54,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
     return True
+
+
+async def _migrate_old_unique_ids(
+    hass: HomeAssistant, entry_id: str, data: HarmonyData
+):
+    names_to_ids = {activity["name"]: activity["id"] for activity in data.activities}
+
+    @callback
+    def _async_migrator(entity_entry: entity_registry.RegistryEntry):
+        # Old format for switches was {remote_unique_id}-{activity_name}
+        # New format is {activity_id}
+        parts = entity_entry.unique_id.split("-")
+        if len(parts) == 2:  # old format
+            activity_name = parts[1]
+            activity_id = names_to_ids.get(activity_name)
+
+            if activity_id is not None:
+                _LOGGER.info(
+                    "Migrating unique_id from [%s] to [%s]",
+                    entity_entry.unique_id,
+                    activity_id,
+                )
+                return {"new_unique_id": activity_id}
+        return None
+
+    await entity_registry.async_migrate_entries(hass, entry_id, _async_migrator)
 
 
 @callback

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -76,7 +76,8 @@ async def _migrate_old_unique_ids(
                     entity_entry.unique_id,
                     activity_id,
                 )
-                return {"new_unique_id": activity_id}
+                return {"new_unique_id": f"{activity_id}"}
+
         return None
 
     await entity_registry.async_migrate_entries(hass, entry_id, _async_migrator)

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -66,8 +66,8 @@ async def _migrate_old_unique_ids(
         # Old format for switches was {remote_unique_id}-{activity_name}
         # New format is {activity_id}
         parts = entity_entry.unique_id.split("-")
-        if len(parts) == 2:  # old format
-            activity_name = parts[1]
+        if len(parts) > 1:  # old format
+            activity_name = "-".join(parts[1:])
             activity_id = names_to_ids.get(activity_name)
 
             if activity_id is not None:

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -59,15 +59,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def _migrate_old_unique_ids(
     hass: HomeAssistant, entry_id: str, data: HarmonyData
 ):
-    names_to_ids = {activity["name"]: activity["id"] for activity in data.activities}
+    names_to_ids = {activity["label"]: activity["id"] for activity in data.activities}
 
     @callback
     def _async_migrator(entity_entry: entity_registry.RegistryEntry):
         # Old format for switches was {remote_unique_id}-{activity_name}
-        # New format is {activity_id}
-        parts = entity_entry.unique_id.split("-")
+        # New format is activity_{activity_id}
+        parts = entity_entry.unique_id.split("-", 1)
         if len(parts) > 1:  # old format
-            activity_name = "-".join(parts[1:])
+            activity_name = parts[1]
             activity_id = names_to_ids.get(activity_name)
 
             if activity_id is not None:

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -76,7 +76,7 @@ async def _migrate_old_unique_ids(
                     entity_entry.unique_id,
                     activity_id,
                 )
-                return {"new_unique_id": f"{activity_id}"}
+                return {"new_unique_id": f"activity_{activity_id}"}
 
         return None
 

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -35,16 +35,26 @@ class HarmonyData(HarmonySubscriberMixin):
         )
 
     @property
+    def activities(self):
+        """List of activity_id: activity_name pairs for all the remotes activities."""
+        activity_list = []
+
+        activity_infos = self._client.config.get("activity", [])
+        for info in activity_infos:
+            activity_id = info["id"]
+            name = info["label"]
+
+            # Filter both ways of representing PowerOff
+            if name is not None and name != ACTIVITY_POWER_OFF:
+                activity_list.append({"id": activity_id, "name": name})
+
+        return activity_list
+
+    @property
     def activity_names(self):
         """Names of all the remotes activities."""
-        activity_infos = self._client.config.get("activity", [])
-        activities = [activity["label"] for activity in activity_infos]
-
-        # Remove both ways of representing PowerOff
-        if None in activities:
-            activities.remove(None)
-        if ACTIVITY_POWER_OFF in activities:
-            activities.remove(ACTIVITY_POWER_OFF)
+        activity_infos = self.activities
+        activities = [activity["name"] for activity in activity_infos]
 
         return activities
 

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -36,25 +36,19 @@ class HarmonyData(HarmonySubscriberMixin):
 
     @property
     def activities(self):
-        """List of activity_id: activity_name pairs for all the remotes activities."""
-        activity_list = []
-
+        """List of all non-poweroff activity objects."""
         activity_infos = self._client.config.get("activity", [])
-        for info in activity_infos:
-            activity_id = info["id"]
-            name = info["label"]
-
-            # Filter both ways of representing PowerOff
-            if name is not None and name != ACTIVITY_POWER_OFF:
-                activity_list.append({"id": activity_id, "name": name})
-
-        return activity_list
+        return [
+            info
+            for info in activity_infos
+            if info["label"] is not None and info["label"] != ACTIVITY_POWER_OFF
+        ]
 
     @property
     def activity_names(self):
         """Names of all the remotes activities."""
         activity_infos = self.activities
-        activities = [activity["name"] for activity in activity_infos]
+        activities = [activity["label"] for activity in activity_infos]
 
         return activities
 

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -15,12 +15,12 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up harmony activity switches."""
     data = hass.data[DOMAIN][entry.entry_id]
-    activities = data.activity_names
+    activities = data.activities
 
     switches = []
     for activity in activities:
         _LOGGER.debug("creating switch for activity: %s", activity)
-        name = f"{entry.data[CONF_NAME]} {activity}"
+        name = f"{entry.data[CONF_NAME]} {activity['name']}"
         switches.append(HarmonyActivitySwitch(name, activity, data))
 
     async_add_entities(switches, True)
@@ -29,11 +29,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
     """Switch representation of a Harmony activity."""
 
-    def __init__(self, name: str, activity: str, data: HarmonyData):
+    def __init__(self, name: str, activity: dict, data: HarmonyData):
         """Initialize HarmonyActivitySwitch class."""
         super().__init__()
         self._name = name
-        self._activity = activity
+        self._activity_name = activity["name"]
+        self._activity_id = activity["id"]
         self._data = data
 
     @property
@@ -44,7 +45,7 @@ class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
     @property
     def unique_id(self):
         """Return the unique id."""
-        return f"{self._data.unique_id}-{self._activity}"
+        return f"{self._activity_id}"
 
     @property
     def device_info(self):
@@ -55,7 +56,7 @@ class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
     def is_on(self):
         """Return if the current activity is the one for this switch."""
         _, activity_name = self._data.current_activity
-        return activity_name == self._activity
+        return activity_name == self._activity_name
 
     @property
     def should_poll(self):
@@ -69,7 +70,7 @@ class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Start this activity."""
-        await self._data.async_start_activity(self._activity)
+        await self._data.async_start_activity(self._activity_name)
 
     async def async_turn_off(self, **kwargs):
         """Stop this activity."""

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -20,7 +20,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     switches = []
     for activity in activities:
         _LOGGER.debug("creating switch for activity: %s", activity)
-        name = f"{entry.data[CONF_NAME]} {activity['name']}"
+        name = f"{entry.data[CONF_NAME]} {activity['label']}"
         switches.append(HarmonyActivitySwitch(name, activity, data))
 
     async_add_entities(switches, True)
@@ -33,7 +33,7 @@ class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
         """Initialize HarmonyActivitySwitch class."""
         super().__init__()
         self._name = name
-        self._activity_name = activity["name"]
+        self._activity_name = activity["label"]
         self._activity_id = activity["id"]
         self._data = data
 

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -45,7 +45,7 @@ class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
     @property
     def unique_id(self):
         """Return the unique id."""
-        return f"{self._activity_id}"
+        return f"activity_{self._activity_id}"
 
     @property
     def device_info(self):

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -123,6 +123,8 @@ class FakeHarmonyClient:
         type(config).config = PropertyMock(
             return_value={
                 "activity": [
+                    {"id": 10000, "label": None},
+                    {"id": -1, "label": "PowerOff"},
                     {"id": WATCH_TV_ACTIVITY_ID, "label": "Watch TV"},
                     {"id": PLAY_MUSIC_ACTIVITY_ID, "label": "Play Music"},
                     {"id": NILE_TV_ACTIVITY_ID, "label": "Nile-TV"},

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 from homeassistant.components.harmony.const import ACTIVITY_POWER_OFF
 
-from .const import PLAY_MUSIC_ACTIVITY_ID, WATCH_TV_ACTIVITY_ID
+from .const import NILE_TV_ACTIVITY_ID, PLAY_MUSIC_ACTIVITY_ID, WATCH_TV_ACTIVITY_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,12 +15,14 @@ ACTIVITIES_TO_IDS = {
     ACTIVITY_POWER_OFF: -1,
     "Watch TV": WATCH_TV_ACTIVITY_ID,
     "Play Music": PLAY_MUSIC_ACTIVITY_ID,
+    "Nile-TV": NILE_TV_ACTIVITY_ID,
 }
 
 IDS_TO_ACTIVITIES = {
     -1: ACTIVITY_POWER_OFF,
     WATCH_TV_ACTIVITY_ID: "Watch TV",
     PLAY_MUSIC_ACTIVITY_ID: "Play Music",
+    NILE_TV_ACTIVITY_ID: "Nile-TV",
 }
 
 TV_DEVICE_ID = 1234
@@ -110,6 +112,7 @@ class FakeHarmonyClient:
             return_value=[
                 {"name": "Watch TV", "id": WATCH_TV_ACTIVITY_ID},
                 {"name": "Play Music", "id": PLAY_MUSIC_ACTIVITY_ID},
+                {"name": "Nile-TV", "id": NILE_TV_ACTIVITY_ID},
             ]
         )
         type(config).devices = PropertyMock(
@@ -122,6 +125,7 @@ class FakeHarmonyClient:
                 "activity": [
                     {"id": WATCH_TV_ACTIVITY_ID, "label": "Watch TV"},
                     {"id": PLAY_MUSIC_ACTIVITY_ID, "label": "Play Music"},
+                    {"id": NILE_TV_ACTIVITY_ID, "label": "Nile-TV"},
                 ]
             }
         )

--- a/tests/components/harmony/conftest.py
+++ b/tests/components/harmony/conftest.py
@@ -7,10 +7,9 @@ import pytest
 
 from homeassistant.components.harmony.const import ACTIVITY_POWER_OFF
 
-_LOGGER = logging.getLogger(__name__)
+from .const import PLAY_MUSIC_ACTIVITY_ID, WATCH_TV_ACTIVITY_ID
 
-WATCH_TV_ACTIVITY_ID = 123
-PLAY_MUSIC_ACTIVITY_ID = 456
+_LOGGER = logging.getLogger(__name__)
 
 ACTIVITIES_TO_IDS = {
     ACTIVITY_POWER_OFF: -1,

--- a/tests/components/harmony/const.py
+++ b/tests/components/harmony/const.py
@@ -4,3 +4,6 @@ HUB_NAME = "Guest Room"
 ENTITY_REMOTE = "remote.guest_room"
 ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
 ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"
+
+WATCH_TV_ACTIVITY_ID = 123
+PLAY_MUSIC_ACTIVITY_ID = 456

--- a/tests/components/harmony/const.py
+++ b/tests/components/harmony/const.py
@@ -4,6 +4,8 @@ HUB_NAME = "Guest Room"
 ENTITY_REMOTE = "remote.guest_room"
 ENTITY_WATCH_TV = "switch.guest_room_watch_tv"
 ENTITY_PLAY_MUSIC = "switch.guest_room_play_music"
+ENTITY_NILE_TV = "switch.guest_room_nile_tv"
 
 WATCH_TV_ACTIVITY_ID = 123
 PLAY_MUSIC_ACTIVITY_ID = 456
+NILE_TV_ACTIVITY_ID = 789

--- a/tests/components/harmony/test_init.py
+++ b/tests/components/harmony/test_init.py
@@ -44,7 +44,7 @@ async def test_unique_id_migration(mock_hc, hass, mock_write_config):
             # new format
             ENTITY_PLAY_MUSIC: entity_registry.RegistryEntry(
                 entity_id=ENTITY_PLAY_MUSIC,
-                unique_id=str(PLAY_MUSIC_ACTIVITY_ID),
+                unique_id=f"activity_{PLAY_MUSIC_ACTIVITY_ID}",
                 platform="harmony",
                 config_entry_id=entry.entry_id,
             ),
@@ -63,10 +63,10 @@ async def test_unique_id_migration(mock_hc, hass, mock_write_config):
     ent_reg = await entity_registry.async_get_registry(hass)
 
     switch_tv = ent_reg.async_get(ENTITY_WATCH_TV)
-    assert switch_tv.unique_id == str(WATCH_TV_ACTIVITY_ID)
+    assert switch_tv.unique_id == f"activity_{WATCH_TV_ACTIVITY_ID}"
 
     switch_nile = ent_reg.async_get(ENTITY_NILE_TV)
-    assert switch_nile.unique_id == str(NILE_TV_ACTIVITY_ID)
+    assert switch_nile.unique_id == f"activity_{NILE_TV_ACTIVITY_ID}"
 
     switch_music = ent_reg.async_get(ENTITY_PLAY_MUSIC)
-    assert switch_music.unique_id == str(PLAY_MUSIC_ACTIVITY_ID)
+    assert switch_music.unique_id == f"activity_{PLAY_MUSIC_ACTIVITY_ID}"

--- a/tests/components/harmony/test_init.py
+++ b/tests/components/harmony/test_init.py
@@ -5,9 +5,11 @@ from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 
 from .const import (
+    ENTITY_NILE_TV,
     ENTITY_PLAY_MUSIC,
     ENTITY_WATCH_TV,
     HUB_NAME,
+    NILE_TV_ACTIVITY_ID,
     PLAY_MUSIC_ACTIVITY_ID,
     WATCH_TV_ACTIVITY_ID,
 )
@@ -29,6 +31,13 @@ async def test_unique_id_migration(mock_hc, hass, mock_write_config):
             ENTITY_WATCH_TV: entity_registry.RegistryEntry(
                 entity_id=ENTITY_WATCH_TV,
                 unique_id="123443-Watch TV",
+                platform="harmony",
+                config_entry_id=entry.entry_id,
+            ),
+            # old format, activity name with -
+            ENTITY_NILE_TV: entity_registry.RegistryEntry(
+                entity_id=ENTITY_NILE_TV,
+                unique_id="123443-Nile-TV",
                 platform="harmony",
                 config_entry_id=entry.entry_id,
             ),
@@ -54,8 +63,10 @@ async def test_unique_id_migration(mock_hc, hass, mock_write_config):
     ent_reg = await entity_registry.async_get_registry(hass)
 
     switch_tv = ent_reg.async_get(ENTITY_WATCH_TV)
-    # TODO constant
     assert switch_tv.unique_id == str(WATCH_TV_ACTIVITY_ID)
+
+    switch_nile = ent_reg.async_get(ENTITY_NILE_TV)
+    assert switch_nile.unique_id == str(NILE_TV_ACTIVITY_ID)
 
     switch_music = ent_reg.async_get(ENTITY_PLAY_MUSIC)
     assert switch_music.unique_id == str(PLAY_MUSIC_ACTIVITY_ID)

--- a/tests/components/harmony/test_init.py
+++ b/tests/components/harmony/test_init.py
@@ -1,0 +1,61 @@
+"""Test init of Logitch Harmony Hub integration."""
+from homeassistant.components.harmony.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.helpers import entity_registry
+from homeassistant.setup import async_setup_component
+
+from .const import (
+    ENTITY_PLAY_MUSIC,
+    ENTITY_WATCH_TV,
+    HUB_NAME,
+    PLAY_MUSIC_ACTIVITY_ID,
+    WATCH_TV_ACTIVITY_ID,
+)
+
+from tests.common import MockConfigEntry, mock_registry
+
+
+async def test_unique_id_migration(mock_hc, hass, mock_write_config):
+    """Test migration of switch unique ids to stable ones."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
+    )
+
+    entry.add_to_hass(hass)
+    mock_registry(
+        hass,
+        {
+            # old format
+            ENTITY_WATCH_TV: entity_registry.RegistryEntry(
+                entity_id=ENTITY_WATCH_TV,
+                unique_id="123443-Watch TV",
+                platform="harmony",
+                config_entry_id=entry.entry_id,
+            ),
+            # new format
+            ENTITY_PLAY_MUSIC: entity_registry.RegistryEntry(
+                entity_id=ENTITY_PLAY_MUSIC,
+                unique_id=str(PLAY_MUSIC_ACTIVITY_ID),
+                platform="harmony",
+                config_entry_id=entry.entry_id,
+            ),
+            # old entity which no longer has a matching activity on the hub. skipped.
+            "switch.some_other_activity": entity_registry.RegistryEntry(
+                entity_id="switch.some_other_activity",
+                unique_id="123443-Some Other Activity",
+                platform="harmony",
+                config_entry_id=entry.entry_id,
+            ),
+        },
+    )
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    ent_reg = await entity_registry.async_get_registry(hass)
+
+    switch_tv = ent_reg.async_get(ENTITY_WATCH_TV)
+    # TODO constant
+    assert switch_tv.unique_id == str(WATCH_TV_ACTIVITY_ID)
+
+    switch_music = ent_reg.async_get(ENTITY_PLAY_MUSIC)
+    assert switch_music.unique_id == str(PLAY_MUSIC_ACTIVITY_ID)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This changes the activity switches in the Harmony integration to use the activity id provided by the harmony API as the unique id. These numeric ids appear to be stable even when the activities are renamed which is not the case for the current unique id implementation.

I've also added some code to migrate old unique ids to the new ones. This will only affect old switch unique ids, as the remote unique id is just a numeric string today.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #42331 - this resolves an issue that folks noticed after that original PR was merged.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
