### PR TITLE
Gracefully handle missing A/V info in Onkyo integration

### DIFF
--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -118,18 +118,20 @@ ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema(
 SERVICE_SELECT_HDMI_OUTPUT = "onkyo_select_hdmi_output"
 
 
-def _parse_onkyo_tuple(tup):
-    """Parse a tuple returned from the eiscp library."""
-    if isinstance(tup, bool):
+def _parse_onkyo_payload(payload):
+    """Parse a payload returned from the eiscp library."""
+    if isinstance(payload, bool):
+        # command not supported by the device
         return False
 
-    if len(tup) < 2:
+    if len(payload) < 2:
+        # no value
         return None
 
-    if isinstance(tup[1], str):
-        return tup[1].split(",")
+    if isinstance(payload[1], str):
+        return payload[1].split(",")
 
-    return tup[1]
+    return payload[1]
 
 
 def _tuple_get(tup, index, default=None):
@@ -321,7 +323,7 @@ class OnkyoDevice(MediaPlayerEntity):
         if not (volume_raw and mute_raw and current_source_raw):
             return
 
-        sources = _parse_onkyo_tuple(current_source_raw)
+        sources = _parse_onkyo_payload(current_source_raw)
 
         for source in sources:
             if source in self._source_mapping:
@@ -448,7 +450,7 @@ class OnkyoDevice(MediaPlayerEntity):
         self.command(f"hdmi-output-selector={output}")
 
     def _parse_audio_information(self, audio_information_raw):
-        values = _parse_onkyo_tuple(audio_information_raw)
+        values = _parse_onkyo_payload(audio_information_raw)
         if values is False:
             self._audio_info_supported = False
             return
@@ -467,7 +469,7 @@ class OnkyoDevice(MediaPlayerEntity):
             self._attributes.pop(ATTR_AUDIO_INFORMATION, None)
 
     def _parse_video_information(self, video_information_raw):
-        values = _parse_onkyo_tuple(video_information_raw)
+        values = _parse_onkyo_payload(video_information_raw)
         if values is False:
             self._video_info_supported = False
             return

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -120,6 +120,9 @@ SERVICE_SELECT_HDMI_OUTPUT = "onkyo_select_hdmi_output"
 
 def _parse_onkyo_tuple(tup):
     """Parse a tuple returned from the eiscp library."""
+    if isinstance(tup, bool):
+        return None
+
     if len(tup) < 2:
         return None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current implementation doesn't handle Onkyo devices that don't report A/V info. this is an attempt to fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46130 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
