### PR TITLE
Hide volume control for cast devices with fixed volume

### DIFF
--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==8.0.0"],
+  "requirements": ["pychromecast==8.1.0"],
   "after_dependencies": ["cloud", "http", "media_source", "plex", "tts", "zeroconf"],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": ["@emontnemery"]

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -10,6 +10,7 @@ import pychromecast
 from pychromecast.controllers.homeassistant import HomeAssistantController
 from pychromecast.controllers.multizone import MultizoneManager
 from pychromecast.controllers.plex import PlexController
+from pychromecast.controllers.receiver import VOLUME_CONTROL_TYPE_FIXED
 from pychromecast.quick_play import quick_play
 from pychromecast.socket_client import (
     CONNECTION_STATUS_CONNECTED,
@@ -82,8 +83,6 @@ SUPPORT_CAST = (
     | SUPPORT_STOP
     | SUPPORT_TURN_OFF
     | SUPPORT_TURN_ON
-    | SUPPORT_VOLUME_MUTE
-    | SUPPORT_VOLUME_SET
 )
 
 
@@ -742,6 +741,10 @@ class CastDevice(MediaPlayerEntity):
         """Flag media player features that are supported."""
         support = SUPPORT_CAST
         media_status = self._media_status()[0]
+
+        if self.cast_status:
+            if self.cast_status.volume_control_type != VOLUME_CONTROL_TYPE_FIXED:
+                support |= SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET
 
         if media_status:
             if media_status.supports_queue_next:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1310,7 +1310,7 @@ pycfdns==1.2.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==8.0.0
+pychromecast==8.1.0
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -681,7 +681,7 @@ pybotvac==0.0.20
 pycfdns==1.2.1
 
 # homeassistant.components.cast
-pychromecast==8.0.0
+pychromecast==8.1.0
 
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.4

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -11,6 +11,19 @@ import pytest
 from homeassistant.components import tts
 from homeassistant.components.cast import media_player as cast
 from homeassistant.components.cast.media_player import ChromecastInfo
+from homeassistant.components.media_player.const import (
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_PLAY_MEDIA,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SEEK,
+    SUPPORT_STOP,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
+)
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import PlatformNotReady
@@ -662,6 +675,17 @@ async def test_entity_cast_status(hass: HomeAssistantType):
     assert state.state == "unknown"
     assert entity_id == reg.async_get_entity_id("media_player", "cast", full_info.uuid)
 
+    assert state.attributes.get("supported_features") == (
+        SUPPORT_PAUSE
+        | SUPPORT_PLAY
+        | SUPPORT_PLAY_MEDIA
+        | SUPPORT_STOP
+        | SUPPORT_TURN_OFF
+        | SUPPORT_TURN_ON
+        | SUPPORT_VOLUME_MUTE
+        | SUPPORT_VOLUME_SET
+    )
+
     cast_status = MagicMock()
     cast_status.volume_level = 0.5
     cast_status.volume_muted = False
@@ -679,6 +703,21 @@ async def test_entity_cast_status(hass: HomeAssistantType):
     state = hass.states.get(entity_id)
     assert state.attributes.get("volume_level") == 0.2
     assert state.attributes.get("is_volume_muted")
+
+    # Disable support for volume control
+    cast_status = MagicMock()
+    cast_status.volume_control_type = "fixed"
+    cast_status_cb(cast_status)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("supported_features") == (
+        SUPPORT_PAUSE
+        | SUPPORT_PLAY
+        | SUPPORT_PLAY_MEDIA
+        | SUPPORT_STOP
+        | SUPPORT_TURN_OFF
+        | SUPPORT_TURN_ON
+    )
 
 
 async def test_entity_play_media(hass: HomeAssistantType):
@@ -894,6 +933,17 @@ async def test_entity_control(hass: HomeAssistantType):
     assert state.state == "unknown"
     assert entity_id == reg.async_get_entity_id("media_player", "cast", full_info.uuid)
 
+    assert state.attributes.get("supported_features") == (
+        SUPPORT_PAUSE
+        | SUPPORT_PLAY
+        | SUPPORT_PLAY_MEDIA
+        | SUPPORT_STOP
+        | SUPPORT_TURN_OFF
+        | SUPPORT_TURN_ON
+        | SUPPORT_VOLUME_MUTE
+        | SUPPORT_VOLUME_SET
+    )
+
     # Turn on
     await common.async_turn_on(hass, entity_id)
     chromecast.play_media.assert_called_once_with(
@@ -939,6 +989,21 @@ async def test_entity_control(hass: HomeAssistantType):
     media_status.supports_seek = True
     media_status_cb(media_status)
     await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("supported_features") == (
+        SUPPORT_PAUSE
+        | SUPPORT_PLAY
+        | SUPPORT_PLAY_MEDIA
+        | SUPPORT_STOP
+        | SUPPORT_TURN_OFF
+        | SUPPORT_TURN_ON
+        | SUPPORT_PREVIOUS_TRACK
+        | SUPPORT_NEXT_TRACK
+        | SUPPORT_SEEK
+        | SUPPORT_VOLUME_MUTE
+        | SUPPORT_VOLUME_SET
+    )
 
     # Media previous
     await common.async_media_previous_track(hass, entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hide volume control for cast devices with fixed volume

Reference in Google cast API: https://developers.google.com/cast/docs/reference/chrome/chrome.cast#.VolumeControlType

Bump pychromecast from 8.0.0 to 8.1.0
Changes:
 - 8.1.0 (https://github.com/home-assistant-libs/pychromecast/releases/tag/8.1.0)
    - Expose volume_control_type [#461](home-assistant-libs/pychromecast#461) @emontnemery
    - Move ReceiverController to its own module [#460](home-assistant-libs/pychromecast#460) @emontnemery

https://github.com/home-assistant-libs/pychromecast/compare/8.0.0...8.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46230

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
