### PR TITLE
Wait for registries to load at startup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -512,7 +512,7 @@ async def _async_set_up_integrations(
     stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
 
     # Load the registries
-    asyncio.gather(
+    await asyncio.gather(
         device_registry.async_load(hass),
         entity_registry.async_load(hass),
         area_registry.async_load(hass),

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -510,10 +510,12 @@ async def _async_set_up_integrations(
 
     stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
 
-    # Kick off loading the registries. They don't need to be awaited.
-    asyncio.create_task(hass.helpers.device_registry.async_get_registry())
-    asyncio.create_task(hass.helpers.entity_registry.async_get_registry())
-    asyncio.create_task(hass.helpers.area_registry.async_get_registry())
+    # Load the registries
+    asyncio.gather(
+        hass.helpers.device_registry.async_load(),
+        hass.helpers.entity_registry.async_load(),
+        hass.helpers.area_registry.async_load(),
+    )
 
     # Start setup
     if stage_1_domains:

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -17,6 +17,7 @@ from homeassistant import config as conf_util, config_entries, core, loader
 from homeassistant.components import http
 from homeassistant.const import REQUIRED_NEXT_PYTHON_DATE, REQUIRED_NEXT_PYTHON_VER
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import area_registry, device_registry, entity_registry
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import (
     DATA_SETUP,
@@ -512,9 +513,9 @@ async def _async_set_up_integrations(
 
     # Load the registries
     asyncio.gather(
-        hass.helpers.device_registry.async_load(),
-        hass.helpers.entity_registry.async_load(),
-        hass.helpers.area_registry.async_load(),
+        device_registry.async_load(hass),
+        entity_registry.async_load(hass),
+        area_registry.async_load(hass),
     )
 
     # Start setup

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -131,13 +131,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # grab device in device registry attached to this node
         dev_id = get_device_id(client, node)
         device = dev_reg.async_get_device({dev_id})
-        # note: removal of entity registry is handled by core
+        assert device
+        # note: removal of entity registry entry is handled by core
         dev_reg.async_remove_device(device.id)
 
     @callback
     def async_on_value_notification(notification: ValueNotification) -> None:
         """Relay stateless value notification events from Z-Wave nodes to hass."""
         device = dev_reg.async_get_device({get_device_id(client, notification.node)})
+        assert device
         value = notification.value
         if notification.metadata.states:
             value = notification.metadata.states.get(str(value), value)
@@ -163,6 +165,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def async_on_notification(notification: Notification) -> None:
         """Relay stateless notification events from Z-Wave nodes to hass."""
         device = dev_reg.async_get_device({get_device_id(client, notification.node)})
+        assert device
         hass.bus.async_fire(
             ZWAVE_JS_EVENT,
             {

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -131,15 +131,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # grab device in device registry attached to this node
         dev_id = get_device_id(client, node)
         device = dev_reg.async_get_device({dev_id})
-        assert device
         # note: removal of entity registry entry is handled by core
-        dev_reg.async_remove_device(device.id)
+        dev_reg.async_remove_device(device.id)  # type: ignore
 
     @callback
     def async_on_value_notification(notification: ValueNotification) -> None:
         """Relay stateless value notification events from Z-Wave nodes to hass."""
         device = dev_reg.async_get_device({get_device_id(client, notification.node)})
-        assert device
         value = notification.value
         if notification.metadata.states:
             value = notification.metadata.states.get(str(value), value)
@@ -151,7 +149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 ATTR_NODE_ID: notification.node.node_id,
                 ATTR_HOME_ID: client.driver.controller.home_id,
                 ATTR_ENDPOINT: notification.endpoint,
-                ATTR_DEVICE_ID: device.id,
+                ATTR_DEVICE_ID: device.id,  # type: ignore
                 ATTR_COMMAND_CLASS: notification.command_class,
                 ATTR_COMMAND_CLASS_NAME: notification.command_class_name,
                 ATTR_LABEL: notification.metadata.label,
@@ -165,7 +163,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def async_on_notification(notification: Notification) -> None:
         """Relay stateless notification events from Z-Wave nodes to hass."""
         device = dev_reg.async_get_device({get_device_id(client, notification.node)})
-        assert device
         hass.bus.async_fire(
             ZWAVE_JS_EVENT,
             {
@@ -173,7 +170,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 ATTR_DOMAIN: DOMAIN,
                 ATTR_NODE_ID: notification.node.node_id,
                 ATTR_HOME_ID: client.driver.controller.home_id,
-                ATTR_DEVICE_ID: device.id,
+                ATTR_DEVICE_ID: device.id,  # type: ignore
                 ATTR_LABEL: notification.notification_label,
                 ATTR_PARAMETERS: notification.parameters,
             },

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -154,14 +154,12 @@ class AreaRegistry:
         return data
 
 
-@bind_hass
 @callback
 def async_get(hass: HomeAssistantType) -> AreaRegistry:
     """Get area registry."""
     return cast(AreaRegistry, hass.data[DATA_REGISTRY])
 
 
-@bind_hass
 async def async_load(hass: HomeAssistantType) -> None:
     """Load area registry."""
     assert DATA_REGISTRY not in hass.data

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -169,11 +169,8 @@ async def async_load(hass: HomeAssistantType) -> None:
 
 @bind_hass
 async def async_get_registry(hass: HomeAssistantType) -> AreaRegistry:
-    """Wait until area registry is loaded, then return it.
+    """Get area registry.
 
     This is deprecated and will be removed in the future. Use async_get instead.
     """
-    if DATA_REGISTRY not in hass.data:
-        await async_load(hass)
-
     return async_get(hass)

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -1,5 +1,5 @@
 """Provide a way to connect devices to one physical location."""
-from asyncio import Event, gather
+from asyncio import gather
 from collections import OrderedDict
 from typing import Container, Dict, Iterable, List, MutableMapping, Optional, cast
 
@@ -155,23 +155,27 @@ class AreaRegistry:
 
 
 @bind_hass
+@callback
+def async_get(hass: HomeAssistantType) -> AreaRegistry:
+    """Get area registry."""
+    return cast(AreaRegistry, hass.data[DATA_REGISTRY])
+
+
+@bind_hass
+async def async_load(hass: HomeAssistantType) -> None:
+    """Load area registry."""
+    assert DATA_REGISTRY not in hass.data
+    hass.data[DATA_REGISTRY] = AreaRegistry(hass)
+    await hass.data[DATA_REGISTRY].async_load()
+
+
+@bind_hass
 async def async_get_registry(hass: HomeAssistantType) -> AreaRegistry:
-    """Return area registry instance."""
-    reg_or_evt = hass.data.get(DATA_REGISTRY)
+    """Wait until area registry is loaded, then return it.
 
-    if not reg_or_evt:
-        evt = hass.data[DATA_REGISTRY] = Event()
+    This is deprecated and will be removed in the future. Use async_get instead.
+    """
+    if DATA_REGISTRY not in hass.data:
+        await async_load(hass)
 
-        reg = AreaRegistry(hass)
-        await reg.async_load()
-
-        hass.data[DATA_REGISTRY] = reg
-        evt.set()
-        return reg
-
-    if isinstance(reg_or_evt, Event):
-        evt = reg_or_evt
-        await evt.wait()
-        return cast(AreaRegistry, hass.data.get(DATA_REGISTRY))
-
-    return cast(AreaRegistry, reg_or_evt)
+    return async_get(hass)

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -608,13 +608,10 @@ async def async_load(hass: HomeAssistantType) -> None:
 
 @bind_hass
 async def async_get_registry(hass: HomeAssistantType) -> DeviceRegistry:
-    """Wait until device registry is loaded, then return it.
+    """Get device registry.
 
     This is deprecated and will be removed in the future. Use async_get instead.
     """
-    if DATA_REGISTRY not in hass.data:
-        await async_load(hass)
-
     return async_get(hass)
 
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -593,14 +593,12 @@ class DeviceRegistry:
                 self._async_update_device(dev_id, area_id=None)
 
 
-@bind_hass
 @callback
 def async_get(hass: HomeAssistantType) -> DeviceRegistry:
     """Get device registry."""
     return cast(DeviceRegistry, hass.data[DATA_REGISTRY])
 
 
-@bind_hass
 async def async_load(hass: HomeAssistantType) -> None:
     """Load device registry."""
     assert DATA_REGISTRY not in hass.data

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2,16 +2,16 @@
 from collections import OrderedDict
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import attr
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import Event, callback
+from homeassistant.loader import bind_hass
 import homeassistant.util.uuid as uuid_util
 
 from .debounce import Debouncer
-from .singleton import singleton
 from .typing import UNDEFINED, HomeAssistantType, UndefinedType
 
 # mypy: disallow_any_generics
@@ -593,12 +593,31 @@ class DeviceRegistry:
                 self._async_update_device(dev_id, area_id=None)
 
 
-@singleton(DATA_REGISTRY)
+@bind_hass
+@callback
+def async_get(hass: HomeAssistantType) -> DeviceRegistry:
+    """Get device registry."""
+    return cast(DeviceRegistry, hass.data[DATA_REGISTRY])
+
+
+@bind_hass
+async def async_load(hass: HomeAssistantType) -> None:
+    """Load device registry."""
+    assert DATA_REGISTRY not in hass.data
+    hass.data[DATA_REGISTRY] = DeviceRegistry(hass)
+    await hass.data[DATA_REGISTRY].async_load()
+
+
+@bind_hass
 async def async_get_registry(hass: HomeAssistantType) -> DeviceRegistry:
-    """Create entity registry."""
-    reg = DeviceRegistry(hass)
-    await reg.async_load()
-    return reg
+    """Wait until device registry is loaded, then return it.
+
+    This is deprecated and will be removed in the future. Use async_get instead.
+    """
+    if DATA_REGISTRY not in hass.data:
+        await async_load(hass)
+
+    return async_get(hass)
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -582,13 +582,10 @@ async def async_load(hass: HomeAssistantType) -> None:
 
 @bind_hass
 async def async_get_registry(hass: HomeAssistantType) -> EntityRegistry:
-    """Wait until entity registry is loaded, then return it.
+    """Get entity registry.
 
     This is deprecated and will be removed in the future. Use async_get instead.
     """
-    if DATA_REGISTRY not in hass.data:
-        await async_load(hass)
-
     return async_get(hass)
 
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -19,6 +19,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    cast,
 )
 
 import attr
@@ -35,10 +36,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, callback, split_entity_id, valid_entity_id
 from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
+from homeassistant.loader import bind_hass
 from homeassistant.util import slugify
 from homeassistant.util.yaml import load_yaml
 
-from .singleton import singleton
 from .typing import UNDEFINED, HomeAssistantType, UndefinedType
 
 if TYPE_CHECKING:
@@ -566,12 +567,31 @@ class EntityRegistry:
             self._add_index(entry)
 
 
-@singleton(DATA_REGISTRY)
+@bind_hass
+@callback
+def async_get(hass: HomeAssistantType) -> EntityRegistry:
+    """Get entity registry."""
+    return cast(EntityRegistry, hass.data[DATA_REGISTRY])
+
+
+@bind_hass
+async def async_load(hass: HomeAssistantType) -> None:
+    """Load entity registry."""
+    assert DATA_REGISTRY not in hass.data
+    hass.data[DATA_REGISTRY] = EntityRegistry(hass)
+    await hass.data[DATA_REGISTRY].async_load()
+
+
+@bind_hass
 async def async_get_registry(hass: HomeAssistantType) -> EntityRegistry:
-    """Create entity registry."""
-    reg = EntityRegistry(hass)
-    await reg.async_load()
-    return reg
+    """Wait until entity registry is loaded, then return it.
+
+    This is deprecated and will be removed in the future. Use async_get instead.
+    """
+    if DATA_REGISTRY not in hass.data:
+        await async_load(hass)
+
+    return async_get(hass)
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -567,14 +567,12 @@ class EntityRegistry:
             self._add_index(entry)
 
 
-@bind_hass
 @callback
 def async_get(hass: HomeAssistantType) -> EntityRegistry:
     """Get entity registry."""
     return cast(EntityRegistry, hass.data[DATA_REGISTRY])
 
 
-@bind_hass
 async def async_load(hass: HomeAssistantType) -> None:
     """Load entity registry."""
     assert DATA_REGISTRY not in hass.data

--- a/tests/common.py
+++ b/tests/common.py
@@ -232,6 +232,13 @@ async def async_test_home_assistant(loop):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, clear_instance)
 
+    # Load the registries
+    asyncio.gather(
+        device_registry.async_load(hass),
+        entity_registry.async_load(hass),
+        area_registry.async_load(hass),
+    )
+
     return hass
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -210,6 +210,14 @@ async def async_test_home_assistant(loop):
     hass.config_entries._entries = []
     hass.config_entries._store._async_ensure_stop_listener = lambda: None
 
+    # Load the registries
+    await asyncio.gather(
+        device_registry.async_load(hass),
+        entity_registry.async_load(hass),
+        area_registry.async_load(hass),
+    )
+    await hass.async_block_till_done()
+
     hass.state = ha.CoreState.running
 
     # Mock async_start
@@ -231,13 +239,6 @@ async def async_test_home_assistant(loop):
         INSTANCES.remove(hass)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, clear_instance)
-
-    # Load the registries
-    await asyncio.gather(
-        device_registry.async_load(hass),
-        entity_registry.async_load(hass),
-        area_registry.async_load(hass),
-    )
 
     return hass
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -233,7 +233,7 @@ async def async_test_home_assistant(loop):
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, clear_instance)
 
     # Load the registries
-    asyncio.gather(
+    await asyncio.gather(
         device_registry.async_load(hass),
         entity_registry.async_load(hass),
         area_registry.async_load(hass),

--- a/tests/common.py
+++ b/tests/common.py
@@ -143,7 +143,7 @@ def get_test_home_assistant():
 
 
 # pylint: disable=protected-access
-async def async_test_home_assistant(loop):
+async def async_test_home_assistant(loop, load_registries=True):
     """Return a Home Assistant object pointing at test config dir."""
     hass = ha.HomeAssistant()
     store = auth_store.AuthStore(hass)
@@ -211,12 +211,13 @@ async def async_test_home_assistant(loop):
     hass.config_entries._store._async_ensure_stop_listener = lambda: None
 
     # Load the registries
-    await asyncio.gather(
-        device_registry.async_load(hass),
-        entity_registry.async_load(hass),
-        area_registry.async_load(hass),
-    )
-    await hass.async_block_till_done()
+    if load_registries:
+        await asyncio.gather(
+            device_registry.async_load(hass),
+            entity_registry.async_load(hass),
+            area_registry.async_load(hass),
+        )
+        await hass.async_block_till_done()
 
     hass.state = ha.CoreState.running
 

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -38,19 +38,17 @@ async def mock_discovery(hass, discoveries, config=BASE_CONFIG):
     """Mock discoveries."""
     with patch("homeassistant.components.zeroconf.async_get_instance"), patch(
         "homeassistant.components.zeroconf.async_setup", return_value=True
-    ):
-        assert await async_setup_component(hass, "discovery", config)
-        await hass.async_block_till_done()
-        await hass.async_start()
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-    with patch.object(discovery, "_discover", discoveries), patch(
+    ), patch.object(discovery, "_discover", discoveries), patch(
         "homeassistant.components.discovery.async_discover", return_value=mock_coro()
     ) as mock_discover, patch(
         "homeassistant.components.discovery.async_load_platform",
         return_value=mock_coro(),
     ) as mock_platform:
+        assert await async_setup_component(hass, "discovery", config)
+        await hass.async_block_till_done()
+        await hass.async_start()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
         async_fire_time_changed(hass, utcnow())
         # Work around an issue where our loop.call_soon not get caught
         await hass.async_block_till_done()

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -3,6 +3,8 @@ from asyncio import Event
 from datetime import timedelta
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.bootstrap import async_from_config_dict
 from homeassistant.components import sensor
 from homeassistant.const import (
@@ -403,6 +405,7 @@ async def test_setup_valid_device_class(hass):
     assert "device_class" not in state.attributes
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_creating_sensor_loads_group(hass):
     """Test setting up template sensor loads group component first."""
     order = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,13 @@ def hass_storage():
 
 
 @pytest.fixture
-def hass(loop, hass_storage, request):
+def load_registries():
+    """Fixture to disable loading registries."""
+    return True
+
+
+@pytest.fixture
+def hass(loop, load_registries, hass_storage, request):
     """Fixture to provide a test instance of Home Assistant."""
 
     def exc_handle(loop, context):
@@ -141,7 +147,7 @@ def hass(loop, hass_storage, request):
         orig_exception_handler(loop, context)
 
     exceptions = []
-    hass = loop.run_until_complete(async_test_home_assistant(loop))
+    hass = loop.run_until_complete(async_test_home_assistant(loop, load_registries))
     orig_exception_handler = loop.get_exception_handler()
     loop.set_exception_handler(exc_handle)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,11 @@ def hass_storage():
 
 @pytest.fixture
 def load_registries():
-    """Fixture to disable loading registries."""
+    """Fixture to control the loading of registries when setting up the hass fixture.
+
+    To avoid loading the registries, tests can be marked with:
+    @pytest.mark.parametrize("load_registries", [False])
+    """
     return True
 
 

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -1,7 +1,4 @@
 """Tests for the Area Registry."""
-import asyncio
-import unittest.mock
-
 import pytest
 
 from homeassistant.core import callback
@@ -164,6 +161,7 @@ async def test_load_area(hass, registry):
     assert list(registry.areas) == list(registry2.areas)
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_loading_area_from_storage(hass, hass_storage):
     """Test loading stored areas on start."""
     hass_storage[area_registry.STORAGE_KEY] = {
@@ -171,20 +169,7 @@ async def test_loading_area_from_storage(hass, hass_storage):
         "data": {"areas": [{"id": "12345A", "name": "mock"}]},
     }
 
-    registry = await area_registry.async_get_registry(hass)
+    await area_registry.async_load(hass)
+    registry = area_registry.async_get(hass)
 
     assert len(registry.areas) == 1
-
-
-async def test_loading_race_condition(hass):
-    """Test only one storage load called when concurrent loading occurred ."""
-    with unittest.mock.patch(
-        "homeassistant.helpers.area_registry.AreaRegistry.async_load"
-    ) as mock_load:
-        results = await asyncio.gather(
-            area_registry.async_get_registry(hass),
-            area_registry.async_get_registry(hass),
-        )
-
-        mock_load.assert_called_once_with()
-        assert results[0] == results[1]

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -761,7 +761,7 @@ async def test_disable_device_disables_entities(hass, registry):
 
 
 async def test_disabled_entities_excluded_from_entity_list(hass, registry):
-    """Test that disabled entities are exclduded from async_entries_for_device."""
+    """Test that disabled entities are excluded from async_entries_for_device."""
     device_registry = mock_device_registry(hass)
     config_entry = MockConfigEntry(domain="light")
 

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1,6 +1,4 @@
 """Tests for the Entity Registry."""
-import asyncio
-import unittest.mock
 from unittest.mock import patch
 
 import pytest
@@ -219,6 +217,7 @@ def test_is_registered(registry):
     assert not registry.async_is_registered("light.non_existing")
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_loading_extra_values(hass, hass_storage):
     """Test we load extra data from the registry."""
     hass_storage[entity_registry.STORAGE_KEY] = {
@@ -258,7 +257,8 @@ async def test_loading_extra_values(hass, hass_storage):
         },
     }
 
-    registry = await entity_registry.async_get_registry(hass)
+    await entity_registry.async_load(hass)
+    registry = entity_registry.async_get(hass)
 
     assert len(registry.entities) == 4
 
@@ -350,6 +350,7 @@ async def test_removing_area_id(registry):
     assert entry_w_area != entry_wo_area
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_migration(hass):
     """Test migration from old data to new."""
     mock_config = MockConfigEntry(domain="test-platform", entry_id="test-config-id")
@@ -366,7 +367,8 @@ async def test_migration(hass):
     with patch("os.path.isfile", return_value=True), patch("os.remove"), patch(
         "homeassistant.helpers.entity_registry.load_yaml", return_value=old_conf
     ):
-        registry = await entity_registry.async_get_registry(hass)
+        await entity_registry.async_load(hass)
+        registry = entity_registry.async_get(hass)
 
     assert registry.async_is_registered("light.kitchen")
     entry = registry.async_get_or_create(
@@ -425,20 +427,6 @@ async def test_loading_invalid_entity_id(hass, hass_storage):
     )
 
     assert valid_entity_id(entity_invalid_start.entity_id)
-
-
-async def test_loading_race_condition(hass):
-    """Test only one storage load called when concurrent loading occurred ."""
-    with unittest.mock.patch(
-        "homeassistant.helpers.entity_registry.EntityRegistry.async_load"
-    ) as mock_load:
-        results = await asyncio.gather(
-            entity_registry.async_get_registry(hass),
-            entity_registry.async_get_registry(hass),
-        )
-
-        mock_load.assert_called_once_with()
-        assert results[0] == results[1]
 
 
 async def test_update_entity_unique_id(registry):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -71,6 +71,7 @@ async def test_load_hassio(hass):
         assert bootstrap._get_domains(hass, {}) == {"hassio"}
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_empty_setup(hass):
     """Test an empty set up loads the core."""
     await bootstrap.async_from_config_dict({}, hass)
@@ -91,6 +92,7 @@ async def test_core_failure_loads_safe_mode(hass, caplog):
     assert "group" not in hass.config.components
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_setting_up_config(hass):
     """Test we set up domains in config."""
     await bootstrap._async_set_up_integrations(
@@ -100,6 +102,7 @@ async def test_setting_up_config(hass):
     assert "group" in hass.config.components
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_setup_after_deps_all_present(hass):
     """Test after_dependencies when all present."""
     order = []
@@ -144,6 +147,7 @@ async def test_setup_after_deps_all_present(hass):
     assert order == ["logger", "root", "first_dep", "second_dep"]
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_setup_after_deps_in_stage_1_ignored(hass):
     """Test after_dependencies are ignored in stage 1."""
     # This test relies on this
@@ -190,6 +194,7 @@ async def test_setup_after_deps_in_stage_1_ignored(hass):
     assert order == ["cloud", "an_after_dep", "normal_integration"]
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_setup_after_deps_via_platform(hass):
     """Test after_dependencies set up via platform."""
     order = []
@@ -239,6 +244,7 @@ async def test_setup_after_deps_via_platform(hass):
     assert order == ["after_dep_of_platform_int", "platform_int"]
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_setup_after_deps_not_trigger_load(hass):
     """Test after_dependencies does not trigger loading it."""
     order = []
@@ -277,6 +283,7 @@ async def test_setup_after_deps_not_trigger_load(hass):
     assert "second_dep" in hass.config.components
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_setup_after_deps_not_present(hass):
     """Test after_dependencies when referenced integration doesn't exist."""
     order = []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wait for registries to load at startup to allow accessing the registries from non coroutines.

Mark the following functions as deprecated:
- `area_registry.async_get_registry`
- `device_registry.async_get_registry`
- `entity_registry.async_get_registry`

The driver for this PR is adding a template filter/function to get a list of entity_ids connected to a device_id, and avoiding either rewriting all template rendering functions as coroutines (not feasible) or bootstrapping the template environments with a reference to the device registry somehow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
