### PR TITLE
Use core constants for helpers

### DIFF
--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -136,7 +136,6 @@ class YamlCollection(ObservableCollection):
 
     async def async_load(self, data: List[dict]) -> None:
         """Load the YAML collection. Overrides existing data."""
-
         old_ids = set(self.data)
 
         change_sets = []

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -549,7 +549,6 @@ unit_system = vol.All(
 
 def template(value: Optional[Any]) -> template_helper.Template:
     """Validate a jinja2 template."""
-
     if value is None:
         raise vol.Invalid("template value is None")
     if isinstance(value, (list, dict, template_helper.Template)):
@@ -566,7 +565,6 @@ def template(value: Optional[Any]) -> template_helper.Template:
 
 def dynamic_template(value: Optional[Any]) -> template_helper.Template:
     """Validate a dynamic (non static) jinja2 template."""
-
     if value is None:
         raise vol.Invalid("template value is None")
     if isinstance(value, (list, dict, template_helper.Template)):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -65,7 +65,6 @@ def async_generate_entity_id(
     hass: Optional[HomeAssistant] = None,
 ) -> str:
     """Generate a unique entity ID based on given entity IDs or used IDs."""
-
     name = (name or DEVICE_DEFAULT_NAME).lower()
     preferred_string = entity_id_format.format(slugify(name))
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -299,7 +299,6 @@ def _async_remove_indexed_listeners(
     job: HassJob,
 ) -> None:
     """Remove a listener."""
-
     callbacks = hass.data[data_key]
 
     for storage_key in storage_keys:
@@ -686,7 +685,6 @@ def async_track_template(
     Callable to unregister the listener.
 
     """
-
     job = HassJob(action)
 
     @callback
@@ -1105,7 +1103,6 @@ def async_track_point_in_time(
     point_in_time: datetime,
 ) -> CALLBACK_TYPE:
     """Add a listener that fires once after a specific point in time."""
-
     job = action if isinstance(action, HassJob) else HassJob(action)
 
     @callback
@@ -1329,7 +1326,6 @@ def async_track_utc_time_change(
     local: bool = False,
 ) -> CALLBACK_TYPE:
     """Add a listener that will fire if time matches a pattern."""
-
     job = HassJob(action)
     # We do not have to wrap the function with time pattern matching logic
     # if no pattern given

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -70,7 +70,6 @@ def report_integration(
 
     Async friendly.
     """
-
     found_frame, integration, path = integration_frame
 
     index = found_frame.filename.index(path)

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -51,7 +51,6 @@ def create_async_httpx_client(
 
     This method must be run in the event loop.
     """
-
     client = httpx.AsyncClient(
         verify=verify_ssl,
         headers={USER_AGENT: SERVER_SOFTWARE},

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -157,13 +157,11 @@ async def async_setup_reload_service(
     hass: HomeAssistantType, domain: str, platforms: Iterable
 ) -> None:
     """Create the reload service for the domain."""
-
     if hass.services.has_service(domain, SERVICE_RELOAD):
         return
 
     async def _reload_config(call: Event) -> None:
         """Reload the platforms."""
-
         await async_reload_integration_platforms(hass, domain, platforms)
         hass.bus.async_fire(f"event_{domain}_reloaded", context=call.context)
 
@@ -176,7 +174,6 @@ def setup_reload_service(
     hass: HomeAssistantType, domain: str, platforms: Iterable
 ) -> None:
     """Sync version of async_setup_reload_service."""
-
     asyncio.run_coroutine_threadsafe(
         async_setup_reload_service(hass, domain, platforms),
         hass.loop,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     ATTR_DEVICE_ID,
     ATTR_ENTITY_ID,
     CONF_SERVICE,
+    CONF_SERVICE_DATA,
     CONF_SERVICE_TEMPLATE,
     CONF_TARGET,
     ENTITY_MATCH_ALL,
@@ -62,7 +63,6 @@ if TYPE_CHECKING:
 
 
 CONF_SERVICE_ENTITY_ID = "entity_id"
-CONF_SERVICE_DATA = "data"
 CONF_SERVICE_DATA_TEMPLATE = "data_template"
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -202,7 +202,6 @@ class Store:
 
     async def _async_handle_write_data(self, *_args):
         """Handle writing the config."""
-
         async with self._write_lock:
             self._async_cleanup_delay_listener()
             self._async_cleanup_final_write_listener()

--- a/homeassistant/helpers/sun.py
+++ b/homeassistant/helpers/sun.py
@@ -19,7 +19,6 @@ DATA_LOCATION_CACHE = "astral_location_cache"
 @bind_hass
 def get_astral_location(hass: HomeAssistantType) -> "astral.Location":
     """Get an astral location for the current Home Assistant configuration."""
-
     from astral import Location  # pylint: disable=import-outside-toplevel
 
     latitude = hass.config.latitude

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1277,7 +1277,6 @@ def relative_time(value):
 
     If the input are not a datetime object the input will be returned unmodified.
     """
-
     if not isinstance(value, datetime):
         return value
     if not value.tzinfo:

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -262,7 +262,6 @@ class CoordinatorEntity(entity.Entity):
 
         Only used by the generic entity update service.
         """
-
         # Ignore manual update requests if the entity is disabled
         if not self.enabled:
             return


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use core constants for helpers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
