### PR TITLE
Fix SNMP engine memory leak in Brother integration

### DIFF
--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -6,12 +6,13 @@ import logging
 from brother import Brother, SnmpError, UnsupportedModel
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_TYPE, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import DATA_CONFIG_ENTRY, DOMAIN, SNMP
+from .utils import get_snmp_engine
 
 PLATFORMS = ["sensor"]
 
@@ -30,15 +31,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     host = entry.data[CONF_HOST]
     kind = entry.data[CONF_TYPE]
 
-    coordinator = BrotherDataUpdateCoordinator(hass, host=host, kind=kind)
+    snmp_engine = get_snmp_engine(hass)
+
+    coordinator = BrotherDataUpdateCoordinator(
+        hass, host=host, kind=kind, snmp_engine=snmp_engine
+    )
     await coordinator.async_refresh()
 
     if not coordinator.last_update_success:
-        coordinator.shutdown()
         raise ConfigEntryNotReady
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    hass.data[DOMAIN].setdefault(DATA_CONFIG_ENTRY, {})
+    hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id] = coordinator
+    hass.data[DOMAIN][SNMP] = snmp_engine
 
     for component in PLATFORMS:
         hass.async_create_task(
@@ -59,7 +65,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
     )
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id).shutdown()
+        hass.data[DOMAIN][DATA_CONFIG_ENTRY].pop(entry.entry_id)
+        if not len(hass.data[DOMAIN][DATA_CONFIG_ENTRY]):
+            hass.data[DOMAIN].pop(SNMP)
+            hass.data[DOMAIN].pop(DATA_CONFIG_ENTRY)
 
     return unload_ok
 
@@ -67,12 +76,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 class BrotherDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Brother data from the printer."""
 
-    def __init__(self, hass, host, kind):
+    def __init__(self, hass, host, kind, snmp_engine):
         """Initialize."""
-        self.brother = Brother(host, kind=kind)
-        self._unsub_stop = hass.bus.async_listen(
-            EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop
-        )
+        self.brother = Brother(host, kind=kind, snmp_engine=snmp_engine)
 
         super().__init__(
             hass,
@@ -83,22 +89,8 @@ class BrotherDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Update data via library."""
-        # Race condition on shutdown. Stop all the fetches.
-        if self._unsub_stop is None:
-            return None
-
         try:
             await self.brother.async_update()
         except (ConnectionError, SnmpError, UnsupportedModel) as error:
             raise UpdateFailed(error) from error
         return self.brother.data
-
-    def shutdown(self):
-        """Shutdown the Brother coordinator."""
-        self._unsub_stop()
-        self._unsub_stop = None
-        self.brother.shutdown()
-
-    def _handle_ha_stop(self, _):
-        """Handle Home Assistant stopping."""
-        self.shutdown()

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -66,7 +66,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
     if unload_ok:
         hass.data[DOMAIN][DATA_CONFIG_ENTRY].pop(entry.entry_id)
-        if not len(hass.data[DOMAIN][DATA_CONFIG_ENTRY]):
+        if not hass.data[DOMAIN][DATA_CONFIG_ENTRY]:
             hass.data[DOMAIN].pop(SNMP)
             hass.data[DOMAIN].pop(DATA_CONFIG_ENTRY)
 

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -41,11 +41,15 @@ ATTR_YELLOW_DRUM_REMAINING_PAGES = "yellow_drum_remaining_pages"
 ATTR_YELLOW_INK_REMAINING = "yellow_ink_remaining"
 ATTR_YELLOW_TONER_REMAINING = "yellow_toner_remaining"
 
+DATA_CONFIG_ENTRY = "config_entry"
+
 DOMAIN = "brother"
 
 UNIT_PAGES = "p"
 
 PRINTER_TYPES = ["laser", "ink"]
+
+SNMP = "snmp"
 
 SENSOR_TYPES = {
     ATTR_STATUS: {

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brother Printer",
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
-  "requirements": ["brother==0.1.20"],
+  "requirements": ["brother==0.1.21"],
   "zeroconf": [{ "type": "_printer._tcp.local.", "name": "brother*" }],
   "config_flow": true,
   "quality_scale": "platinum"

--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -24,6 +24,7 @@ from .const import (
     ATTR_YELLOW_DRUM_COUNTER,
     ATTR_YELLOW_DRUM_REMAINING_LIFE,
     ATTR_YELLOW_DRUM_REMAINING_PAGES,
+    DATA_CONFIG_ENTRY,
     DOMAIN,
     SENSOR_TYPES,
 )
@@ -37,7 +38,7 @@ ATTR_SERIAL = "serial"
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add Brother entities from a config_entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
 
     sensors = []
 

--- a/homeassistant/components/brother/utils.py
+++ b/homeassistant/components/brother/utils.py
@@ -1,0 +1,30 @@
+"""Brother helpers functions."""
+import logging
+
+import pysnmp.hlapi.asyncio as hlapi
+from pysnmp.hlapi.asyncio.cmdgen import lcd
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import callback
+from homeassistant.helpers import singleton
+
+from .const import DOMAIN, SNMP
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@singleton.singleton("snmp_engine")
+def get_snmp_engine(hass):
+    """Get SNMP engine."""
+    _LOGGER.debug("Creating SNMP engine")
+    snmp_engine = hlapi.SnmpEngine()
+
+    @callback
+    def shutdown_listener(ev):
+        if hass.data.get(DOMAIN):
+            _LOGGER.debug("Unconfiguring SNMP engine")
+            lcd.unconfigure(hass.data[DOMAIN][SNMP], None)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown_listener)
+
+    return snmp_engine

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -383,7 +383,7 @@ bravia-tv==1.0.8
 broadlink==0.16.0
 
 # homeassistant.components.brother
-brother==0.1.20
+brother==0.1.21
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -210,7 +210,7 @@ bravia-tv==1.0.8
 broadlink==0.16.0
 
 # homeassistant.components.brother
-brother==0.1.20
+brother==0.1.21
 
 # homeassistant.components.bsblan
 bsblan==0.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`snmp_engine` from `pysnmp` causes memory leak when HA starts and the Brother printer is offline. `unconfigure()` method doesn't free memory. This PR changes the way `snmp_engine` is initialised. One `snmp_engine` is used for config flow and for all configured printers.
I commit this change to `rc` branch because Brother integration in `dev` branch is never than in 2021.2.x. I'll prepare a PR with a similar change for `dev` branch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #45959
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
