### PR TITLE
Add support for bond up and down lights

### DIFF
--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -52,6 +52,9 @@ class BondEntity(Entity):
     @property
     def name(self) -> Optional[str]:
         """Get entity name."""
+        if self._sub_device:
+            sub_device_name = self._sub_device.replace("_", " ").title()
+            return f"{self._device.name} {sub_device_name}"
         return self._device.name
 
     @property

--- a/homeassistant/components/bond/light.py
+++ b/homeassistant/components/bond/light.py
@@ -37,6 +37,18 @@ async def async_setup_entry(
         if DeviceType.is_fan(device.type) and device.supports_light()
     ]
 
+    fan_up_lights: List[Entity] = [
+        BondUpLight(hub, device, bpup_subs, "up_light")
+        for device in hub.devices
+        if DeviceType.is_fan(device.type) and device.supports_up_light()
+    ]
+
+    fan_down_lights: List[Entity] = [
+        BondDownLight(hub, device, bpup_subs, "down_light")
+        for device in hub.devices
+        if DeviceType.is_fan(device.type) and device.supports_down_light()
+    ]
+
     fireplaces: List[Entity] = [
         BondFireplace(hub, device, bpup_subs)
         for device in hub.devices
@@ -55,10 +67,13 @@ async def async_setup_entry(
         if DeviceType.is_light(device.type)
     ]
 
-    async_add_entities(fan_lights + fireplaces + fp_lights + lights, True)
+    async_add_entities(
+        fan_lights + fan_up_lights + fan_down_lights + fireplaces + fp_lights + lights,
+        True,
+    )
 
 
-class BondLight(BondEntity, LightEntity):
+class BondBaseLight(BondEntity, LightEntity):
     """Representation of a Bond light."""
 
     def __init__(
@@ -68,10 +83,34 @@ class BondLight(BondEntity, LightEntity):
         bpup_subs: BPUPSubscriptions,
         sub_device: Optional[str] = None,
     ):
-        """Create HA entity representing Bond fan."""
+        """Create HA entity representing Bond light."""
+        super().__init__(hub, device, bpup_subs, sub_device)
+        self._light: Optional[int] = None
+
+    @property
+    def is_on(self) -> bool:
+        """Return if light is currently on."""
+        return self._light == 1
+
+    @property
+    def supported_features(self) -> Optional[int]:
+        """Flag supported features."""
+        return 0
+
+
+class BondLight(BondBaseLight, BondEntity, LightEntity):
+    """Representation of a Bond light."""
+
+    def __init__(
+        self,
+        hub: BondHub,
+        device: BondDevice,
+        bpup_subs: BPUPSubscriptions,
+        sub_device: Optional[str] = None,
+    ):
+        """Create HA entity representing Bond light."""
         super().__init__(hub, device, bpup_subs, sub_device)
         self._brightness: Optional[int] = None
-        self._light: Optional[int] = None
 
     def _apply_state(self, state: dict):
         self._light = state.get("light")
@@ -83,11 +122,6 @@ class BondLight(BondEntity, LightEntity):
         if self._device.supports_set_brightness():
             return SUPPORT_BRIGHTNESS
         return 0
-
-    @property
-    def is_on(self) -> bool:
-        """Return if light is currently on."""
-        return self._light == 1
 
     @property
     def brightness(self) -> int:
@@ -111,6 +145,44 @@ class BondLight(BondEntity, LightEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
         await self._hub.bond.action(self._device.device_id, Action.turn_light_off())
+
+
+class BondDownLight(BondBaseLight, BondEntity, LightEntity):
+    """Representation of a Bond light."""
+
+    def _apply_state(self, state: dict):
+        self._light = state.get("down_light")
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light."""
+        await self._hub.bond.action(
+            self._device.device_id, Action(Action.TURN_DOWN_LIGHT_ON)
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the light."""
+        await self._hub.bond.action(
+            self._device.device_id, Action(Action.TURN_DOWN_LIGHT_OFF)
+        )
+
+
+class BondUpLight(BondBaseLight, BondEntity, LightEntity):
+    """Representation of a Bond light."""
+
+    def _apply_state(self, state: dict):
+        self._light = state.get("up_light")
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light."""
+        await self._hub.bond.action(
+            self._device.device_id, Action(Action.TURN_UP_LIGHT_ON)
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the light."""
+        await self._hub.bond.action(
+            self._device.device_id, Action(Action.TURN_UP_LIGHT_OFF)
+        )
 
 
 class BondFireplace(BondEntity, LightEntity):

--- a/homeassistant/components/bond/light.py
+++ b/homeassistant/components/bond/light.py
@@ -151,7 +151,7 @@ class BondDownLight(BondBaseLight, BondEntity, LightEntity):
     """Representation of a Bond light."""
 
     def _apply_state(self, state: dict):
-        self._light = state.get("down_light")
+        self._light = state.get("down_light") and state.get("light")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
@@ -170,7 +170,7 @@ class BondUpLight(BondBaseLight, BondEntity, LightEntity):
     """Representation of a Bond light."""
 
     def _apply_state(self, state: dict):
-        self._light = state.get("up_light")
+        self._light = state.get("up_light") and state.get("light")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""

--- a/homeassistant/components/bond/light.py
+++ b/homeassistant/components/bond/light.py
@@ -34,7 +34,9 @@ async def async_setup_entry(
     fan_lights: List[Entity] = [
         BondLight(hub, device, bpup_subs)
         for device in hub.devices
-        if DeviceType.is_fan(device.type) and device.supports_light()
+        if DeviceType.is_fan(device.type)
+        and device.supports_light()
+        and not (device.supports_up_light() and device.supports_down_light())
     ]
 
     fan_up_lights: List[Entity] = [

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -1,7 +1,7 @@
 """Reusable utilities for the Bond component."""
 import asyncio
 import logging
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from aiohttp import ClientResponseError
 from bond_api import Action, Bond
@@ -58,31 +58,39 @@ class BondDevice:
         """Check if Trust State is turned on."""
         return self.props.get("trust_state", False)
 
+    def _has_any_action(self, actions: Set[str]):
+        """Check to see if the device supports any of the actions."""
+        supported_actions: List[str] = self._attrs["actions"]
+        for action in supported_actions:
+            if action in actions:
+                return True
+        return False
+
     def supports_speed(self) -> bool:
         """Return True if this device supports any of the speed related commands."""
-        actions: List[str] = self._attrs["actions"]
-        return bool([action for action in actions if action in [Action.SET_SPEED]])
+        return self._has_any_action({Action.SET_SPEED})
 
     def supports_direction(self) -> bool:
         """Return True if this device supports any of the direction related commands."""
-        actions: List[str] = self._attrs["actions"]
-        return bool([action for action in actions if action in [Action.SET_DIRECTION]])
+        return self._has_any_action({Action.SET_DIRECTION})
 
     def supports_light(self) -> bool:
         """Return True if this device supports any of the light related commands."""
-        actions: List[str] = self._attrs["actions"]
-        return bool(
-            [
-                action
-                for action in actions
-                if action in [Action.TURN_LIGHT_ON, Action.TURN_LIGHT_OFF]
-            ]
+        return self._has_any_action({Action.TURN_LIGHT_ON, Action.TURN_LIGHT_OFF})
+
+    def supports_up_light(self) -> bool:
+        """Return true if the device has an up light."""
+        return self._has_any_action({Action.TURN_UP_LIGHT_ON, Action.TURN_UP_LIGHT_OFF})
+
+    def supports_down_light(self) -> bool:
+        """Return true if the device has a down light."""
+        return self._has_any_action(
+            {Action.TURN_DOWN_LIGHT_ON, Action.TURN_DOWN_LIGHT_OFF}
         )
 
     def supports_set_brightness(self) -> bool:
         """Return True if this device supports setting a light brightness."""
-        actions: List[str] = self._attrs["actions"]
-        return bool([action for action in actions if action in [Action.SET_BRIGHTNESS]])
+        return self._has_any_action({Action.SET_BRIGHTNESS})
 
 
 class BondHub:

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -343,7 +343,7 @@ async def test_update_reports_up_light_is_on(hass: core.HomeAssistant):
     """Tests that update command sets correct state when Bond API reports the up light is on."""
     await setup_platform(hass, LIGHT_DOMAIN, up_light_ceiling_fan("name-1"))
 
-    with patch_bond_device_state(return_value={"up_light": 1}):
+    with patch_bond_device_state(return_value={"up_light": 1, "light": 1}):
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
 
@@ -354,7 +354,7 @@ async def test_update_reports_up_light_is_off(hass: core.HomeAssistant):
     """Tests that update command sets correct state when Bond API reports the up light is off."""
     await setup_platform(hass, LIGHT_DOMAIN, up_light_ceiling_fan("name-1"))
 
-    with patch_bond_device_state(return_value={"up_light": 0}):
+    with patch_bond_device_state(return_value={"up_light": 0, "light": 0}):
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
 
@@ -365,7 +365,7 @@ async def test_update_reports_down_light_is_on(hass: core.HomeAssistant):
     """Tests that update command sets correct state when Bond API reports the down light is on."""
     await setup_platform(hass, LIGHT_DOMAIN, down_light_ceiling_fan("name-1"))
 
-    with patch_bond_device_state(return_value={"down_light": 1}):
+    with patch_bond_device_state(return_value={"down_light": 1, "light": 1}):
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
 
@@ -376,7 +376,7 @@ async def test_update_reports_down_light_is_off(hass: core.HomeAssistant):
     """Tests that update command sets correct state when Bond API reports the down light is off."""
     await setup_platform(hass, LIGHT_DOMAIN, down_light_ceiling_fan("name-1"))
 
-    with patch_bond_device_state(return_value={"down_light": 0}):
+    with patch_bond_device_state(return_value={"down_light": 0, "light": 0}):
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
 

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -317,6 +317,98 @@ async def test_turn_on_light_with_brightness(hass: core.HomeAssistant):
     )
 
 
+async def test_turn_on_up_light(hass: core.HomeAssistant):
+    """Tests that turn on command, on an up light, delegates to API."""
+    await setup_platform(
+        hass,
+        LIGHT_DOMAIN,
+        up_light_ceiling_fan("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    with patch_bond_action() as mock_turn_on, patch_bond_device_state():
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "light.name_1_up_light"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_turn_on.assert_called_once_with(
+        "test-device-id", Action(Action.TURN_UP_LIGHT_ON)
+    )
+
+
+async def test_turn_off_up_light(hass: core.HomeAssistant):
+    """Tests that turn off command, on an up light, delegates to API."""
+    await setup_platform(
+        hass,
+        LIGHT_DOMAIN,
+        up_light_ceiling_fan("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    with patch_bond_action() as mock_turn_off, patch_bond_device_state():
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "light.name_1_up_light"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_turn_off.assert_called_once_with(
+        "test-device-id", Action(Action.TURN_UP_LIGHT_OFF)
+    )
+
+
+async def test_turn_on_down_light(hass: core.HomeAssistant):
+    """Tests that turn on command, on a down light, delegates to API."""
+    await setup_platform(
+        hass,
+        LIGHT_DOMAIN,
+        down_light_ceiling_fan("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    with patch_bond_action() as mock_turn_on, patch_bond_device_state():
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "light.name_1_down_light"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_turn_on.assert_called_once_with(
+        "test-device-id", Action(Action.TURN_DOWN_LIGHT_ON)
+    )
+
+
+async def test_turn_off_down_light(hass: core.HomeAssistant):
+    """Tests that turn off command, on a down light, delegates to API."""
+    await setup_platform(
+        hass,
+        LIGHT_DOMAIN,
+        down_light_ceiling_fan("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    with patch_bond_action() as mock_turn_off, patch_bond_device_state():
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "light.name_1_down_light"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_turn_off.assert_called_once_with(
+        "test-device-id", Action(Action.TURN_DOWN_LIGHT_OFF)
+    )
+
+
 async def test_update_reports_light_is_on(hass: core.HomeAssistant):
     """Tests that update command sets correct state when Bond API reports the light is on."""
     await setup_platform(hass, LIGHT_DOMAIN, ceiling_fan("name-1"))


### PR DESCRIPTION
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support for bond devices with up and down lights has been added. Previously, if the device had two lights, only a single light entity would be created that would not function properly. The functional light entity will need to be manually removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #46187
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
