### PR TITLE
Update powerwall for new authentication requirements

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -194,9 +194,9 @@ def _async_start_reauth(hass: HomeAssistant, entry: ConfigEntry):
 
 def _login_and_fetch_base_info(power_wall: Powerwall, password: str):
     """Login to the powerwall and fetch the base info."""
-    power_wall.detect_and_pin_version()
     if password is not None:
         power_wall.login("", password)
+    power_wall.detect_and_pin_version()
     return call_base_info(power_wall)
 
 

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -4,10 +4,15 @@ from datetime import timedelta
 import logging
 
 import requests
-from tesla_powerwall import MissingAttributeError, Powerwall, PowerwallUnreachableError
+from tesla_powerwall import (
+    AccessDeniedError,
+    MissingAttributeError,
+    Powerwall,
+    PowerwallUnreachableError,
+)
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry
@@ -93,17 +98,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN].setdefault(entry_id, {})
     http_session = requests.Session()
+
+    password = entry.data.get(CONF_PASSWORD)
     power_wall = Powerwall(entry.data[CONF_IP_ADDRESS], http_session=http_session)
     try:
-        await hass.async_add_executor_job(power_wall.detect_and_pin_version)
-        await hass.async_add_executor_job(_fetch_powerwall_data, power_wall)
-        powerwall_data = await hass.async_add_executor_job(call_base_info, power_wall)
+        powerwall_data = await hass.async_add_executor_job(
+            _login_and_fetch_base_info, power_wall, password
+        )
     except PowerwallUnreachableError as err:
         http_session.close()
         raise ConfigEntryNotReady from err
     except MissingAttributeError as err:
         http_session.close()
         await _async_handle_api_changed_error(hass, err)
+        return False
+    except AccessDeniedError as err:
+        _LOGGER.debug("Authentication failed", exc_info=err)
+        http_session.close()
+        _async_start_reauth(hass, entry)
         return False
 
     await _migrate_old_unique_ids(hass, entry_id, powerwall_data)
@@ -154,6 +166,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
     return True
+
+
+def _async_start_reauth(hass: HomeAssistant, entry: ConfigEntry):
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "reauth"},
+            data=entry.data,
+        )
+    )
+    _LOGGER.error("Password is no longer valid. Please reauthenticate")
+
+
+def _login_and_fetch_base_info(power_wall: Powerwall, password: str):
+    """Login to the powerwall and fetch the base info."""
+    power_wall.detect_and_pin_version()
+    if password is not None:
+        power_wall.login("", password)
+    return call_base_info(power_wall)
 
 
 def call_base_info(power_wall):

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -132,7 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             return await _async_update_powerwall_data(hass, entry, power_wall)
         except AccessDeniedError:
             if password is None:
-                return
+                raise
 
             # If the session expired, relogin, and try again
             await hass.async_add_executor_job(power_wall.login, "", password)

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -21,9 +21,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def _login_and_fetch_site_info(power_wall: Powerwall, password: str):
     """Login to the powerwall and fetch the base info."""
-    power_wall.detect_and_pin_version()
     if password is not None:
         power_wall.login("", password)
+    power_wall.detect_and_pin_version()
     return power_wall.get_site_info()
 
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -1,17 +1,30 @@
 """Config flow for Tesla Powerwall integration."""
 import logging
 
-from tesla_powerwall import MissingAttributeError, Powerwall, PowerwallUnreachableError
+from tesla_powerwall import (
+    AccessDeniedError,
+    MissingAttributeError,
+    Powerwall,
+    PowerwallUnreachableError,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.components.dhcp import IP_ADDRESS
-from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import callback
 
 from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _login_and_fetch_site_info(power_wall: Powerwall, password: str):
+    """Login to the powerwall and fetch the base info."""
+    power_wall.detect_and_pin_version()
+    if password is not None:
+        power_wall.login("", password)
+    return power_wall.get_site_info()
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -21,12 +34,12 @@ async def validate_input(hass: core.HomeAssistant, data):
     """
 
     power_wall = Powerwall(data[CONF_IP_ADDRESS])
+    password = data[CONF_PASSWORD]
 
     try:
-        await hass.async_add_executor_job(power_wall.detect_and_pin_version)
-        site_info = await hass.async_add_executor_job(power_wall.get_site_info)
-    except PowerwallUnreachableError as err:
-        raise CannotConnect from err
+        site_info = await hass.async_add_executor_job(
+            _login_and_fetch_site_info, power_wall, password
+        )
     except MissingAttributeError as err:
         # Only log the exception without the traceback
         _LOGGER.error(str(err))
@@ -62,26 +75,43 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 info = await validate_input(self.hass, user_input)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
+            except PowerwallUnreachableError:
+                errors[CONF_IP_ADDRESS] = "cannot_connect"
             except WrongVersion:
                 errors["base"] = "wrong_version"
+            except AccessDeniedError:
+                errors[CONF_PASSWORD] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
-            if "base" not in errors:
-                await self.async_set_unique_id(user_input[CONF_IP_ADDRESS])
-                self._abort_if_unique_id_configured()
+            if not errors:
+                existing_entry = await self.async_set_unique_id(
+                    user_input[CONF_IP_ADDRESS]
+                )
+                if existing_entry:
+                    self.hass.config_entries.async_update_entry(
+                        existing_entry, data=user_input
+                    )
+                    await self.hass.config_entries.async_reload(existing_entry.entry_id)
+                    return self.async_abort(reason="reauth_successful")
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
-                {vol.Required(CONF_IP_ADDRESS, default=self.ip_address): str}
+                {
+                    vol.Required(CONF_IP_ADDRESS, default=self.ip_address): str,
+                    vol.Optional(CONF_PASSWORD): str,
+                }
             ),
             errors=errors,
         )
+
+    async def async_step_reauth(self, data):
+        """Handle configuration by re-auth."""
+        self.ip_address = data[CONF_IP_ADDRESS]
+        return await self.async_step_user()
 
     @callback
     def _async_ip_address_already_configured(self, ip_address):
@@ -90,10 +120,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if entry.data.get(CONF_IP_ADDRESS) == ip_address:
                 return True
         return False
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
 
 
 class WrongVersion(exceptions.HomeAssistantError):

--- a/homeassistant/components/powerwall/manifest.json
+++ b/homeassistant/components/powerwall/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tesla Powerwall",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/powerwall",
-  "requirements": ["tesla-powerwall==0.3.3"],
+  "requirements": ["tesla-powerwall==0.3.5"],
   "codeowners": ["@bdraco", "@jrester"],
   "dhcp": [
      {"hostname":"1118431-*","macaddress":"88DA1A*"},

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Connect to the powerwall",
-        "description": "The password is usually the last 5 characters of the serial number and can be found in the Telsa app.",
+        "description": "The password is usually the last 5 characters of the serial number for Backup Gateway and can be found in the Telsa app; or the last 5 characters of the password found inside the door for Backup Gateway 2.",
         "data": {
           "ip_address": "[%key:common::config_flow::data::ip%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -4,18 +4,22 @@
     "step": {
       "user": {
         "title": "Connect to the powerwall",
+        "description": "The password is usually the last 5 characters of the serial number and can be found in the Telsa app.",
         "data": {
-          "ip_address": "[%key:common::config_flow::data::ip%]"
+          "ip_address": "[%key:common::config_flow::data::ip%]",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved.",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/homeassistant/components/powerwall/translations/en.json
+++ b/homeassistant/components/powerwall/translations/en.json
@@ -17,7 +17,7 @@
                     "ip_address": "IP Address",
                     "password": "Password"
                 },
-                "description": "The password is usually the last 5 characters of the serial number and can be found in the Telsa app.",
+                "description": "The password is usually the last 5 characters of the serial number for Backup Gateway and can be found in the Telsa app; or the last 5 characters of the password found inside the door for Backup Gateway 2.",
                 "title": "Connect to the powerwall"
             }
         }

--- a/homeassistant/components/powerwall/translations/en.json
+++ b/homeassistant/components/powerwall/translations/en.json
@@ -1,10 +1,12 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error",
             "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved."
         },
@@ -12,8 +14,10 @@
         "step": {
             "user": {
                 "data": {
-                    "ip_address": "IP Address"
+                    "ip_address": "IP Address",
+                    "password": "Password"
                 },
+                "description": "The password is usually the last 5 characters of the serial number and can be found in the Telsa app.",
                 "title": "Connect to the powerwall"
             }
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2184,7 +2184,7 @@ temperusb==1.5.3
 # tensorflow==2.3.0
 
 # homeassistant.components.powerwall
-tesla-powerwall==0.3.3
+tesla-powerwall==0.3.5
 
 # homeassistant.components.tesla
 teslajsonpy==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1102,7 +1102,7 @@ synologydsm-api==1.0.1
 tellduslive==0.10.11
 
 # homeassistant.components.powerwall
-tesla-powerwall==0.3.3
+tesla-powerwall==0.3.5
 
 # homeassistant.components.tesla
 teslajsonpy==0.10.4

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -7,11 +7,13 @@ from tesla_powerwall import MissingAttributeError, PowerwallUnreachableError
 from homeassistant import config_entries, setup
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.powerwall.const import DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 
 from .mocks import _mock_powerwall_side_effect, _mock_powerwall_site_name
 
 from tests.common import MockConfigEntry
+
+VALID_CONFIG = {CONF_IP_ADDRESS: "1.2.3.4", CONF_PASSWORD: "00GGX"}
 
 
 async def test_form_source_user(hass):
@@ -36,13 +38,13 @@ async def test_form_source_user(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_IP_ADDRESS: "1.2.3.4"},
+            VALID_CONFIG,
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "My site"
-    assert result2["data"] == {CONF_IP_ADDRESS: "1.2.3.4"}
+    assert result2["data"] == VALID_CONFIG
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -61,11 +63,11 @@ async def test_form_cannot_connect(hass):
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_IP_ADDRESS: "1.2.3.4"},
+            VALID_CONFIG,
         )
 
     assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result2["errors"] == {CONF_IP_ADDRESS: "cannot_connect"}
 
 
 async def test_form_unknown_exeption(hass):
@@ -81,8 +83,7 @@ async def test_form_unknown_exeption(hass):
         return_value=mock_powerwall,
     ):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_IP_ADDRESS: "1.2.3.4"},
+            result["flow_id"], VALID_CONFIG
         )
 
     assert result2["type"] == "form"
@@ -105,7 +106,7 @@ async def test_form_wrong_version(hass):
     ):
         result3 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_IP_ADDRESS: "1.2.3.4"},
+            VALID_CONFIG,
         )
 
     assert result3["type"] == "form"
@@ -178,16 +179,54 @@ async def test_dhcp_discovery(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_IP_ADDRESS: "1.1.1.1",
-            },
+            VALID_CONFIG,
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Some site"
-    assert result2["data"] == {
-        CONF_IP_ADDRESS: "1.1.1.1",
-    }
+    assert result2["data"] == VALID_CONFIG
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_reauth(hass):
+    """Test reauthenticate."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id="1.2.3.4",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "reauth"}, data=entry.data
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    mock_powerwall = await _mock_powerwall_site_name(hass, "My site")
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ), patch(
+        "homeassistant.components.powerwall.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.powerwall.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_IP_ADDRESS: "1.2.3.4",
+                CONF_PASSWORD: "new-test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "reauth_successful"
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Powerwall now requires authentication with the latest firmware (its effectively broken after the firmware update).

This integration is using the ip address as the unique id and should
be migrated to use the serial numbers in a future PR.  I didn't do it in
this PR since the integration is currently broken and did not want to increase
the scope of the change or review.

<img width="496" alt="Screen Shot 2021-02-08 at 1 30 34 PM" src="https://user-images.githubusercontent.com/663432/107294715-06bdf500-6a12-11eb-9279-ca93c68ea519.png">


<img width="343" alt="Screen Shot 2021-02-08 at 1 30 43 PM" src="https://user-images.githubusercontent.com/663432/107294711-058cc800-6a12-11eb-8d1d-662fe78bfc0c.png">




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45955 fixes #46243 fixes #46266
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
