### PR TITLE
Revert "Convert ozw climate values to correct units"

### DIFF
--- a/homeassistant/components/ozw/climate.py
+++ b/homeassistant/components/ozw/climate.py
@@ -28,7 +28,6 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util.temperature import convert as convert_temperature
 
 from .const import DATA_UNSUBSCRIBE, DOMAIN
 from .entity import ZWaveDeviceEntity
@@ -155,13 +154,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
 
-def convert_units(units):
-    """Return units as a farenheit or celsius constant."""
-    if units == "F":
-        return TEMP_FAHRENHEIT
-    return TEMP_CELSIUS
-
-
 class ZWaveClimateEntity(ZWaveDeviceEntity, ClimateEntity):
     """Representation of a Z-Wave Climate device."""
 
@@ -207,18 +199,16 @@ class ZWaveClimateEntity(ZWaveDeviceEntity, ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return convert_units(self._current_mode_setpoint_values[0].units)
+        if self.values.temperature is not None and self.values.temperature.units == "F":
+            return TEMP_FAHRENHEIT
+        return TEMP_CELSIUS
 
     @property
     def current_temperature(self):
         """Return the current temperature."""
         if not self.values.temperature:
             return None
-        return convert_temperature(
-            self.values.temperature.value,
-            convert_units(self._current_mode_setpoint_values[0].units),
-            self.temperature_unit,
-        )
+        return self.values.temperature.value
 
     @property
     def hvac_action(self):
@@ -246,29 +236,17 @@ class ZWaveClimateEntity(ZWaveDeviceEntity, ClimateEntity):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return convert_temperature(
-            self._current_mode_setpoint_values[0].value,
-            convert_units(self._current_mode_setpoint_values[0].units),
-            self.temperature_unit,
-        )
+        return self._current_mode_setpoint_values[0].value
 
     @property
     def target_temperature_low(self) -> Optional[float]:
         """Return the lowbound target temperature we try to reach."""
-        return convert_temperature(
-            self._current_mode_setpoint_values[0].value,
-            convert_units(self._current_mode_setpoint_values[0].units),
-            self.temperature_unit,
-        )
+        return self._current_mode_setpoint_values[0].value
 
     @property
     def target_temperature_high(self) -> Optional[float]:
         """Return the highbound target temperature we try to reach."""
-        return convert_temperature(
-            self._current_mode_setpoint_values[1].value,
-            convert_units(self._current_mode_setpoint_values[1].units),
-            self.temperature_unit,
-        )
+        return self._current_mode_setpoint_values[1].value
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature.
@@ -284,29 +262,14 @@ class ZWaveClimateEntity(ZWaveDeviceEntity, ClimateEntity):
             setpoint = self._current_mode_setpoint_values[0]
             target_temp = kwargs.get(ATTR_TEMPERATURE)
             if setpoint is not None and target_temp is not None:
-                target_temp = convert_temperature(
-                    target_temp,
-                    self.temperature_unit,
-                    convert_units(setpoint.units),
-                )
                 setpoint.send_value(target_temp)
         elif len(self._current_mode_setpoint_values) == 2:
             (setpoint_low, setpoint_high) = self._current_mode_setpoint_values
             target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
             target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
             if setpoint_low is not None and target_temp_low is not None:
-                target_temp_low = convert_temperature(
-                    target_temp_low,
-                    self.temperature_unit,
-                    convert_units(setpoint_low.units),
-                )
                 setpoint_low.send_value(target_temp_low)
             if setpoint_high is not None and target_temp_high is not None:
-                target_temp_high = convert_temperature(
-                    target_temp_high,
-                    self.temperature_unit,
-                    convert_units(setpoint_high.units),
-                )
                 setpoint_high.send_value(target_temp_high)
 
     async def async_set_fan_mode(self, fan_mode):

--- a/tests/components/ozw/test_climate.py
+++ b/tests/components/ozw/test_climate.py
@@ -16,8 +16,6 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT_COOL,
     HVAC_MODE_OFF,
 )
-from homeassistant.components.ozw.climate import convert_units
-from homeassistant.const import TEMP_FAHRENHEIT
 
 from .common import setup_ozw
 
@@ -38,8 +36,8 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
         HVAC_MODE_HEAT_COOL,
     ]
     assert state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
-    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 73.5
-    assert state.attributes[ATTR_TEMPERATURE] == 70.0
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 23.1
+    assert state.attributes[ATTR_TEMPERATURE] == 21.1
     assert state.attributes.get(ATTR_TARGET_TEMP_LOW) is None
     assert state.attributes.get(ATTR_TARGET_TEMP_HIGH) is None
     assert state.attributes[ATTR_FAN_MODE] == "Auto Low"
@@ -56,7 +54,7 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
     msg = sent_messages[-1]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     # Celsius is converted to Fahrenheit here!
-    assert round(msg["payload"]["Value"], 2) == 26.1
+    assert round(msg["payload"]["Value"], 2) == 78.98
     assert msg["payload"]["ValueIDKey"] == 281475099443218
 
     # Test hvac_mode with set_temperature
@@ -74,7 +72,7 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
     msg = sent_messages[-1]
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
     # Celsius is converted to Fahrenheit here!
-    assert round(msg["payload"]["Value"], 2) == 24.1
+    assert round(msg["payload"]["Value"], 2) == 75.38
     assert msg["payload"]["ValueIDKey"] == 281475099443218
 
     # Test set mode
@@ -129,8 +127,8 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
     assert state is not None
     assert state.state == HVAC_MODE_HEAT_COOL
     assert state.attributes.get(ATTR_TEMPERATURE) is None
-    assert state.attributes[ATTR_TARGET_TEMP_LOW] == 70.0
-    assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 78.0
+    assert state.attributes[ATTR_TARGET_TEMP_LOW] == 21.1
+    assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 25.6
 
     # Test setting high/low temp on multiple setpoints
     await hass.services.async_call(
@@ -146,11 +144,11 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
     assert len(sent_messages) == 7  # 2 messages !
     msg = sent_messages[-2]  # low setpoint
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert round(msg["payload"]["Value"], 2) == 20.0
+    assert round(msg["payload"]["Value"], 2) == 68.0
     assert msg["payload"]["ValueIDKey"] == 281475099443218
     msg = sent_messages[-1]  # high setpoint
     assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert round(msg["payload"]["Value"], 2) == 25.0
+    assert round(msg["payload"]["Value"], 2) == 77.0
     assert msg["payload"]["ValueIDKey"] == 562950076153874
 
     # Test basic/single-setpoint thermostat (node 16 in dump)
@@ -327,5 +325,3 @@ async def test_climate(hass, climate_data, sent_messages, climate_msg, caplog):
     )
     assert len(sent_messages) == 12
     assert "does not support setting a mode" in caplog.text
-
-    assert convert_units("F") == TEMP_FAHRENHEIT


### PR DESCRIPTION
This reverts commit 1b6ee8301a5c076f93d0799b9f7fcb82cc6eb902.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reverts #45369  per https://discord.com/channels/330944238910963714/800356888827002880/808021017637027852


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46057 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
